### PR TITLE
Fix trying to load a new book from mobile app

### DIFF
--- a/lib/ambry/media/player_state.ex
+++ b/lib/ambry/media/player_state.ex
@@ -13,8 +13,8 @@ defmodule Ambry.Media.PlayerState do
     belongs_to :media, Media
     belongs_to :user, User
 
-    field :playback_rate, :decimal, default: 1
-    field :position, :decimal, default: 0
+    field :playback_rate, :decimal, default: Decimal.new(1)
+    field :position, :decimal, default: Decimal.new(0)
     field :duration, :decimal
 
     timestamps()


### PR DESCRIPTION
When trying to load a new book from the mobile app, the JSON fails to serialize because it's being given integer defaults and it expects Decimals.