### PR TITLE
Add status to player state and filter by it

### DIFF
--- a/assets/js/hooks/media_player.js
+++ b/assets/js/hooks/media_player.js
@@ -52,7 +52,14 @@ export const MediaPlayerHook = {
 
   seekRelative (seconds) {
     const player = this.player
-    player.seek(player.time() + seconds * player.getPlaybackRate())
+    const duration = player.duration()
+
+    let position = player.time() + seconds * player.getPlaybackRate()
+
+    position = position < 0 ? 0 : position
+    position = position > duration ? duration : position
+
+    player.seek(position)
   },
 
   seekRatio (ratio) {
@@ -91,6 +98,10 @@ export const MediaPlayerHook = {
     this.pushEvent('duration-loaded', { duration: player.duration() })
 
     if (opts.play) {
+      // WARNING: mutating opts state so that the next time this callback fires
+      // it doesn't auto-play. It's only meant to auto-play the FIRST time it
+      // fires.
+      opts.play = false
       this.play()
     }
   },

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -135,7 +135,7 @@ defmodule Ambry.Media do
   """
   def get_recent_player_states(user_id, offset \\ 0, limit \\ 10) do
     PlayerState
-    |> where([ps], ps.user_id == ^user_id)
+    |> where([ps], ps.user_id == ^user_id and ps.status == :in_progress)
     |> order_by({:desc, :updated_at})
     |> offset(^offset)
     |> limit(^limit)

--- a/priv/repo/migrations/20211020225645_add_status_to_player_state.exs
+++ b/priv/repo/migrations/20211020225645_add_status_to_player_state.exs
@@ -1,0 +1,9 @@
+defmodule Ambry.Repo.Migrations.AddStatusToPlayerState do
+  use Ecto.Migration
+
+  def change do
+    alter table(:player_states) do
+      add :status, :text, null: false, default: "in_progress"
+    end
+  end
+end


### PR DESCRIPTION
Close #14 

Even though this doesn't accomplish actually "deleting" player states, it can effectively serve to keep a user's list of "active" player states down. A user could (for example) reset the progress back to zero to effectively hide it.