### PR TITLE
Don't link progress-tracker; just let it die 🔗

### DIFF
--- a/lib/ambry/media/processor/mp3.ex
+++ b/lib/ambry/media/processor/mp3.ex
@@ -38,7 +38,7 @@ defmodule Ambry.Media.Processor.MP3 do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start_link(media, progress_file_path, @extensions)
+    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
     command = "ffmpeg"
 

--- a/lib/ambry/media/processor/mp4_concat.ex
+++ b/lib/ambry/media/processor/mp4_concat.ex
@@ -39,7 +39,7 @@ defmodule Ambry.Media.Processor.MP4Concat do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start_link(media, progress_file_path, @extensions)
+    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
     command = "ffmpeg"
 

--- a/lib/ambry/media/processor/mp4_re_encode.ex
+++ b/lib/ambry/media/processor/mp4_re_encode.ex
@@ -39,7 +39,7 @@ defmodule Ambry.Media.Processor.MP4ReEncode do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start_link(media, progress_file_path, @extensions)
+    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
     command = "ffmpeg"
 

--- a/lib/ambry/media/processor/progress_tracker.ex
+++ b/lib/ambry/media/processor/progress_tracker.ex
@@ -13,11 +13,11 @@ defmodule Ambry.Media.Processor.ProgressTracker do
 
   # Client
 
-  def start_link(media, file, extensions) do
+  def start(media, file, extensions) do
     file_path = Media.out_path(media, file)
     File.touch!(file_path)
 
-    GenServer.start_link(__MODULE__, %{media: media, file_path: file_path, extensions: extensions})
+    GenServer.start(__MODULE__, %{media: media, file_path: file_path, extensions: extensions})
   end
 
   # Server (callbacks)

--- a/lib/ambry/media/processor/shared.ex
+++ b/lib/ambry/media/processor/shared.ex
@@ -42,7 +42,7 @@ defmodule Ambry.Media.Processor.Shared do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start_link(media, progress_file_path, extensions)
+    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, extensions)
 
     command = "ffmpeg"
 


### PR DESCRIPTION
The progress tracker is not super important and shouldn't take down the media processor if it crashes for any reason.  For now the simplest solution is to just not link it; a better solution can be implemented later.

Closes #402 