### PR TITLE
Don't use runtime config in plugs

### DIFF
--- a/lib/ambry_web/plugs/first_time_setup.ex
+++ b/lib/ambry_web/plugs/first_time_setup.ex
@@ -12,20 +12,21 @@ defmodule AmbryWeb.Plugs.FirstTimeSetup do
   alias Plug.Conn
 
   @impl Plug
-  @spec init([]) :: boolean()
-  def init([]) do
-    Application.get_env(:ambry, :first_time_setup, false)
-  end
+  @spec init([]) :: []
+  def init([]), do: []
 
   @impl Plug
-  @spec call(Conn.t(), boolean) :: Conn.t()
-  def call(conn, false), do: conn
+  @spec call(Conn.t(), []) :: Conn.t()
+  def call(conn, []) do
+    first_time_setup? = Application.get_env(:ambry, :first_time_setup, false)
+    setup_path? = match?(%Conn{path_info: ["first_time_setup" | _]}, conn)
 
-  def call(%Conn{path_info: ["first_time_setup" | _]} = conn, true), do: conn
-
-  def call(conn, true) do
-    conn
-    |> redirect(to: Routes.first_time_setup_setup_index_path(conn, :index))
-    |> Conn.halt()
+    if first_time_setup? and not setup_path? do
+      conn
+      |> redirect(to: Routes.first_time_setup_setup_index_path(conn, :index))
+      |> Conn.halt()
+    else
+      conn
+    end
   end
 end


### PR DESCRIPTION
`init/1` will be called at compile-time in production

Closes #483