### PR TITLE
Convert imported audnexus book description to markdown

### DIFF
--- a/lib/ambry_web/live/admin/book_live/form_component.ex
+++ b/lib/ambry_web/live/admin/book_live/form_component.ex
@@ -3,7 +3,7 @@ defmodule AmbryWeb.Admin.BookLive.FormComponent do
 
   use AmbryWeb, :live_component
 
-  import AmbryWeb.Admin.{Components, UploadHelpers}
+  import AmbryWeb.Admin.{Components, HTMLToMD, UploadHelpers}
   import AmbryWeb.Admin.ParamHelpers, only: [map_to_list: 2]
 
   alias Ambry.{Authors, Books, Series}
@@ -119,7 +119,7 @@ defmodule AmbryWeb.Admin.BookLive.FormComponent do
       |> init_book_param()
       |> Map.merge(%{
         "title" => book_details["title"],
-        "description" => book_details["summary"],
+        "description" => parse_description(book_details["summary"]),
         "image_import_url" => book_details["image"]
       })
       |> Map.update!("book_authors", fn
@@ -140,6 +140,13 @@ defmodule AmbryWeb.Admin.BookLive.FormComponent do
       end)
 
     Books.change_book(book, params)
+  end
+
+  defp parse_description(html_string) do
+    case html_to_md(html_string) do
+      {:ok, description} -> description
+      :error -> html_string
+    end
   end
 
   defp audnexus_matching_authors(book_details) do

--- a/lib/ambry_web/live/admin/book_live/form_component.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form_component.html.heex
@@ -55,13 +55,21 @@
       </div>
     </div>
 
-    <.input
-      field={@form[:description]}
-      label="Description"
-      type="textarea"
-      phx-hook="maintain-attrs"
-      data-attrs="style"
-    />
+    <div class="flex gap-2">
+      <.input
+        field={@form[:description]}
+        label="Description"
+        type="textarea"
+        phx-hook="maintain-attrs"
+        data-attrs="style"
+        container_class="w-1/2"
+      />
+      <div class="relative w-1/2 flex-1 rounded-md border border-zinc-300 dark:border-zinc-800">
+        <div class="absolute top-0 right-0 bottom-0 left-0 overflow-auto">
+          <.markdown content={@form[:description].value || ""} class="p-4" />
+        </div>
+      </div>
+    </div>
 
     <div class="space-y-2">
       <.label>Written by</.label>

--- a/lib/ambry_web/live/admin/html_to_md.ex
+++ b/lib/ambry_web/live/admin/html_to_md.ex
@@ -1,0 +1,41 @@
+defmodule AmbryWeb.Admin.HTMLToMD do
+  @moduledoc """
+  A very simple/naive HTML to Markdown converter.
+
+  It only handles <p>, <b>, and <i> tags, and doesn't work great in all cases.
+  """
+
+  def html_to_md(html_string) do
+    case html_string |> clean_string() |> Floki.parse_document() do
+      {:ok, document} ->
+        {:ok,
+         document
+         |> Floki.traverse_and_update(&translate/1)
+         |> Floki.text()
+         |> String.trim("\n")}
+
+      _else ->
+        :error
+    end
+  end
+
+  defp translate(node) do
+    case node do
+      {"p", [], children} -> {"p", [], ["\n"] ++ children ++ ["\n"]}
+      {"b", [], children} -> {"b", [], ["**"] ++ children ++ ["**"]}
+      {"i", [], children} -> {"i", [], ["_"] ++ children ++ ["_"]}
+      other -> other
+    end
+  end
+
+  defp clean_string(string) do
+    string
+    |> String.replace("\n", "")
+    |> String.replace("\u00a0", "")
+    |> String.replace("\u201C", "\"")
+    |> String.replace("\u201D", "\"")
+    |> String.replace("\u2018", "'")
+    |> String.replace("\u2019", "'")
+    |> String.trim()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule Ambry.MixProject do
       {:familiar, "~> 0.1"},
       {:file_size, "~> 3.0"},
       {:finch, "~> 0.13"},
-      {:floki, ">= 0.30.0", only: :test},
+      {:floki, ">= 0.30.0"},
       {:gettext, "~> 0.20"},
       {:hashids, "~> 2.0"},
       {:jason, "~> 1.2"},


### PR DESCRIPTION
When importing books from the Audnexus API, convert the possibly HTML book description into markdown (best effort attempt).