### PR TITLE
Stop Dependabot from updating Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,3 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-
-  - package-ecosystem: docker
-    directory: "/"
-    schedule:
-      interval: daily


### PR DESCRIPTION
It's sometimes wrong and causes downgrades, and also, we need to keep the image versions in sync anyway, and it can't do that...