### PR TITLE
Fix player states syncing for all users instead of just the logged-in user

### DIFF
--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -103,8 +103,8 @@ defmodule AmbrySchema.Resolvers do
   def media_narrators_changed_since(args, _resolution),
     do: Sync.changes_since(MediaNarrator, args[:since])
 
-  def player_states_changed_since(args, _resolution),
-    do: Sync.changes_since(PlayerState, args[:since])
+  def player_states_changed_since(args, %{context: %{current_user: %User{} = user}}),
+    do: Sync.changes_since(from(ps in PlayerState, where: ps.user_id == ^user.id), args[:since])
 
   def deletions_since(args, _resolution), do: Sync.deletions_since(args[:since])
 


### PR DESCRIPTION
This affects the new in-progress mobile app.  _all_ player states were being synced to the app instead of just the player states for the current user. 😅 