### PR TITLE
Improve ProgressTracker handling

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 # NOTE: make sure these versions match in Containerfile
 
 elixir 1.18.2-otp-27
-erlang 27.2.2
+erlang 27.2.4

--- a/lib/ambry/media/processor/mp3.ex
+++ b/lib/ambry/media/processor/mp3.ex
@@ -38,23 +38,27 @@ defmodule Ambry.Media.Processor.MP3 do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
+    {:ok, progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
-    run_command!(
-      "ffmpeg",
-      [
-        "-loglevel",
-        "quiet",
-        "-vn",
-        "-i",
-        "#{mp3_file}",
-        "-progress",
-        progress_file_path,
-        "#{id}.mp4"
-      ],
-      cd: Media.out_path(media)
-    )
+    try do
+      run_command!(
+        "ffmpeg",
+        [
+          "-loglevel",
+          "quiet",
+          "-vn",
+          "-i",
+          "#{mp3_file}",
+          "-progress",
+          progress_file_path,
+          "#{id}.mp4"
+        ],
+        cd: Media.out_path(media)
+      )
 
-    id
+      id
+    after
+      ProgressTracker.stop(progress_tracker)
+    end
   end
 end

--- a/lib/ambry/media/processor/mp4_concat.ex
+++ b/lib/ambry/media/processor/mp4_concat.ex
@@ -39,29 +39,33 @@ defmodule Ambry.Media.Processor.MP4Concat do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
+    {:ok, progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
-    run_command!(
-      "ffmpeg",
-      [
-        "-loglevel",
-        "quiet",
-        "-f",
-        "concat",
-        "-safe",
-        "0",
-        "-vn",
-        "-acodec",
-        "copy",
-        "-i",
-        "files.txt",
-        "-progress",
-        progress_file_path,
-        "#{id}.mp4"
-      ],
-      cd: Media.out_path(media)
-    )
+    try do
+      run_command!(
+        "ffmpeg",
+        [
+          "-loglevel",
+          "quiet",
+          "-f",
+          "concat",
+          "-safe",
+          "0",
+          "-vn",
+          "-acodec",
+          "copy",
+          "-i",
+          "files.txt",
+          "-progress",
+          progress_file_path,
+          "#{id}.mp4"
+        ],
+        cd: Media.out_path(media)
+      )
 
-    id
+      id
+    after
+      ProgressTracker.stop(progress_tracker)
+    end
   end
 end

--- a/lib/ambry/media/processor/mp4_copy.ex
+++ b/lib/ambry/media/processor/mp4_copy.ex
@@ -39,23 +39,27 @@ defmodule Ambry.Media.Processor.MP4Copy do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
+    {:ok, progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
-    run_command!(
-      "ffmpeg",
-      [
-        "-vn",
-        "-i",
-        "#{mp4_file}",
-        "-c",
-        "copy",
-        "-progress",
-        progress_file_path,
-        "#{id}.mp4"
-      ],
-      cd: Media.out_path(media)
-    )
+    try do
+      run_command!(
+        "ffmpeg",
+        [
+          "-vn",
+          "-i",
+          "#{mp4_file}",
+          "-c",
+          "copy",
+          "-progress",
+          progress_file_path,
+          "#{id}.mp4"
+        ],
+        cd: Media.out_path(media)
+      )
 
-    id
+      id
+    after
+      ProgressTracker.stop(progress_tracker)
+    end
   end
 end

--- a/lib/ambry/media/processor/mp4_re_encode.ex
+++ b/lib/ambry/media/processor/mp4_re_encode.ex
@@ -39,23 +39,27 @@ defmodule Ambry.Media.Processor.MP4ReEncode do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
+    {:ok, progress_tracker} = ProgressTracker.start(media, progress_file_path, @extensions)
 
-    run_command!(
-      "ffmpeg",
-      [
-        "-loglevel",
-        "quiet",
-        "-vn",
-        "-i",
-        "#{mp4_file}",
-        "-progress",
-        progress_file_path,
-        "#{id}.mp4"
-      ],
-      cd: Media.out_path(media)
-    )
+    try do
+      run_command!(
+        "ffmpeg",
+        [
+          "-loglevel",
+          "quiet",
+          "-vn",
+          "-i",
+          "#{mp4_file}",
+          "-progress",
+          progress_file_path,
+          "#{id}.mp4"
+        ],
+        cd: Media.out_path(media)
+      )
 
-    id
+      id
+    after
+      ProgressTracker.stop(progress_tracker)
+    end
   end
 end

--- a/lib/ambry/media/processor/progress_tracker.ex
+++ b/lib/ambry/media/processor/progress_tracker.ex
@@ -17,7 +17,11 @@ defmodule Ambry.Media.Processor.ProgressTracker do
     file_path = Media.out_path(media, file)
     File.touch!(file_path)
 
-    GenServer.start(__MODULE__, %{media: media, file_path: file_path, extensions: extensions})
+    GenServer.start_link(__MODULE__, %{media: media, file_path: file_path, extensions: extensions})
+  end
+
+  def stop(pid) do
+    GenServer.cast(pid, :stop)
   end
 
   # Server (callbacks)
@@ -59,6 +63,12 @@ defmodule Ambry.Media.Processor.ProgressTracker do
         Port.close(port)
         {:stop, :normal, state}
     end
+  end
+
+  @impl GenServer
+  def handle_cast(:stop, %{port: port} = state) do
+    Port.close(port)
+    {:stop, :normal, state}
   end
 
   defp publish_progress(media, duration, current_time) do

--- a/lib/ambry/media/processor/shared.ex
+++ b/lib/ambry/media/processor/shared.ex
@@ -44,28 +44,32 @@ defmodule Ambry.Media.Processor.Shared do
     id = Media.output_id(media)
     progress_file_path = "#{id}.progress"
 
-    {:ok, _progress_tracker} = ProgressTracker.start(media, progress_file_path, extensions)
+    {:ok, progress_tracker} = ProgressTracker.start(media, progress_file_path, extensions)
 
-    run_command!(
-      "ffmpeg",
-      [
-        "-loglevel",
-        "quiet",
-        "-f",
-        "concat",
-        "-safe",
-        "0",
-        "-vn",
-        "-i",
-        "files.txt",
-        "-progress",
-        progress_file_path,
-        "#{id}.mp4"
-      ],
-      cd: Media.out_path(media)
-    )
+    try do
+      run_command!(
+        "ffmpeg",
+        [
+          "-loglevel",
+          "quiet",
+          "-f",
+          "concat",
+          "-safe",
+          "0",
+          "-vn",
+          "-i",
+          "files.txt",
+          "-progress",
+          progress_file_path,
+          "#{id}.mp4"
+        ],
+        cd: Media.out_path(media)
+      )
 
-    id
+      id
+    after
+      ProgressTracker.stop(progress_tracker)
+    end
   end
 
   def create_stream!(media, id) do


### PR DESCRIPTION
- Bump Erlang version from 27.2.2 to 27.2.4 in .tool-versions
- Modify media processors to properly stop ProgressTracker using try/after
- Ensure ProgressTracker is stopped even if ffmpeg command fails