### PR TITLE
Pin Hex to 2.3.1 in CI (work around 2.4.x metadata.config limit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # Hex 2.4.x fails to unpack ex_fontawesome's tarball ("Unpacking tarball
+        # failed: file too big: metadata.config"). Pin to the last known-good 2.3.x
+        # until the upstream regression is fixed.
+        run: mix local.hex 2.3.1 --force
       - name: Install dependencies
         run: mix deps.get
       - name: Compile dependencies
@@ -42,6 +47,11 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # Hex 2.4.x fails to unpack ex_fontawesome's tarball ("Unpacking tarball
+        # failed: file too big: metadata.config"). Pin to the last known-good 2.3.x
+        # until the upstream regression is fixed.
+        run: mix local.hex 2.3.1 --force
       - name: Install dependencies
         run: mix deps.get
       - name: Check for retired packages
@@ -82,6 +92,11 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # Hex 2.4.x fails to unpack ex_fontawesome's tarball ("Unpacking tarball
+        # failed: file too big: metadata.config"). Pin to the last known-good 2.3.x
+        # until the upstream regression is fixed.
+        run: mix local.hex 2.3.1 --force
       - name: Install dependencies
         run: mix deps.get
       - name: Compile dependencies
@@ -116,6 +131,11 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # Hex 2.4.x fails to unpack ex_fontawesome's tarball ("Unpacking tarball
+        # failed: file too big: metadata.config"). Pin to the last known-good 2.3.x
+        # until the upstream regression is fixed.
+        run: mix local.hex 2.3.1 --force
       - name: Install dependencies
         run: mix deps.get
       - name: Compile dependencies
@@ -137,6 +157,11 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # Hex 2.4.x fails to unpack ex_fontawesome's tarball ("Unpacking tarball
+        # failed: file too big: metadata.config"). Pin to the last known-good 2.3.x
+        # until the upstream regression is fixed.
+        run: mix local.hex 2.3.1 --force
       - name: Install dependencies
         run: mix deps.get
       - name: Compile dependencies
@@ -156,6 +181,11 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # Hex 2.4.x fails to unpack ex_fontawesome's tarball ("Unpacking tarball
+        # failed: file too big: metadata.config"). Pin to the last known-good 2.3.x
+        # until the upstream regression is fixed.
+        run: mix local.hex 2.3.1 --force
       - name: Install dependencies
         run: mix deps.get
       - name: Compile dependencies
@@ -179,6 +209,9 @@ jobs:
         with:
           version-file: .tool-versions
           version-type: strict
+      - name: Pin Hex
+        # See note above: Hex 2.4.x breaks ex_fontawesome's tarball unpacking.
+        run: mix local.hex 2.3.1 --force
       - name: Cache PLT files
         id: cache-plt
         uses: actions/cache@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ WORKDIR /src
 
 # system updates
 
+# NOTE: Hex pinned to 2.3.1 — 2.4.x fails to unpack ex_fontawesome's tarball
+# ("file too big: metadata.config"). Remove the version pin once that's fixed upstream.
 RUN mix do \
   local.rebar --force,\
-  local.hex --force
+  local.hex 2.3.1 --force
 
 RUN apk --update upgrade && \
   apk add build-base git


### PR DESCRIPTION
## Problem

All CI jobs and the Docker build fail at `mix deps.get` with:

```
** (Mix) Unpacking tarball failed: file too big: metadata.config
```

This blocks every open PR (the 5 Dependabot bumps #1110–#1114) and the container build.

## Root cause

`erlef/setup-beam` and the Dockerfile install the **latest** Hex (currently **2.4.2**). Hex 2.4.x introduced a metadata size cap in `mix_hex_tarball.erl`:

| Hex version | `MAX_METADATA_SIZE` |
|---|---|
| 2.4.0 | *no check* |
| **2.4.2** (latest) | **128 KiB** |
| main (fixed, unreleased) | 1 MiB |

Our `ex_fontawesome` dependency ships a **164 KiB** `metadata.config`, which exceeds the 128 KiB cap in 2.4.2 → unpack fails. (`.tool-versions` pins Elixir/Erlang but not Hex, so CI silently tracked the broken release.)

This is filed and **already fixed upstream** — [hexpm/hex#1158](https://github.com/hexpm/hex/issues/1158) raises the cap to 1 MiB on `main` — but **not yet released**.

## Fix

Pin Hex to the last known-good **2.3.1** in all 7 CI jobs and the Dockerfile.

⚠️ **Temporary:** 2.4.2 also carries a security fix (CVE-2026-32148, raise on `mix.lock` checksum mismatch). This pin forgoes it in CI/build (low risk: committed, stable lockfile). **Remove the pin once Hex ships the release with the 1 MiB cap.**

## Verification

Reproduced locally: `mix deps.get` fails on `ex_fontawesome` with Hex 2.4.2, succeeds with 2.3.1.