### PR TITLE
Add "Replace audio" for existing media (#392)

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -349,6 +349,55 @@ defmodule Ambry.Media do
     |> Oban.insert()
   end
 
+  @doc """
+  Replaces a media's source audio files with a new set of files and re-runs
+  processing, overwriting the streaming output files in place.
+
+  This is intended for swapping in corrected files for the *same*
+  edition/recording (for example, fixing a corrupt, mistagged, or low-quality
+  source) — not for switching to a different edition. Because the timeline is
+  expected to line up, chapters and listeners' saved positions and bookmarks are
+  deliberately left untouched.
+
+  The streaming output files keep the same URLs (they are overwritten in place);
+  `Plug.Static` serves them with mtime-based ETags, so clients revalidate and
+  pick up the new audio the next time they play. Offline downloads in the mobile
+  app are *not* automatically invalidated and must be re-downloaded by the user.
+
+  The previous source folder is deleted asynchronously once the new files are in
+  place.
+
+  ## Examples
+
+      iex> replace_media(media, %{source_path: path, source_files: files, processor: :auto})
+      {:ok, %Media{}}
+
+  """
+  def replace_media(%Media{} = media, %{
+        source_path: source_path,
+        source_files: source_files,
+        processor: processor
+      }) do
+    old_source_path = media.source_path
+
+    with {:ok, updated_media} <-
+           update_media(media, %{
+             source_path: source_path,
+             source_files: source_files,
+             status: :pending
+           }),
+         {:ok, _job} <- run_processor_async(updated_media, processor) do
+      delete_old_source_folder_async(old_source_path, source_path)
+      {:ok, updated_media}
+    end
+  end
+
+  defp delete_old_source_folder_async(old_source_path, new_source_path)
+       when old_source_path in [nil, new_source_path], do: {:ok, :noop}
+
+  defp delete_old_source_folder_async(old_source_path, _new_source_path),
+    do: try_delete_files_async([], [old_source_path])
+
   defdelegate available_processors(media_or_filenames), to: Processor, as: :matched_processors
 
   @doc """

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -80,6 +80,9 @@
           <.link navigate={~p"/admin/media/#{media}/edit"}>
             <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
           </.link>
+          <.link navigate={~p"/admin/media/#{media}/replace"} title="Replace audio">
+            <.icon name="fa-upload" class="h-4 w-4 text-current transition-colors hover:text-lime-500" />
+          </.link>
           <span phx-click="delete" phx-value-id={media.id} data-confirm="Are you sure?">
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
           </span>

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -1,0 +1,156 @@
+defmodule AmbryWeb.Admin.MediaLive.Replace do
+  @moduledoc false
+  use AmbryWeb, :admin_live_view
+
+  import Ambry.Paths
+  import AmbryWeb.Admin.UploadHelpers
+
+  alias Ambry.Media
+  alias AmbryWeb.Admin.MediaLive.Form.FileBrowser
+  alias Ecto.Changeset
+
+  @impl Phoenix.LiveView
+  def mount(%{"id" => id}, _session, socket) do
+    media = Media.get_media!(id)
+    local_import_path = Ambry.Paths.local_import_path()
+
+    changeset =
+      Media.change_media(media, %{"source_type" => default_source_type(local_import_path)})
+
+    {:ok,
+     socket
+     |> allow_audio_upload(:audio)
+     |> assign_form(changeset)
+     |> assign(
+       page_title: "#{media.book.title} - Replace audio",
+       media: media,
+       local_import_path: local_import_path,
+       select_files: false,
+       selected_files: MapSet.new()
+     )}
+  end
+
+  defp default_source_type(nil), do: "upload"
+  defp default_source_type(_local_import_path), do: "local_import"
+
+  @impl Phoenix.LiveView
+  def handle_params(%{"browse" => _}, _url, socket) do
+    {:noreply, assign(socket, select_files: true)}
+  end
+
+  def handle_params(_params, _url, socket) do
+    {:noreply, assign(socket, select_files: false)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", %{"media" => media_params}, socket) do
+    changeset =
+      socket.assigns.media
+      |> Media.change_media(media_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign_form(socket, changeset)}
+  end
+
+  def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :audio, ref)}
+  end
+
+  def handle_event("submit", %{"media" => media_params}, socket) do
+    case consume_audio_files(socket, media_params) do
+      {:ok, source_path, source_files} ->
+        attrs = %{
+          source_path: source_path,
+          source_files: source_files,
+          processor: requested_processor(media_params)
+        }
+
+        case Media.replace_media(socket.assigns.media, attrs) do
+          {:ok, media} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Replacing audio for #{media.book.title}")
+             |> push_navigate(to: ~p"/admin/media")}
+
+          {:error, %Changeset{} = changeset} ->
+            {:noreply, assign_form(socket, changeset)}
+        end
+
+      {:error, :no_files} ->
+        {:noreply, put_flash(socket, :error, "You must provide at least one audio file")}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:files_selected, files}, socket) do
+    {:noreply,
+     socket
+     |> assign(selected_files: files)
+     |> push_patch(to: ~p"/admin/media/#{socket.assigns.media}/replace", replace: true)}
+  end
+
+  # Consumes browser uploads into a fresh source folder, or references the
+  # server-side files selected via the file browser, returning the new
+  # source_path and the sorted list of source files for the replacement.
+  defp consume_audio_files(socket, %{"source_type" => "local_import"}) do
+    case Enum.to_list(socket.assigns.selected_files) do
+      [] ->
+        {:error, :no_files}
+
+      selected_files ->
+        {:ok, source_media_disk_path(Ecto.UUID.generate()),
+         Enum.sort(selected_files, NaturalOrder)}
+    end
+  end
+
+  defp consume_audio_files(socket, _media_params) do
+    source_path = source_media_disk_path(Ecto.UUID.generate())
+
+    audio_files =
+      consume_uploaded_entries(socket, :audio, fn %{path: path}, entry ->
+        File.mkdir_p!(source_path)
+        dest = Path.join([source_path, entry.client_name])
+        File.cp!(path, dest)
+
+        {:ok, dest}
+      end)
+
+    case audio_files do
+      [] -> {:error, :no_files}
+      files -> {:ok, source_path, Enum.sort(files, NaturalOrder)}
+    end
+  end
+
+  defp requested_processor(media_params) do
+    case media_params["processor"] do
+      blank when blank in [nil, ""] -> :auto
+      string -> String.to_existing_atom(string)
+    end
+  end
+
+  defp assign_form(socket, %Changeset{} = changeset) do
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp processor_options(uploads, selected_files) do
+    cond do
+      uploads != [] ->
+        uploads |> Enum.map(& &1.client_name) |> to_processor_options()
+
+      not Enum.empty?(selected_files) ->
+        selected_files |> Enum.map(&Path.basename/1) |> to_processor_options()
+
+      true ->
+        []
+    end
+  end
+
+  defp to_processor_options(filenames) do
+    filenames
+    |> Media.available_processors()
+    |> Enum.map(&{&1.name(), &1})
+  end
+
+  defp open_file_browser(media), do: JS.patch(~p"/admin/media/#{media}/replace?browse=files")
+  defp close_file_browser(media), do: JS.patch(~p"/admin/media/#{media}/replace", replace: true)
+end

--- a/lib/ambry_web/live/admin/media_live/replace.html.heex
+++ b/lib/ambry_web/live/admin/media_live/replace.html.heex
@@ -1,0 +1,106 @@
+<.layout title={@page_title} user={@current_user}>
+  <.modal :if={@select_files} id="select-files-modal" show on_cancel={close_file_browser(@media)}>
+    <.live_component id="file-browser" module={FileBrowser} root_path={Application.get_env(:ambry, :source_path)} />
+  </.modal>
+
+  <div class="max-w-3xl space-y-6">
+    <div class="flex gap-3 rounded-sm border border-yellow-400 bg-yellow-50 p-4 text-yellow-800 dark:border-yellow-600 dark:bg-yellow-950 dark:text-yellow-200">
+      <.icon name="fa-triangle-exclamation" class="mt-1 h-5 w-5 flex-none text-current" />
+      <div class="space-y-2 text-sm">
+        <p class="font-semibold">Replacing audio is disruptive.</p>
+        <p>
+          This re-processes the book and overwrites the streaming files. It is meant for fixing the
+          files of the <strong>same edition/recording</strong>
+          (e.g. a corrupt or low-quality source), <strong>not</strong>
+          for switching to a different edition.
+        </p>
+        <p>
+          Chapters and listeners' saved positions are left as-is. Anyone streaming will pick up the new
+          audio automatically, but anyone who <strong>downloaded</strong> this book for offline listening
+          must delete and re-download it to get the new files.
+        </p>
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <.label>Current audio file(s)</.label>
+      <div class="max-h-64 overflow-x-auto rounded-sm border-2 border-dashed border-zinc-600 bg-zinc-950 p-4">
+        <p :if={@media.source_files == []} class="text-sm italic text-zinc-500">
+          No source files on record.
+        </p>
+        <p :for={file <- @media.source_files} class="text-sm italic">
+          {Path.basename(file)}
+        </p>
+      </div>
+    </div>
+
+    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+      <div class="space-y-2">
+        <%= if @local_import_path do %>
+          <.tabs
+            field={@form[:source_type]}
+            options={[
+              {"Upload from your file-system", "upload"},
+              {"Import from server file-system", "local_import"}
+            ]}
+          >
+            <.label>New audio file(s)</.label>
+          </.tabs>
+        <% else %>
+          <.label>New audio file(s)</.label>
+          <.input type="hidden" field={@form[:source_type]} />
+        <% end %>
+
+        <.note>
+          <:label>Supported formats</:label>
+          mp3, mp4, m4a, m4b, opus
+        </.note>
+
+        <div :if={@form[:source_type].value == "upload"} class="space-y-2">
+          <.file_input upload={@uploads.audio} on_cancel="cancel-upload" />
+        </div>
+
+        <div :if={@form[:source_type].value == "local_import"} class="space-y-2">
+          <div>
+            <div class="flex items-center rounded-sm rounded-b-none border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 sm:text-sm sm:leading-6">
+              <button
+                class="py-[7px] px-[11px] bg-zinc-600 font-bold text-zinc-100 hover:bg-zinc-500"
+                type="button"
+                phx-click={open_file_browser(@media)}
+              >
+                Browse...
+              </button>
+              <p class="overflow-hidden text-ellipsis whitespace-nowrap px-2">
+                {Enum.count(@selected_files)} File(s) selected
+              </p>
+            </div>
+            <div class="max-h-64 space-y-4 overflow-x-auto rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4">
+              <.icon
+                :if={Enum.empty?(@selected_files)}
+                name="fa-file-circle-exclamation"
+                class="mx-auto my-4 block h-8 w-8 text-current"
+              />
+              <p :for={file <- Enum.sort(@selected_files, NaturalOrder)}>
+                {Path.basename(file)}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <.label for={@form[:processor].name}>Processor</.label>
+        <.input
+          type="select"
+          field={@form[:processor]}
+          prompt="auto-select"
+          options={processor_options(@uploads.audio.entries, @selected_files)}
+        />
+      </div>
+
+      <:actions>
+        <.button>Replace audio</.button>
+      </:actions>
+    </.simple_form>
+  </div>
+</.layout>

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -185,6 +185,7 @@ defmodule AmbryWeb.Router do
       live "/media", MediaLive.Index
       live "/media/new", MediaLive.Form, :new
       live "/media/:id/edit", MediaLive.Form, :edit
+      live "/media/:id/replace", MediaLive.Replace
       live "/media/:id/chapters", MediaLive.Chapters
 
       live "/users", UserLive.Index

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -657,7 +657,11 @@ defmodule Ambry.MediaTest do
       # The streaming files actually exist on disk at those paths.
       assert processed.mp4_path |> Paths.web_to_disk() |> File.exists?()
       assert processed.hls_path |> Paths.web_to_disk() |> File.exists?()
-      assert processed.hls_path |> Paths.hls_playlist_path() |> Paths.web_to_disk() |> File.exists?()
+
+      assert processed.hls_path
+             |> Paths.hls_playlist_path()
+             |> Paths.web_to_disk()
+             |> File.exists?()
 
       # Duration was recomputed from the new audio by the processor.
       assert %Decimal{} = processed.duration

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -543,6 +543,127 @@ defmodule Ambry.MediaTest do
     end
   end
 
+  describe "replace_media/2" do
+    setup do
+      media =
+        :media
+        |> build(book: build(:book))
+        |> with_source_files()
+        |> insert()
+        |> with_output_files()
+
+      media =
+        Repo.update!(
+          Ecto.Changeset.change(media, %{
+            chapters: [
+              %Ambry.Media.Media.Chapter{time: Decimal.new("0.0"), title: "Chapter 1"},
+              %Ambry.Media.Media.Chapter{time: Decimal.new("60.0"), title: "Chapter 2"}
+            ]
+          })
+        )
+
+      player_state =
+        insert(:player_state,
+          media: media,
+          user: build(:user),
+          position: Decimal.new("123.4"),
+          status: :in_progress
+        )
+
+      %{media: media, player_state: player_state}
+    end
+
+    test "updates source files, marks the media pending, and queues reprocessing", %{media: media} do
+      new_source_path = Paths.source_media_disk_path(Ecto.UUID.generate())
+      new_source_files = [valid_audio(:mp3)]
+
+      {:ok, replaced} =
+        Media.replace_media(media, %{
+          source_path: new_source_path,
+          source_files: new_source_files,
+          processor: :auto
+        })
+
+      assert replaced.source_path == new_source_path
+      assert replaced.source_files == new_source_files
+      assert replaced.status == :pending
+
+      assert_enqueued worker: Ambry.Media.RunProcessor,
+                      args: %{"media_id" => media.id, "processor" => "auto"}
+    end
+
+    test "keeps the same streaming output URLs (overwrites in place)", %{media: media} do
+      {:ok, replaced} =
+        Media.replace_media(media, %{
+          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
+          source_files: [valid_audio(:mp3)],
+          processor: :auto
+        })
+
+      assert replaced.mp4_path == media.mp4_path
+      assert replaced.mpd_path == media.mpd_path
+      assert replaced.hls_path == media.hls_path
+    end
+
+    test "leaves chapters and listeners' saved positions untouched", %{
+      media: media,
+      player_state: player_state
+    } do
+      {:ok, replaced} =
+        Media.replace_media(media, %{
+          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
+          source_files: [valid_audio(:mp3)],
+          processor: :auto
+        })
+
+      assert Enum.map(replaced.chapters, & &1.title) == ["Chapter 1", "Chapter 2"]
+
+      reloaded_player_state = Media.get_player_state!(player_state.id)
+      assert Decimal.equal?(reloaded_player_state.position, Decimal.new("123.4"))
+    end
+
+    test "deletes the old source folder with a background job", %{media: media} do
+      old_source_path = media.source_path
+
+      {:ok, _replaced} =
+        Media.replace_media(media, %{
+          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
+          source_files: [valid_audio(:mp3)],
+          processor: :auto
+        })
+
+      assert_enqueued worker: DeleteFiles,
+                      args: %{"disk_paths" => [], "folder_paths" => [old_source_path]}
+    end
+
+    test "end-to-end: reprocessing regenerates the streaming files in place", %{media: media} do
+      {:ok, replaced} =
+        Media.replace_media(media, %{
+          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
+          source_files: [valid_audio(:m4a)],
+          processor: :auto
+        })
+
+      # Simulate the enqueued RunProcessor Oban job running.
+      {:ok, processed} = Ambry.Media.Processor.run!(Media.get_media!(replaced.id))
+
+      assert processed.status == :ready
+
+      # Same URLs as before -> overwritten in place, not orphaned.
+      assert processed.mp4_path == media.mp4_path
+      assert processed.mpd_path == media.mpd_path
+      assert processed.hls_path == media.hls_path
+
+      # The streaming files actually exist on disk at those paths.
+      assert processed.mp4_path |> Paths.web_to_disk() |> File.exists?()
+      assert processed.hls_path |> Paths.web_to_disk() |> File.exists?()
+      assert processed.hls_path |> Paths.hls_playlist_path() |> Paths.web_to_disk() |> File.exists?()
+
+      # Duration was recomputed from the new audio by the processor.
+      assert %Decimal{} = processed.duration
+    end
+  end
+
   describe "generate_thumbnails_async/1" do
     test "schedules a job to generate thumbnails if they're missing" do
       media =

--- a/test/ambry_web/live/admin/media_live/replace_test.exs
+++ b/test/ambry_web/live/admin/media_live/replace_test.exs
@@ -1,0 +1,41 @@
+defmodule AmbryWeb.Admin.MediaLive.ReplaceTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_admin_user
+
+  describe "Replace" do
+    setup do
+      media =
+        :media
+        |> build(book: build(:book))
+        |> with_source_files()
+        |> insert()
+
+      %{media: media}
+    end
+
+    test "renders the disruption warning and the current source files", %{
+      conn: conn,
+      media: media
+    } do
+      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/replace")
+
+      assert html =~ "Replacing audio is disruptive"
+      assert html =~ "Current audio file(s)"
+      assert html =~ Path.basename(hd(media.source_files))
+    end
+
+    test "shows an error when submitting with no files", %{conn: conn, media: media} do
+      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media}/replace")
+
+      html =
+        view
+        |> form("form", media: %{processor: ""})
+        |> render_submit()
+
+      assert html =~ "You must provide at least one audio file"
+    end
+  end
+end


### PR DESCRIPTION
Closes #392.

Allow an admin to upload a new set of source audio files that **replaces** the current one for an existing media, re-running processing and overwriting the streaming output files in place.

This is intended for swapping in corrected files for the **same edition/recording** (e.g. fixing a corrupt, mistagged, or low-quality source) — **not** for switching to a different edition. Because the timeline is expected to line up, chapters and listeners' saved positions/bookmarks are deliberately left untouched.

## How it works

- **`Ambry.Media.replace_media/2`** — updates the media with the new `source_path`/`source_files`, marks it `:pending`, keeps the existing `mpd/hls/mp4` paths (so the processor reuses the same output UUID and overwrites in place), enqueues the existing `RunProcessor` job, and async-deletes the old source folder.
- **`AmbryWeb.Admin.MediaLive.Replace`** — a focused `/admin/media/:id/replace` page with a disruption warning, browser upload **or** server-side file browser, and processor select. New uploads land in a fresh source folder.
- Route + an upload action icon on the media index row.

## End-to-end / mobile

The output files keep the **same URLs** (overwritten in place). `/uploads/media` is served by `Plug.Static`, whose ETag is mtime+size based, so streaming clients revalidate and pick up the new audio on next play — **no mobile changes required**. Offline downloads are not auto-invalidated; users must delete & re-download (called out in the UI warning).

## Tests

- `replace_media/2` context tests (source/status swap, job enqueue, old-folder cleanup, chapters + positions preserved) and a **real-ffmpeg end-to-end** test that reprocesses and confirms the streaming files are regenerated in place with a recomputed duration.
- LiveView render + no-files-error tests.

Verified locally: `compile --warnings-as-errors`, `credo --strict`, `dialyzer` (0 errors), full suite **544 passed** + new tests.