### PR TITLE
Remove leftover ex_fontawesome config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,8 +50,6 @@ config :esbuild,
     env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
   ]
 
-config :ex_fontawesome, type: "solid"
-
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",


### PR DESCRIPTION
The `ex_fontawesome` dependency was dropped in #1118 in favor of vendored
FontAwesome Free SVGs rendered as Tailwind CSS masks, but this config line
was left behind. It configures an application that is no longer in the
dependency tree.

No functional change — purely removing dead configuration.

---

⚠️ Note: the **Check Dependencies** job is expected to fail on this PR. That
job runs `mix hex.audit`, and `earmark 1.4.49` was retired upstream
(_"Earmark is no longer maintained. Migrate to a replacement, for example
MDEx"_). This affects every open PR and is unrelated to this change — it is
being tracked separately.