### PR TITLE
Use a GitHub App token to enable Dependabot auto-merge

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,6 +7,9 @@ on:
     tags: ["v*.*.*"]
   pull_request:
     branches: [main]
+  # Manual escape hatch: lets an image be built for main without waiting for a
+  # push, for when a merge lands without dispatching this workflow.
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -12,8 +12,25 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      # Auto-merge is enabled with a GitHub App token rather than GITHUB_TOKEN.
+      # GitHub does not trigger workflow runs from events created with
+      # GITHUB_TOKEN, so merges performed under it pushed to main silently: no
+      # CI run and, more importantly, no container image published. Between
+      # 2026-06-08 and 2026-07-30 every merge to main was a Dependabot
+      # auto-merge, and no image was published for any of them.
+      #
+      # NOTE: these are *Dependabot* secrets, not Actions secrets. Workflow runs
+      # triggered by Dependabot read from the Dependabot secret store, so both
+      # must be set under Settings -> Secrets and variables -> Dependabot.
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## The problem

GitHub does not trigger workflow runs from events created with `GITHUB_TOKEN` — it's
their infinite-loop guard. `dependabot.yml` enabled auto-merge with `GITHUB_TOKEN`, so
when a Dependabot PR auto-merged, the resulting push to `main` dispatched **nothing**:
no CI run, and no container image published.

Every merge to `main` between **2026-06-08 and 2026-07-30** was a Dependabot
auto-merge, so no image was published for roughly seven weeks. Merged-but-unpublished
work included the "Replace audio" feature (#1120), the Decimal 3 migration (#1117), and
the Elixir 1.20 / OTP 29 upgrade (#1119).

Today's merges confirmed the mechanism directly — same repo, same branch, minutes apart:

| Merge | Time | How | CI | Container |
|---|---|---|---|---|
| #1140 | 17:49:56 | merged by hand | ✅ ran | ✅ ran |
| #1137 | 17:58:50 | auto-merge | ❌ nothing | ❌ nothing |
| #1133 | 18:04:48 | auto-merge | ❌ nothing | ❌ nothing |

## The fix

Generate a scoped GitHub App token and use it for `gh pr merge --auto`. The merge is
then attributed to the app rather than to GitHub Actions, so the push dispatches
workflows normally.

Also adds `workflow_dispatch` to the Container workflow — a manual escape hatch to
rebuild `main`'s image without waiting for a push, useful if this ever regresses.

## ⚠️ Required setup before this works

This PR is **inert until the App exists and its secrets are set.** Until then the
`Generate app token` step fails and Dependabot PRs stop auto-merging — so please set
this up at merge time rather than letting it sit.

**1. Create a GitHub App** (Settings → Developer settings → GitHub Apps → New).
   - Repository permissions: **Contents: Read and write**, **Pull requests: Read and write**
   - No webhook needed; uncheck Active
   - Install it on `ambry-app/ambry` only
   - Note the **App ID**, and generate a **private key** (downloads a `.pem`)

**2. Add two secrets — under Dependabot, not Actions.**

   Settings → Secrets and variables → **Dependabot** → New repository secret:
   - `APP_ID` — the App ID
   - `APP_PRIVATE_KEY` — the full contents of the `.pem`, including the
     `-----BEGIN...` / `-----END...` lines

   This is the easy part to get wrong. Workflow runs triggered by Dependabot read from
   the **Dependabot** secret store, not the Actions one. Secrets added under Actions
   will silently resolve to empty here.

## Verifying it worked

The next Dependabot PR that auto-merges should produce a `Container` run on `main`.
If it doesn't, check the `Generate app token` step first — an empty `APP_ID` or
`APP_PRIVATE_KEY` is the likely cause.

## Not addressed here

`ci.yml` and `container.yml` both use `pull_request: branches: [main]`, which matches the
**base** branch — so any PR not targeting `main` gets zero CI jobs. That dead-ended a
stacked PR earlier today (#1140 had to be retargeted). Left alone as a separate
workflow-policy decision.