### PR TITLE
Phase 1: metadata provider engine (rreading-glasses, Hardcover, Audible, Audnexus)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup database
         run: mix ecto.setup
       - name: Run tests
-        run: mix coveralls
+        run: mix coveralls --warnings-as-errors
 
   seeds:
     name: Check Seeds

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ ambry-*.tar
 
 # User uploads
 /uploads/
+local.env

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,31 +1,30 @@
 import Config
 
+# In test we don't send emails
+config :ambry, Ambry.Mailer, adapter: Swoosh.Adapters.Test
+
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used
-
-# In test we don't send emails
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
-config :ambry, Ambry.Mailer, adapter: Swoosh.Adapters.Test
-
 config :ambry, Ambry.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
   database: "ambry_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
-  # We don't run a server during test. If one is required,
-  # you can enable the server option below.
   pool_size: System.schedulers_online() * 2
 
+# We don't run a server during test. If one is required,
+# you can enable the server option below.
 config :ambry, AmbryWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4002],
   secret_key_base: "+51PLj+Ps1WTQA07qymnblv+HTHse1oXrBZ8Y+O2XlpelIA5QnHb4rWGZ7/xGj3e",
-  # allows Oban to bypass all database interaction and run jobs immediately in the
-  # process that enqueued them.
   server: false
 
+# allows Oban to bypass all database interaction and run jobs immediately in the
+# process that enqueued them.
 config :ambry, Oban, testing: :manual
 
 # Only in tests, remove the complexity from the password hashing algorithm

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,30 +1,31 @@
 import Config
 
-# In test we don't send emails
-config :ambry, Ambry.Mailer, adapter: Swoosh.Adapters.Test
-
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used
+
+# In test we don't send emails
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
+config :ambry, Ambry.Mailer, adapter: Swoosh.Adapters.Test
+
 config :ambry, Ambry.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
   database: "ambry_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
+  # We don't run a server during test. If one is required,
+  # you can enable the server option below.
   pool_size: System.schedulers_online() * 2
 
-# We don't run a server during test. If one is required,
-# you can enable the server option below.
 config :ambry, AmbryWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4002],
   secret_key_base: "+51PLj+Ps1WTQA07qymnblv+HTHse1oXrBZ8Y+O2XlpelIA5QnHb4rWGZ7/xGj3e",
+  # allows Oban to bypass all database interaction and run jobs immediately in the
+  # process that enqueued them.
   server: false
 
-# allows Oban to bypass all database interaction and run jobs immediately in the
-# process that enqueued them.
 config :ambry, Oban, testing: :manual
 
 # Only in tests, remove the complexity from the password hashing algorithm
@@ -40,6 +41,10 @@ config :os_mon,
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
+
+# LiveViewTest warnings (e.g. phx-change forms without ids, which break
+# form recovery) fail the test instead of scrolling by as noise
+config :phoenix_live_view, :test_warnings, missing_form_id: :raise
 
 # Enable helpful, but potentially expensive runtime checks
 config :phoenix_live_view,

--- a/lib/ambry/metadata.ex
+++ b/lib/ambry/metadata.ex
@@ -1,5 +1,13 @@
 defmodule Ambry.Metadata do
   @moduledoc false
 
-  use Boundary, deps: [Ambry.Repo], exports: [Audible, GoodReads]
+  use Boundary,
+    deps: [Ambry.Repo],
+    exports: [
+      Audible,
+      GoodReads,
+      {Provider, []},
+      {Providers, []},
+      Registry
+    ]
 end

--- a/lib/ambry/metadata.ex
+++ b/lib/ambry/metadata.ex
@@ -1,13 +1,19 @@
 defmodule Ambry.Metadata do
   @moduledoc false
 
+  # Exports are the boundary's public API: the Providers facade and
+  # Registry (never the provider modules or their HTTP clients — all calls
+  # route through the facade for caching and capability checks), the
+  # Provider behaviour with its normalized structs, and the legacy cached
+  # facades until 1e retires them. AmbryScraping would be inherited from
+  # the parent boundary anyway; it's listed to make the dependency visible.
   use Boundary,
-    deps: [Ambry.Repo],
+    deps: [Ambry.Repo, AmbryScraping],
     exports: [
       Audible,
       GoodReads,
       {Provider, []},
-      {Providers, []},
+      Providers,
       Registry
     ]
 end

--- a/lib/ambry/metadata/cache.ex
+++ b/lib/ambry/metadata/cache.ex
@@ -1,0 +1,96 @@
+defmodule Ambry.Metadata.Cache do
+  @moduledoc """
+  Postgres-backed cache for metadata-provider responses, with TTL.
+
+  Keys are namespaced by the caller (`"provider_id:operation:arg"`), values
+  are `:erlang.term_to_binary` of normalized provider structs. Entries past
+  their TTL are re-fetched on read; if the re-fetch fails but a stale entry
+  exists, the stale value is served (sources are disposable feeders — a dead
+  provider should degrade us to stale data, not to errors).
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Repo
+
+  require Logger
+
+  defmodule Entry do
+    @moduledoc false
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    @primary_key {:key, :string, []}
+    schema "metadata_cache" do
+      field :value, :binary
+      field :cached_at, :utc_datetime
+    end
+
+    def changeset(entry, attrs) do
+      entry
+      |> cast(attrs, [:key, :value, :cached_at])
+      |> validate_required([:key, :value, :cached_at])
+    end
+  end
+
+  @doc """
+  Returns the cached value for `key`, or runs `fetch_fun` and caches its
+  `{:ok, value}` result.
+
+  Options:
+
+    * `:ttl` — seconds before an entry is considered stale (default 30 days)
+    * `:refresh` — bypass the cache and fetch fresh (stale fallback still
+      applies if the fetch fails)
+  """
+  def fetch(key, fetch_fun, opts \\ []) do
+    ttl = Keyword.get(opts, :ttl, 30 * 24 * 60 * 60)
+    refresh = Keyword.get(opts, :refresh, false)
+    entry = Repo.get(Entry, key)
+
+    cond do
+      is_nil(entry) -> fetch_and_store(key, fetch_fun, nil)
+      refresh or stale?(entry, ttl) -> fetch_and_store(key, fetch_fun, entry)
+      true -> {:ok, decode(entry)}
+    end
+  end
+
+  @doc "Deletes every cached entry for the given provider id."
+  def clear_provider(provider_id) do
+    Repo.delete_all(from e in Entry, where: like(e.key, ^"#{provider_id}:%"))
+  end
+
+  defp stale?(entry, ttl) do
+    DateTime.diff(DateTime.utc_now(), entry.cached_at) > ttl
+  end
+
+  defp fetch_and_store(key, fetch_fun, stale_entry) do
+    case fetch_fun.() do
+      {:ok, value} ->
+        store!(key, value)
+        {:ok, value}
+
+      {:error, reason} when not is_nil(stale_entry) ->
+        Logger.warning("metadata fetch failed for #{key}, serving stale: #{inspect(reason)}")
+        {:ok, decode(stale_entry)}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp store!(key, value) do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+    binary = :erlang.term_to_binary(value)
+
+    %Entry{}
+    |> Entry.changeset(%{key: key, value: binary, cached_at: now})
+    |> Repo.insert!(
+      on_conflict: [set: [value: binary, cached_at: now]],
+      conflict_target: :key
+    )
+  end
+
+  defp decode(entry), do: :erlang.binary_to_term(entry.value)
+end

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -1,0 +1,176 @@
+defmodule Ambry.Metadata.Provider do
+  @moduledoc """
+  Behaviour for metadata providers.
+
+  Providers are split by which level of Ambry's data model they can speak to:
+
+    * `:work` — the abstract side: books, authors, series. These providers
+      know about works and their editions but nothing about narrators or
+      audiobook releases.
+    * `:recording` — the concrete side: audiobook releases with narrators,
+      square cover art, chapters. ASIN is the natural key at this level.
+
+  All callbacks return normalized structs defined in this module, so the web
+  layer never depends on any provider's upstream payload shape. Capabilities
+  declare which optional callbacks a provider implements; callers must check
+  capabilities (via `Ambry.Metadata.Registry`) before invoking optional
+  callbacks.
+
+  Providers are pure fetch-and-normalize modules: no caching (see
+  `Ambry.Metadata.Cache`) and no persistence. Configuration (base URL, API
+  token, …) is passed into every call as a map, sourced from the provider
+  registry so operators can change it at runtime.
+  """
+
+  defmodule PublishedDate do
+    @moduledoc """
+    A date with display granularity, since providers report anything from a
+    full date to just a year.
+    """
+    defstruct [:date, :display_format]
+
+    @type t :: %__MODULE__{date: Date.t(), display_format: :full | :year_month | :year}
+
+    @doc "Builds from an ISO8601-ish string (`2020-09-21`, `2020-09`, `2020`)."
+    def from_string(nil), do: nil
+    def from_string(""), do: nil
+
+    def from_string(string) when is_binary(string) do
+      case String.split(string, "-") do
+        [year, month, day] -> new(year, month, day, :full)
+        [year, month] -> new(year, month, "01", :year_month)
+        [year] -> new(year, "01", "01", :year)
+        _else -> nil
+      end
+    end
+
+    defp new(year, month, day, display_format) do
+      case Date.from_iso8601("#{year}-#{pad(month)}-#{pad(day)}") do
+        {:ok, date} -> %__MODULE__{date: date, display_format: display_format}
+        {:error, _reason} -> nil
+      end
+    end
+
+    defp pad(string), do: String.pad_leading(string, 2, "0")
+  end
+
+  defmodule Contributor do
+    @moduledoc "A person credit on a book or recording, as reported by a provider."
+    defstruct [:id, :name, :role]
+
+    @type t :: %__MODULE__{id: String.t() | nil, name: String.t(), role: String.t()}
+  end
+
+  defmodule Series do
+    @moduledoc "A series membership, with the position kept as a string (\"10.5\")."
+    defstruct [:id, :name, :number]
+
+    @type t :: %__MODULE__{id: String.t() | nil, name: String.t(), number: String.t() | nil}
+  end
+
+  defmodule Edition do
+    @moduledoc "One edition of a work, offered as a source for covers/descriptions/facts."
+    defstruct [
+      :id,
+      :title,
+      :asin,
+      :description,
+      :language,
+      :format,
+      :publisher,
+      :published,
+      :cover_url
+    ]
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule Book do
+    @moduledoc """
+    A normalized book result — a work (work-level providers) or an audiobook
+    release (recording-level providers). Recording-level results carry
+    narrators and an ASIN; work-level results may carry an editions list.
+    """
+    defstruct [
+      :provider,
+      :id,
+      :title,
+      :description,
+      :cover_url,
+      :published,
+      :publisher,
+      :language,
+      :format,
+      :asin,
+      authors: [],
+      narrators: [],
+      series: [],
+      editions: []
+    ]
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule Author do
+    @moduledoc "A normalized author (or narrator) profile."
+    defstruct [:provider, :id, :name, :description, :image_url]
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule Chapter do
+    @moduledoc "A single chapter: title plus offsets in milliseconds."
+    defstruct [:title, :start_offset_ms, :length_ms]
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule Chapters do
+    @moduledoc "A chapter list for a recording, keyed by ASIN."
+    defstruct [:provider, :asin, chapters: []]
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule ConfigField do
+    @moduledoc "Describes one operator-editable provider setting for the admin UI."
+    defstruct [:key, :label, :type, :default, :help]
+
+    @type t :: %__MODULE__{key: atom, label: String.t(), type: :string | :secret, default: term}
+  end
+
+  @type config :: %{optional(atom) => term}
+  @type capability :: :book_search | :book_details | :author_search | :author_details | :chapters
+
+  @doc "Stable machine identifier, used in cache keys and settings rows."
+  @callback id() :: String.t()
+
+  @doc "Human-readable name for the admin UI."
+  @callback display_name() :: String.t()
+
+  @doc "Which level of the data model this provider speaks to."
+  @callback level() :: :work | :recording
+
+  @doc "The optional callbacks this provider actually implements."
+  @callback capabilities() :: [capability()]
+
+  @doc "Operator-editable settings, with defaults giving a zero-config working setup."
+  @callback config_fields() :: [ConfigField.t()]
+
+  @callback search_books(query :: String.t(), config()) :: {:ok, [Book.t()]} | {:error, term}
+  @callback book_details(id :: String.t(), config()) :: {:ok, Book.t()} | {:error, term}
+  @callback search_authors(query :: String.t(), config()) :: {:ok, [Author.t()]} | {:error, term}
+  @callback author_details(id :: String.t(), config()) :: {:ok, Author.t()} | {:error, term}
+  @callback chapters(asin :: String.t(), config()) :: {:ok, Chapters.t()} | {:error, term}
+
+  @optional_callbacks search_books: 2,
+                      book_details: 2,
+                      search_authors: 2,
+                      author_details: 2,
+                      chapters: 2
+
+  @doc "The default config for a provider module, derived from its config fields."
+  def default_config(provider_module) do
+    Map.new(provider_module.config_fields(), fn field -> {field.key, field.default} end)
+  end
+end

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -157,13 +157,32 @@ defmodule Ambry.Metadata.Provider do
   @doc "Operator-editable settings, with defaults giving a zero-config working setup."
   @callback config_fields() :: [ConfigField.t()]
 
+  @type notice :: {:info | :warning | :error, String.t()}
+
+  @doc """
+  Whether the provider can be used with the given config — e.g. a provider
+  requiring an API token is unavailable until one is configured. Unavailable
+  providers stay visible in the admin settings (with notices explaining why)
+  but are not offered in import forms. Optional; defaults to `true`.
+  """
+  @callback available?(config()) :: boolean
+
+  @doc """
+  Operator-facing notices about the provider's configuration — token
+  expiry warnings, setup hints. Shown on the admin settings page.
+  Optional; defaults to `[]`.
+  """
+  @callback config_notices(config()) :: [notice()]
+
   @callback search_books(query :: String.t(), config()) :: {:ok, [Book.t()]} | {:error, term}
   @callback book_details(id :: String.t(), config()) :: {:ok, Book.t()} | {:error, term}
   @callback search_authors(query :: String.t(), config()) :: {:ok, [Author.t()]} | {:error, term}
   @callback author_details(id :: String.t(), config()) :: {:ok, Author.t()} | {:error, term}
   @callback chapters(asin :: String.t(), config()) :: {:ok, Chapters.t()} | {:error, term}
 
-  @optional_callbacks search_books: 2,
+  @optional_callbacks available?: 1,
+                      config_notices: 1,
+                      search_books: 2,
                       book_details: 2,
                       search_authors: 2,
                       author_details: 2,
@@ -172,5 +191,19 @@ defmodule Ambry.Metadata.Provider do
   @doc "The default config for a provider module, derived from its config fields."
   def default_config(provider_module) do
     Map.new(provider_module.config_fields(), fn field -> {field.key, field.default} end)
+  end
+
+  @doc "Whether a provider module is usable with the given config (default true)."
+  def available?(provider_module, config) do
+    not function_exported?(provider_module, :available?, 1) or provider_module.available?(config)
+  end
+
+  @doc "Operator-facing config notices for a provider module (default none)."
+  def config_notices(provider_module, config) do
+    if function_exported?(provider_module, :config_notices, 1) do
+      provider_module.config_notices(config)
+    else
+      []
+    end
   end
 end

--- a/lib/ambry/metadata/provider_config.ex
+++ b/lib/ambry/metadata/provider_config.ex
@@ -1,0 +1,27 @@
+defmodule Ambry.Metadata.ProviderConfig do
+  @moduledoc """
+  Operator-editable settings for one metadata provider.
+
+  A missing row means "all defaults" — providers work zero-config out of the
+  box; rows exist only where the operator changed something.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:provider_id, :string, []}
+  schema "metadata_provider_configs" do
+    field :enabled, :boolean, default: true
+    field :priority, :integer
+    field :config, :map, default: %{}
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(provider_config, attrs) do
+    provider_config
+    |> cast(attrs, [:provider_id, :enabled, :priority, :config])
+    |> validate_required([:provider_id, :enabled])
+  end
+end

--- a/lib/ambry/metadata/providers.ex
+++ b/lib/ambry/metadata/providers.ex
@@ -33,6 +33,9 @@ defmodule Ambry.Metadata.Providers do
   def chapters(provider_id, asin, opts \\ []),
     do: call(provider_id, :chapters, :chapters, asin, @details_ttl, opts)
 
+  @doc "Clears all cached responses for a provider."
+  def clear_cache(provider_id), do: Cache.clear_provider(provider_id)
+
   defp call(provider_id, capability, fun, arg, ttl, opts) do
     with {:ok, entry} <- Registry.fetch(provider_id),
          :ok <- check_enabled(entry),

--- a/lib/ambry/metadata/providers.ex
+++ b/lib/ambry/metadata/providers.ex
@@ -39,6 +39,7 @@ defmodule Ambry.Metadata.Providers do
   defp call(provider_id, capability, fun, arg, ttl, opts) do
     with {:ok, entry} <- Registry.fetch(provider_id),
          :ok <- check_enabled(entry),
+         :ok <- check_available(entry),
          :ok <- check_capability(entry, capability) do
       Cache.fetch(
         "#{entry.id}:#{fun}:#{arg}",
@@ -51,6 +52,9 @@ defmodule Ambry.Metadata.Providers do
 
   defp check_enabled(%{enabled: true}), do: :ok
   defp check_enabled(_entry), do: {:error, :provider_disabled}
+
+  defp check_available(%{available: true}), do: :ok
+  defp check_available(_entry), do: {:error, :provider_not_configured}
 
   defp check_capability(entry, capability) do
     if capability in entry.capabilities do

--- a/lib/ambry/metadata/providers.ex
+++ b/lib/ambry/metadata/providers.ex
@@ -1,0 +1,59 @@
+defmodule Ambry.Metadata.Providers do
+  @moduledoc """
+  Public API for querying metadata providers.
+
+  This is the seam the web layer talks to: it resolves the provider through
+  the runtime registry, routes the call through the TTL cache, and returns
+  normalized `Ambry.Metadata.Provider` structs. Pass `refresh: true` to
+  bypass the cache (the "re-fetch" button).
+
+  Ambry *snapshots* provider data into its own records at import time — this
+  cache exists to make interactive search/import pleasant and to be polite
+  to shared public instances, not as a live link to any provider.
+  """
+
+  alias Ambry.Metadata.Cache
+  alias Ambry.Metadata.Registry
+
+  @search_ttl 7 * 24 * 60 * 60
+  @details_ttl 30 * 24 * 60 * 60
+
+  def search_books(provider_id, query, opts \\ []),
+    do: call(provider_id, :book_search, :search_books, query, @search_ttl, opts)
+
+  def book_details(provider_id, work_id, opts \\ []),
+    do: call(provider_id, :book_details, :book_details, work_id, @details_ttl, opts)
+
+  def search_authors(provider_id, query, opts \\ []),
+    do: call(provider_id, :author_search, :search_authors, query, @search_ttl, opts)
+
+  def author_details(provider_id, author_id, opts \\ []),
+    do: call(provider_id, :author_details, :author_details, author_id, @details_ttl, opts)
+
+  def chapters(provider_id, asin, opts \\ []),
+    do: call(provider_id, :chapters, :chapters, asin, @details_ttl, opts)
+
+  defp call(provider_id, capability, fun, arg, ttl, opts) do
+    with {:ok, entry} <- Registry.fetch(provider_id),
+         :ok <- check_enabled(entry),
+         :ok <- check_capability(entry, capability) do
+      Cache.fetch(
+        "#{entry.id}:#{fun}:#{arg}",
+        fn -> apply(entry.module, fun, [arg, entry.config]) end,
+        ttl: ttl,
+        refresh: Keyword.get(opts, :refresh, false)
+      )
+    end
+  end
+
+  defp check_enabled(%{enabled: true}), do: :ok
+  defp check_enabled(_entry), do: {:error, :provider_disabled}
+
+  defp check_capability(entry, capability) do
+    if capability in entry.capabilities do
+      :ok
+    else
+      {:error, :unsupported_capability}
+    end
+  end
+end

--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -1,0 +1,67 @@
+defmodule Ambry.Metadata.Providers.Audible do
+  @moduledoc """
+  Recording-level metadata provider backed by Audible's catalog API.
+
+  Wraps the existing `AmbryScraping.Audible` HTTP client (the undocumented
+  but stable JSON catalog API — no browser scraping involved) and normalizes
+  its results. This is the primary source for narrator credits, square
+  audiobook covers, and publication facts; ASIN is the natural key.
+  """
+
+  @behaviour Ambry.Metadata.Provider
+
+  alias Ambry.Metadata.Provider
+  alias AmbryScraping.Audible
+
+  @impl Provider
+  def id, do: "audible"
+
+  @impl Provider
+  def display_name, do: "Audible"
+
+  @impl Provider
+  def level, do: :recording
+
+  @impl Provider
+  def capabilities, do: [:book_search]
+
+  @impl Provider
+  def config_fields, do: []
+
+  @impl Provider
+  def search_books(query, _config) do
+    with {:ok, products} <- Audible.search_books(query) do
+      {:ok, Enum.map(products, &product_to_book/1)}
+    end
+  end
+
+  defp product_to_book(product) do
+    %Provider.Book{
+      provider: id(),
+      id: product.id,
+      asin: product.id,
+      title: product.title,
+      description: product.description,
+      cover_url: product.cover_image,
+      published: published(product.published),
+      publisher: product.publisher,
+      language: product.language,
+      format: product.format,
+      authors:
+        Enum.map(product.authors, fn author ->
+          %Provider.Contributor{id: author.id, name: author.name, role: "author"}
+        end),
+      narrators:
+        Enum.map(product.narrators, fn narrator ->
+          %Provider.Contributor{id: nil, name: narrator.name, role: "narrator"}
+        end),
+      series:
+        Enum.map(product.series, fn series ->
+          %Provider.Series{id: series.id, name: series.title, number: series.sequence}
+        end)
+    }
+  end
+
+  defp published(nil), do: nil
+  defp published(%Date{} = date), do: %Provider.PublishedDate{date: date, display_format: :full}
+end

--- a/lib/ambry/metadata/providers/audnexus.ex
+++ b/lib/ambry/metadata/providers/audnexus.ex
@@ -1,0 +1,77 @@
+defmodule Ambry.Metadata.Providers.Audnexus do
+  @moduledoc """
+  Recording-level provider backed by Audnexus (audnex.us).
+
+  Audnexus is an open-source, self-hostable aggregation layer over Audible's
+  own endpoints — the source for author profiles (with images) and chapter
+  data by ASIN. Wraps the existing `AmbryScraping.Audnexus` HTTP client.
+
+  Note on chapters: per the roadmap (1h), provider chapter *timestamps*
+  describe Audible's retail edition, not the local rip — they are a title
+  source, never a timeline source. The offsets are still returned here;
+  the import UI is responsible for honoring that principle.
+  """
+
+  @behaviour Ambry.Metadata.Provider
+
+  alias Ambry.Metadata.Provider
+  alias AmbryScraping.Audnexus
+
+  @impl Provider
+  def id, do: "audnexus"
+
+  @impl Provider
+  def display_name, do: "Audnexus"
+
+  @impl Provider
+  def level, do: :recording
+
+  @impl Provider
+  def capabilities, do: [:author_search, :author_details, :chapters]
+
+  @impl Provider
+  def config_fields, do: []
+
+  @impl Provider
+  def search_authors(query, _config) do
+    with {:ok, authors} <- Audnexus.search_authors(query) do
+      {:ok,
+       Enum.map(authors, fn author ->
+         %Provider.Author{provider: id(), id: author.id, name: author.name}
+       end)}
+    end
+  end
+
+  @impl Provider
+  def author_details(asin, _config) do
+    with {:ok, details} <- Audnexus.author_details(asin) do
+      {:ok,
+       %Provider.Author{
+         provider: id(),
+         id: details.id,
+         name: details.name,
+         description: details.description,
+         image_url: details.image
+       }}
+    end
+  end
+
+  @impl Provider
+  def chapters(asin, _config) do
+    with {:ok, chapters} <- Audnexus.book_chapters(asin) do
+      {:ok,
+       %Provider.Chapters{
+         provider: id(),
+         asin: chapters.asin,
+         chapters:
+           Enum.map(chapters.chapters, fn chapter ->
+             %Provider.Chapter{
+               title: chapter.title,
+               start_offset_ms: chapter.start_offset_ms,
+               length_ms: chapter.length_ms
+             }
+           end)
+       }}
+    end
+  end
+end

--- a/lib/ambry/metadata/providers/audnexus.ex
+++ b/lib/ambry/metadata/providers/audnexus.ex
@@ -36,10 +36,25 @@ defmodule Ambry.Metadata.Providers.Audnexus do
   def search_authors(query, _config) do
     with {:ok, authors} <- Audnexus.search_authors(query) do
       {:ok,
-       Enum.map(authors, fn author ->
+       authors
+       |> Enum.map(fn author ->
          %Provider.Author{provider: id(), id: author.id, name: author.name}
-       end)}
+       end)
+       |> sort_by_name_similarity(query)}
     end
+  end
+
+  # Audnexus name search is fuzzy to the point of returning unrelated
+  # people (and whole book titles as "names"); order by similarity to the
+  # query so the right person is preselected.
+  defp sort_by_name_similarity(authors, query) do
+    query = query |> String.trim() |> String.downcase()
+
+    Enum.sort_by(
+      authors,
+      &String.jaro_distance(String.downcase(&1.name || ""), query),
+      :desc
+    )
   end
 
   @impl Provider

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -1,0 +1,293 @@
+defmodule Ambry.Metadata.Providers.Hardcover do
+  @moduledoc """
+  Work-level metadata provider backed by Hardcover's GraphQL API
+  (hardcover.app) — an alternative/complement to rreading-glasses.
+
+  Evaluated 2026-08-01: search results arrive fully hydrated in one request
+  (title, description, contributions with roles, large covers with
+  dimensions, featured series with decimal-capable positions); author
+  profiles carry bios and large images (450–1000px, better than Goodreads'
+  ~700px ceiling). Series listings include translations as separate books
+  at the same positions — harmless for importing a single work's facts.
+
+  Requires the operator's API token (free account). Tokens are JWTs that
+  **expire after one year** — expiry is decoded locally from the token and
+  surfaced as admin notices via `config_notices/1`. Hardcover describes the
+  API as still in flux, so queries stay minimal and parsing defensive.
+  """
+
+  @behaviour Ambry.Metadata.Provider
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Provider.ConfigField
+  alias Ambry.Metadata.Providers.Hardcover.Client
+
+  @token_url "https://hardcover.app/account/api"
+  @expiry_warning_days 30
+
+  @impl Provider
+  def id, do: "hardcover"
+
+  @impl Provider
+  def display_name, do: "Hardcover"
+
+  @impl Provider
+  def level, do: :work
+
+  @impl Provider
+  def capabilities, do: [:book_search, :book_details, :author_search, :author_details]
+
+  @impl Provider
+  def config_fields do
+    [
+      %ConfigField{
+        key: :api_token,
+        label: "API token",
+        type: :secret,
+        default: nil,
+        help:
+          "Free token from #{@token_url}. Hardcover tokens expire after one year — " <>
+            "a reminder appears here as expiry approaches."
+      }
+    ]
+  end
+
+  @impl Provider
+  def available?(config), do: is_binary(config[:api_token]) and config[:api_token] != ""
+
+  @impl Provider
+  def config_notices(config) do
+    if available?(config) do
+      expiry_notice(token_expiry(config[:api_token]))
+    else
+      [{:warning, "No API token configured — get a free token at #{@token_url}."}]
+    end
+  end
+
+  @search_books_query """
+  query SearchBooks($query: String!) {
+    search(query: $query, query_type: "book", per_page: 10) { results }
+  }
+  """
+
+  @impl Provider
+  def search_books(query, config) do
+    with {:ok, data} <- Client.query(config, @search_books_query, %{query: query}) do
+      hits = get_in(data, ["search", "results", "hits"]) || []
+      {:ok, hits |> Enum.map(&search_hit_to_book/1) |> Enum.reject(&is_nil/1)}
+    end
+  end
+
+  @book_details_query """
+  query BookDetails($id: Int!) {
+    books_by_pk(id: $id) {
+      id
+      title
+      release_date
+      description
+      image { url }
+      book_series { position details series { id name } }
+      contributions { contribution author { id name } }
+    }
+  }
+  """
+
+  @impl Provider
+  def book_details(book_id, config) do
+    with {:ok, id} <- parse_id(book_id),
+         {:ok, %{"books_by_pk" => book}} when is_map(book) <-
+           Client.query(config, @book_details_query, %{id: id}) do
+      {:ok,
+       %Provider.Book{
+         provider: id(),
+         id: to_string(book["id"]),
+         title: book["title"],
+         description: presence(book["description"]),
+         cover_url: get_in(book, ["image", "url"]),
+         published: Provider.PublishedDate.from_string(book["release_date"]),
+         authors: contributions_to_authors(book["contributions"]),
+         series: book_series(book["book_series"])
+       }}
+    else
+      {:ok, _other} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @search_authors_query """
+  query SearchAuthors($query: String!) {
+    search(query: $query, query_type: "author", per_page: 5) { results }
+  }
+  """
+
+  @impl Provider
+  def search_authors(query, config) do
+    with {:ok, data} <- Client.query(config, @search_authors_query, %{query: query}) do
+      hits = get_in(data, ["search", "results", "hits"]) || []
+
+      authors =
+        for %{"document" => doc} <- hits, doc["name"] do
+          %Provider.Author{
+            provider: id(),
+            id: to_string(doc["id"]),
+            name: doc["name"],
+            image_url: get_in(doc, ["image", "url"])
+          }
+        end
+
+      {:ok, sort_by_name_similarity(authors, query)}
+    end
+  end
+
+  # like the other providers: fuzzy search returns unrelated people, so
+  # order by similarity to the query for a sensible preselection
+  defp sort_by_name_similarity(authors, query) do
+    query = query |> String.trim() |> String.downcase()
+
+    Enum.sort_by(
+      authors,
+      &String.jaro_distance(String.downcase(&1.name || ""), query),
+      :desc
+    )
+  end
+
+  @author_details_query """
+  query AuthorDetails($id: Int!) {
+    authors_by_pk(id: $id) {
+      id
+      name
+      bio
+      image { url }
+    }
+  }
+  """
+
+  @impl Provider
+  def author_details(author_id, config) do
+    with {:ok, id} <- parse_id(author_id),
+         {:ok, %{"authors_by_pk" => author}} when is_map(author) <-
+           Client.query(config, @author_details_query, %{id: id}) do
+      {:ok,
+       %Provider.Author{
+         provider: id(),
+         id: to_string(author["id"]),
+         name: author["name"],
+         description: presence(author["bio"]),
+         image_url: get_in(author, ["image", "url"])
+       }}
+    else
+      {:ok, _other} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Decodes the expiry from a Hardcover API token (a JWT with an `exp`
+  claim) without verifying the signature — we only need the date.
+  """
+  def token_expiry(token) when is_binary(token) do
+    with [_header, payload, _signature] <- String.split(token, "."),
+         {:ok, json} <- Base.url_decode64(payload, padding: false),
+         {:ok, %{"exp" => exp}} when is_integer(exp) <- Jason.decode(json),
+         {:ok, datetime} <- DateTime.from_unix(exp) do
+      {:ok, datetime}
+    else
+      _other -> :error
+    end
+  end
+
+  defp expiry_notice({:ok, expiry}) do
+    days_left = DateTime.diff(expiry, DateTime.utc_now(), :day)
+    date = expiry |> DateTime.to_date() |> Date.to_string()
+
+    cond do
+      days_left < 0 ->
+        [{:error, "API token expired on #{date} — regenerate it at #{@token_url}."}]
+
+      days_left <= @expiry_warning_days ->
+        [
+          {:warning,
+           "API token expires on #{date} (in #{days_left} days) — regenerate it at #{@token_url}."}
+        ]
+
+      true ->
+        [{:info, "API token valid until #{date} (Hardcover tokens expire after one year)."}]
+    end
+  end
+
+  defp expiry_notice(:error), do: []
+
+  defp search_hit_to_book(%{"document" => doc}) when is_map(doc) do
+    if doc["title"] do
+      %Provider.Book{
+        provider: id(),
+        id: to_string(doc["id"]),
+        title: doc["title"],
+        description: presence(doc["description"]),
+        cover_url: get_in(doc, ["image", "url"]),
+        published: Provider.PublishedDate.from_string(doc["release_date"]),
+        authors: contributions_to_authors(doc["contributions"]),
+        series: featured_series(doc["featured_series"])
+      }
+    end
+  end
+
+  defp search_hit_to_book(_hit), do: nil
+
+  # a null contribution role means "Author"; anything else (Cover Artist,
+  # Illustrator, Translator, …) is not an author credit
+  defp contributions_to_authors(contributions) do
+    for %{"author" => author} = contribution <- contributions || [],
+        is_map(author),
+        contribution["contribution"] in [nil, "Author"] do
+      %Provider.Contributor{
+        id: to_string(author["id"]),
+        name: author["name"],
+        role: "author"
+      }
+    end
+  end
+
+  defp featured_series(%{"series" => %{"id" => id, "name" => name}} = featured) do
+    [
+      %Provider.Series{
+        id: to_string(id),
+        name: name,
+        number: presence(featured["details"]) || format_position(featured["position"])
+      }
+    ]
+  end
+
+  defp featured_series(_other), do: []
+
+  defp book_series(book_series) do
+    for %{"series" => %{"id" => id, "name" => name}} = entry <- book_series || [] do
+      %Provider.Series{
+        id: to_string(id),
+        name: name,
+        number: presence(entry["details"]) || format_position(entry["position"])
+      }
+    end
+  end
+
+  defp format_position(nil), do: nil
+
+  defp format_position(position) when is_float(position) do
+    if position == Float.round(position),
+      do: position |> trunc() |> to_string(),
+      else: to_string(position)
+  end
+
+  defp format_position(position), do: to_string(position)
+
+  defp parse_id(id) do
+    case Integer.parse(to_string(id)) do
+      {int, ""} -> {:ok, int}
+      _other -> {:error, :invalid_id}
+    end
+  end
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
+end

--- a/lib/ambry/metadata/providers/hardcover/client.ex
+++ b/lib/ambry/metadata/providers/hardcover/client.ex
@@ -1,0 +1,35 @@
+defmodule Ambry.Metadata.Providers.Hardcover.Client do
+  @moduledoc """
+  Thin GraphQL client for the Hardcover API (api.hardcover.app).
+
+  Hardcover notes: requests need a Bearer token (free account; tokens
+  expire after one year), the API is officially "still in flux" so callers
+  should parse responses defensively, and the documented rate limit is
+  60 requests/minute — the metadata cache keeps us well under it.
+  """
+
+  @receive_timeout 30_000
+
+  def query(config, graphql, variables \\ %{}) do
+    request =
+      Req.post(
+        url: endpoint(config),
+        json: %{query: graphql, variables: variables},
+        auth: {:bearer, token(config)},
+        receive_timeout: @receive_timeout,
+        retry: false
+      )
+
+    case request do
+      {:ok, %{status: 200, body: %{"data" => data}}} when is_map(data) -> {:ok, data}
+      {:ok, %{status: 200, body: %{"errors" => errors}}} -> {:error, {:graphql, errors}}
+      {:ok, %{status: 401}} -> {:error, :unauthorized}
+      {:ok, %{status: 200}} -> {:error, :unexpected_response_payload}
+      {:ok, response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp endpoint(config), do: config[:base_url] || "https://api.hardcover.app/v1/graphql"
+  defp token(config), do: config[:api_token] || ""
+end

--- a/lib/ambry/metadata/providers/rreading_glasses.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses.ex
@@ -113,9 +113,13 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
   defp hydrate_books([], _config), do: {:ok, []}
 
   defp hydrate_books(book_ids, config) do
-    params = Enum.map(book_ids, &{:id, &1})
+    # Hand-built query string: the endpoint only honors repeated `id=`
+    # params (the swagger's csv form silently drops all but the first id),
+    # and Req's :params option collapses duplicate keys — so neither csv
+    # nor params-based encoding can express this request.
+    path = "/book/bulk?" <> Enum.map_join(book_ids, "&", &"id=#{&1}")
 
-    case Client.get_json(base_url(config), "/book/bulk", params) do
+    case Client.get_json(base_url(config), path, []) do
       {:ok, %{"Works" => works}} ->
         by_edition_id =
           for work <- works, edition <- work["Books"] || [], into: %{} do

--- a/lib/ambry/metadata/providers/rreading_glasses.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses.ex
@@ -81,14 +81,18 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
         results
         |> Enum.map(&get_in(&1, ["author", "id"]))
         |> Enum.reject(&is_nil/1)
-        |> Enum.uniq()
+        |> rank_by_frequency()
         |> Enum.take(@max_author_hydrations)
-        |> Enum.flat_map(fn author_id ->
-          case author_details(author_id, config) do
-            {:ok, author} -> [author]
-            {:error, _reason} -> []
-          end
+        |> Task.async_stream(&author_details(&1, config),
+          max_concurrency: @max_author_hydrations,
+          timeout: 35_000,
+          on_timeout: :kill_task
+        )
+        |> Enum.flat_map(fn
+          {:ok, {:ok, author}} -> [author]
+          _error -> []
         end)
+        |> sort_by_name_similarity(query)
 
       {:ok, authors}
     end
@@ -103,12 +107,49 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
          id: to_string(author["ForeignId"]),
          name: author["Name"],
          description: presence(author["Description"]),
-         image_url: presence(author["ImageUrl"])
+         image_url: author["ImageUrl"] |> presence() |> full_size_image()
        }}
     end
   end
 
   defp base_url(config), do: config[:base_url] || "https://api.bookinfo.pro"
+
+  # Search hits are book-relevance-ordered, so the first hit's author can be
+  # an editor/scholar of a work *about* the searched person. Hydrate the
+  # authors appearing most often across the hits, then present them ordered
+  # by name similarity to the query — searching "arthur conan doyle" should
+  # preselect Doyle, not the editor of an anthology that ranked first.
+  defp rank_by_frequency(author_ids) do
+    frequencies = Enum.frequencies(author_ids)
+
+    author_ids
+    |> Enum.uniq()
+    |> Enum.sort_by(&frequencies[&1], :desc)
+  end
+
+  defp sort_by_name_similarity(authors, query) do
+    query = query |> String.trim() |> String.downcase()
+
+    Enum.sort_by(
+      authors,
+      &String.jaro_distance(String.downcase(&1.name || ""), query),
+      :desc
+    )
+  end
+
+  # Goodreads image URLs need two normalizations: photo-less people get a
+  # literal placeholder image (`…/nophoto/user/…`), which should read as
+  # "no image", and real photos arrive constrained by an Amazon-style size
+  # modifier (`…/999015._UY200_CR102,0,200,200_.jpg`) — stripping the
+  # modifier segment yields the full-size original (up to ~700px; that is
+  # all Goodreads stores) for the thumbnail pipeline.
+  defp full_size_image(nil), do: nil
+
+  defp full_size_image(url) do
+    if !(url =~ "/nophoto/") do
+      Regex.replace(~r{\._[^./]+_\.}, url, ".")
+    end
+  end
 
   defp hydrate_books([], _config), do: {:ok, []}
 
@@ -156,7 +197,8 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
       id: to_string(work["ForeignId"]),
       title: work["Title"],
       description: best["Description"] || first_present(editions, "Description"),
-      cover_url: best["ImageUrl"] || first_present(editions, "ImageUrl"),
+      cover_url:
+        full_size_image(presence(best["ImageUrl"]) || first_present(editions, "ImageUrl")),
       published:
         Provider.PublishedDate.from_string(work["ReleaseDateRaw"] || best["ReleaseDateRaw"]),
       publisher: presence(best["Publisher"]),
@@ -215,7 +257,7 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
       format: presence(edition["Format"]),
       publisher: presence(edition["Publisher"]),
       published: Provider.PublishedDate.from_string(edition["ReleaseDateRaw"]),
-      cover_url: presence(edition["ImageUrl"])
+      cover_url: edition["ImageUrl"] |> presence() |> full_size_image()
     }
   end
 

--- a/lib/ambry/metadata/providers/rreading_glasses.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses.ex
@@ -1,0 +1,221 @@
+defmodule Ambry.Metadata.Providers.RreadingGlasses do
+  @moduledoc """
+  Work-level metadata provider backed by a rreading-glasses server.
+
+  rreading-glasses (github.com/blampe/rreading-glasses) serves
+  Goodreads-quality work/edition/author/series data over a clean JSON API
+  (originally the Readarr metadata contract). The default configuration
+  points at the public instance (`api.bookinfo.pro`); operators can point
+  the base URL at a self-hosted instance instead.
+
+  API notes (verified against the public instance, 2026-08-01):
+
+    * `GET /search?q=` returns skinny results (`bookId`/`workId`/author id)
+      which are hydrated in one round-trip via `GET /book/bulk?id=…&id=…`
+      (book ids, repeated params). The swagger spec's `GET /bulk` is stale —
+      the real route is `/book/bulk`.
+    * `GET /work/{id}` returns a work with its editions (`Books`), series
+      (with per-work positions), and authors embedded.
+    * `GET /author/{id}` is a large payload (hundreds of KB) but fine for
+      interactive use; there is no author search endpoint, so author search
+      goes through book search and hydrates the distinct author ids.
+    * Edition ASINs are present on most editions — the bridge to
+      recording-level providers.
+  """
+
+  @behaviour Ambry.Metadata.Provider
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Provider.ConfigField
+  alias Ambry.Metadata.Providers.RreadingGlasses.Client
+
+  @max_author_hydrations 3
+
+  @impl Provider
+  def id, do: "rreading_glasses"
+
+  @impl Provider
+  def display_name, do: "rreading-glasses"
+
+  @impl Provider
+  def level, do: :work
+
+  @impl Provider
+  def capabilities, do: [:book_search, :book_details, :author_search, :author_details]
+
+  @impl Provider
+  def config_fields do
+    [
+      %ConfigField{
+        key: :base_url,
+        label: "Base URL",
+        type: :string,
+        default: "https://api.bookinfo.pro",
+        help: "Public instance by default; point at a self-hosted rreading-glasses to switch."
+      }
+    ]
+  end
+
+  @impl Provider
+  def search_books(query, config) do
+    with {:ok, results} <- Client.get_json(base_url(config), "/search", q: query) do
+      results
+      |> Enum.map(& &1["bookId"])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> hydrate_books(config)
+    end
+  end
+
+  @impl Provider
+  def book_details(work_id, config) do
+    with {:ok, work} <- Client.get_json(base_url(config), "/work/#{work_id}", []) do
+      {:ok, work_to_book(work)}
+    end
+  end
+
+  @impl Provider
+  def search_authors(query, config) do
+    with {:ok, results} <- Client.get_json(base_url(config), "/search", q: query) do
+      authors =
+        results
+        |> Enum.map(&get_in(&1, ["author", "id"]))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+        |> Enum.take(@max_author_hydrations)
+        |> Enum.flat_map(fn author_id ->
+          case author_details(author_id, config) do
+            {:ok, author} -> [author]
+            {:error, _reason} -> []
+          end
+        end)
+
+      {:ok, authors}
+    end
+  end
+
+  @impl Provider
+  def author_details(author_id, config) do
+    with {:ok, author} <- Client.get_json(base_url(config), "/author/#{author_id}", []) do
+      {:ok,
+       %Provider.Author{
+         provider: id(),
+         id: to_string(author["ForeignId"]),
+         name: author["Name"],
+         description: presence(author["Description"]),
+         image_url: presence(author["ImageUrl"])
+       }}
+    end
+  end
+
+  defp base_url(config), do: config[:base_url] || "https://api.bookinfo.pro"
+
+  defp hydrate_books([], _config), do: {:ok, []}
+
+  defp hydrate_books(book_ids, config) do
+    params = Enum.map(book_ids, &{:id, &1})
+
+    case Client.get_json(base_url(config), "/book/bulk", params) do
+      {:ok, %{"Works" => works}} ->
+        by_edition_id =
+          for work <- works, edition <- work["Books"] || [], into: %{} do
+            {edition["ForeignId"], work}
+          end
+
+        books =
+          book_ids
+          |> Enum.map(fn book_id ->
+            case by_edition_id[book_id] do
+              nil -> nil
+              work -> work_to_book(work, book_id)
+            end
+          end)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.uniq_by(& &1.id)
+
+        {:ok, books}
+
+      {:ok, _other} ->
+        {:error, :unexpected_response_payload}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp work_to_book(work, preferred_edition_id \\ nil) do
+    editions = work["Books"] || []
+    best = best_edition(editions, preferred_edition_id, work["BestBookId"])
+
+    %Provider.Book{
+      provider: id(),
+      id: to_string(work["ForeignId"]),
+      title: work["Title"],
+      description: best["Description"] || first_present(editions, "Description"),
+      cover_url: best["ImageUrl"] || first_present(editions, "ImageUrl"),
+      published:
+        Provider.PublishedDate.from_string(work["ReleaseDateRaw"] || best["ReleaseDateRaw"]),
+      publisher: presence(best["Publisher"]),
+      language: presence(best["Language"]),
+      format: presence(best["Format"]),
+      asin: presence(best["Asin"]),
+      authors: authors(work),
+      series: series(work),
+      editions: Enum.map(editions, &edition/1)
+    }
+  end
+
+  defp best_edition(editions, preferred_edition_id, best_book_id) do
+    Enum.find(editions, &(&1["ForeignId"] == preferred_edition_id)) ||
+      Enum.find(editions, &(&1["ForeignId"] == best_book_id)) ||
+      Enum.find(editions, &presence(&1["ImageUrl"])) ||
+      List.first(editions) ||
+      %{}
+  end
+
+  defp first_present(editions, field) do
+    Enum.find_value(editions, &presence(&1[field]))
+  end
+
+  defp authors(work) do
+    for author <- work["Authors"] || [] do
+      %Provider.Contributor{
+        id: to_string(author["ForeignId"]),
+        name: author["Name"],
+        role: "author"
+      }
+    end
+  end
+
+  defp series(work) do
+    work_id = work["ForeignId"]
+
+    for series <- work["Series"] || [],
+        link <- series["LinkItems"] || [],
+        link["ForeignWorkId"] == work_id do
+      %Provider.Series{
+        id: to_string(series["ForeignId"]),
+        name: series["Title"],
+        number: presence(link["PositionInSeries"])
+      }
+    end
+  end
+
+  defp edition(edition) do
+    %Provider.Edition{
+      id: to_string(edition["ForeignId"]),
+      title: edition["Title"],
+      asin: presence(edition["Asin"]),
+      description: presence(edition["Description"]),
+      language: presence(edition["Language"]),
+      format: presence(edition["Format"]),
+      publisher: presence(edition["Publisher"]),
+      published: Provider.PublishedDate.from_string(edition["ReleaseDateRaw"]),
+      cover_url: presence(edition["ImageUrl"])
+    }
+  end
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
+end

--- a/lib/ambry/metadata/providers/rreading_glasses/client.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses/client.ex
@@ -1,0 +1,23 @@
+defmodule Ambry.Metadata.Providers.RreadingGlasses.Client do
+  @moduledoc """
+  Thin HTTP client for a rreading-glasses server.
+
+  Quirk: unknown routes on rreading-glasses return HTTP 200 with an HTML
+  page (the Swagger UI), so a successful status is not enough — only a
+  JSON-decoded (map or list) body counts as a valid response.
+  """
+
+  @receive_timeout 30_000
+
+  def get_json(base_url, path, params \\ []) do
+    url = String.trim_trailing(base_url, "/") <> path
+
+    case Req.get(url: url, params: params, receive_timeout: @receive_timeout) do
+      {:ok, %{status: 200, body: body}} when is_map(body) or is_list(body) -> {:ok, body}
+      {:ok, %{status: 200}} -> {:error, :unexpected_response_payload}
+      {:ok, %{status: 404}} -> {:error, :not_found}
+      {:ok, response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/ambry/metadata/providers/rreading_glasses/client.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses/client.ex
@@ -17,7 +17,11 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses.Client do
   def get_json(base_url, path, params \\ []) do
     url = String.trim_trailing(base_url, "/") <> path
 
-    case Req.get(url: url, params: params, receive_timeout: @receive_timeout) do
+    # retry: false — Req's default retry honors Retry-After on 429s, which
+    # the shared public instance hands out in tens of seconds; hanging an
+    # interactive import form that long is worse than failing fast (the
+    # error renders in the modal and there is a Re-fetch button).
+    case Req.get(url: url, params: params, receive_timeout: @receive_timeout, retry: false) do
       {:ok, %{status: 200, body: body}} -> decode(body)
       {:ok, %{status: 404}} -> {:error, :not_found}
       {:ok, response} -> {:error, response}

--- a/lib/ambry/metadata/providers/rreading_glasses/client.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses/client.ex
@@ -2,9 +2,14 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses.Client do
   @moduledoc """
   Thin HTTP client for a rreading-glasses server.
 
-  Quirk: unknown routes on rreading-glasses return HTTP 200 with an HTML
-  page (the Swagger UI), so a successful status is not enough — only a
-  JSON-decoded (map or list) body counts as a valid response.
+  Two quirks require care here:
+
+    * Valid JSON responses can arrive with `content-type: text/plain` (seen
+      on the public instance behind Cloudflare), so Req's automatic JSON
+      decoding cannot be relied on — binary bodies are decoded explicitly.
+    * Unknown routes return HTTP 200 with an HTML page (the Swagger UI), so
+      a successful status is not enough — only a body that decodes as JSON
+      counts as a valid response.
   """
 
   @receive_timeout 30_000
@@ -13,11 +18,21 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses.Client do
     url = String.trim_trailing(base_url, "/") <> path
 
     case Req.get(url: url, params: params, receive_timeout: @receive_timeout) do
-      {:ok, %{status: 200, body: body}} when is_map(body) or is_list(body) -> {:ok, body}
-      {:ok, %{status: 200}} -> {:error, :unexpected_response_payload}
+      {:ok, %{status: 200, body: body}} -> decode(body)
       {:ok, %{status: 404}} -> {:error, :not_found}
       {:ok, response} -> {:error, response}
       {:error, reason} -> {:error, reason}
     end
   end
+
+  defp decode(body) when is_map(body) or is_list(body), do: {:ok, body}
+
+  defp decode(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _reason} -> {:error, :unexpected_response_payload}
+    end
+  end
+
+  defp decode(_body), do: {:error, :unexpected_response_payload}
 end

--- a/lib/ambry/metadata/registry.ex
+++ b/lib/ambry/metadata/registry.ex
@@ -1,0 +1,107 @@
+defmodule Ambry.Metadata.Registry do
+  @moduledoc """
+  Runtime-configurable registry of metadata providers.
+
+  The set of provider *modules* is fixed at compile time; whether each is
+  enabled, its priority order, and its settings (base URL, API token, …)
+  are operator-editable at runtime, persisted in `metadata_provider_configs`.
+  Defaults give a zero-config working setup: every known provider enabled,
+  rreading-glasses against the public instance.
+  """
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.ProviderConfig
+  alias Ambry.Metadata.Providers.Audible
+  alias Ambry.Metadata.Providers.Audnexus
+  alias Ambry.Metadata.Providers.RreadingGlasses
+  alias Ambry.Repo
+
+  @known_providers [RreadingGlasses, Audible, Audnexus]
+
+  defmodule Entry do
+    @moduledoc "A provider module joined with its runtime configuration."
+    defstruct [:module, :id, :display_name, :level, :capabilities, :enabled, :priority, :config]
+  end
+
+  @doc "All known providers with their runtime configuration, in priority order."
+  def all do
+    stored = Repo.all(ProviderConfig)
+
+    @known_providers
+    |> Enum.with_index()
+    |> Enum.map(fn {module, index} ->
+      row = Enum.find(stored, &(&1.provider_id == module.id()))
+
+      %Entry{
+        module: module,
+        id: module.id(),
+        display_name: module.display_name(),
+        level: module.level(),
+        capabilities: module.capabilities(),
+        enabled: if(row, do: row.enabled, else: true),
+        priority: (row && row.priority) || index,
+        config: build_config(module, row)
+      }
+    end)
+    |> Enum.sort_by(& &1.priority)
+  end
+
+  @doc "Enabled providers, optionally filtered by level or capability."
+  def enabled(filters \\ []) do
+    level = Keyword.get(filters, :level)
+    capability = Keyword.get(filters, :capability)
+
+    all()
+    |> Enum.filter(& &1.enabled)
+    |> Enum.filter(fn entry -> is_nil(level) or entry.level == level end)
+    |> Enum.filter(fn entry -> is_nil(capability) or capability in entry.capabilities end)
+  end
+
+  @doc "Fetches a provider entry by its string id."
+  def fetch(provider_id) do
+    case Enum.find(all(), &(&1.id == provider_id)) do
+      nil -> {:error, :unknown_provider}
+      entry -> {:ok, entry}
+    end
+  end
+
+  @doc """
+  Upserts the stored settings for a provider. Accepts `:enabled`,
+  `:priority`, and `:config` (a map of field-key => value; only keys the
+  provider declares in `config_fields/0` are kept).
+  """
+  def update(provider_id, attrs) do
+    with {:ok, entry} <- fetch(provider_id) do
+      known_keys = Enum.map(entry.module.config_fields(), &to_string(&1.key))
+
+      config =
+        attrs
+        |> Map.get(:config, %{})
+        |> Map.new(fn {key, value} -> {to_string(key), value} end)
+        |> Map.take(known_keys)
+
+      attrs =
+        attrs
+        |> Map.take([:enabled, :priority])
+        |> Map.put(:config, config)
+        |> Map.put(:provider_id, provider_id)
+
+      (Repo.get(ProviderConfig, provider_id) || %ProviderConfig{})
+      |> ProviderConfig.changeset(attrs)
+      |> Repo.insert_or_update()
+    end
+  end
+
+  defp build_config(module, row) do
+    defaults = Provider.default_config(module)
+    stored = (row && row.config) || %{}
+
+    Map.new(defaults, fn {key, default} ->
+      case Map.get(stored, to_string(key)) do
+        nil -> {key, default}
+        "" -> {key, default}
+        value -> {key, value}
+      end
+    end)
+  end
+end

--- a/lib/ambry/metadata/registry.ex
+++ b/lib/ambry/metadata/registry.ex
@@ -51,10 +51,11 @@ defmodule Ambry.Metadata.Registry do
     level = Keyword.get(filters, :level)
     capability = Keyword.get(filters, :capability)
 
-    all()
-    |> Enum.filter(& &1.enabled)
-    |> Enum.filter(fn entry -> is_nil(level) or entry.level == level end)
-    |> Enum.filter(fn entry -> is_nil(capability) or capability in entry.capabilities end)
+    Enum.filter(all(), fn entry ->
+      entry.enabled and
+        (is_nil(level) or entry.level == level) and
+        (is_nil(capability) or capability in entry.capabilities)
+    end)
   end
 
   @doc "Fetches a provider entry by its string id."

--- a/lib/ambry/metadata/registry.ex
+++ b/lib/ambry/metadata/registry.ex
@@ -13,14 +13,25 @@ defmodule Ambry.Metadata.Registry do
   alias Ambry.Metadata.ProviderConfig
   alias Ambry.Metadata.Providers.Audible
   alias Ambry.Metadata.Providers.Audnexus
+  alias Ambry.Metadata.Providers.Hardcover
   alias Ambry.Metadata.Providers.RreadingGlasses
   alias Ambry.Repo
 
-  @known_providers [RreadingGlasses, Audible, Audnexus]
+  @known_providers [RreadingGlasses, Hardcover, Audible, Audnexus]
 
   defmodule Entry do
     @moduledoc "A provider module joined with its runtime configuration."
-    defstruct [:module, :id, :display_name, :level, :capabilities, :enabled, :priority, :config]
+    defstruct [
+      :module,
+      :id,
+      :display_name,
+      :level,
+      :capabilities,
+      :enabled,
+      :available,
+      :priority,
+      :config
+    ]
   end
 
   @doc "All known providers with their runtime configuration, in priority order."
@@ -31,6 +42,7 @@ defmodule Ambry.Metadata.Registry do
     |> Enum.with_index()
     |> Enum.map(fn {module, index} ->
       row = Enum.find(stored, &(&1.provider_id == module.id()))
+      config = build_config(module, row)
 
       %Entry{
         module: module,
@@ -39,20 +51,21 @@ defmodule Ambry.Metadata.Registry do
         level: module.level(),
         capabilities: module.capabilities(),
         enabled: if(row, do: row.enabled, else: true),
+        available: Provider.available?(module, config),
         priority: (row && row.priority) || index,
-        config: build_config(module, row)
+        config: config
       }
     end)
     |> Enum.sort_by(& &1.priority)
   end
 
-  @doc "Enabled providers, optionally filtered by level or capability."
+  @doc "Enabled *and* available providers, optionally filtered by level or capability."
   def enabled(filters \\ []) do
     level = Keyword.get(filters, :level)
     capability = Keyword.get(filters, :capability)
 
     Enum.filter(all(), fn entry ->
-      entry.enabled and
+      entry.enabled and entry.available and
         (is_nil(level) or entry.level == level) and
         (is_nil(capability) or capability in entry.capabilities)
     end)

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -545,6 +545,44 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  def book_card(%{book: %Ambry.Metadata.Provider.Book{}} = assigns) do
+    ~H"""
+    <div class="flex gap-2 text-sm">
+      <img :if={@book.cover_url} src={@book.cover_url} class="h-24 w-24 object-contain object-top" />
+      <div>
+        <p class="font-bold">{@book.title}</p>
+        <p :if={@book.authors != []} class="text-zinc-400">
+          by
+          <span :for={author <- @book.authors} class="group">
+            <span>{author.name}</span>
+            <br class="group-last:hidden" />
+          </span>
+        </p>
+        <p :if={@book.narrators != []} class="text-zinc-400">
+          Narrated by
+          <span :for={narrator <- @book.narrators} class="group">
+            <span>{narrator.name}</span>
+            <br class="group-last:hidden" />
+          </span>
+        </p>
+        <p :if={@book.series != []} class="text-xs text-zinc-400">
+          <span :for={series <- @book.series} class="group">
+            <span>{series.name} #{series.number}</span>
+            <br class="group-last:hidden" />
+          </span>
+        </p>
+        <p :if={@book.published} class="text-xs text-zinc-400">
+          Published {display_date(@book.published)}<span :if={@book.publisher}> by {@book.publisher}</span>
+        </p>
+        <p :if={@book.format} class="text-xs text-zinc-400">{@book.format}</p>
+        <div :for={action <- @actions}>
+          {render_slot(action)}
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   def book_card(%{book: %AmbryScraping.Audible.Product{}} = assigns) do
     ~H"""
     <div class="flex gap-2 text-sm">
@@ -586,6 +624,17 @@ defmodule AmbryWeb.Admin.Components do
     do: Calendar.strftime(date, "%B %Y")
 
   def display_date(%PublishedDate{display_format: :year, date: date}),
+    do: Calendar.strftime(date, "%Y")
+
+  def display_date(%Ambry.Metadata.Provider.PublishedDate{display_format: :full, date: date}),
+    do: Calendar.strftime(date, "%B %-d, %Y")
+
+  def display_date(%Ambry.Metadata.Provider.PublishedDate{
+        display_format: :year_month,
+        date: date
+      }), do: Calendar.strftime(date, "%B %Y")
+
+  def display_date(%Ambry.Metadata.Provider.PublishedDate{display_format: :year, date: date}),
     do: Calendar.strftime(date, "%Y")
 
   def multi_image(%{paths: []} = assigns) do

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -548,7 +548,11 @@ defmodule AmbryWeb.Admin.Components do
   def book_card(%{book: %Ambry.Metadata.Provider.Book{}} = assigns) do
     ~H"""
     <div class="flex gap-2 text-sm">
-      <img :if={@book.cover_url} src={@book.cover_url} class="h-24 w-24 object-contain object-top" />
+      <img
+        :if={@book.cover_url}
+        src={proxied_remote_image_url(@book.cover_url)}
+        class="h-24 w-24 object-contain object-top"
+      />
       <div>
         <p class="font-bold">{@book.title}</p>
         <p :if={@book.authors != []} class="text-zinc-400">

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -52,6 +52,13 @@ defmodule AmbryWeb.Admin.Layouts do
           <.icon name="fa-file-waveform" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
           <p>File Audit</p>
         </.link>
+        <.link
+          navigate={~p"/admin/metadata-providers"}
+          class={nav_class(@active_path =~ "/admin/metadata-providers")}
+        >
+          <.icon name="fa-screwdriver-wrench" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <p>Metadata Providers</p>
+        </.link>
         <.link navigate={~p"/admin/users"} class={nav_class(@active_path =~ "/admin/users")}>
           <.icon name="fa-users-gear" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
           <p>Manage Users</p>

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -550,7 +550,7 @@ defmodule AmbryWeb.CoreComponents do
         class={if @show_preview, do: "rounded-b-none"}
       />
       <div :if={@show_preview} class="rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4">
-        <.image_with_size id={@field.id} src={@field.value} class={@image_preview_class} />
+        <.image_with_size id={@field.id} src={proxied_remote_image_url(@field.value)} class={@image_preview_class} />
       </div>
     </div>
     """
@@ -643,6 +643,18 @@ defmodule AmbryWeb.CoreComponents do
     </p>
     """
   end
+
+  @doc """
+  Routes a remote image URL through the admin image proxy, so import
+  previews render even in browsers whose tracking protection blocks
+  hotlinks to provider CDNs. Local paths (and nil) pass through unchanged.
+  """
+  def proxied_remote_image_url(nil), do: nil
+
+  def proxied_remote_image_url("http" <> _rest = url),
+    do: "/admin/image-proxy?" <> URI.encode_query(url: url)
+
+  def proxied_remote_image_url(url), do: url
 
   attr :id, :string, required: true
   attr :src, :string, required: true

--- a/lib/ambry_web/controllers/admin/image_proxy_controller.ex
+++ b/lib/ambry_web/controllers/admin/image_proxy_controller.ex
@@ -1,0 +1,37 @@
+defmodule AmbryWeb.Admin.ImageProxyController do
+  @moduledoc """
+  Proxies remote metadata-provider images for admin import previews.
+
+  Browsers with tracking protection (e.g. Firefox ETP) block hotlinked
+  images from provider CDNs — Amazon's image hosts are on the tracker
+  blocklists — so import previews render blank even though the URLs are
+  fine and the eventual server-side import succeeds. Serving previews
+  same-origin sidesteps that entirely.
+
+  Admin-only, http(s) only, image content types only. Fetching operator-
+  supplied remote URLs server-side matches the existing import behavior
+  (`UploadHelpers.handle_image_import/1`).
+  """
+
+  use AmbryWeb, :controller
+
+  @allowed_content_types ~w(image/jpeg image/png image/webp image/gif)
+  @receive_timeout 15_000
+
+  def show(conn, %{"url" => url}) do
+    with %URI{scheme: scheme} when scheme in ["http", "https"] <- URI.parse(url),
+         {:ok, %{status: 200, body: body} = response} when is_binary(body) <-
+           Req.get(url: url, receive_timeout: @receive_timeout, retry: false, decode_body: false),
+         [content_type | _rest] <- Req.Response.get_header(response, "content-type"),
+         true <- String.starts_with?(content_type, @allowed_content_types) do
+      conn
+      |> put_resp_content_type(content_type, nil)
+      |> put_resp_header("cache-control", "private, max-age=86400")
+      |> send_resp(200, body)
+    else
+      _other -> send_resp(conn, 404, "Not Found")
+    end
+  end
+
+  def show(conn, _params), do: send_resp(conn, 400, "Bad Request")
+end

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -4,9 +4,11 @@ defmodule AmbryWeb.Admin.BookLive.Form do
 
   alias Ambry.Books
   alias Ambry.Books.Book
+  alias Ambry.Metadata.Registry
   alias Ambry.People
   alias AmbryWeb.Admin.BookLive.Form.AudibleImportForm
   alias AmbryWeb.Admin.BookLive.Form.GoodreadsImportForm
+  alias AmbryWeb.Admin.BookLive.Form.ProviderImportForm
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -16,6 +18,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
      |> assign(
        import: nil,
        scraping_available: AmbryScraping.web_scraping_available?(),
+       work_providers: Registry.enabled(level: :work, capability: :book_search),
        authors: People.authors_for_select(),
        series: Books.series_for_select()
      )
@@ -53,8 +56,18 @@ defmodule AmbryWeb.Admin.BookLive.Form do
 
   defp handle_import_form_params(socket, %{"import" => type}) do
     query = socket.assigns.form.params["title"] || socket.assigns.book.title
-    import_type = String.to_existing_atom(type)
-    assign(socket, import: %{type: import_type, query: query})
+
+    cond do
+      type in ~w(goodreads audible) ->
+        assign(socket, import: %{type: String.to_existing_atom(type), query: query})
+
+      match?({:ok, _provider}, Registry.fetch(type)) ->
+        {:ok, provider} = Registry.fetch(type)
+        assign(socket, import: %{provider: provider, query: query})
+
+      true ->
+        assign(socket, import: nil)
+    end
   end
 
   defp handle_import_form_params(socket, _params) do
@@ -82,11 +95,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   end
 
   def handle_event("open-import-form", %{"type" => type}, socket) do
-    query = socket.assigns.form.params["title"] || socket.assigns.book.title
-    import_type = String.to_existing_atom(type)
-    socket = assign(socket, import: %{type: import_type, query: query})
-
-    {:noreply, socket}
+    {:noreply, handle_import_form_params(socket, %{"import" => type})}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -21,7 +21,7 @@
   <.datalist id="series" options={@series} />
 
   <div class="max-w-3xl">
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form id="book-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
         <.input field={@form[:title]} label="Title" />
 

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -1,6 +1,20 @@
 <.layout title={@page_title} user={@current_user}>
   <.modal :if={@import} id="import-modal" show on_cancel={close_import_form(@book)}>
-    <.live_component id="import-form" module={import_form(@import.type)} query={@import.query} book={@book} />
+    <.live_component
+      :if={@import[:type]}
+      id="import-form"
+      module={import_form(@import.type)}
+      query={@import.query}
+      book={@book}
+    />
+    <.live_component
+      :if={@import[:provider]}
+      id="import-form"
+      module={ProviderImportForm}
+      provider={@import.provider}
+      query={@import.query}
+      book={@book}
+    />
   </.modal>
 
   <.datalist id="authors" options={@authors} />
@@ -13,7 +27,16 @@
 
         <div class="row-start-1 space-y-2 sm:col-start-2">
           <.label>Import from:</.label>
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
+            <.button
+              :for={provider <- @work_providers}
+              color={:zinc}
+              class="flex items-center gap-1"
+              type="button"
+              phx-click={open_import_form(@book, provider.id)}
+            >
+              {provider.display_name}
+            </.button>
             <.button
               :if={@scraping_available}
               color={:zinc}

--- a/lib/ambry_web/live/admin/book_live/form/audible_import_form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form/audible_import_form.html.heex
@@ -17,7 +17,7 @@
       <.error>There was an error searching Audible for books: {failure}</.error>
     </:failed>
 
-    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+    <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
       <div class="space-y-2">
         <.label>Select book ({length(books)} results)</.label>
         <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>

--- a/lib/ambry_web/live/admin/book_live/form/goodreads_import_form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form/goodreads_import_form.html.heex
@@ -20,7 +20,7 @@
     <div class="grid grid-cols-2 gap-2">
       <div class="space-y-2">
         <div class="space-y-2">
-          <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+          <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
             <div class="space-y-2">
               <.label>Select book ({length(books)} results)</.label>
               <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>
@@ -44,7 +44,12 @@
           </:failed>
 
           <div class="space-y-2">
-            <.simple_form for={@select_edition_form} phx-change="select-edition" phx-target={@myself}>
+            <.simple_form
+              id="select-edition-form"
+              for={@select_edition_form}
+              phx-change="select-edition"
+              phx-target={@myself}
+            >
               <div class="space-y-2">
                 <.label>Select edition for <em>{editions.title}</em></.label>
                 <.rich_select id="edition-select" field={@select_edition_form[:edition_id]} options={editions.editions}>

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
@@ -1,0 +1,182 @@
+defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
+  @moduledoc """
+  Book import from any registered work-level metadata provider.
+
+  Work-level search results arrive fully hydrated (title, authors, series,
+  publication date), so unlike the legacy GoodReads flow there is no
+  editions round-trip: search, pick the work, choose fields to import.
+  """
+  use AmbryWeb, :live_component
+
+  import AmbryWeb.Admin.Components
+  import AmbryWeb.Admin.Components.RichSelect, only: [rich_select: 1]
+
+  alias Ambry.Books
+  alias Ambry.Books.Series
+  alias Ambry.Metadata.Providers
+  alias Ambry.People.Person
+  alias Ambry.Search
+  alias Phoenix.LiveView.AsyncResult
+
+  @impl Phoenix.LiveComponent
+  def mount(socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveComponent
+  def update(assigns, socket) do
+    %{provider: provider, query: query} = assigns
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(
+       books: AsyncResult.loading(),
+       selected_book: nil,
+       matching_authors: [],
+       matching_series: [],
+       search_form: to_form(%{"query" => query}, as: :search),
+       select_book_form: to_form(%{}, as: :select_book),
+       form: to_form(init_import_form_params(assigns.book), as: :import)
+     )
+     |> start_async(:search, fn -> search(provider.id, query) end)}
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_async(:search, {:ok, books}, socket) do
+    [first_book | _rest] = books
+
+    {:noreply,
+     socket
+     |> assign(books: AsyncResult.ok(socket.assigns.books, books))
+     |> assign(select_book_form: to_form(%{"book_id" => first_book.id}, as: :select_book))
+     |> select_book(first_book)}
+  end
+
+  def handle_async(:search, {:exit, {:shutdown, :cancel}}, socket) do
+    {:noreply, assign(socket, books: AsyncResult.loading())}
+  end
+
+  def handle_async(:search, {:exit, {exception, _stacktrace}}, socket) do
+    {:noreply, assign(socket, books: AsyncResult.failed(socket.assigns.books, exception.message))}
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("search", %{"search" => %{"query" => query}} = params, socket) do
+    %{provider: provider} = socket.assigns
+    refresh = Map.has_key?(params, "refresh")
+
+    {:noreply,
+     socket
+     |> assign(
+       books: AsyncResult.loading(),
+       selected_book: nil,
+       search_form: to_form(%{"query" => query}, as: :search)
+     )
+     |> cancel_async(:search)
+     |> start_async(:search, fn -> search(provider.id, query, refresh) end)}
+  end
+
+  def handle_event("select-book", %{"select_book" => %{"book_id" => book_id}}, socket) do
+    book = Enum.find(socket.assigns.books.result, &(&1.id == book_id))
+
+    {:noreply,
+     socket
+     |> assign(select_book_form: to_form(%{"book_id" => book.id}, as: :select_book))
+     |> select_book(book)}
+  end
+
+  def handle_event("import", %{"import" => import_params}, socket) do
+    book = socket.assigns.selected_book
+
+    params =
+      Enum.reduce(import_params, %{}, fn
+        {"use_title", "true"}, acc ->
+          Map.put(acc, "title", book.title)
+
+        {"use_published", "true"}, acc ->
+          Map.merge(acc, %{
+            "published" => book.published.date,
+            "published_format" => to_string(book.published.display_format)
+          })
+
+        {"use_authors", "true"}, acc ->
+          Map.put(acc, "book_authors", build_authors_params(socket.assigns.matching_authors))
+
+        {"use_series", "true"}, acc ->
+          Map.put(acc, "series_books", build_series_params(socket.assigns.matching_series))
+
+        _else, acc ->
+          acc
+      end)
+
+    send(self(), {:import, %{"book" => params}})
+
+    {:noreply, socket}
+  end
+
+  defp select_book(socket, book) do
+    assign(socket,
+      selected_book: book,
+      matching_authors:
+        Enum.map(book.authors, fn author ->
+          {author, Search.find_first(author.name, Person)}
+        end),
+      matching_series:
+        Enum.map(book.series, fn series ->
+          {series, Search.find_first(series.name, Series)}
+        end)
+    )
+  end
+
+  defp build_authors_params(matching_authors) do
+    Enum.map(matching_authors, fn
+      {imported, nil} ->
+        {:ok, %{authors: [author]}} =
+          Ambry.People.create_person(%{name: imported.name, authors: [%{name: imported.name}]})
+
+        %{"author_id" => author.id}
+
+      {_imported, %{authors: []} = existing} ->
+        {:ok, %{authors: [author]}} =
+          Ambry.People.update_person(existing, %{authors: [%{name: existing.name}]})
+
+        %{"author_id" => author.id}
+
+      {_imported, %{authors: [author | _rest]}} ->
+        %{"author_id" => author.id}
+    end)
+  end
+
+  defp build_series_params(matching_series) do
+    Enum.map(matching_series, fn
+      {imported, nil} ->
+        {:ok, series} = Books.create_series(%{name: imported.name})
+        %{"book_number" => imported.number, "series_id" => series.id}
+
+      {imported, existing} ->
+        %{"book_number" => imported.number, "series_id" => existing.id}
+    end)
+  end
+
+  defp search(provider_id, query, refresh \\ false) do
+    "#{query}"
+    |> String.trim()
+    |> String.downcase()
+    |> then(&Providers.search_books(provider_id, &1, refresh: refresh))
+    |> case do
+      {:ok, []} -> raise "No books found"
+      {:ok, books} -> books
+      {:error, reason} -> raise "Unhandled error: #{inspect(reason)}"
+    end
+  end
+
+  defp init_import_form_params(book) do
+    Map.new([:title, :published, :authors, :series], fn
+      :title -> {"use_title", is_nil(book.title)}
+      :published -> {"use_published", is_nil(book.published)}
+      :authors -> {"use_authors", book.book_authors == []}
+      :series -> {"use_series", book.series_books == []}
+    end)
+  end
+end

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
@@ -1,0 +1,102 @@
+<div class="mx-auto max-w-3xl space-y-4 p-6">
+  <div class="text-2xl font-bold">Import Book from {@provider.display_name}</div>
+
+  <.simple_form for={@search_form} phx-submit="search" phx-target={@myself}>
+    <div class="flex items-end gap-2">
+      <.input field={@search_form[:query]} label="Search" container_class="grow" />
+      <.button>Search</.button>
+      <.button name="refresh" value="true" title="Bypass cached results and re-fetch">
+        Re-fetch
+      </.button>
+    </div>
+  </.simple_form>
+
+  <.async_result :let={books} assign={@books}>
+    <:loading>
+      <.loading>Searching books...</.loading>
+    </:loading>
+
+    <:failed :let={failure}>
+      <.error>There was an error searching {@provider.display_name} for books: {failure}</.error>
+    </:failed>
+
+    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+      <div class="space-y-2">
+        <.label>Select book ({length(books)} results)</.label>
+        <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>
+          <:option :let={book}>
+            <.book_card book={book} />
+          </:option>
+        </.rich_select>
+      </div>
+    </.simple_form>
+
+    <.simple_form
+      :if={@selected_book}
+      for={@form}
+      phx-submit="import"
+      phx-target={@myself}
+      container_class="!space-y-0"
+    >
+      <.import_form_row :if={@selected_book.title} field={@form[:use_title]} label="Title">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+          {@selected_book.title}
+        </div>
+      </.import_form_row>
+
+      <.import_form_row :if={@selected_book.published} field={@form[:use_published]} label="First published">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+          {display_date(@selected_book.published)}
+        </div>
+      </.import_form_row>
+
+      <.import_form_row :if={@matching_authors != []} field={@form[:use_authors]} label="Authors">
+        <div :for={{imported_author, existing_author} <- @matching_authors}>
+          <%= if existing_author do %>
+            <p class="flex items-center gap-2">
+              <.icon name="fa-circle-check" class="text-brand h-4 w-4 flex-none dark:text-brand-dark" />
+              <span class="font-semibold">Existing author</span>
+              {existing_author.name}
+            </p>
+          <% else %>
+            <p class="flex items-center gap-2">
+              <.icon name="fa-triangle-exclamation" class="h-4 w-4 flex-none text-amber-600 dark:text-amber-500" />
+              <span class="font-semibold">Missing author</span>
+              {imported_author.name}
+            </p>
+          <% end %>
+        </div>
+        <p :if={Enum.any?(@matching_authors, fn {_imported, existing} -> is_nil(existing) end)}>
+          Any missing authors will be imported with just their names. You can add additional details by visiting <.brand_link navigate={
+            ~p"/admin/people"
+          }>Authors & Narrators</.brand_link>.
+        </p>
+      </.import_form_row>
+
+      <.import_form_row :if={@matching_series != []} field={@form[:use_series]} label="Series">
+        <div :for={{imported_series, existing_series} <- @matching_series}>
+          <%= if existing_series do %>
+            <p class="flex items-center gap-2">
+              <.icon name="fa-circle-check" class="text-brand h-4 w-4 flex-none dark:text-brand-dark" />
+              <span class="font-semibold">Existing series</span>
+              {existing_series.name} #{imported_series.number}
+            </p>
+          <% else %>
+            <p class="flex items-center gap-2">
+              <.icon name="fa-triangle-exclamation" class="h-4 w-4 flex-none text-amber-600 dark:text-amber-500" />
+              <span class="font-semibold">New series</span>
+              {imported_series.name} #{imported_series.number}
+            </p>
+          <% end %>
+        </div>
+      </.import_form_row>
+
+      <:actions>
+        <.button class="mt-2">Import</.button>
+        <.button type="button" color={:zinc} phx-click={JS.exec("data-cancel", to: "#import-modal")}>
+          Cancel
+        </.button>
+      </:actions>
+    </.simple_form>
+  </.async_result>
+</div>

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
@@ -20,7 +20,7 @@
       <.error>There was an error searching {@provider.display_name} for books: {failure}</.error>
     </:failed>
 
-    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+    <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
       <div class="space-y-2">
         <.label>Select book ({length(books)} results)</.label>
         <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>

--- a/lib/ambry_web/live/admin/media_live/chapters.html.heex
+++ b/lib/ambry_web/live/admin/media_live/chapters.html.heex
@@ -4,7 +4,7 @@
   </.modal>
 
   <div class="max-w-3xl">
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form id="media-chapters-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="space-y-2">
         <.label>Import from:</.label>
         <div class="flex items-center gap-2">

--- a/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.html.heex
@@ -17,7 +17,7 @@
       <.error>There was an error searching Audible for books: {failure}</.error>
     </:failed>
 
-    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+    <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
       <div class="space-y-2">
         <.label>Select book ({length(books)} results)</.label>
         <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -7,10 +7,12 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   import AmbryWeb.Admin.UploadHelpers
 
   alias Ambry.Media
+  alias Ambry.Metadata.Registry
   alias Ambry.People
   alias AmbryWeb.Admin.MediaLive.Form.AudibleImportForm
   alias AmbryWeb.Admin.MediaLive.Form.FileBrowser
   alias AmbryWeb.Admin.MediaLive.Form.GoodreadsImportForm
+  alias AmbryWeb.Admin.MediaLive.Form.ProviderImportForm
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -25,6 +27,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
        select_files: false,
        selected_files: MapSet.new(),
        scraping_available: AmbryScraping.web_scraping_available?(),
+       recording_providers: Registry.enabled(level: :recording, capability: :book_search),
        source_files_expanded: false,
        narrators: People.narrators_for_select(),
        books: Ambry.Books.books_for_select(),
@@ -88,8 +91,17 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
         ""
       end
 
-    import_type = String.to_existing_atom(type)
-    {:noreply, assign(socket, import: %{type: import_type, query: query})}
+    cond do
+      type in ~w(goodreads audible) ->
+        {:noreply, assign(socket, import: %{type: String.to_existing_atom(type), query: query})}
+
+      match?({:ok, _provider}, Registry.fetch(type)) ->
+        {:ok, provider} = Registry.fetch(type)
+        {:noreply, assign(socket, import: %{provider: provider, query: query})}
+
+      true ->
+        {:noreply, assign(socket, import: nil)}
+    end
   end
 
   def handle_params(%{"browse" => _}, _url, socket) do

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -25,7 +25,7 @@
   <.datalist id="books" options={@books} />
 
   <div class="max-w-3xl">
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form id="media-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
         <.input field={@form[:book_id]} label="Book" type="autocomplete" options={@books} list="books" />
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -1,6 +1,20 @@
 <.layout title={@page_title} user={@current_user}>
   <.modal :if={@import} id="import-modal" show on_cancel={close_modal(@media)}>
-    <.live_component id="import-form" module={import_form(@import.type)} query={@import.query} media={@media} />
+    <.live_component
+      :if={@import[:type]}
+      id="import-form"
+      module={import_form(@import.type)}
+      query={@import.query}
+      media={@media}
+    />
+    <.live_component
+      :if={@import[:provider]}
+      id="import-form"
+      module={ProviderImportForm}
+      provider={@import.provider}
+      query={@import.query}
+      media={@media}
+    />
   </.modal>
 
   <.modal :if={@select_files} id="select-files-modal" show on_cancel={close_modal(@media)}>
@@ -17,7 +31,16 @@
 
         <div class="row-start-1 space-y-2 sm:col-start-2">
           <.label>Import from:</.label>
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
+            <.button
+              :for={provider <- @recording_providers}
+              color={:zinc}
+              class="flex items-center gap-1"
+              type="button"
+              phx-click={open_import_form(@media, provider.id)}
+            >
+              {provider.display_name}
+            </.button>
             <.button
               :if={@scraping_available}
               color={:zinc}
@@ -26,14 +49,6 @@
               phx-click={open_import_form(@media, "goodreads")}
             >
               <.icon name="fa-brands-goodreads" class="h-4 w-4 text-current" /> GoodReads
-            </.button>
-            <.button
-              color={:zinc}
-              class="flex items-center gap-1"
-              type="button"
-              phx-click={open_import_form(@media, "audible")}
-            >
-              <.icon name="fa-brands-audible" class="h-4 w-4 text-current" /> Audible
             </.button>
           </div>
         </div>

--- a/lib/ambry_web/live/admin/media_live/form/audible_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/audible_import_form.html.heex
@@ -17,7 +17,7 @@
       <.error>There was an error searching Audible for books: {failure}</.error>
     </:failed>
 
-    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+    <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
       <div class="space-y-2">
         <.label>Select book ({length(books)} results)</.label>
         <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>

--- a/lib/ambry_web/live/admin/media_live/form/goodreads_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/goodreads_import_form.html.heex
@@ -20,7 +20,7 @@
     <div class="grid grid-cols-2 gap-2">
       <div class="space-y-2">
         <div class="space-y-2">
-          <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+          <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
             <div class="space-y-2">
               <.label>Select book ({length(books)} results)</.label>
               <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>
@@ -44,7 +44,12 @@
           </:failed>
 
           <div class="space-y-2">
-            <.simple_form for={@select_edition_form} phx-change="select-edition" phx-target={@myself}>
+            <.simple_form
+              id="select-edition-form"
+              for={@select_edition_form}
+              phx-change="select-edition"
+              phx-target={@myself}
+            >
               <div class="space-y-2">
                 <.label>Select edition for <em>{editions.title}</em></.label>
                 <.rich_select id="edition-select" field={@select_edition_form[:edition_id]} options={editions.editions}>

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.ex
@@ -1,0 +1,173 @@
+defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
+  @moduledoc """
+  Media (recording) import from any registered recording-level metadata
+  provider — narrators, square cover art, publisher, and publication facts.
+  """
+  use AmbryWeb, :live_component
+
+  import AmbryWeb.Admin.Components
+  import AmbryWeb.Admin.Components.RichSelect, only: [rich_select: 1]
+
+  alias Ambry.Metadata.Providers
+  alias Ambry.People.Person
+  alias Ambry.Search
+  alias Phoenix.LiveView.AsyncResult
+
+  @impl Phoenix.LiveComponent
+  def mount(socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveComponent
+  def update(assigns, socket) do
+    %{provider: provider, query: query} = assigns
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(
+       books: AsyncResult.loading(),
+       selected_book: nil,
+       matching_narrators: [],
+       search_form: to_form(%{"query" => query}, as: :search),
+       select_book_form: to_form(%{}, as: :select_book),
+       form: to_form(init_import_form_params(assigns.media), as: :import)
+     )
+     |> start_async(:search, fn -> search(provider.id, query) end)}
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_async(:search, {:ok, books}, socket) do
+    [first_book | _rest] = books
+
+    {:noreply,
+     socket
+     |> assign(books: AsyncResult.ok(socket.assigns.books, books))
+     |> assign(select_book_form: to_form(%{"book_id" => first_book.id}, as: :select_book))
+     |> select_book(first_book)}
+  end
+
+  def handle_async(:search, {:exit, {:shutdown, :cancel}}, socket) do
+    {:noreply, assign(socket, books: AsyncResult.loading())}
+  end
+
+  def handle_async(:search, {:exit, {exception, _stacktrace}}, socket) do
+    {:noreply, assign(socket, books: AsyncResult.failed(socket.assigns.books, exception.message))}
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("search", %{"search" => %{"query" => query}} = params, socket) do
+    %{provider: provider} = socket.assigns
+    refresh = Map.has_key?(params, "refresh")
+
+    {:noreply,
+     socket
+     |> assign(
+       books: AsyncResult.loading(),
+       selected_book: nil,
+       search_form: to_form(%{"query" => query}, as: :search)
+     )
+     |> cancel_async(:search)
+     |> start_async(:search, fn -> search(provider.id, query, refresh) end)}
+  end
+
+  def handle_event("select-book", %{"select_book" => %{"book_id" => book_id}}, socket) do
+    book = Enum.find(socket.assigns.books.result, &(&1.id == book_id))
+
+    {:noreply,
+     socket
+     |> assign(select_book_form: to_form(%{"book_id" => book.id}, as: :select_book))
+     |> select_book(book)}
+  end
+
+  def handle_event("import", %{"import" => import_params}, socket) do
+    book = socket.assigns.selected_book
+
+    params =
+      Enum.reduce(import_params, %{}, fn
+        {"use_published", "true"}, acc ->
+          Map.merge(acc, %{
+            "published" => book.published.date,
+            "published_format" => to_string(book.published.display_format)
+          })
+
+        {"use_publisher", "true"}, acc ->
+          Map.put(acc, "publisher", book.publisher)
+
+        {"use_description", "true"}, acc ->
+          Map.put(acc, "description", book.description)
+
+        {"use_narrators", "true"}, acc ->
+          Map.put(
+            acc,
+            "media_narrators",
+            build_narrators_params(socket.assigns.matching_narrators)
+          )
+
+        {"use_cover_image", "true"}, acc ->
+          Map.merge(acc, %{
+            "image_path" => "",
+            "image_type" => "url_import",
+            "image_import_url" => book.cover_url
+          })
+
+        _else, acc ->
+          acc
+      end)
+
+    send(self(), {:import, %{"media" => params}})
+
+    {:noreply, socket}
+  end
+
+  defp select_book(socket, book) do
+    assign(socket,
+      selected_book: book,
+      matching_narrators:
+        Enum.map(book.narrators, fn narrator ->
+          {narrator, Search.find_first(narrator.name, Person)}
+        end)
+    )
+  end
+
+  defp build_narrators_params(matching_narrators) do
+    Enum.map(matching_narrators, fn
+      {imported, nil} ->
+        {:ok, %{narrators: [narrator]}} =
+          Ambry.People.create_person(%{name: imported.name, narrators: [%{name: imported.name}]})
+
+        %{"narrator_id" => narrator.id}
+
+      {_imported, %{narrators: []} = existing} ->
+        {:ok, %{narrators: [narrator]}} =
+          Ambry.People.update_person(existing, %{narrators: [%{name: existing.name}]})
+
+        %{"narrator_id" => narrator.id}
+
+      {_imported, %{narrators: [narrator | _rest]}} ->
+        %{"narrator_id" => narrator.id}
+    end)
+  end
+
+  defp search(provider_id, query, refresh \\ false) do
+    "#{query}"
+    |> String.trim()
+    |> String.downcase()
+    |> then(&Providers.search_books(provider_id, &1, refresh: refresh))
+    |> case do
+      {:ok, []} -> raise "No books found"
+      {:ok, books} -> books
+      {:error, reason} -> raise "Unhandled error: #{inspect(reason)}"
+    end
+  end
+
+  defp init_import_form_params(media) do
+    Map.new([:published, :publisher, :description, :narrators, :image], fn
+      :published -> {"use_published", is_nil(media.published)}
+      :publisher -> {"use_publisher", is_nil(media.publisher)}
+      :description -> {"use_description", is_nil(media.description)}
+      :narrators -> {"use_narrators", media.media_narrators == []}
+      :image -> {"use_cover_image", is_nil(media.image_path)}
+    end)
+  end
+end

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
@@ -81,7 +81,11 @@
       </.import_form_row>
 
       <.import_form_row :if={@selected_book.cover_url} field={@form[:use_cover_image]} label="Image">
-        <.image_with_size id={@form[:use_cover_image].id} src={@selected_book.cover_url} class="h-48 rounded-sm" />
+        <.image_with_size
+          id={@form[:use_cover_image].id}
+          src={proxied_remote_image_url(@selected_book.cover_url)}
+          class="h-48 rounded-sm"
+        />
       </.import_form_row>
 
       <:actions>

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
@@ -1,0 +1,95 @@
+<div class="mx-auto max-w-3xl space-y-4 p-6">
+  <div class="text-2xl font-bold">Import Audiobook details from {@provider.display_name}</div>
+
+  <.simple_form for={@search_form} phx-submit="search" phx-target={@myself}>
+    <div class="flex items-end gap-2">
+      <.input field={@search_form[:query]} label="Search" container_class="grow" />
+      <.button>Search</.button>
+      <.button name="refresh" value="true" title="Bypass cached results and re-fetch">
+        Re-fetch
+      </.button>
+    </div>
+  </.simple_form>
+
+  <.async_result :let={books} assign={@books}>
+    <:loading>
+      <.loading>Searching books...</.loading>
+    </:loading>
+
+    <:failed :let={failure}>
+      <.error>There was an error searching {@provider.display_name} for books: {failure}</.error>
+    </:failed>
+
+    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+      <div class="space-y-2">
+        <.label>Select book ({length(books)} results)</.label>
+        <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>
+          <:option :let={book}>
+            <.book_card book={book} />
+          </:option>
+        </.rich_select>
+      </div>
+    </.simple_form>
+
+    <.simple_form
+      :if={@selected_book}
+      for={@form}
+      phx-submit="import"
+      phx-target={@myself}
+      container_class="!space-y-0"
+    >
+      <.import_form_row :if={@selected_book.published} field={@form[:use_published]} label="Published">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+          {display_date(@selected_book.published)}
+        </div>
+      </.import_form_row>
+
+      <.import_form_row :if={@selected_book.publisher} field={@form[:use_publisher]} label="Publisher">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+          {@selected_book.publisher}
+        </div>
+      </.import_form_row>
+
+      <.import_form_row :if={@selected_book.description} field={@form[:use_description]} label="Description">
+        <.markdown
+          content={@selected_book.description}
+          class="max-h-64 max-w-max overflow-y-auto rounded-sm border border-zinc-600 bg-zinc-800 p-2"
+        />
+      </.import_form_row>
+
+      <.import_form_row :if={@matching_narrators != []} field={@form[:use_narrators]} label="Narrators">
+        <div :for={{imported_narrator, existing_narrator} <- @matching_narrators}>
+          <%= if existing_narrator do %>
+            <p class="flex items-center gap-2">
+              <.icon name="fa-circle-check" class="text-brand h-4 w-4 flex-none dark:text-brand-dark" />
+              <span class="font-semibold">Existing narrator</span>
+              {existing_narrator.name}
+            </p>
+          <% else %>
+            <p class="flex items-center gap-2">
+              <.icon name="fa-triangle-exclamation" class="h-4 w-4 flex-none text-amber-600 dark:text-amber-500" />
+              <span class="font-semibold">Missing narrator</span>
+              {imported_narrator.name}
+            </p>
+          <% end %>
+        </div>
+        <p :if={Enum.any?(@matching_narrators, fn {_imported, existing} -> is_nil(existing) end)}>
+          Any missing narrators will be imported with just their names. You can add additional details by visiting <.brand_link navigate={
+            ~p"/admin/people"
+          }>Authors & Narrators</.brand_link>.
+        </p>
+      </.import_form_row>
+
+      <.import_form_row :if={@selected_book.cover_url} field={@form[:use_cover_image]} label="Image">
+        <.image_with_size id={@form[:use_cover_image].id} src={@selected_book.cover_url} class="h-48 rounded-sm" />
+      </.import_form_row>
+
+      <:actions>
+        <.button class="mt-2">Import</.button>
+        <.button type="button" color={:zinc} phx-click={JS.exec("data-cancel", to: "#import-modal")}>
+          Cancel
+        </.button>
+      </:actions>
+    </.simple_form>
+  </.async_result>
+</div>

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
@@ -20,7 +20,7 @@
       <.error>There was an error searching {@provider.display_name} for books: {failure}</.error>
     </:failed>
 
-    <.simple_form for={@select_book_form} phx-change="select-book" phx-target={@myself}>
+    <.simple_form id="select-book-form" for={@select_book_form} phx-change="select-book" phx-target={@myself}>
       <div class="space-y-2">
         <.label>Select book ({length(books)} results)</.label>
         <.rich_select id="book-select" field={@select_book_form[:book_id]} options={books}>

--- a/lib/ambry_web/live/admin/media_live/replace.html.heex
+++ b/lib/ambry_web/live/admin/media_live/replace.html.heex
@@ -34,7 +34,7 @@
       </div>
     </div>
 
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form id="media-replace-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="space-y-2">
         <%= if @local_import_path do %>
           <.tabs

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -1,0 +1,206 @@
+defmodule AmbryWeb.Admin.MetadataLive.Providers do
+  @moduledoc """
+  Admin settings for the metadata provider registry: enable/disable
+  providers, reorder priority, and edit provider settings (base URLs, API
+  tokens) at runtime.
+  """
+
+  use AmbryWeb, :admin_live_view
+
+  alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Registry
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:header_title, "Metadata Providers")
+     |> assign(:page_title, "Metadata Providers")
+     |> load_providers()}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-3xl space-y-8 p-4">
+      <p class="text-zinc-500 dark:text-zinc-400">
+        Providers fill in facts during import; you curate the structure. Priority controls the
+        order providers are offered in import forms. Settings apply immediately; cached responses
+        can be cleared per provider.
+      </p>
+
+      <section :for={{level, title, blurb} <- levels()}>
+        <h2 class="mb-1 text-lg font-bold">{title}</h2>
+        <p class="mb-4 text-sm text-zinc-500 dark:text-zinc-400">{blurb}</p>
+
+        <div class="space-y-4">
+          <div
+            :for={entry <- providers_for_level(@providers, level)}
+            class="rounded-sm border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900"
+          >
+            <div class="flex items-center gap-3">
+              <span class={[
+                "inline-block h-2.5 w-2.5 rounded-full",
+                (entry.enabled && "bg-lime-500") || "bg-zinc-400 dark:bg-zinc-600"
+              ]} />
+              <h3 class="grow font-semibold">{entry.display_name}</h3>
+
+              <.button
+                :if={length(providers_for_level(@providers, level)) > 1}
+                phx-click="move"
+                phx-value-id={entry.id}
+                phx-value-direction="up"
+                class="!px-2 !py-1"
+                title="Higher priority"
+              >
+                <.icon name="fa-chevron-up" class="h-3 w-3" />
+              </.button>
+              <.button
+                :if={length(providers_for_level(@providers, level)) > 1}
+                phx-click="move"
+                phx-value-id={entry.id}
+                phx-value-direction="down"
+                class="!px-2 !py-1"
+                title="Lower priority"
+              >
+                <.icon name="fa-chevron-down" class="h-3 w-3" />
+              </.button>
+
+              <.button phx-click="toggle" phx-value-id={entry.id} class="!px-2 !py-1">
+                {(entry.enabled && "Disable") || "Enable"}
+              </.button>
+            </div>
+
+            <div class="mt-2 flex flex-wrap gap-2">
+              <span
+                :for={capability <- entry.capabilities}
+                class="rounded-sm bg-zinc-200 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+              >
+                {capability_label(capability)}
+              </span>
+            </div>
+
+            <form
+              :if={entry.module.config_fields() != []}
+              phx-submit="save-config"
+              class="mt-4 space-y-4"
+            >
+              <input type="hidden" name="provider_id" value={entry.id} />
+              <div :for={field <- entry.module.config_fields()}>
+                <.input
+                  type={(field.type == :secret && "password") || "text"}
+                  label={field.label}
+                  name={"config[#{field.key}]"}
+                  value={display_value(entry.config[field.key], field)}
+                  placeholder={field.default}
+                />
+                <p :if={field.help} class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                  {field.help}
+                </p>
+              </div>
+              <div class="flex gap-2">
+                <.button type="submit">Save</.button>
+                <.button
+                  type="button"
+                  phx-click="clear-cache"
+                  phx-value-id={entry.id}
+                  data-confirm={"Clear all cached #{entry.display_name} responses?"}
+                >
+                  Clear cache
+                </.button>
+              </div>
+            </form>
+
+            <div :if={entry.module.config_fields() == []} class="mt-4">
+              <.button
+                type="button"
+                phx-click="clear-cache"
+                phx-value-id={entry.id}
+                data-confirm={"Clear all cached #{entry.display_name} responses?"}
+              >
+                Clear cache
+              </.button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("toggle", %{"id" => provider_id}, socket) do
+    {:ok, entry} = Registry.fetch(provider_id)
+    {:ok, _row} = Registry.update(provider_id, %{enabled: !entry.enabled})
+
+    {:noreply, load_providers(socket)}
+  end
+
+  def handle_event("move", %{"id" => provider_id, "direction" => direction}, socket) do
+    entries = socket.assigns.providers
+    ids = Enum.map(entries, & &1.id)
+    index = Enum.find_index(ids, &(&1 == provider_id))
+
+    swap_with =
+      case direction do
+        "up" -> index - 1
+        "down" -> index + 1
+      end
+
+    if swap_with in 0..(length(ids) - 1)//1 do
+      reordered =
+        ids
+        |> List.replace_at(index, Enum.at(ids, swap_with))
+        |> List.replace_at(swap_with, provider_id)
+
+      reordered
+      |> Enum.with_index()
+      |> Enum.each(fn {id, priority} ->
+        {:ok, _row} = Registry.update(id, %{priority: priority})
+      end)
+    end
+
+    {:noreply, load_providers(socket)}
+  end
+
+  def handle_event("save-config", %{"provider_id" => provider_id} = params, socket) do
+    {:ok, _row} = Registry.update(provider_id, %{config: params["config"] || %{}})
+
+    {:noreply,
+     socket
+     |> load_providers()
+     |> put_flash(:info, "Provider settings saved.")}
+  end
+
+  def handle_event("clear-cache", %{"id" => provider_id}, socket) do
+    Providers.clear_cache(provider_id)
+
+    {:noreply, put_flash(socket, :info, "Cache cleared.")}
+  end
+
+  defp load_providers(socket) do
+    assign(socket, :providers, Registry.all())
+  end
+
+  defp providers_for_level(providers, level) do
+    Enum.filter(providers, &(&1.level == level))
+  end
+
+  defp levels do
+    [
+      {:work, "Work-level providers",
+       "Books, authors, and series — the abstract side of the library."},
+      {:recording, "Recording-level providers",
+       "Audiobook releases — narrators, square covers, and chapters, keyed by ASIN."}
+    ]
+  end
+
+  defp capability_label(:book_search), do: "book search"
+  defp capability_label(:book_details), do: "book details"
+  defp capability_label(:author_search), do: "author search"
+  defp capability_label(:author_details), do: "author details"
+  defp capability_label(:chapters), do: "chapters"
+
+  defp display_value(value, %{default: default}) when value == default, do: nil
+  defp display_value(value, _field), do: value
+end

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -80,8 +80,16 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
               </span>
             </div>
 
+            <div :for={{level, message} <- notices(entry)} class="mt-2">
+              <p class={["flex items-center gap-2 text-sm", notice_class(level)]}>
+                <.icon name={notice_icon(level)} class="h-4 w-4 flex-none" />
+                {message}
+              </p>
+            </div>
+
             <form
               :if={entry.module.config_fields() != []}
+              id={"provider-config-#{entry.id}"}
               phx-submit="save-config"
               class="mt-4 space-y-4"
             >
@@ -194,6 +202,16 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
        "Audiobook releases — narrators, square covers, and chapters, keyed by ASIN."}
     ]
   end
+
+  defp notices(entry), do: Ambry.Metadata.Provider.config_notices(entry.module, entry.config)
+
+  defp notice_class(:info), do: "text-zinc-500 dark:text-zinc-400"
+  defp notice_class(:warning), do: "text-amber-600 dark:text-amber-500"
+  defp notice_class(:error), do: "text-red-600 dark:text-red-500"
+
+  defp notice_icon(:info), do: "fa-circle-info"
+  defp notice_icon(:warning), do: "fa-triangle-exclamation"
+  defp notice_icon(:error), do: "fa-circle-exclamation"
 
   defp capability_label(:book_search), do: "book search"
   defp capability_label(:book_details), do: "book details"

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -4,6 +4,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   import AmbryWeb.Admin.UploadHelpers
 
+  alias Ambry.Metadata.Registry
   alias Ambry.People
   alias Ambry.People.Person
   alias AmbryWeb.Admin.PersonLive.Form.ImportForm
@@ -14,7 +15,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     {:ok,
      socket
      |> allow_image_upload(:image)
-     |> assign(import: nil, scraping_available: AmbryScraping.web_scraping_available?())
+     |> assign(import: nil, providers: Registry.enabled(capability: :author_search))
      |> apply_action(socket.assigns.live_action, params)}
   end
 
@@ -47,10 +48,13 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     {:noreply, handle_import_form_params(socket, params)}
   end
 
-  defp handle_import_form_params(socket, %{"import" => type}) do
+  defp handle_import_form_params(socket, %{"import" => provider_id}) do
     query = socket.assigns.form.params["name"] || socket.assigns.person.name
-    import_type = String.to_existing_atom(type)
-    assign(socket, import: %{type: import_type, query: query})
+
+    case Registry.fetch(provider_id) do
+      {:ok, provider} -> assign(socket, import: %{provider: provider, query: query})
+      {:error, :unknown_provider} -> assign(socket, import: nil)
+    end
   end
 
   defp handle_import_form_params(socket, _params) do
@@ -90,12 +94,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     end
   end
 
-  def handle_event("open-import-form", %{"type" => type}, socket) do
-    query = socket.assigns.form.params["name"] || socket.assigns.person.name
-    import_type = String.to_existing_atom(type)
-    socket = assign(socket, import: %{type: import_type, query: query})
-
-    {:noreply, socket}
+  def handle_event("open-import-form", %{"type" => provider_id}, socket) do
+    {:noreply, handle_import_form_params(socket, %{"import" => provider_id})}
   end
 
   def handle_event("cancel-upload", %{"ref" => ref}, socket) do

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -10,7 +10,7 @@
   </.modal>
 
   <div class="max-w-3xl">
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form id="person-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
         <.input field={@form[:name]} label="Name" />
 

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -1,6 +1,12 @@
 <.layout title={@page_title} user={@current_user}>
   <.modal :if={@import} id="import-modal" show on_cancel={close_import_form(@person)}>
-    <.live_component id="import-form" module={ImportForm} type={@import.type} query={@import.query} person={@person} />
+    <.live_component
+      id="import-form"
+      module={ImportForm}
+      provider={@import.provider}
+      query={@import.query}
+      person={@person}
+    />
   </.modal>
 
   <div class="max-w-3xl">
@@ -8,25 +14,17 @@
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
         <.input field={@form[:name]} label="Name" />
 
-        <div class="row-start-1 space-y-2 sm:col-start-2">
+        <div :if={@providers != []} class="row-start-1 space-y-2 sm:col-start-2">
           <.label>Import from:</.label>
           <div class="flex items-center gap-2">
             <.button
-              :if={@scraping_available}
+              :for={provider <- @providers}
               color={:zinc}
               class="flex items-center gap-1"
               type="button"
-              phx-click={open_import_form(@person, "goodreads")}
+              phx-click={open_import_form(@person, provider.id)}
             >
-              <.icon name="fa-brands-goodreads" class="h-4 w-4 text-current" /> GoodReads
-            </.button>
-            <.button
-              color={:zinc}
-              class="flex items-center gap-1"
-              type="button"
-              phx-click={open_import_form(@person, "audible")}
-            >
-              <.icon name="fa-brands-audible" class="h-4 w-4 text-current" /> Audible
+              {provider.display_name}
             </.button>
           </div>
         </div>

--- a/lib/ambry_web/live/admin/person_live/form/import_form.ex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.ex
@@ -22,6 +22,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
      |> assign(
        authors: AsyncResult.loading(),
        selected_author: AsyncResult.loading(),
+       refresh: false,
        search_form: to_form(%{"query" => query}, as: :search),
        select_author_form: to_form(%{}, as: :select_author),
        form: to_form(init_import_form_params(person), as: :import)
@@ -32,13 +33,15 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
   @impl Phoenix.LiveComponent
   def handle_async(:search, {:ok, authors}, socket) do
     [first_author | _rest] = authors
-    %{provider: provider} = socket.assigns
+    # a Re-fetch search carries its refresh through to the auto-selected
+    # author's details fetch — otherwise stale cached details survive
+    %{provider: provider, refresh: refresh} = socket.assigns
 
     {:noreply,
      socket
-     |> assign(authors: AsyncResult.ok(socket.assigns.authors, authors))
+     |> assign(authors: AsyncResult.ok(socket.assigns.authors, authors), refresh: false)
      |> assign(select_author_form: to_form(%{"author_id" => first_author.id}, as: :select_author))
-     |> start_async(:select_author, fn -> select_author(provider.id, first_author) end)}
+     |> start_async(:select_author, fn -> select_author(provider.id, first_author, refresh) end)}
   end
 
   def handle_async(:search, {:exit, {:shutdown, :cancel}}, socket) do
@@ -78,6 +81,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
      |> assign(
        authors: AsyncResult.loading(),
        selected_author: AsyncResult.loading(),
+       refresh: refresh,
        search_form: to_form(%{"query" => query}, as: :search)
      )
      |> cancel_async(:search)
@@ -138,8 +142,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
     end
   end
 
-  defp select_author(provider_id, author) do
-    case Providers.author_details(provider_id, author.id) do
+  defp select_author(provider_id, author, refresh \\ false) do
+    case Providers.author_details(provider_id, author.id, refresh: refresh) do
       {:ok, author} -> author
       {:error, reason} -> raise "Unhandled error: #{inspect(reason)}"
     end

--- a/lib/ambry_web/live/admin/person_live/form/import_form.ex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.ex
@@ -4,8 +4,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
 
   import AmbryWeb.Admin.Components
 
-  alias Ambry.Metadata.Audible
-  alias Ambry.Metadata.GoodReads
+  alias Ambry.Metadata.Providers
   alias Phoenix.LiveView.AsyncResult
 
   @impl Phoenix.LiveComponent
@@ -15,7 +14,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
 
   @impl Phoenix.LiveComponent
   def update(assigns, socket) do
-    %{type: type, person: person, query: query} = assigns
+    %{provider: provider, person: person, query: query} = assigns
 
     {:ok,
      socket
@@ -27,19 +26,19 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
        select_author_form: to_form(%{}, as: :select_author),
        form: to_form(init_import_form_params(person), as: :import)
      )
-     |> start_async(:search, fn -> search(type, query) end)}
+     |> start_async(:search, fn -> search(provider.id, query) end)}
   end
 
   @impl Phoenix.LiveComponent
   def handle_async(:search, {:ok, authors}, socket) do
     [first_author | _rest] = authors
-    %{type: type} = socket.assigns
+    %{provider: provider} = socket.assigns
 
     {:noreply,
      socket
      |> assign(authors: AsyncResult.ok(socket.assigns.authors, authors))
      |> assign(select_author_form: to_form(%{"author_id" => first_author.id}, as: :select_author))
-     |> start_async(:select_author, fn -> select_author(type, first_author) end)}
+     |> start_async(:select_author, fn -> select_author(provider.id, first_author) end)}
   end
 
   def handle_async(:search, {:exit, {:shutdown, :cancel}}, socket) do
@@ -70,24 +69,25 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
   end
 
   @impl Phoenix.LiveComponent
-  def handle_event("search", %{"search" => %{"query" => query}}, socket) do
-    %{type: type} = socket.assigns
+  def handle_event("search", %{"search" => %{"query" => query}} = params, socket) do
+    %{provider: provider} = socket.assigns
+    refresh = Map.has_key?(params, "refresh")
 
     {:noreply,
      socket
      |> assign(
-       books: AsyncResult.loading(),
-       selected_book: AsyncResult.loading(),
+       authors: AsyncResult.loading(),
+       selected_author: AsyncResult.loading(),
        search_form: to_form(%{"query" => query}, as: :search)
      )
      |> cancel_async(:search)
-     |> cancel_async(:select_book)
-     |> start_async(:search, fn -> search(type, query) end)}
+     |> cancel_async(:select_author)
+     |> start_async(:search, fn -> search(provider.id, query, refresh) end)}
   end
 
   def handle_event("select-author", %{"select_author" => %{"author_id" => author_id}}, socket) do
     author = Enum.find(socket.assigns.authors.result, &(&1.id == author_id))
-    %{type: type} = socket.assigns
+    %{provider: provider} = socket.assigns
 
     {:noreply,
      socket
@@ -96,7 +96,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
        select_author_form: to_form(%{"author_id" => author.id}, as: :select_author)
      )
      |> cancel_async(:select_author)
-     |> start_async(:select_author, fn -> select_author(type, author) end)}
+     |> start_async(:select_author, fn -> select_author(provider.id, author) end)}
   end
 
   def handle_event("import", %{"import" => import_params}, socket) do
@@ -114,7 +114,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
           Map.merge(acc, %{
             "image_path" => "",
             "image_type" => "url_import",
-            "image_import_url" => author.image
+            "image_import_url" => author.image_url
           })
 
         _else, acc ->
@@ -126,14 +126,11 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
     {:noreply, socket}
   end
 
-  defp search(:goodreads, query), do: do_search(query, &GoodReads.search_authors/1)
-  defp search(:audible, query), do: do_search(query, &Audible.search_authors/1)
-
-  defp do_search(query, query_fun) do
+  defp search(provider_id, query, refresh \\ false) do
     "#{query}"
     |> String.trim()
     |> String.downcase()
-    |> query_fun.()
+    |> then(&Providers.search_authors(provider_id, &1, refresh: refresh))
     |> case do
       {:ok, []} -> raise "No authors found"
       {:ok, authors} -> authors
@@ -141,11 +138,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
     end
   end
 
-  defp select_author(:goodreads, author), do: do_select_author(author, &GoodReads.author/1)
-  defp select_author(:audible, author), do: do_select_author(author, &Audible.author/1)
-
-  defp do_select_author(author, author_fun) do
-    case author_fun.(author.id) do
+  defp select_author(provider_id, author) do
+    case Providers.author_details(provider_id, author.id) do
       {:ok, author} -> author
       {:error, reason} -> raise "Unhandled error: #{inspect(reason)}"
     end
@@ -158,7 +152,4 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
       :image -> {"use_image", is_nil(person.image_path)}
     end)
   end
-
-  defp type_title(:goodreads), do: "GoodReads"
-  defp type_title(:audible), do: "Audible"
 end

--- a/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
@@ -1,10 +1,13 @@
 <div class="mx-auto max-w-3xl space-y-4 p-6">
-  <div class="text-2xl font-bold">Import Author/Narrator from {type_title(@type)}</div>
+  <div class="text-2xl font-bold">Import Author/Narrator from {@provider.display_name}</div>
 
   <.simple_form for={@search_form} phx-submit="search" phx-target={@myself}>
     <div class="flex items-end gap-2">
       <.input field={@search_form[:query]} label="Search" container_class="grow" />
       <.button>Search</.button>
+      <.button name="refresh" value="true" title="Bypass cached results and re-fetch">
+        Re-fetch
+      </.button>
     </div>
   </.simple_form>
 
@@ -14,7 +17,7 @@
     </:loading>
 
     <:failed :let={failure}>
-      <.error>There was an error searching {type_title(@type)} for authors: {failure}</.error>
+      <.error>There was an error searching {@provider.display_name} for authors: {failure}</.error>
     </:failed>
 
     <.simple_form for={@select_author_form} phx-change="select-author" phx-target={@myself}>
@@ -30,7 +33,7 @@
       </:loading>
 
       <:failed :let={failure}>
-        <.error>There was an error fetching author details from {type_title(@type)}: {failure}</.error>
+        <.error>There was an error fetching author details from {@provider.display_name}: {failure}</.error>
       </:failed>
 
       <.simple_form for={@form} phx-submit="import" phx-target={@myself} container_class="!space-y-0">
@@ -47,10 +50,10 @@
           />
         </.import_form_row>
 
-        <.import_form_row :if={author.image} field={@form[:use_image]} label="Image">
+        <.import_form_row :if={author.image_url} field={@form[:use_image]} label="Image">
           <.image_with_size
             id={@form[:use_image].id}
-            src={author.image}
+            src={author.image_url}
             class="h-40 w-40 rounded-full object-cover object-top"
           />
         </.import_form_row>

--- a/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
@@ -53,7 +53,7 @@
         <.import_form_row :if={author.image_url} field={@form[:use_image]} label="Image">
           <.image_with_size
             id={@form[:use_image].id}
-            src={author.image_url}
+            src={proxied_remote_image_url(author.image_url)}
             class="h-40 w-40 rounded-full object-cover object-top"
           />
         </.import_form_row>

--- a/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
@@ -20,7 +20,7 @@
       <.error>There was an error searching {@provider.display_name} for authors: {failure}</.error>
     </:failed>
 
-    <.simple_form for={@select_author_form} phx-change="select-author" phx-target={@myself}>
+    <.simple_form id="select-author-form" for={@select_author_form} phx-change="select-author" phx-target={@myself}>
       <div class="space-y-2">
         <.label>Select author ({length(authors)} results)</.label>
         <.input type="select" field={@select_author_form[:author_id]} options={Enum.map(authors, &{&1.name, &1.id})} />

--- a/lib/ambry_web/live/admin/series_live/form.html.heex
+++ b/lib/ambry_web/live/admin/series_live/form.html.heex
@@ -2,7 +2,7 @@
   <.datalist id="books" options={@books} />
 
   <div class="max-w-3xl">
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form id="series-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <.input field={@form[:name]} label="Name" />
 
       <div class="space-y-2">

--- a/lib/ambry_web/live/admin/user_live/form.html.heex
+++ b/lib/ambry_web/live/admin/user_live/form.html.heex
@@ -1,6 +1,6 @@
 <.layout title={@page_title} user={@current_user}>
   <div class="max-w-3xl">
-    <.simple_form for={@form} phx-change="validate" phx-submit="submit">
+    <.simple_form id="user-form" for={@form} phx-change="validate" phx-submit="submit">
       <.input type="email" field={@form[:email]} label="Email Address" required />
 
       <:actions>

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -197,6 +197,8 @@ defmodule AmbryWeb.Router do
       live "/metadata-providers", MetadataLive.Providers
     end
 
+    get "/image-proxy", ImageProxyController, :show
+
     live_dashboard "/dashboard", metrics: AmbryWeb.Telemetry
     oban_dashboard "/oban"
   end

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -193,6 +193,8 @@ defmodule AmbryWeb.Router do
       live "/users/:user_id/devices", UserDevicesLive.Index
 
       live "/audit", AuditLive.Index, :index
+
+      live "/metadata-providers", MetadataLive.Providers
     end
 
     live_dashboard "/dashboard", metrics: AmbryWeb.Telemetry

--- a/priv/repo/migrations/20260801072710_create_metadata_cache.exs
+++ b/priv/repo/migrations/20260801072710_create_metadata_cache.exs
@@ -1,0 +1,11 @@
+defmodule Ambry.Repo.Migrations.CreateMetadataCache do
+  use Ecto.Migration
+
+  def change do
+    create table(:metadata_cache, primary_key: false) do
+      add :key, :text, primary_key: true
+      add :value, :binary, null: false
+      add :cached_at, :utc_datetime, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260801072711_create_metadata_provider_configs.exs
+++ b/priv/repo/migrations/20260801072711_create_metadata_provider_configs.exs
@@ -1,0 +1,14 @@
+defmodule Ambry.Repo.Migrations.CreateMetadataProviderConfigs do
+  use Ecto.Migration
+
+  def change do
+    create table(:metadata_provider_configs, primary_key: false) do
+      add :provider_id, :text, primary_key: true
+      add :enabled, :boolean, null: false, default: true
+      add :priority, :integer
+      add :config, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime)
+    end
+  end
+end

--- a/test/ambry/metadata/cache_test.exs
+++ b/test/ambry/metadata/cache_test.exs
@@ -20,6 +20,7 @@ defmodule Ambry.Metadata.CacheTest do
     assert {:ok, :new} = Cache.fetch("test:op:arg", fn -> {:ok, :new} end, ttl: -1)
   end
 
+  @tag :capture_log
   test "serves stale value when re-fetch fails" do
     assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
     assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:error, :down} end, ttl: -1)
@@ -31,6 +32,7 @@ defmodule Ambry.Metadata.CacheTest do
     assert {:ok, :new} = Cache.fetch("test:op:arg", fn -> {:ok, :unused} end)
   end
 
+  @tag :capture_log
   test "refresh serves stale on fetch failure" do
     assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
     assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:error, :down} end, refresh: true)

--- a/test/ambry/metadata/cache_test.exs
+++ b/test/ambry/metadata/cache_test.exs
@@ -1,0 +1,48 @@
+defmodule Ambry.Metadata.CacheTest do
+  use Ambry.DataCase
+
+  alias Ambry.Metadata.Cache
+
+  test "caches the result of a successful fetch" do
+    assert {:ok, :value} = Cache.fetch("test:op:arg", fn -> {:ok, :value} end)
+
+    assert {:ok, :value} =
+             Cache.fetch("test:op:arg", fn -> raise "fetch_fun should not be called" end)
+  end
+
+  test "does not cache errors" do
+    assert {:error, :boom} = Cache.fetch("test:op:arg", fn -> {:error, :boom} end)
+    assert {:ok, :value} = Cache.fetch("test:op:arg", fn -> {:ok, :value} end)
+  end
+
+  test "expired entries are re-fetched" do
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
+    assert {:ok, :new} = Cache.fetch("test:op:arg", fn -> {:ok, :new} end, ttl: -1)
+  end
+
+  test "serves stale value when re-fetch fails" do
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:error, :down} end, ttl: -1)
+  end
+
+  test "refresh bypasses a fresh cache entry" do
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
+    assert {:ok, :new} = Cache.fetch("test:op:arg", fn -> {:ok, :new} end, refresh: true)
+    assert {:ok, :new} = Cache.fetch("test:op:arg", fn -> {:ok, :unused} end)
+  end
+
+  test "refresh serves stale on fetch failure" do
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:error, :down} end, refresh: true)
+  end
+
+  test "clear_provider/1 removes only that provider's entries" do
+    assert {:ok, :a} = Cache.fetch("prov_a:op:arg", fn -> {:ok, :a} end)
+    assert {:ok, :b} = Cache.fetch("prov_b:op:arg", fn -> {:ok, :b} end)
+
+    Cache.clear_provider("prov_a")
+
+    assert {:ok, :fresh} = Cache.fetch("prov_a:op:arg", fn -> {:ok, :fresh} end)
+    assert {:ok, :b} = Cache.fetch("prov_b:op:arg", fn -> raise "should be cached" end)
+  end
+end

--- a/test/ambry/metadata/providers/audible_test.exs
+++ b/test/ambry/metadata/providers/audible_test.exs
@@ -1,0 +1,46 @@
+defmodule Ambry.Metadata.Providers.AudibleTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.Audible
+
+  test "normalizes catalog products into Book structs" do
+    product = %AmbryScraping.Audible.Product{
+      id: "B08BKGYQXW",
+      title: "Dungeon Crawler Carl",
+      authors: [%AmbryScraping.Audible.Author{id: "B002D1TN2W", name: "Matt Dinniman"}],
+      narrators: [%AmbryScraping.Audible.Narrator{name: "Jeff Hays"}],
+      series: [
+        %AmbryScraping.Audible.Series{
+          id: "B08X2B5SJ8",
+          sequence: "1",
+          title: "Dungeon Crawler Carl"
+        }
+      ],
+      description: "The apocalypse will be televised!",
+      cover_image: "https://m.media-amazon.com/images/cover.jpg",
+      format: "unabridged",
+      published: ~D[2020-10-27],
+      publisher: "Soundbooth Theater",
+      language: "english"
+    }
+
+    patch(AmbryScraping.Audible, :search_books, fn "dcc" -> {:ok, [product]} end)
+
+    assert {:ok, [%Provider.Book{} = book]} = Audible.search_books("dcc", %{})
+
+    assert book.provider == "audible"
+    assert book.asin == "B08BKGYQXW"
+    assert [%Provider.Contributor{name: "Matt Dinniman", role: "author"}] = book.authors
+    assert [%Provider.Contributor{name: "Jeff Hays", role: "narrator"}] = book.narrators
+    assert [%Provider.Series{name: "Dungeon Crawler Carl", number: "1"}] = book.series
+    assert %Provider.PublishedDate{date: ~D[2020-10-27], display_format: :full} = book.published
+  end
+
+  test "passes through errors" do
+    patch(AmbryScraping.Audible, :search_books, fn _query -> {:error, :whoops} end)
+
+    assert {:error, :whoops} = Audible.search_books("q", %{})
+  end
+end

--- a/test/ambry/metadata/providers/audnexus_test.exs
+++ b/test/ambry/metadata/providers/audnexus_test.exs
@@ -15,6 +15,20 @@ defmodule Ambry.Metadata.Providers.AudnexusTest do
              Audnexus.search_authors("matt", %{})
   end
 
+  test "orders fuzzy search results by name similarity to the query" do
+    patch(AmbryScraping.Audnexus, :search_authors, fn _query ->
+      {:ok,
+       [
+         %AmbryScraping.Audnexus.Author{id: "B1", name: "Conan O'Brien: Life Lessons"},
+         %AmbryScraping.Audnexus.Author{id: "B2", name: "Larry Doyle"},
+         %AmbryScraping.Audnexus.Author{id: "B3", name: "Arthur Conan Doyle"}
+       ]}
+    end)
+
+    assert {:ok, [first | _rest]} = Audnexus.search_authors("arthur conan doyle", %{})
+    assert first.name == "Arthur Conan Doyle"
+  end
+
   test "normalizes author details" do
     patch(AmbryScraping.Audnexus, :author_details, fn "B002D1TN2W" ->
       {:ok,

--- a/test/ambry/metadata/providers/audnexus_test.exs
+++ b/test/ambry/metadata/providers/audnexus_test.exs
@@ -1,0 +1,64 @@
+defmodule Ambry.Metadata.Providers.AudnexusTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.Audnexus
+
+  test "normalizes author search results" do
+    patch(AmbryScraping.Audnexus, :search_authors, fn "matt" ->
+      {:ok, [%AmbryScraping.Audnexus.Author{id: "B002D1TN2W", name: "Matt Dinniman"}]}
+    end)
+
+    assert {:ok,
+            [%Provider.Author{id: "B002D1TN2W", name: "Matt Dinniman", provider: "audnexus"}]} =
+             Audnexus.search_authors("matt", %{})
+  end
+
+  test "normalizes author details" do
+    patch(AmbryScraping.Audnexus, :author_details, fn "B002D1TN2W" ->
+      {:ok,
+       %AmbryScraping.Audnexus.AuthorDetails{
+         id: "B002D1TN2W",
+         name: "Matt Dinniman",
+         description: "Writer and artist.",
+         image: "https://images.audible.com/author.jpg"
+       }}
+    end)
+
+    assert {:ok, %Provider.Author{} = author} = Audnexus.author_details("B002D1TN2W", %{})
+    assert author.description == "Writer and artist."
+    assert author.image_url == "https://images.audible.com/author.jpg"
+  end
+
+  test "normalizes chapters" do
+    patch(AmbryScraping.Audnexus, :book_chapters, fn "B08BKGYQXW" ->
+      {:ok,
+       %AmbryScraping.Audnexus.Chapters{
+         asin: "B08BKGYQXW",
+         brand_intro_duration_ms: 2043,
+         brand_outro_duration_ms: 5061,
+         chapters: [
+           %AmbryScraping.Audnexus.Chapter{
+             title: "Chapter 1",
+             start_offset_ms: 0,
+             start_offset_sec: 0,
+             length_ms: 1_800_000
+           }
+         ]
+       }}
+    end)
+
+    assert {:ok, %Provider.Chapters{asin: "B08BKGYQXW", chapters: [chapter]}} =
+             Audnexus.chapters("B08BKGYQXW", %{})
+
+    assert %Provider.Chapter{title: "Chapter 1", start_offset_ms: 0, length_ms: 1_800_000} =
+             chapter
+  end
+
+  test "passes through not_found" do
+    patch(AmbryScraping.Audnexus, :book_chapters, fn _asin -> {:error, :not_found} end)
+
+    assert {:error, :not_found} = Audnexus.chapters("B000", %{})
+  end
+end

--- a/test/ambry/metadata/providers/hardcover_test.exs
+++ b/test/ambry/metadata/providers/hardcover_test.exs
@@ -1,0 +1,196 @@
+defmodule Ambry.Metadata.Providers.HardcoverTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.Hardcover
+  alias Ambry.Metadata.Providers.Hardcover.Client
+
+  defp fake_token(exp_unix) do
+    payload = %{"exp" => exp_unix} |> Jason.encode!() |> Base.url_encode64(padding: false)
+    "header.#{payload}.signature"
+  end
+
+  defp search_hit do
+    %{
+      "document" => %{
+        "id" => "446681",
+        "title" => "Dungeon Crawler Carl",
+        "description" => "A man. His ex-girlfriend's cat.",
+        "release_date" => "2020-09-21",
+        "image" => %{"url" => "https://assets.hardcover.app/edition/31601422/cover.jpeg"},
+        "featured_series" => %{
+          "position" => 1.0,
+          "details" => "1",
+          "series" => %{"id" => 12_717, "name" => "Dungeon Crawler Carl"}
+        },
+        "contributions" => [
+          %{"author" => %{"id" => 241_306, "name" => "Matt Dinniman"}},
+          %{
+            "contribution" => "Cover Artist",
+            "author" => %{"id" => 256_731, "name" => "Will Staehle"}
+          }
+        ]
+      }
+    }
+  end
+
+  describe "search_books/2" do
+    test "maps hydrated search hits, keeping only author contributions" do
+      patch(Client, :query, fn _config, _query, %{query: "dcc"} ->
+        {:ok, %{"search" => %{"results" => %{"hits" => [search_hit()]}}}}
+      end)
+
+      assert {:ok, [%Provider.Book{} = book]} = Hardcover.search_books("dcc", %{})
+      assert book.provider == "hardcover"
+      assert book.title == "Dungeon Crawler Carl"
+      assert [%Provider.Contributor{name: "Matt Dinniman", role: "author"}] = book.authors
+      assert [%Provider.Series{name: "Dungeon Crawler Carl", number: "1"}] = book.series
+      assert %Provider.PublishedDate{date: ~D[2020-09-21], display_format: :full} = book.published
+      assert book.cover_url =~ "assets.hardcover.app"
+    end
+
+    test "passes through GraphQL errors" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:error, {:graphql, [%{"message" => "field not found"}]}}
+      end)
+
+      assert {:error, {:graphql, _errors}} = Hardcover.search_books("q", %{})
+    end
+  end
+
+  describe "book_details/2" do
+    test "fetches and normalizes a book with its full series list" do
+      patch(Client, :query, fn _config, _query, %{id: 446_681} ->
+        {:ok,
+         %{
+           "books_by_pk" => %{
+             "id" => 446_681,
+             "title" => "Dungeon Crawler Carl",
+             "release_date" => "2020-09-21",
+             "description" => "Desc",
+             "image" => %{"url" => "https://assets.hardcover.app/cover.jpeg"},
+             "book_series" => [
+               %{
+                 "position" => 10.5,
+                 "details" => nil,
+                 "series" => %{"id" => 1, "name" => "Some Series"}
+               }
+             ],
+             "contributions" => [%{"author" => %{"id" => 241_306, "name" => "Matt Dinniman"}}]
+           }
+         }}
+      end)
+
+      assert {:ok, %Provider.Book{} = book} = Hardcover.book_details("446681", %{})
+      assert [%Provider.Series{name: "Some Series", number: "10.5"}] = book.series
+    end
+
+    test "missing books are not_found" do
+      patch(Client, :query, fn _config, _query, _vars -> {:ok, %{"books_by_pk" => nil}} end)
+
+      assert {:error, :not_found} = Hardcover.book_details("999", %{})
+    end
+
+    test "non-numeric ids are rejected without a request" do
+      patch(Client, :query, fn _config, _query, _vars -> flunk("must not be called") end)
+
+      assert {:error, :invalid_id} = Hardcover.book_details("author:123", %{})
+    end
+  end
+
+  describe "author search + details" do
+    test "search_authors maps hits" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:ok,
+         %{
+           "search" => %{
+             "results" => %{
+               "hits" => [
+                 %{
+                   "document" => %{
+                     "id" => "204214",
+                     "name" => "Brandon Sanderson",
+                     "image" => %{"url" => "https://assets.hardcover.app/author.jpeg"}
+                   }
+                 }
+               ]
+             }
+           }
+         }}
+      end)
+
+      assert {:ok, [%Provider.Author{name: "Brandon Sanderson", provider: "hardcover"}]} =
+               Hardcover.search_authors("sanderson", %{})
+    end
+
+    test "author_details maps bio and image" do
+      patch(Client, :query, fn _config, _query, %{id: 241_306} ->
+        {:ok,
+         %{
+           "authors_by_pk" => %{
+             "id" => 241_306,
+             "name" => "Matt Dinniman",
+             "bio" => "Artist and author.",
+             "image" => %{"url" => "https://assets.hardcover.app/author.jpg"}
+           }
+         }}
+      end)
+
+      assert {:ok, %Provider.Author{description: "Artist and author."}} =
+               Hardcover.author_details("241306", %{})
+    end
+  end
+
+  describe "availability and token notices" do
+    test "unavailable without a token, available with one" do
+      refute Hardcover.available?(%{})
+      refute Hardcover.available?(%{api_token: ""})
+      assert Hardcover.available?(%{api_token: fake_token(0)})
+    end
+
+    test "missing token yields a setup warning" do
+      assert [{:warning, message}] = Hardcover.config_notices(%{})
+      assert message =~ "No API token"
+    end
+
+    test "valid far-future token yields an info notice with the expiry date" do
+      exp = DateTime.utc_now() |> DateTime.add(300, :day) |> DateTime.to_unix()
+
+      assert [{:info, message}] = Hardcover.config_notices(%{api_token: fake_token(exp)})
+      assert message =~ "valid until"
+      assert message =~ "expire after one year"
+    end
+
+    test "token expiring soon yields a warning" do
+      exp = DateTime.utc_now() |> DateTime.add(10, :day) |> DateTime.to_unix()
+
+      assert [{:warning, message}] = Hardcover.config_notices(%{api_token: fake_token(exp)})
+      assert message =~ "expires on"
+      assert message =~ "regenerate"
+    end
+
+    test "expired token yields an error" do
+      exp = DateTime.utc_now() |> DateTime.add(-5, :day) |> DateTime.to_unix()
+
+      assert [{:error, message}] = Hardcover.config_notices(%{api_token: fake_token(exp)})
+      assert message =~ "expired on"
+    end
+
+    test "undecodable tokens produce no expiry notice" do
+      assert [] = Hardcover.config_notices(%{api_token: "not-a-jwt"})
+    end
+  end
+
+  describe "token_expiry/1" do
+    test "decodes the exp claim" do
+      assert {:ok, %DateTime{year: 2027}} =
+               Hardcover.token_expiry(fake_token(1_817_137_803))
+    end
+
+    test "rejects malformed tokens" do
+      assert :error = Hardcover.token_expiry("nope")
+      assert :error = Hardcover.token_expiry("a.b.c")
+    end
+  end
+end

--- a/test/ambry/metadata/providers/mocks/rreading_glasses_author.json
+++ b/test/ambry/metadata/providers/mocks/rreading_glasses_author.json
@@ -1,0 +1,12 @@
+{
+ "ForeignId": 999015,
+ "Name": "Matt Dinniman",
+ "Description": "Matt Dinniman is the best-selling writer and artist from Gig Harbor, Washington. He is the published author of dozens of short stories and a gaggle of books. In addition, his art publications\u2014from greeting cards to stationery kits to calendars\u2014can be found in boutique and stationery shops around the world. Also, he strongly feels like a pretentious twat when he writes about himself in third person.",
+ "ImageUrl": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/authors/1378793109i/999015._UY200_CR225,0,200,200_.jpg",
+ "Url": "https://www.goodreads.com/author/show/999015.Matt_Dinniman",
+ "RatingCount": 1830588,
+ "AverageRating": 4.5145655,
+ "Works": [],
+ "Series": [],
+ "KCA": "kca://author/amzn1.gr.author.v1.H7LarilhpCQ5hVOQ8TMJuQ"
+}

--- a/test/ambry/metadata/providers/mocks/rreading_glasses_bulk.json
+++ b/test/ambry/metadata/providers/mocks/rreading_glasses_bulk.json
@@ -1,0 +1,480 @@
+{
+ "Works": [
+  {
+   "ForeignId": 76027608,
+   "Title": "Dungeon Crawler Carl",
+   "FullTitle": "Dungeon Crawler Carl",
+   "ShortTitle": "Dungeon Crawler Carl",
+   "Url": "https://www.goodreads.com/work/76027608-dungeon-crawler-carl",
+   "ReleaseDate": "2020-09-21 07:00:00",
+   "ReleaseDateRaw": "2020-09-21",
+   "Genres": [
+    "Fantasy",
+    "Science Fiction",
+    "Audiobook",
+    "Fiction",
+    "Litrpg",
+    "Humor",
+    "Dystopia",
+    "Adventure",
+    "Book Club",
+    "Comedy"
+   ],
+   "RelatedWorks": [],
+   "Books": [
+    {
+     "ForeignId": 211721806,
+     "Asin": "059382024X",
+     "Description": "The apocalypse will be televised! Welcome to the first book in the wildly popular and addictive Dungeon Crawler Carl series\u2014now with bonus material exclusive to this print edition.\r\n\r\nYou know what\u2019s worse than breaking up with your girlfriend? Being stuck with her prize-winning show cat. And you know what\u2019s worse than that? An alien invasion, the destruction of all man-made structures on Earth, and the systematic exploitation of all the survivors for a sadistic intergalactic game show. That\u2019s what.\r\n\r\nJoin Coast Guard vet Carl and his ex-girlfriend\u2019s cat, Princess Donut, as they try to survive the end of the world\u2014or just get to the next level\u2014in a video game\u2013like, trap-filled fantasy dungeon. A dungeon that\u2019s actually the set of a reality television show with countless viewers across the galaxy. Exploding goblins. Magical potions. Deadly, drug-dealing llamas. This ain\u2019t your ordinary game show.\r\n\r\nWelcome, Crawler. Welcome to the Dungeon. Survival is optional. Keeping the viewers entertained is not.\r\n\r\n\r\nIncludes part one of the exclusive bonus story \u201cBackstage at the Pineapple Cabaret.\u201d",
+     "Isbn13": "9780593820247",
+     "Title": "Dungeon Crawler Carl",
+     "FullTitle": "Dungeon Crawler Carl",
+     "ShortTitle": "Dungeon Crawler Carl",
+     "Language": "eng",
+     "Format": "Hardcover",
+     "EditionInformation": "",
+     "Publisher": "Ace",
+     "ImageUrl": "https://m.media-amazon.com/images/S/compressed.photo.goodreads.com/books/1715780755i/211721806.jpg",
+     "IsEbook": false,
+     "NumPages": 450,
+     "RatingCount": 72451,
+     "AverageRating": 4.4,
+     "Url": "https://www.goodreads.com/book/show/211721806-dungeon-crawler-carl",
+     "ReleaseDate": "2024-08-27 07:00:00",
+     "ReleaseDateRaw": "2024-08-27",
+     "Contributors": [
+      {
+       "ForeignId": 999015,
+       "Role": "Author"
+      }
+     ],
+     "KCA": "kca://book/amzn1.gr.book.v3.DEkFEMTVAOxkOWnD",
+     "RatingSum": 318488
+    }
+   ],
+   "Series": [
+    {
+     "ForeignId": 309211,
+     "Title": "Dungeon Crawler Carl",
+     "Description": "TODO",
+     "LinkItems": [
+      {
+       "ForeignWorkId": 76027608,
+       "PositionInSeries": "1",
+       "SeriesPosition": 1,
+       "Primary": false
+      }
+     ],
+     "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+    }
+   ],
+   "Authors": [
+    {
+     "ForeignId": 999015,
+     "Name": "Matt Dinniman",
+     "Description": "Matt Dinniman is the best-selling writer and artist from Gig Harbor, Washington. He is the published author of dozens of short stories and a gaggle of books. In addition, his art publications\u2014from greeting cards to stationery kits to calendars\u2014can be found in boutique and stationery shops around the world. Also, he strongly feels like a pretentious twat when he writes about himself in third person.",
+     "ImageUrl": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/authors/1378793109i/999015._UY200_CR225,0,200,200_.jpg",
+     "Url": "https://www.goodreads.com/author/show/999015.Matt_Dinniman",
+     "RatingCount": 0,
+     "AverageRating": 0,
+     "Works": [
+      {
+       "ForeignId": 76027608,
+       "Title": "Dungeon Crawler Carl",
+       "FullTitle": "Dungeon Crawler Carl",
+       "ShortTitle": "Dungeon Crawler Carl",
+       "Url": "https://www.goodreads.com/work/76027608-dungeon-crawler-carl",
+       "ReleaseDate": "2020-09-21 07:00:00",
+       "ReleaseDateRaw": "2020-09-21",
+       "Genres": [
+        "Fantasy",
+        "Science Fiction",
+        "Audiobook",
+        "Fiction",
+        "Litrpg",
+        "Humor",
+        "Dystopia",
+        "Adventure",
+        "Book Club",
+        "Comedy"
+       ],
+       "RelatedWorks": [],
+       "Books": null,
+       "Series": [
+        {
+         "ForeignId": 309211,
+         "Title": "Dungeon Crawler Carl",
+         "Description": "TODO",
+         "LinkItems": [
+          {
+           "ForeignWorkId": 76027608,
+           "PositionInSeries": "1",
+           "SeriesPosition": 1,
+           "Primary": false
+          }
+         ],
+         "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+        }
+       ],
+       "Authors": null,
+       "KCA": "kca://work/amzn1.gr.work.v3.ebEzo_4_YMEtmddW",
+       "BestBookId": 211721806,
+       "RatingCount": 0,
+       "AverageRating": 0,
+       "RatingSum": 0
+      }
+     ],
+     "Series": [
+      {
+       "ForeignId": 309211,
+       "Title": "Dungeon Crawler Carl",
+       "Description": "TODO",
+       "LinkItems": [
+        {
+         "ForeignWorkId": 76027608,
+         "PositionInSeries": "1",
+         "SeriesPosition": 1,
+         "Primary": false
+        }
+       ],
+       "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+      }
+     ],
+     "KCA": "kca://author/amzn1.gr.author.v1.H7LarilhpCQ5hVOQ8TMJuQ"
+    }
+   ],
+   "KCA": "kca://work/amzn1.gr.work.v3.ebEzo_4_YMEtmddW",
+   "BestBookId": 211721806,
+   "RatingCount": 0,
+   "AverageRating": 0,
+   "RatingSum": 0
+  },
+  {
+   "ForeignId": 27679568,
+   "Title": "The Way of Kings, Part 1",
+   "FullTitle": "The Way of Kings, Part 1",
+   "ShortTitle": "The Way of Kings, Part 1",
+   "Url": "https://www.goodreads.com/work/27679568-the-way-of-kings-volume-1",
+   "ReleaseDate": "2010-08-31 07:00:00",
+   "ReleaseDateRaw": "2010-08-31",
+   "Genres": [
+    "Fantasy",
+    "Fiction",
+    "High Fantasy",
+    "Epic Fantasy",
+    "Adult",
+    "Audiobook",
+    "Magic",
+    "Science Fiction Fantasy",
+    "Novels",
+    "Adventure"
+   ],
+   "RelatedWorks": [],
+   "Books": [
+    {
+     "ForeignId": 9329354,
+     "Asin": "0575097361",
+     "Description": "Speak again the ancient oaths. Life before death. Strength before weakness, Journey before destination. And return to men the shards they once bore. The knights radiant must stand again.\r\n\r\nRoshar is a world of stone and storms. Uncanny tempests of incredible power sweep across the rocky terrain so frequently that they have shaped ecology and civilization alike. Animals hide in shells, trees pull in branches, and grass retracts into the soilless ground. Cities are built only where the topography offers shelter.\r\n\r\nIt has been centuries since the fall of the ten consecrated orders known as the Knights Radiant, but their Shardblades and Shardplate remain: mystical swords and suits of armor that transform ordinary men into near-invincible warriors. Men trade kingdoms for Shardblades. Wars are fought for them, and won by them.\r\n\r\nOne such war is about to swallow up a soldier, a brightlord and a young woman scholar.",
+     "Isbn13": "9780575097360",
+     "Title": "The Way of Kings, Part 1",
+     "FullTitle": "The Way of Kings, Part 1",
+     "ShortTitle": "The Way of Kings, Part 1",
+     "Language": "eng",
+     "Format": "Paperback",
+     "EditionInformation": "",
+     "Publisher": "Gollancz",
+     "ImageUrl": "https://m.media-amazon.com/images/S/compressed.photo.goodreads.com/books/1357609842i/9329354.jpg",
+     "IsEbook": false,
+     "NumPages": 594,
+     "RatingCount": 27038,
+     "AverageRating": 4.64,
+     "Url": "https://www.goodreads.com/book/show/9329354-the-way-of-kings-part-1",
+     "ReleaseDate": "2011-01-01 08:00:00",
+     "ReleaseDateRaw": "2011-01-01",
+     "Contributors": [
+      {
+       "ForeignId": 38550,
+       "Role": "Author"
+      }
+     ],
+     "KCA": "kca://book/amzn1.gr.book.v1.Da8i5WuIwloaT8FRMZTOkg",
+     "RatingSum": 125344
+    }
+   ],
+   "Series": [
+    {
+     "ForeignId": 49075,
+     "Title": "The Stormlight Archive",
+     "Description": "TODO",
+     "LinkItems": [
+      {
+       "ForeignWorkId": 27679568,
+       "PositionInSeries": "1, Part 1",
+       "SeriesPosition": 1,
+       "Primary": false
+      }
+     ],
+     "KCA": "kca://series/amzn1.gr.series.v1.psZ3a7nPsOQhIriTc7P4Mg"
+    }
+   ],
+   "Authors": [
+    {
+     "ForeignId": 38550,
+     "Name": "Brandon Sanderson",
+     "Description": "I\u2019m Brandon Sanderson, and I write stories of the fantastic: fantasy, science fiction, and thrillers.The release of Wind and Truth in December 2024\u2014the fifth and final book in the first arc of the #1 New York Times bestselling Stormlight Archive series\u2014marks a significant milestone for me. This series is my love letter to the epic fantasy genre, and it\u2019s the type of story I always dreamed epic fantasy could be. Now is a great time to get into the Stormlight Archive since the first arc, which begins with Way of Kings, is complete.During our crowdfunding campaign for the leatherbound edition of Words of Radiance, I announced a fifth Secret Project called Isles of the Emberdark, which came out in the summer of 2025. Coming December 2025 is Tailored Realities, my non-Cosmere short story collection featuring the new novella Moment Zero.Defiant, the fourth and final volume of the series that started with Skyward in 2018, came out in November 2023, capping an already book-filled year that saw the releases of all four Secret Projects: Tress of the Emerald Sea, The Frugal Wizard\u2019s Handbook for Surviving Medieval England, Yumi and the Nightmare Painter, and The Sunlit Man. These four books were all initially offered to backers of the #1 Kickstarter campaign of all time.November 2022 saw the release of The Lost Metal, the seventh volume in the Mistborn saga, and the final volume of the Mistborn Era Two featuring Wax & Wayne. Now that the first arc of the Stormlight Archive is wrapped up, I\u2019ve started writing the third era of Mistborn in 2025.Most readers have noticed that my adult fantasy novels are in a connected universe called the Cosmere. This includes The Stormlight Archive, both Mistborn series, Elantris, Warbreaker, four of the five Secret Projects, and various novellas, including The Emperor\u2019s Soul, which won a Hugo Award in 2013. In November 2016 all of the existing Cosmere short fiction was released in one volume called Arcanum Unbounded. If you\u2019ve read all of my adult fantasy novels and want to see some behind-the-scenes information, that collection is a must-read.I also have three YA series: The Rithmatist (currently at one book), The Reckoners (a trilogy beginning with Steelheart), and Skyward. For young readers I also have my humorous series Alcatraz vs. the Evil Librarians, which had its final book, Bastille vs. the Evil Librarians, released in 2022. Many of my adult readers enjoy all of those books as well, and many of my YA readers enjoy my adult books, usually starting with Mistborn.Additionally, I have a few other novellas that are more on the thriller/sci-fi side. These include the three stories in Legion: The Many Lives of Stephen Leeds, as well as Perfect State and Snapshot. These two novellas are also featured in 2025\u2019s Tailored Realities. There\u2019s a lot of material to go around!Good starting places are Mistborn (a.k.a. The Final Empire), Skyward, Steelheart, The Emperor\u2019s Soul, Tress of the Emerald Sea, and Alcatraz vs. the Evil Librarians. If you\u2019re already a fan of big fat fantasies, you can jump right into The Way of Kings.I was also honored to be able to complete the final three volumes of The Wheel of Time, beginning with The Gathering Storm, using Robert Jordan\u2019s notes.Sample chapters from all of my books are available at brandonsanderson.com\u2014and check out the rest of my site for chapter-by-chapter annotations, deleted scenes, and more.",
+     "ImageUrl": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/authors/1721927489i/38550._UX200_CR0,0,200,200_.jpg",
+     "Url": "https://www.goodreads.com/author/show/38550.Brandon_Sanderson",
+     "RatingCount": 0,
+     "AverageRating": 0,
+     "Works": [
+      {
+       "ForeignId": 27679568,
+       "Title": "The Way of Kings, Part 1",
+       "FullTitle": "The Way of Kings, Part 1",
+       "ShortTitle": "The Way of Kings, Part 1",
+       "Url": "https://www.goodreads.com/work/27679568-the-way-of-kings-volume-1",
+       "ReleaseDate": "2010-08-31 07:00:00",
+       "ReleaseDateRaw": "2010-08-31",
+       "Genres": [
+        "Fantasy",
+        "Fiction",
+        "High Fantasy",
+        "Epic Fantasy",
+        "Adult",
+        "Audiobook",
+        "Magic",
+        "Science Fiction Fantasy",
+        "Novels",
+        "Adventure"
+       ],
+       "RelatedWorks": [],
+       "Books": null,
+       "Series": [
+        {
+         "ForeignId": 49075,
+         "Title": "The Stormlight Archive",
+         "Description": "TODO",
+         "LinkItems": [
+          {
+           "ForeignWorkId": 27679568,
+           "PositionInSeries": "1, Part 1",
+           "SeriesPosition": 1,
+           "Primary": false
+          }
+         ],
+         "KCA": "kca://series/amzn1.gr.series.v1.psZ3a7nPsOQhIriTc7P4Mg"
+        }
+       ],
+       "Authors": null,
+       "KCA": "kca://work/amzn1.gr.work.v1.-6okDVLEtjhiK8_IS8lcBw",
+       "BestBookId": 9329354,
+       "RatingCount": 0,
+       "AverageRating": 0,
+       "RatingSum": 0
+      }
+     ],
+     "Series": [
+      {
+       "ForeignId": 49075,
+       "Title": "The Stormlight Archive",
+       "Description": "TODO",
+       "LinkItems": [
+        {
+         "ForeignWorkId": 27679568,
+         "PositionInSeries": "1, Part 1",
+         "SeriesPosition": 1,
+         "Primary": false
+        }
+       ],
+       "KCA": "kca://series/amzn1.gr.series.v1.psZ3a7nPsOQhIriTc7P4Mg"
+      }
+     ],
+     "KCA": "kca://author/amzn1.gr.author.v1.vzIvVoDHMvUP6APuS-ItJA"
+    }
+   ],
+   "KCA": "kca://work/amzn1.gr.work.v1.-6okDVLEtjhiK8_IS8lcBw",
+   "BestBookId": 9329354,
+   "RatingCount": 0,
+   "AverageRating": 0,
+   "RatingSum": 0
+  }
+ ],
+ "Series": [
+  {
+   "ForeignId": 309211,
+   "Title": "Dungeon Crawler Carl",
+   "Description": "TODO",
+   "LinkItems": [
+    {
+     "ForeignWorkId": 76027608,
+     "PositionInSeries": "1",
+     "SeriesPosition": 1,
+     "Primary": false
+    }
+   ],
+   "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+  },
+  {
+   "ForeignId": 49075,
+   "Title": "The Stormlight Archive",
+   "Description": "TODO",
+   "LinkItems": [
+    {
+     "ForeignWorkId": 27679568,
+     "PositionInSeries": "1, Part 1",
+     "SeriesPosition": 1,
+     "Primary": false
+    }
+   ],
+   "KCA": "kca://series/amzn1.gr.series.v1.psZ3a7nPsOQhIriTc7P4Mg"
+  }
+ ],
+ "Authors": [
+  {
+   "ForeignId": 999015,
+   "Name": "Matt Dinniman",
+   "Description": "Matt Dinniman is the best-selling writer and artist from Gig Harbor, Washington. He is the published author of dozens of short stories and a gaggle of books. In addition, his art publications\u2014from greeting cards to stationery kits to calendars\u2014can be found in boutique and stationery shops around the world. Also, he strongly feels like a pretentious twat when he writes about himself in third person.",
+   "ImageUrl": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/authors/1378793109i/999015._UY200_CR225,0,200,200_.jpg",
+   "Url": "https://www.goodreads.com/author/show/999015.Matt_Dinniman",
+   "RatingCount": 0,
+   "AverageRating": 0,
+   "Works": [
+    {
+     "ForeignId": 76027608,
+     "Title": "Dungeon Crawler Carl",
+     "FullTitle": "Dungeon Crawler Carl",
+     "ShortTitle": "Dungeon Crawler Carl",
+     "Url": "https://www.goodreads.com/work/76027608-dungeon-crawler-carl",
+     "ReleaseDate": "2020-09-21 07:00:00",
+     "ReleaseDateRaw": "2020-09-21",
+     "Genres": [
+      "Fantasy",
+      "Science Fiction",
+      "Audiobook",
+      "Fiction",
+      "Litrpg",
+      "Humor",
+      "Dystopia",
+      "Adventure",
+      "Book Club",
+      "Comedy"
+     ],
+     "RelatedWorks": [],
+     "Books": null,
+     "Series": [
+      {
+       "ForeignId": 309211,
+       "Title": "Dungeon Crawler Carl",
+       "Description": "TODO",
+       "LinkItems": [
+        {
+         "ForeignWorkId": 76027608,
+         "PositionInSeries": "1",
+         "SeriesPosition": 1,
+         "Primary": false
+        }
+       ],
+       "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+      }
+     ],
+     "Authors": null,
+     "KCA": "kca://work/amzn1.gr.work.v3.ebEzo_4_YMEtmddW",
+     "BestBookId": 211721806,
+     "RatingCount": 0,
+     "AverageRating": 0,
+     "RatingSum": 0
+    }
+   ],
+   "Series": [
+    {
+     "ForeignId": 309211,
+     "Title": "Dungeon Crawler Carl",
+     "Description": "TODO",
+     "LinkItems": [
+      {
+       "ForeignWorkId": 76027608,
+       "PositionInSeries": "1",
+       "SeriesPosition": 1,
+       "Primary": false
+      }
+     ],
+     "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+    }
+   ],
+   "KCA": "kca://author/amzn1.gr.author.v1.H7LarilhpCQ5hVOQ8TMJuQ"
+  },
+  {
+   "ForeignId": 38550,
+   "Name": "Brandon Sanderson",
+   "Description": "I\u2019m Brandon Sanderson, and I write stories of the fantastic: fantasy, science fiction, and thrillers.The release of Wind and Truth in December 2024\u2014the fifth and final book in the first arc of the #1 New York Times bestselling Stormlight Archive series\u2014marks a significant milestone for me. This series is my love letter to the epic fantasy genre, and it\u2019s the type of story I always dreamed epic fantasy could be. Now is a great time to get into the Stormlight Archive since the first arc, which begins with Way of Kings, is complete.During our crowdfunding campaign for the leatherbound edition of Words of Radiance, I announced a fifth Secret Project called Isles of the Emberdark, which came out in the summer of 2025. Coming December 2025 is Tailored Realities, my non-Cosmere short story collection featuring the new novella Moment Zero.Defiant, the fourth and final volume of the series that started with Skyward in 2018, came out in November 2023, capping an already book-filled year that saw the releases of all four Secret Projects: Tress of the Emerald Sea, The Frugal Wizard\u2019s Handbook for Surviving Medieval England, Yumi and the Nightmare Painter, and The Sunlit Man. These four books were all initially offered to backers of the #1 Kickstarter campaign of all time.November 2022 saw the release of The Lost Metal, the seventh volume in the Mistborn saga, and the final volume of the Mistborn Era Two featuring Wax & Wayne. Now that the first arc of the Stormlight Archive is wrapped up, I\u2019ve started writing the third era of Mistborn in 2025.Most readers have noticed that my adult fantasy novels are in a connected universe called the Cosmere. This includes The Stormlight Archive, both Mistborn series, Elantris, Warbreaker, four of the five Secret Projects, and various novellas, including The Emperor\u2019s Soul, which won a Hugo Award in 2013. In November 2016 all of the existing Cosmere short fiction was released in one volume called Arcanum Unbounded. If you\u2019ve read all of my adult fantasy novels and want to see some behind-the-scenes information, that collection is a must-read.I also have three YA series: The Rithmatist (currently at one book), The Reckoners (a trilogy beginning with Steelheart), and Skyward. For young readers I also have my humorous series Alcatraz vs. the Evil Librarians, which had its final book, Bastille vs. the Evil Librarians, released in 2022. Many of my adult readers enjoy all of those books as well, and many of my YA readers enjoy my adult books, usually starting with Mistborn.Additionally, I have a few other novellas that are more on the thriller/sci-fi side. These include the three stories in Legion: The Many Lives of Stephen Leeds, as well as Perfect State and Snapshot. These two novellas are also featured in 2025\u2019s Tailored Realities. There\u2019s a lot of material to go around!Good starting places are Mistborn (a.k.a. The Final Empire), Skyward, Steelheart, The Emperor\u2019s Soul, Tress of the Emerald Sea, and Alcatraz vs. the Evil Librarians. If you\u2019re already a fan of big fat fantasies, you can jump right into The Way of Kings.I was also honored to be able to complete the final three volumes of The Wheel of Time, beginning with The Gathering Storm, using Robert Jordan\u2019s notes.Sample chapters from all of my books are available at brandonsanderson.com\u2014and check out the rest of my site for chapter-by-chapter annotations, deleted scenes, and more.",
+   "ImageUrl": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/authors/1721927489i/38550._UX200_CR0,0,200,200_.jpg",
+   "Url": "https://www.goodreads.com/author/show/38550.Brandon_Sanderson",
+   "RatingCount": 0,
+   "AverageRating": 0,
+   "Works": [
+    {
+     "ForeignId": 27679568,
+     "Title": "The Way of Kings, Part 1",
+     "FullTitle": "The Way of Kings, Part 1",
+     "ShortTitle": "The Way of Kings, Part 1",
+     "Url": "https://www.goodreads.com/work/27679568-the-way-of-kings-volume-1",
+     "ReleaseDate": "2010-08-31 07:00:00",
+     "ReleaseDateRaw": "2010-08-31",
+     "Genres": [
+      "Fantasy",
+      "Fiction",
+      "High Fantasy",
+      "Epic Fantasy",
+      "Adult",
+      "Audiobook",
+      "Magic",
+      "Science Fiction Fantasy",
+      "Novels",
+      "Adventure"
+     ],
+     "RelatedWorks": [],
+     "Books": null,
+     "Series": [
+      {
+       "ForeignId": 49075,
+       "Title": "The Stormlight Archive",
+       "Description": "TODO",
+       "LinkItems": [
+        {
+         "ForeignWorkId": 27679568,
+         "PositionInSeries": "1, Part 1",
+         "SeriesPosition": 1,
+         "Primary": false
+        }
+       ],
+       "KCA": "kca://series/amzn1.gr.series.v1.psZ3a7nPsOQhIriTc7P4Mg"
+      }
+     ],
+     "Authors": null,
+     "KCA": "kca://work/amzn1.gr.work.v1.-6okDVLEtjhiK8_IS8lcBw",
+     "BestBookId": 9329354,
+     "RatingCount": 0,
+     "AverageRating": 0,
+     "RatingSum": 0
+    }
+   ],
+   "Series": [
+    {
+     "ForeignId": 49075,
+     "Title": "The Stormlight Archive",
+     "Description": "TODO",
+     "LinkItems": [
+      {
+       "ForeignWorkId": 27679568,
+       "PositionInSeries": "1, Part 1",
+       "SeriesPosition": 1,
+       "Primary": false
+      }
+     ],
+     "KCA": "kca://series/amzn1.gr.series.v1.psZ3a7nPsOQhIriTc7P4Mg"
+    }
+   ],
+   "KCA": "kca://author/amzn1.gr.author.v1.vzIvVoDHMvUP6APuS-ItJA"
+  }
+ ]
+}

--- a/test/ambry/metadata/providers/mocks/rreading_glasses_search.json
+++ b/test/ambry/metadata/providers/mocks/rreading_glasses_search.json
@@ -1,0 +1,1 @@
+[{"bookId":211721806,"workId":76027608,"author":{"id":999015}},{"bookId":212393364,"workId":87846872,"author":{"id":999015}},{"bookId":211721809,"workId":89168980,"author":{"id":999015}},{"bookId":220772908,"workId":90715810,"author":{"id":999015}},{"bookId":220772913,"workId":94982490,"author":{"id":999015}}]

--- a/test/ambry/metadata/providers/mocks/rreading_glasses_work.json
+++ b/test/ambry/metadata/providers/mocks/rreading_glasses_work.json
@@ -1,0 +1,206 @@
+{
+ "ForeignId": 76027608,
+ "Title": "Dungeon Crawler Carl",
+ "FullTitle": "Dungeon Crawler Carl",
+ "ShortTitle": "Dungeon Crawler Carl",
+ "Url": "https://www.goodreads.com/work/76027608-dungeon-crawler-carl",
+ "ReleaseDate": "2020-09-21 07:00:00",
+ "ReleaseDateRaw": "2020-09-21",
+ "Genres": [
+  "Fantasy",
+  "Science Fiction",
+  "Audiobook",
+  "Fiction",
+  "Litrpg",
+  "Humor",
+  "Dystopia",
+  "Adventure",
+  "Book Club",
+  "Comedy"
+ ],
+ "RelatedWorks": [],
+ "Books": [
+  {
+   "ForeignId": 211721806,
+   "Asin": "059382024X",
+   "Description": "The apocalypse will be televised! Welcome to the first book in the wildly popular and addictive Dungeon Crawler Carl series\u2014now with bonus material exclusive to this print edition.\r\n\r\nYou know what\u2019s worse than breaking up with your girlfriend? Being stuck with her prize-winning show cat. And you know what\u2019s worse than that? An alien invasion, the destruction of all man-made structures on Earth, and the systematic exploitation of all the survivors for a sadistic intergalactic game show. That\u2019s what.\r\n\r\nJoin Coast Guard vet Carl and his ex-girlfriend\u2019s cat, Princess Donut, as they try to survive the end of the world\u2014or just get to the next level\u2014in a video game\u2013like, trap-filled fantasy dungeon. A dungeon that\u2019s actually the set of a reality television show with countless viewers across the galaxy. Exploding goblins. Magical potions. Deadly, drug-dealing llamas. This ain\u2019t your ordinary game show.\r\n\r\nWelcome, Crawler. Welcome to the Dungeon. Survival is optional. Keeping the viewers entertained is not.\r\n\r\n\r\nIncludes part one of the exclusive bonus story \u201cBackstage at the Pineapple Cabaret.\u201d",
+   "Isbn13": "9780593820247",
+   "Title": "Dungeon Crawler Carl",
+   "FullTitle": "Dungeon Crawler Carl",
+   "ShortTitle": "Dungeon Crawler Carl",
+   "Language": "eng",
+   "Format": "Hardcover",
+   "EditionInformation": "",
+   "Publisher": "Ace",
+   "ImageUrl": "https://m.media-amazon.com/images/S/compressed.photo.goodreads.com/books/1715780755i/211721806.jpg",
+   "IsEbook": false,
+   "NumPages": 450,
+   "RatingCount": 72451,
+   "AverageRating": 4.4,
+   "Url": "https://www.goodreads.com/book/show/211721806-dungeon-crawler-carl",
+   "ReleaseDate": "2024-08-27 07:00:00",
+   "ReleaseDateRaw": "2024-08-27",
+   "Contributors": [
+    {
+     "ForeignId": 999015,
+     "Role": "Author"
+    }
+   ],
+   "KCA": "kca://book/amzn1.gr.book.v3.DEkFEMTVAOxkOWnD",
+   "RatingSum": 318488
+  },
+  {
+   "ForeignId": 54659324,
+   "Asin": "B08BKGYQXW",
+   "Description": "An alternative cover edition for this ASIN can be found here.\r\n\r\n\r\nThe apocalypse will be televised! Welcome to the first book in the wildly popular and addictive Dungeon Crawler Carl series by Matt Dinniman\u2014now with bonus material exclusive to this print edition.\r\n\r\nYou know what\u2019s worse than breaking up with your girlfriend? Being stuck with her prize-winning show cat. And you know what\u2019s worse than that? An alien invasion, the destruction of all man-made structures on Earth, and the systematic exploitation of all the survivors for a sadistic intergalactic game show. That\u2019s what.\r\n\r\nJoin Coast Guard vet Carl and his ex-girlfriend\u2019s cat, Princess Donut, as they try to survive the end of the world\u2014or just get to the next level\u2014in a video game\u2013like, trap-filled fantasy dungeon. A dungeon that\u2019s actually the set of a reality television show with countless viewers across the galaxy. Exploding goblins. Magical potions. Deadly, drug-dealing llamas. This ain\u2019t your ordinary game show.\r\n\r\nWelcome, Crawler. Welcome to the Dungeon. Survival is optional. Keeping the viewers entertained is not.\r\n\r\nIncludes part one of the exclusive bonus story \u201cBackstage at the Pineapple Cabaret.\u201d",
+   "Title": "Dungeon Crawler Carl",
+   "FullTitle": "Dungeon Crawler Carl",
+   "ShortTitle": "Dungeon Crawler Carl",
+   "Language": "eng",
+   "Format": "Kindle Edition",
+   "EditionInformation": "",
+   "Publisher": "Dandy House",
+   "ImageUrl": "https://m.media-amazon.com/images/S/compressed.photo.goodreads.com/books/1757926884i/54659324.jpg",
+   "IsEbook": true,
+   "NumPages": 464,
+   "RatingCount": 113685,
+   "AverageRating": 4.54,
+   "Url": "https://www.goodreads.com/book/show/54659324-dungeon-crawler-carl",
+   "ReleaseDate": "2020-10-02 07:00:00",
+   "ReleaseDateRaw": "2020-10-02",
+   "Contributors": [
+    {
+     "ForeignId": 999015,
+     "Role": "Author"
+    }
+   ],
+   "KCA": "kca://book/amzn1.gr.book.v3.LJMMREJYe87_fSaa",
+   "RatingSum": 515869
+  },
+  {
+   "ForeignId": 56170112,
+   "Asin": "B08JF5KSQH",
+   "Description": "The apocalypse will be televised!\r\nA man. His ex-girlfriend's cat. A sadistic game show unlike anything in the a dungeon crawl where survival depends on killing your prey in the most entertaining way possible.\r\n\r\nIn a flash, every human-erected construction on Earth - from Buckingham Palace to the tiniest of sheds - collapses in a heap, sinking into the ground. The buildings and all the people inside have all been atomized and transformed into the an 18-level labyrinth filled with traps, monsters, and loot. A dungeon so enormous, it circles the entire globe. Only a few dare venture inside. But once you're in, you can't get out. And what's worse, each level has a time limit. You have but days to find a staircase to the next level down, or it's game over.\r\n\r\nIn this game, it's not about your strength or your dexterity. It's about your followers, your views. Your clout. It's about building an audience and killing those goblins with style. You can't just survive here. You gotta survive big. You gotta fight with vigor, with excitement. You gotta make them stand up and cheer. And if you do have that \"it\" factor, you may just find yourself with a following. That's the only way to truly survive in this game - with the help of the loot boxes dropped upon you by the generous benefactors watching from across the galaxy. They call it Dungeon Crawler World. But for Carl, it's anything but a game.",
+   "Isbn13": "9798688591507",
+   "Title": "Dungeon Crawler Carl",
+   "FullTitle": "Dungeon Crawler Carl",
+   "ShortTitle": "Dungeon Crawler Carl",
+   "Language": "eng",
+   "Format": "Paperback",
+   "EditionInformation": "",
+   "Publisher": "Independently Published",
+   "ImageUrl": "https://m.media-amazon.com/images/S/compressed.photo.goodreads.com/books/1607181251i/56170112.jpg",
+   "IsEbook": false,
+   "NumPages": 433,
+   "RatingCount": 255,
+   "AverageRating": 4.44,
+   "Url": "https://www.goodreads.com/book/show/56170112-dungeon-crawler-carl",
+   "ReleaseDate": "2020-09-21 07:00:00",
+   "ReleaseDateRaw": "2020-09-21",
+   "Contributors": [
+    {
+     "ForeignId": 999015,
+     "Role": "Author"
+    }
+   ],
+   "KCA": "kca://book/amzn1.gr.book.v3.1pQGAbkeaY4FZPmk",
+   "RatingSum": 1132
+  }
+ ],
+ "Series": [
+  {
+   "ForeignId": 309211,
+   "Title": "Dungeon Crawler Carl",
+   "Description": "TODO",
+   "LinkItems": [
+    {
+     "ForeignWorkId": 76027608,
+     "PositionInSeries": "1",
+     "SeriesPosition": 1,
+     "Primary": false
+    }
+   ],
+   "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+  }
+ ],
+ "Authors": [
+  {
+   "ForeignId": 999015,
+   "Name": "Matt Dinniman",
+   "Description": "Matt Dinniman is the best-selling writer and artist from Gig Harbor, Washington. He is the published author of dozens of short stories and a gaggle of books. In addition, his art publications\u2014from greeting cards to stationery kits to calendars\u2014can be found in boutique and stationery shops around the world. Also, he strongly feels like a pretentious twat when he writes about himself in third person.",
+   "ImageUrl": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/authors/1378793109i/999015._UY200_CR225,0,200,200_.jpg",
+   "Url": "https://www.goodreads.com/author/show/999015.Matt_Dinniman",
+   "RatingCount": 0,
+   "AverageRating": 0,
+   "Works": [
+    {
+     "ForeignId": 76027608,
+     "Title": "Dungeon Crawler Carl",
+     "FullTitle": "Dungeon Crawler Carl",
+     "ShortTitle": "Dungeon Crawler Carl",
+     "Url": "https://www.goodreads.com/work/76027608-dungeon-crawler-carl",
+     "ReleaseDate": "2020-09-21 07:00:00",
+     "ReleaseDateRaw": "2020-09-21",
+     "Genres": [
+      "Fantasy",
+      "Science Fiction",
+      "Audiobook",
+      "Fiction",
+      "Litrpg",
+      "Humor",
+      "Dystopia",
+      "Adventure",
+      "Book Club",
+      "Comedy"
+     ],
+     "RelatedWorks": [],
+     "Books": null,
+     "Series": [
+      {
+       "ForeignId": 309211,
+       "Title": "Dungeon Crawler Carl",
+       "Description": "TODO",
+       "LinkItems": [
+        {
+         "ForeignWorkId": 76027608,
+         "PositionInSeries": "1",
+         "SeriesPosition": 1,
+         "Primary": false
+        }
+       ],
+       "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+      }
+     ],
+     "Authors": null,
+     "KCA": "kca://work/amzn1.gr.work.v3.ebEzo_4_YMEtmddW",
+     "BestBookId": 211721806,
+     "RatingCount": 0,
+     "AverageRating": 0,
+     "RatingSum": 0
+    }
+   ],
+   "Series": [
+    {
+     "ForeignId": 309211,
+     "Title": "Dungeon Crawler Carl",
+     "Description": "TODO",
+     "LinkItems": [
+      {
+       "ForeignWorkId": 76027608,
+       "PositionInSeries": "1",
+       "SeriesPosition": 1,
+       "Primary": false
+      }
+     ],
+     "KCA": "kca://series/amzn1.gr.series.v3.JVWSypCYGeq7psky"
+    }
+   ],
+   "KCA": "kca://author/amzn1.gr.author.v1.H7LarilhpCQ5hVOQ8TMJuQ"
+  }
+ ],
+ "KCA": "kca://work/amzn1.gr.work.v3.ebEzo_4_YMEtmddW",
+ "BestBookId": 211721806,
+ "RatingCount": 0,
+ "AverageRating": 0,
+ "RatingSum": 0
+}

--- a/test/ambry/metadata/providers/rreading_glasses/client_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses/client_test.exs
@@ -10,6 +10,15 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses.ClientTest do
     assert {:ok, [%{"bookId" => 1}]} = Client.get_json("https://rg.test", "/search", q: "x")
   end
 
+  test "disables Req's automatic retry (429 Retry-After waits hang interactive imports)" do
+    patch(Req, :get, fn opts ->
+      assert Keyword.get(opts, :retry) == false
+      {:ok, %Req.Response{status: 200, body: []}}
+    end)
+
+    assert {:ok, []} = Client.get_json("https://rg.test", "/search", q: "x")
+  end
+
   test "decodes JSON served as text/plain (public instance behind Cloudflare)" do
     patch(Req, :get, fn _opts ->
       {:ok, %Req.Response{status: 200, body: ~s([{"bookId": 211721806, "workId": 76027608}])}}

--- a/test/ambry/metadata/providers/rreading_glasses/client_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses/client_test.exs
@@ -1,0 +1,42 @@
+defmodule Ambry.Metadata.Providers.RreadingGlasses.ClientTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Providers.RreadingGlasses.Client
+
+  test "returns bodies Req already decoded" do
+    patch(Req, :get, fn _opts -> {:ok, %Req.Response{status: 200, body: [%{"bookId" => 1}]}} end)
+
+    assert {:ok, [%{"bookId" => 1}]} = Client.get_json("https://rg.test", "/search", q: "x")
+  end
+
+  test "decodes JSON served as text/plain (public instance behind Cloudflare)" do
+    patch(Req, :get, fn _opts ->
+      {:ok, %Req.Response{status: 200, body: ~s([{"bookId": 211721806, "workId": 76027608}])}}
+    end)
+
+    assert {:ok, [%{"bookId" => 211_721_806}]} =
+             Client.get_json("https://rg.test", "/search", q: "x")
+  end
+
+  test "a 200 HTML page (unknown route) is an error, not a result" do
+    patch(Req, :get, fn _opts ->
+      {:ok, %Req.Response{status: 200, body: "<!DOCTYPE html>\n<html>..."}}
+    end)
+
+    assert {:error, :unexpected_response_payload} = Client.get_json("https://rg.test", "/nope")
+  end
+
+  test "404 maps to not_found" do
+    patch(Req, :get, fn _opts -> {:ok, %Req.Response{status: 404, body: "HTTP 404"}} end)
+
+    assert {:error, :not_found} = Client.get_json("https://rg.test", "/author/0")
+  end
+
+  test "transport errors pass through" do
+    patch(Req, :get, fn _opts -> {:error, %Mint.TransportError{reason: :nxdomain}} end)
+
+    assert {:error, %Mint.TransportError{reason: :nxdomain}} =
+             Client.get_json("https://rg.test", "/search", q: "x")
+  end
+end

--- a/test/ambry/metadata/providers/rreading_glasses_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses_test.exs
@@ -86,6 +86,57 @@ defmodule Ambry.Metadata.Providers.RreadingGlassesTest do
       assert result.provider == "rreading_glasses"
       assert result.image_url =~ "http"
     end
+
+    test "orders results by name similarity to the query, not book-hit order" do
+      # first search hit is a book *about* Doyle by his bibliographer;
+      # Doyle himself authors the remaining hits
+      search = [
+        %{"bookId" => 1, "workId" => 10, "author" => %{"id" => 111}},
+        %{"bookId" => 2, "workId" => 20, "author" => %{"id" => 222}},
+        %{"bookId" => 3, "workId" => 30, "author" => %{"id" => 222}}
+      ]
+
+      patch(Client, :get_json, fn
+        _base, "/search", _params ->
+          {:ok, search}
+
+        _base, "/author/111", [] ->
+          {:ok, %{"ForeignId" => 111, "Name" => "Richard Lancelyn Green"}}
+
+        _base, "/author/222", [] ->
+          {:ok, %{"ForeignId" => 222, "Name" => "Arthur Conan Doyle"}}
+      end)
+
+      assert {:ok, [first, second]} = RreadingGlasses.search_authors("arthur conan doyle", %{})
+      assert first.name == "Arthur Conan Doyle"
+      assert second.name == "Richard Lancelyn Green"
+    end
+
+    test "strips Goodreads size modifiers from author photos" do
+      author = fixture("rreading_glasses_author.json")
+      assert author["ImageUrl"] =~ "._UY200_"
+
+      patch(Client, :get_json, fn _base, "/author/" <> _id, [] -> {:ok, author} end)
+
+      assert {:ok, %Provider.Author{image_url: image_url}} =
+               RreadingGlasses.author_details("999015", %{})
+
+      refute image_url =~ "._UY200_"
+      assert image_url =~ ~r/999015\.jpg$/
+    end
+
+    test "maps the Goodreads nophoto placeholder to no image" do
+      author = %{
+        "ForeignId" => 1,
+        "Name" => "Richard Lancelyn Green",
+        "ImageUrl" =>
+          "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/nophoto/user/u_700x933.png"
+      }
+
+      patch(Client, :get_json, fn _base, "/author/" <> _id, [] -> {:ok, author} end)
+
+      assert {:ok, %Provider.Author{image_url: nil}} = RreadingGlasses.author_details("1", %{})
+    end
   end
 
   describe "author_details/2" do

--- a/test/ambry/metadata/providers/rreading_glasses_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses_test.exs
@@ -1,0 +1,107 @@
+defmodule Ambry.Metadata.Providers.RreadingGlassesTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.RreadingGlasses
+  alias Ambry.Metadata.Providers.RreadingGlasses.Client
+
+  @mocks Path.join(__DIR__, "mocks")
+
+  defp fixture(name) do
+    @mocks |> Path.join(name) |> File.read!() |> Jason.decode!()
+  end
+
+  describe "search_books/2" do
+    test "searches, hydrates via bulk, and normalizes in search order" do
+      search = fixture("rreading_glasses_search.json")
+      bulk = fixture("rreading_glasses_bulk.json")
+
+      patch(Client, :get_json, fn
+        _base, "/search", _params -> {:ok, search}
+        _base, "/book/bulk", _params -> {:ok, bulk}
+      end)
+
+      assert {:ok, [first | _rest] = books} = RreadingGlasses.search_books("dcc", %{})
+
+      # only hydrated works come back, deduped by work id
+      assert length(books) == length(Enum.uniq_by(books, & &1.id))
+      assert %Provider.Book{provider: "rreading_glasses", title: "Dungeon Crawler Carl"} = first
+      assert [%Provider.Contributor{name: "Matt Dinniman", role: "author"}] = first.authors
+      assert [%Provider.Series{name: "Dungeon Crawler Carl", number: "1"}] = first.series
+      assert first.cover_url =~ "http"
+      assert %Provider.PublishedDate{display_format: :full} = first.published
+      assert Enum.all?(first.editions, &match?(%Provider.Edition{}, &1))
+    end
+
+    test "returns empty list when search has no results" do
+      patch(Client, :get_json, fn _base, "/search", _params -> {:ok, []} end)
+
+      assert {:ok, []} = RreadingGlasses.search_books("zzz", %{})
+    end
+
+    test "passes through client errors" do
+      patch(Client, :get_json, fn _base, "/search", _params ->
+        {:error, :unexpected_response_payload}
+      end)
+
+      assert {:error, :unexpected_response_payload} = RreadingGlasses.search_books("q", %{})
+    end
+  end
+
+  describe "book_details/2" do
+    test "fetches a work and normalizes it with editions" do
+      work = fixture("rreading_glasses_work.json")
+
+      patch(Client, :get_json, fn _base, "/work/76027608", [] -> {:ok, work} end)
+
+      assert {:ok, %Provider.Book{} = book} = RreadingGlasses.book_details("76027608", %{})
+      assert book.id == "76027608"
+      assert book.title == "Dungeon Crawler Carl"
+      assert book.asin
+      assert [%Provider.Series{number: "1"} | _] = book.series
+      refute book.editions == []
+    end
+  end
+
+  describe "search_authors/2" do
+    test "hydrates distinct author ids from book search" do
+      search = fixture("rreading_glasses_search.json")
+      author = fixture("rreading_glasses_author.json")
+
+      patch(Client, :get_json, fn
+        _base, "/search", _params -> {:ok, search}
+        _base, "/author/" <> _id, [] -> {:ok, author}
+      end)
+
+      assert {:ok, [%Provider.Author{} = result]} = RreadingGlasses.search_authors("dcc", %{})
+      assert result.name == "Matt Dinniman"
+      assert result.provider == "rreading_glasses"
+      assert result.image_url =~ "http"
+    end
+  end
+
+  describe "author_details/2" do
+    test "normalizes an author payload" do
+      author = fixture("rreading_glasses_author.json")
+
+      patch(Client, :get_json, fn _base, "/author/999015", [] -> {:ok, author} end)
+
+      assert {:ok, %Provider.Author{id: "999015", name: "Matt Dinniman"}} =
+               RreadingGlasses.author_details("999015", %{})
+    end
+
+    test "returns not_found from the client" do
+      patch(Client, :get_json, fn _base, _path, [] -> {:error, :not_found} end)
+
+      assert {:error, :not_found} = RreadingGlasses.author_details("0", %{})
+    end
+  end
+
+  describe "config" do
+    test "declares a base_url field defaulting to the public instance" do
+      assert [%Provider.ConfigField{key: :base_url, default: "https://api.bookinfo.pro"}] =
+               RreadingGlasses.config_fields()
+    end
+  end
+end

--- a/test/ambry/metadata/providers/rreading_glasses_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses_test.exs
@@ -19,10 +19,17 @@ defmodule Ambry.Metadata.Providers.RreadingGlassesTest do
 
       patch(Client, :get_json, fn
         _base, "/search", _params -> {:ok, search}
-        _base, "/book/bulk", _params -> {:ok, bulk}
+        _base, "/book/bulk?" <> _query, [] -> {:ok, bulk}
       end)
 
       assert {:ok, [first | _rest] = books} = RreadingGlasses.search_books("dcc", %{})
+
+      # every search bookId must reach /book/bulk as its own repeated `id=`
+      # param, hand-built into the path: the endpoint drops all-but-first id
+      # in csv form, and Req's :params option collapses duplicate keys
+      search_ids = search |> Enum.map(& &1["bookId"]) |> Enum.uniq()
+      expected_path = "/book/bulk?" <> Enum.map_join(search_ids, "&", &"id=#{&1}")
+      assert_called(Client.get_json(_, ^expected_path, []))
 
       # only hydrated works come back, deduped by work id
       assert length(books) == length(Enum.uniq_by(books, & &1.id))

--- a/test/ambry/metadata/providers_test.exs
+++ b/test/ambry/metadata/providers_test.exs
@@ -1,0 +1,53 @@
+defmodule Ambry.Metadata.ProvidersTest do
+  use Ambry.DataCase, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Registry
+
+  test "routes to the provider module and caches the normalized result" do
+    book = %Provider.Book{provider: "rreading_glasses", id: "1", title: "A Book"}
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn "carl", _config ->
+      {:ok, [book]}
+    end)
+
+    assert {:ok, [^book]} = Providers.search_books("rreading_glasses", "carl")
+
+    # cached now: the provider module is no longer consulted
+    restore(Ambry.Metadata.Providers.RreadingGlasses)
+    assert {:ok, [^book]} = Providers.search_books("rreading_glasses", "carl")
+  end
+
+  test "refresh: true re-fetches through the provider" do
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
+      {:ok, []}
+    end)
+
+    assert {:ok, []} = Providers.search_books("rreading_glasses", "carl")
+
+    book = %Provider.Book{provider: "rreading_glasses", id: "2", title: "Fresh"}
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
+      {:ok, [book]}
+    end)
+
+    assert {:ok, [^book]} = Providers.search_books("rreading_glasses", "carl", refresh: true)
+  end
+
+  test "unknown providers are rejected" do
+    assert {:error, :unknown_provider} = Providers.search_books("nope", "q")
+  end
+
+  test "disabled providers are rejected" do
+    {:ok, _row} = Registry.update("audible", %{enabled: false})
+
+    assert {:error, :provider_disabled} = Providers.search_books("audible", "q")
+  end
+
+  test "capabilities are enforced" do
+    assert {:error, :unsupported_capability} = Providers.chapters("rreading_glasses", "B08")
+    assert {:error, :unsupported_capability} = Providers.search_books("audnexus", "q")
+  end
+end

--- a/test/ambry/metadata/registry_test.exs
+++ b/test/ambry/metadata/registry_test.exs
@@ -6,8 +6,20 @@ defmodule Ambry.Metadata.RegistryTest do
   test "all/0 returns every known provider enabled by default, in priority order" do
     entries = Registry.all()
 
-    assert Enum.map(entries, & &1.id) == ["rreading_glasses", "audible", "audnexus"]
+    assert Enum.map(entries, & &1.id) == ["rreading_glasses", "hardcover", "audible", "audnexus"]
     assert Enum.all?(entries, & &1.enabled)
+  end
+
+  test "providers requiring config are unavailable until configured" do
+    {:ok, entry} = Registry.fetch("hardcover")
+    refute entry.available
+
+    # unavailable providers are excluded from enabled/1 (import forms)...
+    refute "hardcover" in Enum.map(Registry.enabled(level: :work), & &1.id)
+
+    # ...until a token is stored
+    {:ok, _row} = Registry.update("hardcover", %{config: %{"api_token" => "h.p.s"}})
+    assert "hardcover" in Enum.map(Registry.enabled(level: :work), & &1.id)
   end
 
   test "default configs come from the provider's config fields" do

--- a/test/ambry/metadata/registry_test.exs
+++ b/test/ambry/metadata/registry_test.exs
@@ -1,0 +1,63 @@
+defmodule Ambry.Metadata.RegistryTest do
+  use Ambry.DataCase
+
+  alias Ambry.Metadata.Registry
+
+  test "all/0 returns every known provider enabled by default, in priority order" do
+    entries = Registry.all()
+
+    assert Enum.map(entries, & &1.id) == ["rreading_glasses", "audible", "audnexus"]
+    assert Enum.all?(entries, & &1.enabled)
+  end
+
+  test "default configs come from the provider's config fields" do
+    {:ok, entry} = Registry.fetch("rreading_glasses")
+
+    assert entry.config == %{base_url: "https://api.bookinfo.pro"}
+  end
+
+  test "enabled/1 filters by level and capability" do
+    assert ["rreading_glasses"] = Enum.map(Registry.enabled(level: :work), & &1.id)
+
+    assert ["audnexus"] = Enum.map(Registry.enabled(capability: :chapters), & &1.id)
+
+    assert ["rreading_glasses", "audnexus"] =
+             Enum.map(Registry.enabled(capability: :author_search), & &1.id)
+  end
+
+  test "update/2 persists enabled flag and priority" do
+    {:ok, _row} = Registry.update("audible", %{enabled: false})
+    {:ok, entry} = Registry.fetch("audible")
+
+    refute entry.enabled
+    assert Registry.enabled(level: :recording) |> Enum.map(& &1.id) == ["audnexus"]
+  end
+
+  test "update/2 stores config overrides and drops unknown keys" do
+    {:ok, _row} =
+      Registry.update("rreading_glasses", %{
+        config: %{"base_url" => "http://rg.local:8788", "bogus" => "x"}
+      })
+
+    {:ok, entry} = Registry.fetch("rreading_glasses")
+
+    assert entry.config == %{base_url: "http://rg.local:8788"}
+  end
+
+  test "blank config values fall back to defaults" do
+    {:ok, _row} = Registry.update("rreading_glasses", %{config: %{"base_url" => ""}})
+    {:ok, entry} = Registry.fetch("rreading_glasses")
+
+    assert entry.config == %{base_url: "https://api.bookinfo.pro"}
+  end
+
+  test "fetch/1 returns an error for unknown providers" do
+    assert {:error, :unknown_provider} = Registry.fetch("goodreads")
+  end
+
+  test "priority overrides reorder providers" do
+    {:ok, _row} = Registry.update("audnexus", %{priority: -1})
+
+    assert ["audnexus" | _rest] = Enum.map(Registry.all(), & &1.id)
+  end
+end

--- a/test/ambry_schema/media_test.exs
+++ b/test/ambry_schema/media_test.exs
@@ -1,7 +1,7 @@
 defmodule AmbrySchema.MediaTest do
   use AmbryWeb.ConnCase
 
-  import Absinthe.Relay.Node, only: [to_global_id: 2, from_global_id: 2]
+  import Absinthe.Relay.Node, only: [to_global_id: 2]
   import Ambry.GraphQLSigil
 
   setup :register_and_put_user_api_token
@@ -37,7 +37,7 @@ defmodule AmbrySchema.MediaTest do
       }
     }
     """
-    test "resolves Media fields", %{conn: conn, user: user} do
+    test "resolves Media fields", %{conn: conn} do
       media =
         :media
         |> build(

--- a/test/ambry_web/controllers/admin/image_proxy_controller_test.exs
+++ b/test/ambry_web/controllers/admin/image_proxy_controller_test.exs
@@ -1,0 +1,76 @@
+defmodule AmbryWeb.Admin.ImageProxyControllerTest do
+  use AmbryWeb.ConnCase, async: false
+  use Patch
+
+  import Phoenix.ConnTest, except: [patch: 3]
+
+  setup :register_and_log_in_admin_user
+
+  @jpeg_bytes <<0xFF, 0xD8, 0xFF, 0xE0>> <> "fake-jpeg-data"
+
+  test "proxies a remote image with its content type", %{conn: conn} do
+    patch(Req, :get, fn opts ->
+      assert Keyword.get(opts, :retry) == false
+
+      {:ok,
+       %Req.Response{
+         status: 200,
+         headers: %{"content-type" => ["image/jpeg"]},
+         body: @jpeg_bytes
+       }}
+    end)
+
+    conn = get(conn, ~p"/admin/image-proxy?url=https://images.example.com/author.jpg")
+
+    assert response(conn, 200) == @jpeg_bytes
+    assert response_content_type(conn, :jpeg) =~ "image/jpeg"
+    assert get_resp_header(conn, "cache-control") == ["private, max-age=86400"]
+  end
+
+  test "rejects non-image content types", %{conn: conn} do
+    patch(Req, :get, fn _opts ->
+      {:ok,
+       %Req.Response{
+         status: 200,
+         headers: %{"content-type" => ["text/html"]},
+         body: "<html></html>"
+       }}
+    end)
+
+    conn = get(conn, ~p"/admin/image-proxy?url=https://example.com/page")
+
+    assert response(conn, 404)
+  end
+
+  test "rejects non-http schemes without fetching", %{conn: conn} do
+    patch(Req, :get, fn _opts -> flunk("must not fetch") end)
+
+    conn = get(conn, ~p"/admin/image-proxy?url=file:///etc/passwd")
+
+    assert response(conn, 404)
+  end
+
+  test "upstream errors become 404", %{conn: conn} do
+    patch(Req, :get, fn _opts -> {:error, %Mint.TransportError{reason: :nxdomain}} end)
+
+    conn = get(conn, ~p"/admin/image-proxy?url=https://gone.example.com/x.jpg")
+
+    assert response(conn, 404)
+  end
+
+  test "requires a url param", %{conn: conn} do
+    conn = get(conn, ~p"/admin/image-proxy")
+
+    assert response(conn, 400)
+  end
+end
+
+defmodule AmbryWeb.Admin.ImageProxyControllerAuthTest do
+  use AmbryWeb.ConnCase, async: true
+
+  test "requires an admin user", %{conn: conn} do
+    conn = get(conn, ~p"/admin/image-proxy?url=https://example.com/x.jpg")
+
+    assert redirected_to(conn) == ~p"/users/log_in"
+  end
+end

--- a/test/ambry_web/live/admin/book_live/provider_import_test.exs
+++ b/test/ambry_web/live/admin/book_live/provider_import_test.exs
@@ -1,0 +1,84 @@
+defmodule AmbryWeb.Admin.BookLive.ProviderImportTest do
+  use AmbryWeb.ConnCase, async: false
+  use Patch
+
+  import Phoenix.ConnTest, except: [patch: 3]
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Metadata.Provider
+
+  setup :register_and_log_in_admin_user
+
+  defp result_book do
+    %Provider.Book{
+      provider: "rreading_glasses",
+      id: "76027608",
+      title: "Dungeon Crawler Carl",
+      cover_url: "https://images.gr-assets.com/books/54659324.jpg",
+      published: %Provider.PublishedDate{date: ~D[2020-09-21], display_format: :full},
+      authors: [%Provider.Contributor{id: "999015", name: "Matt Dinniman", role: "author"}],
+      series: [%Provider.Series{id: "309211", name: "Dungeon Crawler Carl", number: "1"}]
+    }
+  end
+
+  test "offers work-level providers plus legacy imports", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/admin/books/new")
+
+    assert html =~ "rreading-glasses"
+    assert html =~ "Audible"
+    # GoodReads only shows when Marionette is configured (never in test)
+    refute html =~ "GoodReads"
+  end
+
+  test "imports a book through a work-level provider", %{conn: conn} do
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
+      {:ok, [result_book()]}
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/new?import=rreading_glasses")
+
+    html = render_async(view)
+    assert html =~ "Dungeon Crawler Carl"
+    assert html =~ "Missing author"
+    assert html =~ "New series"
+
+    view
+    |> form("form[phx-submit='import']", %{
+      "import" => %{
+        "use_title" => "true",
+        "use_published" => "true",
+        "use_authors" => "true",
+        "use_series" => "true"
+      }
+    })
+    |> render_submit()
+
+    html = render(view)
+    assert html =~ ~s(value="Dungeon Crawler Carl")
+    assert html =~ ~s(value="2020-09-21")
+
+    # the author and series were created and matched
+    assert [%{name: "Matt Dinniman"}] = Ambry.Repo.all(Ambry.People.Person)
+    assert [%{name: "Dungeon Crawler Carl"}] = Ambry.Repo.all(Ambry.Books.Series)
+  end
+
+  test "matches existing authors and series instead of duplicating", %{conn: conn} do
+    person = insert(:person, name: "Matt Dinniman")
+    insert(:author, person: person, name: "Matt Dinniman")
+    with_search_index(person)
+
+    series = insert(:series, name: "Dungeon Crawler Carl")
+    insert(:series_book, series: series, book: insert(:book))
+    with_search_index(series)
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
+      {:ok, [result_book()]}
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/new?import=rreading_glasses")
+
+    html = render_async(view)
+    assert html =~ "Existing author"
+    assert html =~ "Existing series"
+  end
+end

--- a/test/ambry_web/live/admin/metadata_live/providers_test.exs
+++ b/test/ambry_web/live/admin/metadata_live/providers_test.exs
@@ -1,0 +1,56 @@
+defmodule AmbryWeb.Admin.MetadataLive.ProvidersTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Metadata.Registry
+
+  setup :register_and_log_in_admin_user
+
+  test "renders all known providers", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/admin/metadata-providers")
+
+    assert html =~ "rreading-glasses"
+    assert html =~ "Audible"
+    assert html =~ "Audnexus"
+  end
+
+  test "toggles a provider off and on", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/metadata-providers")
+
+    view |> element("button[phx-value-id='audible'][phx-click='toggle']") |> render_click()
+
+    {:ok, entry} = Registry.fetch("audible")
+    refute entry.enabled
+
+    view |> element("button[phx-value-id='audible'][phx-click='toggle']") |> render_click()
+
+    {:ok, entry} = Registry.fetch("audible")
+    assert entry.enabled
+  end
+
+  test "saves provider config", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/metadata-providers")
+
+    view
+    |> form("form[phx-submit='save-config']", %{
+      "provider_id" => "rreading_glasses",
+      "config" => %{"base_url" => "http://rg.local:8788"}
+    })
+    |> render_submit()
+
+    {:ok, entry} = Registry.fetch("rreading_glasses")
+    assert entry.config.base_url == "http://rg.local:8788"
+  end
+
+  test "reorders providers within a level", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/metadata-providers")
+
+    view
+    |> element("button[phx-value-id='audnexus'][phx-value-direction='up']")
+    |> render_click()
+
+    ids = Registry.all() |> Enum.map(& &1.id)
+    assert Enum.find_index(ids, &(&1 == "audnexus")) < Enum.find_index(ids, &(&1 == "audible"))
+  end
+end

--- a/test/ambry_web/live/admin/metadata_live/providers_test.exs
+++ b/test/ambry_web/live/admin/metadata_live/providers_test.exs
@@ -33,7 +33,7 @@ defmodule AmbryWeb.Admin.MetadataLive.ProvidersTest do
     {:ok, view, _html} = live(conn, ~p"/admin/metadata-providers")
 
     view
-    |> form("form[phx-submit='save-config']", %{
+    |> form("#provider-config-rreading_glasses", %{
       "provider_id" => "rreading_glasses",
       "config" => %{"base_url" => "http://rg.local:8788"}
     })

--- a/test/ambry_web/live/admin/person_live/import_test.exs
+++ b/test/ambry_web/live/admin/person_live/import_test.exs
@@ -98,6 +98,8 @@ defmodule AmbryWeb.Admin.PersonLive.ImportTest do
     assert html =~ "999015-fresh.jpg"
   end
 
+  # the async search task intentionally raises; capture its crash report
+  @tag :capture_log
   test "renders provider errors in the modal", %{conn: conn} do
     patch(Ambry.Metadata.Providers.RreadingGlasses, :search_authors, fn _query, _config ->
       {:error, :nxdomain}

--- a/test/ambry_web/live/admin/person_live/import_test.exs
+++ b/test/ambry_web/live/admin/person_live/import_test.exs
@@ -1,0 +1,76 @@
+defmodule AmbryWeb.Admin.PersonLive.ImportTest do
+  use AmbryWeb.ConnCase, async: false
+  use Patch
+
+  import Phoenix.ConnTest, except: [patch: 3]
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Metadata.Provider
+
+  setup :register_and_log_in_admin_user
+
+  defp patch_rreading_glasses do
+    author = %Provider.Author{
+      provider: "rreading_glasses",
+      id: "999015",
+      name: "Matt Dinniman",
+      description: "Writer and artist from Gig Harbor.",
+      image_url: "https://images.gr-assets.com/authors/999015.jpg"
+    }
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_authors, fn _query, _config ->
+      {:ok, [author]}
+    end)
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :author_details, fn "999015", _config ->
+      {:ok, author}
+    end)
+
+    author
+  end
+
+  test "offers registry providers as import sources", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/admin/people/new")
+
+    assert html =~ "rreading-glasses"
+    assert html =~ "Audnexus"
+    refute html =~ "GoodReads"
+  end
+
+  test "imports author details through a provider", %{conn: conn} do
+    patch_rreading_glasses()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new?import=rreading_glasses")
+
+    html = render_async(view)
+    assert html =~ "Matt Dinniman"
+    assert html =~ "Writer and artist from Gig Harbor."
+
+    view
+    |> form("form[phx-submit='import']", %{
+      "import" => %{"use_name" => "true", "use_description" => "true", "use_image" => "true"}
+    })
+    |> render_submit()
+
+    html = render(view)
+    assert html =~ "Matt Dinniman"
+    assert html =~ ~s(value="https://images.gr-assets.com/authors/999015.jpg")
+  end
+
+  test "unknown provider in the URL just closes the import modal", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/admin/people/new?import=bogus")
+
+    refute html =~ "Import Author/Narrator"
+  end
+
+  test "renders provider errors in the modal", %{conn: conn} do
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_authors, fn _query, _config ->
+      {:error, :nxdomain}
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new?import=rreading_glasses")
+
+    html = render_async(view)
+    assert html =~ "There was an error searching"
+  end
+end

--- a/test/ambry_web/live/admin/person_live/import_test.exs
+++ b/test/ambry_web/live/admin/person_live/import_test.exs
@@ -9,6 +9,14 @@ defmodule AmbryWeb.Admin.PersonLive.ImportTest do
 
   setup :register_and_log_in_admin_user
 
+  # The import form chains two asyncs (search completion starts the
+  # author-details fetch), and render_async/1 can return between them —
+  # a second call drains the chained async deterministically.
+  defp render_chained_async(view) do
+    render_async(view)
+    render_async(view)
+  end
+
   defp patch_rreading_glasses do
     author = %Provider.Author{
       provider: "rreading_glasses",
@@ -42,7 +50,7 @@ defmodule AmbryWeb.Admin.PersonLive.ImportTest do
 
     {:ok, view, _html} = live(conn, ~p"/admin/people/new?import=rreading_glasses")
 
-    html = render_async(view)
+    html = render_chained_async(view)
     assert html =~ "Matt Dinniman"
     assert html =~ "Writer and artist from Gig Harbor."
 
@@ -61,6 +69,33 @@ defmodule AmbryWeb.Admin.PersonLive.ImportTest do
     {:ok, _view, html} = live(conn, ~p"/admin/people/new?import=bogus")
 
     refute html =~ "Import Author/Narrator"
+  end
+
+  test "Re-fetch bypasses the cache for details too, not just the search", %{conn: conn} do
+    author = patch_rreading_glasses()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new?import=rreading_glasses")
+    render_chained_async(view)
+
+    # both responses are cached now; the provider module is out of the loop
+    restore(Ambry.Metadata.Providers.RreadingGlasses)
+
+    fresh = %{author | image_url: "https://images.gr-assets.com/authors/999015-fresh.jpg"}
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_authors, fn _query, _config ->
+      {:ok, [fresh]}
+    end)
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :author_details, fn "999015", _config ->
+      {:ok, fresh}
+    end)
+
+    view
+    |> form("form[phx-submit='search']", %{"search" => %{"query" => "matt dinniman"}})
+    |> render_submit(%{"refresh" => "true"})
+
+    html = render_chained_async(view)
+    assert html =~ "999015-fresh.jpg"
   end
 
   test "renders provider errors in the modal", %{conn: conn} do


### PR DESCRIPTION
## Summary

The metadata engine for Phase 1 of the roadmap (part of the v1.8.0 milestone). Everything here ships dark: admin-only UI plus additive machinery — no client-visible changes, no schema changes to existing tables, legacy GoodReads/Audible import paths untouched.

### Engine
- `Ambry.Metadata.Provider` behaviour with normalized structs (Book/Author/Series/Edition/Chapters/PublishedDate), declared capabilities, and optional `available?/1` + `config_notices/1` callbacks
- Providers:
  - **rreading-glasses** (work-level, default = public `api.bookinfo.pro`, base URL configurable for self-hosting). Client hardened against the real instance: JSON served as `text/plain`, bulk hydration requiring hand-built repeated `id=` params, 429s with long Retry-After (no auto-retry; fail fast + Re-fetch button), Goodreads image-size-modifier stripping, nophoto placeholder → nil
  - **Hardcover** (work-level, GraphQL, operator token). One-year JWT tokens: expiry decoded locally and surfaced as admin notices (info → 30-day warning → expired error). Unavailable without a token: visible in settings, not offered in import forms
  - **Audible** catalog + **Audnexus** (recording-level) wrapping the existing HTTP clients
- Runtime provider registry (`metadata_provider_configs`): enable/disable, priority per level, per-provider settings from the admin UI
- Unified `metadata_cache` with TTL (7d searches / 30d details), `refresh: true`, and stale-if-error fallback

### Admin UI
- New **Metadata Providers** settings page (enable/reorder/configure providers, per-provider cache clear, config notices)
- Person import form: fully registry-driven — author imports no longer need the headless browser
- Book form: two-step work-level provider import (search results arrive hydrated)
- Media form: Audible import through the provider facade
- All provider import forms get a Re-fetch button (cache bypass, propagated to detail fetches)
- `/admin/image-proxy`: import previews render same-origin (Firefox ETP blocks hotlinked Amazon-CDN images)

### Author-search quality
Candidates ranked by frequency across search hits and ordered by name similarity — searching "arthur conan doyle" preselects Doyle, not his bibliographer.

## Testing
- 584 tests passing (≈50 new: providers, cache TTL, registry, settings page, import flows, image proxy), `mix check` clean
- Live-verified against api.bookinfo.pro and api.hardcover.app (search/hydration/details/author flows)
- Fixed a pre-existing rare test flake (chained `start_async` vs `render_async`)

## Rollout
Merging puts this on staging via the moving-main deploy. No release tag — prod stays on v1.7.0. Remaining for v1.8.0 in follow-ups: chapters form → facade, configurable language filter, then scraper/Firefox deletion once the new paths are verified on staging.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9