### PR TITLE
Phase 1: chapters import via providers + configurable language filter

### DIFF
--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -26,14 +26,29 @@ defmodule Ambry.Metadata.Providers.Audible do
   def capabilities, do: [:book_search]
 
   @impl Provider
-  def config_fields, do: []
+  def config_fields do
+    [
+      %Provider.ConfigField{
+        key: :language,
+        label: "Language",
+        type: :string,
+        default: "english",
+        help:
+          "Only show search results in this language (Audible's language names, e.g. " <>
+            ~s{"english", "german"). Set to "any" to disable filtering. } <>
+            "Clear the cache after changing so old results don't linger."
+      }
+    ]
+  end
 
   @impl Provider
-  def search_books(query, _config) do
-    with {:ok, products} <- Audible.search_books(query) do
+  def search_books(query, config) do
+    with {:ok, products} <- Audible.search_books(query, language: language(config)) do
       {:ok, Enum.map(products, &product_to_book/1)}
     end
   end
+
+  defp language(config), do: config[:language] || "english"
 
   defp product_to_book(product) do
     %Provider.Book{

--- a/lib/ambry_scraping/audible.ex
+++ b/lib/ambry_scraping/audible.ex
@@ -66,6 +66,7 @@ defmodule AmbryScraping.Audible do
   Searches for audiobooks by name.
 
   This function uses the public Audible API to search for audiobooks.
+  See `AmbryScraping.Audible.Products.search/2` for options (`:language`).
   """
-  def search_books(query), do: Products.search(query)
+  def search_books(query, opts \\ []), do: Products.search(query, opts)
 end

--- a/lib/ambry_scraping/audible/products.ex
+++ b/lib/ambry_scraping/audible/products.ex
@@ -30,10 +30,19 @@ defmodule AmbryScraping.Audible.Products do
 
   @doc """
   Returns product details for a given title search query.
-  """
-  def search(""), do: {:ok, []}
 
-  def search(query) do
+  Options:
+
+    * `:language` — only return products in this language (compared
+      case-insensitively against Audible's language names, which are
+      English words like "english", "german"). Defaults to `"english"`;
+      pass `"any"` (or `nil`) to disable filtering.
+  """
+  def search(query, opts \\ [])
+
+  def search("", _opts), do: {:ok, []}
+
+  def search(query, opts) do
     params = %{
       title: query,
       response_groups: Enum.join(@response_groups, ","),
@@ -42,22 +51,31 @@ defmodule AmbryScraping.Audible.Products do
     }
 
     case Client.get("/catalog/products", params) do
-      {:ok, %{status: status} = response} when status in 200..299 -> parse_response(response.body)
-      {:ok, response} -> {:error, response}
-      {:error, reason} -> {:error, reason}
+      {:ok, %{status: status} = response} when status in 200..299 ->
+        parse_response(response.body, Keyword.get(opts, :language, "english"))
+
+      {:ok, response} ->
+        {:error, response}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp parse_response(%{"products" => products}) do
-    {:ok,
-     products
-     |> Enum.map(&parse_product/1)
-     # FUTURE: make language filtering configurable
-     |> Enum.filter(&(&1.language == "english"))}
+  defp parse_response(%{"products" => products}, language) do
+    {:ok, products |> Enum.map(&parse_product/1) |> filter_language(language)}
   end
 
-  defp parse_response(_body) do
+  defp parse_response(_body, _language) do
     {:error, :unexpected_response_payload}
+  end
+
+  defp filter_language(products, language) when language in [nil, "any"], do: products
+
+  defp filter_language(products, language) do
+    language = String.downcase(language)
+
+    Enum.filter(products, &(String.downcase(&1.language || "") == language))
   end
 
   defp parse_product(product) do

--- a/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.ex
+++ b/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.ex
@@ -1,12 +1,23 @@
 defmodule AmbryWeb.Admin.MediaLive.Chapters.AudibleImportForm do
-  @moduledoc false
+  @moduledoc """
+  Chapter import via the metadata provider facade: Audible catalog search
+  for the recording, Audnexus for its chapter list (keyed by ASIN).
+
+  Per the roadmap (1h): provider chapter timestamps describe Audible's
+  retail edition, not the local rip — importing them wholesale is the
+  legacy behavior this form keeps for now; the markers-vs-titles split
+  arrives with the chapter-model work.
+  """
   use AmbryWeb, :live_component
 
   import AmbryWeb.Admin.Components
   import AmbryWeb.Admin.Components.RichSelect, only: [rich_select: 1]
 
-  alias Ambry.Metadata.Audible
+  alias Ambry.Metadata.Providers
   alias Phoenix.LiveView.AsyncResult
+
+  @search_provider "audible"
+  @chapters_provider "audnexus"
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
@@ -21,6 +32,7 @@ defmodule AmbryWeb.Admin.MediaLive.Chapters.AudibleImportForm do
      |> assign(
        books: AsyncResult.loading(),
        chapters: AsyncResult.loading(),
+       refresh: false,
        search_form: to_form(%{"query" => assigns.query}, as: :search),
        select_book_form: to_form(%{}, as: :select_book),
        form: to_form(init_import_form_params(assigns.media), as: :import)
@@ -31,12 +43,15 @@ defmodule AmbryWeb.Admin.MediaLive.Chapters.AudibleImportForm do
   @impl Phoenix.LiveComponent
   def handle_async(:search, {:ok, books}, socket) do
     [first_book | _rest] = books
+    # a Re-fetch search carries its refresh through to the chained
+    # chapters fetch — otherwise stale cached chapters survive
+    refresh = socket.assigns.refresh
 
     {:noreply,
      socket
-     |> assign(books: AsyncResult.ok(socket.assigns.books, books))
+     |> assign(books: AsyncResult.ok(socket.assigns.books, books), refresh: false)
      |> assign(select_book_form: to_form(%{"book_id" => first_book.id}, as: :select_book))
-     |> start_async(:fetch_chapters, fn -> fetch_chapters(first_book) end)}
+     |> start_async(:fetch_chapters, fn -> fetch_chapters(first_book, refresh) end)}
   end
 
   def handle_async(:search, {:exit, {:shutdown, :cancel}}, socket) do
@@ -63,17 +78,20 @@ defmodule AmbryWeb.Admin.MediaLive.Chapters.AudibleImportForm do
   end
 
   @impl Phoenix.LiveComponent
-  def handle_event("search", %{"search" => %{"query" => query}}, socket) do
+  def handle_event("search", %{"search" => %{"query" => query}} = params, socket) do
+    refresh = Map.has_key?(params, "refresh")
+
     {:noreply,
      socket
      |> assign(
        books: AsyncResult.loading(),
        chapters: AsyncResult.loading(),
+       refresh: refresh,
        search_form: to_form(%{"query" => query}, as: :search)
      )
      |> cancel_async(:search)
      |> cancel_async(:fetch_chapters)
-     |> start_async(:search, fn -> search(query) end)}
+     |> start_async(:search, fn -> search(query, refresh) end)}
   end
 
   def handle_event("select-book", %{"select_book" => %{"book_id" => book_id}}, socket) do
@@ -121,11 +139,11 @@ defmodule AmbryWeb.Admin.MediaLive.Chapters.AudibleImportForm do
   defp time(chapter),
     do: chapter.start_offset_ms |> Decimal.new() |> Decimal.div(1000) |> Decimal.round(2)
 
-  defp search(query) do
+  defp search(query, refresh \\ false) do
     "#{query}"
     |> String.trim()
     |> String.downcase()
-    |> Audible.search_books()
+    |> then(&Providers.search_books(@search_provider, &1, refresh: refresh))
     |> case do
       {:ok, []} -> raise "No books found"
       {:ok, books} -> books
@@ -133,8 +151,8 @@ defmodule AmbryWeb.Admin.MediaLive.Chapters.AudibleImportForm do
     end
   end
 
-  defp fetch_chapters(book) do
-    case Audible.chapters(book.id) do
+  defp fetch_chapters(book, refresh \\ false) do
+    case Providers.chapters(@chapters_provider, book.asin, refresh: refresh) do
       {:ok, chapters} -> chapters
       {:error, reason} -> raise "Unhandled error: #{inspect(reason)}"
     end

--- a/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.html.heex
@@ -5,6 +5,9 @@
     <div class="flex items-end gap-2">
       <.input field={@search_form[:query]} label="Search" container_class="grow" />
       <.button>Search</.button>
+      <.button name="refresh" value="true" title="Bypass cached results and re-fetch">
+        Re-fetch
+      </.button>
     </div>
   </.simple_form>
 

--- a/test/ambry/metadata/providers/audible_test.exs
+++ b/test/ambry/metadata/providers/audible_test.exs
@@ -26,7 +26,7 @@ defmodule Ambry.Metadata.Providers.AudibleTest do
       language: "english"
     }
 
-    patch(AmbryScraping.Audible, :search_books, fn "dcc" -> {:ok, [product]} end)
+    patch(AmbryScraping.Audible, :search_books, fn "dcc", _opts -> {:ok, [product]} end)
 
     assert {:ok, [%Provider.Book{} = book]} = Audible.search_books("dcc", %{})
 
@@ -39,8 +39,21 @@ defmodule Ambry.Metadata.Providers.AudibleTest do
   end
 
   test "passes through errors" do
-    patch(AmbryScraping.Audible, :search_books, fn _query -> {:error, :whoops} end)
+    patch(AmbryScraping.Audible, :search_books, fn _query, _opts -> {:error, :whoops} end)
 
     assert {:error, :whoops} = Audible.search_books("q", %{})
+  end
+
+  test "passes the configured language through, defaulting to english" do
+    patch(AmbryScraping.Audible, :search_books, fn _query, opts ->
+      send(self(), {:language, Keyword.get(opts, :language)})
+      {:ok, []}
+    end)
+
+    assert {:ok, []} = Audible.search_books("q", %{})
+    assert_received {:language, "english"}
+
+    assert {:ok, []} = Audible.search_books("q", %{language: "german"})
+    assert_received {:language, "german"}
   end
 end

--- a/test/ambry_scraping/audible_test.exs
+++ b/test/ambry_scraping/audible_test.exs
@@ -88,5 +88,28 @@ defmodule AmbryScraping.AudibleTest do
     test "returns an empty list if given an empty query" do
       assert {:ok, []} = Audible.search_books("")
     end
+
+    test "filters results by language, configurably" do
+      patch(Client, :get, fn _url, _params ->
+        {:ok,
+         %{
+           status: 200,
+           body:
+             "test/ambry_scraping/audible/mocks/search_books_jaws.json"
+             |> File.read!()
+             |> Jason.decode!()
+         }}
+      end)
+
+      # the fixture holds 14 english products and 1 with no language
+      assert {:ok, books} = Audible.search_books("Jaws")
+      assert length(books) == 14
+      assert Enum.all?(books, &(&1.language == "english"))
+
+      assert {:ok, books} = Audible.search_books("Jaws", language: "any")
+      assert length(books) == 15
+
+      assert {:ok, []} = Audible.search_books("Jaws", language: "german")
+    end
   end
 end

--- a/test/ambry_web/live/admin/media_live/chapters_import_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_import_test.exs
@@ -1,0 +1,90 @@
+defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
+  use AmbryWeb.ConnCase, async: false
+  use Patch
+
+  import Phoenix.ConnTest, except: [patch: 3]
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Metadata.Provider
+
+  setup :register_and_log_in_admin_user
+
+  # search completion chains the chapters fetch; drain both asyncs
+  defp render_chained_async(view) do
+    render_async(view)
+    render_async(view)
+  end
+
+  defp insert_media do
+    :media
+    |> build(book: build(:book), chapters: [])
+    |> with_source_files()
+    |> insert()
+  end
+
+  defp patch_providers do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+      {:ok,
+       [
+         %Provider.Book{
+           provider: "audible",
+           id: "B08BKGYQXW",
+           asin: "B08BKGYQXW",
+           title: "Dungeon Crawler Carl",
+           narrators: [%Provider.Contributor{name: "Jeff Hays", role: "narrator"}]
+         }
+       ]}
+    end)
+
+    patch(Ambry.Metadata.Providers.Audnexus, :chapters, fn "B08BKGYQXW", _config ->
+      {:ok,
+       %Provider.Chapters{
+         provider: "audnexus",
+         asin: "B08BKGYQXW",
+         chapters: [
+           %Provider.Chapter{title: "Chapter 1", start_offset_ms: 0},
+           %Provider.Chapter{title: "Chapter 2", start_offset_ms: 1_500_250}
+         ]
+       }}
+    end)
+  end
+
+  test "imports chapters through the provider facade", %{conn: conn} do
+    patch_providers()
+    media = insert_media()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/chapters?import=audible")
+
+    html = render_chained_async(view)
+    assert html =~ "Chapter 1"
+    assert html =~ "Chapter 2"
+
+    view
+    |> form("form[phx-submit='import']", %{"import" => %{"use_chapters" => "true"}})
+    |> render_submit()
+
+    html = render(view)
+    # chapter rows landed in the editor form with ms converted to seconds
+    assert html =~ ~s(value="Chapter 2")
+    assert html =~ ~s(value="1500.25")
+  end
+
+  # the async chapters task intentionally raises; capture its crash report
+  @tag :capture_log
+  test "renders chapter-fetch errors in the modal", %{conn: conn} do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+      {:ok, [%Provider.Book{provider: "audible", id: "B000", asin: "B000", title: "X"}]}
+    end)
+
+    patch(Ambry.Metadata.Providers.Audnexus, :chapters, fn "B000", _config ->
+      {:error, :not_found}
+    end)
+
+    media = insert_media()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/chapters?import=audible")
+
+    html = render_chained_async(view)
+    assert html =~ "There was an error fetching chapters"
+  end
+end


### PR DESCRIPTION
## Summary

Finishes the two remaining server items for the v1.8.0 metadata-engine milestone (follow-up to #1145):

- **Chapters import → provider facade.** The chapter import modal now uses the metadata providers (Audible catalog search, Audnexus chapters by ASIN) with normalized structs, cached with TTL, and gains the Re-fetch button (refresh propagates through the chained chapters fetch). This was the last import UI still on the legacy `Ambry.Metadata.Audible` path.
- **Configurable language filter.** The hard-coded english-only filter in Audible catalog search (the `FUTURE` comment) is now an option: legacy callers keep the english default, and the Audible provider exposes it as a **Language** setting on the admin Metadata Providers page (Audible's language names; "any" disables filtering).

With this merged, everything left for v1.8.0 is the 1e deletion step (GoodReads scrapers, Marionette, Firefox containers) — gated on verifying the new import paths on staging.

## Testing

588 tests passing, `mix check` clean. New coverage: language filtering at the scraping layer (fixture has a language mix), config pass-through in the provider, and end-to-end chapter import + error rendering in the LiveView.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9