### PR TITLE
Phase 1a: composite authors — authors ↔ people many-to-many

### DIFF
--- a/lib/ambry/deletions/deletion.ex
+++ b/lib/ambry/deletions/deletion.ex
@@ -7,7 +7,8 @@ defmodule Ambry.Deletions.Deletion do
 
   schema "deletions" do
     field :type, Ecto.Enum,
-      values: ~w(person author narrator book book_author series series_book media media_narrator)a
+      values:
+        ~w(person author author_person narrator book book_author series series_book media media_narrator)a
 
     field :record_id, :integer
     field :deleted_at, :utc_datetime

--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -7,6 +7,7 @@ defmodule Ambry.People do
     deps: [Ambry],
     exports: [
       Author,
+      AuthorPerson,
       BookAuthor,
       Narrator,
       Person,
@@ -22,6 +23,7 @@ defmodule Ambry.People do
 
   alias Ambry.Paths
   alias Ambry.People.Author
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.Narrator
   alias Ambry.People.Person
   alias Ambry.People.PersonFlat
@@ -34,7 +36,7 @@ defmodule Ambry.People do
   alias Ambry.Thumbnails
   alias Ambry.Thumbnails.GenerateThumbnails
 
-  @person_direct_assoc_preloads [:authors, :narrators]
+  @person_direct_assoc_preloads [:authors, :narrators, author_people: [author: :people]]
 
   def person_standard_preloads, do: @person_direct_assoc_preloads
 
@@ -161,11 +163,46 @@ defmodule Ambry.People do
       changeset = Person.changeset(person, attrs)
 
       with {:ok, updated_person} <- Repo.update(changeset),
+           :ok <- delete_orphaned_authors(person, changeset),
            :ok <- Search.update(updated_person),
            {:ok, _job_or_noop} <- delete_unused_files_async(person, updated_person),
            {:ok, _job_or_noop} <- generate_thumbnails_async(updated_person),
            {:ok, _job} <- broadcast_person_updated(updated_person) do
         {:ok, updated_person}
+      end
+    end)
+  end
+
+  # Unlinking a pen name from a person must not leave an author with no people
+  # behind: authors that lost their last link are deleted (blocked with an
+  # error if they're still in use by books).
+  defp delete_orphaned_authors(%Person{} = person, %Ecto.Changeset{} = changeset) do
+    previously_linked_ids = Enum.map(person.author_people, & &1.author_id)
+
+    orphaned_authors =
+      Repo.all(
+        from author in Author,
+          as: :author,
+          where: author.id in ^previously_linked_ids,
+          where: not exists(from ap in AuthorPerson, where: ap.author_id == parent_as(:author).id)
+      )
+
+    Enum.reduce_while(orphaned_authors, :ok, fn author, :ok ->
+      author
+      |> Author.changeset(%{})
+      |> Repo.delete()
+      |> case do
+        {:ok, _author} ->
+          {:cont, :ok}
+
+        {:error, %Ecto.Changeset{} = author_changeset} ->
+          {message, _opts} = author_changeset.errors[:id]
+
+          {:halt,
+           {:error,
+            changeset
+            |> Ecto.Changeset.add_error(:author_people, "#{author.name}: #{message}")
+            |> Map.put(:action, :update)}}
       end
     end)
   end
@@ -220,14 +257,47 @@ defmodule Ambry.People do
     Repo.transact(fn ->
       changeset = Person.changeset(person, %{})
 
-      with {:ok, deleted_person} <- Repo.delete(changeset),
+      with :ok <- delete_exclusive_authors(person),
+           {:ok, deleted_person} <- Repo.delete(changeset),
            :ok <- Search.delete(deleted_person),
            {:ok, _job_or_noop} <- delete_all_files_async(deleted_person),
            {:ok, _job} <- broadcast_person_deleted(deleted_person) do
         {:ok, deleted_person}
       else
+        {:error, :has_authored_books} ->
+          {:error, :has_authored_books}
+
         {:error, %Ecto.Changeset{} = changeset} ->
           deleted_person_changeset_error(changeset)
+      end
+    end)
+  end
+
+  # Deleting a person cascades their author links away, so authors exclusive
+  # to this person are deleted up front (composite authors shared with other
+  # people survive). Deletion is blocked if an exclusive author still has
+  # books.
+  defp delete_exclusive_authors(%Person{} = person) do
+    exclusive_authors =
+      Repo.all(
+        from author in Author,
+          as: :author,
+          join: ap in assoc(author, :author_people),
+          on: ap.person_id == ^person.id,
+          where:
+            not exists(
+              from other in AuthorPerson,
+                where: other.author_id == parent_as(:author).id and other.person_id != ^person.id
+            )
+      )
+
+    Enum.reduce_while(exclusive_authors, :ok, fn author, :ok ->
+      author
+      |> Author.changeset(%{})
+      |> Repo.delete()
+      |> case do
+        {:ok, _author} -> {:cont, :ok}
+        {:error, %Ecto.Changeset{}} -> {:halt, {:error, :has_authored_books}}
       end
     end)
   end
@@ -246,12 +316,10 @@ defmodule Ambry.People do
   end
 
   defp deleted_person_changeset_error(%Ecto.Changeset{} = changeset) do
-    cond do
-      Keyword.has_key?(changeset.errors, :author) ->
-        {:error, :has_authored_books}
-
-      Keyword.has_key?(changeset.errors, :narrator) ->
-        {:error, :has_narrated_media}
+    if Keyword.has_key?(changeset.errors, :narrator) do
+      {:error, :has_narrated_media}
+    else
+      {:error, changeset}
     end
   end
 
@@ -347,7 +415,7 @@ defmodule Ambry.People do
 
   Raises `Ecto.NoResultsError` if the Author does not exist.
   """
-  def get_author!(id), do: Author |> preload(:person) |> Repo.get!(id)
+  def get_author!(id), do: Author |> preload(:people) |> Repo.get!(id)
 
   @doc """
   Returns all authors for use in `Select` components.

--- a/lib/ambry/people/author.ex
+++ b/lib/ambry/people/author.ex
@@ -2,20 +2,23 @@ defmodule Ambry.People.Author do
   @moduledoc """
   An author writes books.
 
-  Belongs to a Person, so one person can write as multiple authors (pen names).
+  Linked to one or more People, so one person can write as multiple authors
+  (pen names), and one author name can be shared by multiple people (composite
+  pen names like James S.A. Corey).
   """
 
   use Ecto.Schema
 
   import Ecto.Changeset
 
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
-  alias Ambry.People.Person
 
   schema "authors" do
     has_many :book_authors, BookAuthor
     has_many :books, through: [:book_authors, :book]
-    belongs_to :person, Person
+    has_many :author_people, AuthorPerson
+    has_many :people, through: [:author_people, :person]
 
     field :name, :string
 

--- a/lib/ambry/people/author_person.ex
+++ b/lib/ambry/people/author_person.ex
@@ -1,0 +1,60 @@
+defmodule Ambry.People.AuthorPerson do
+  @moduledoc """
+  Join table between authors and people.
+
+  An author (pen name) can belong to multiple people (e.g. James S.A. Corey is
+  Daniel Abraham and Ty Franck), and a person can write under multiple author
+  names.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.People.Author
+  alias Ambry.People.Person
+
+  schema "authors_people" do
+    belongs_to :author, Author
+    belongs_to :person, Person
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(author_person, attrs) do
+    attrs = maybe_put_new_author(author_person, attrs)
+
+    author_person
+    |> cast(attrs, [:author_id])
+    |> cast_assoc(:author)
+    |> validate_author()
+    |> unique_constraint([:author_id, :person_id])
+  end
+
+  # A brand-new row with neither an author_id (link to an existing author) nor
+  # nested author params is a freshly added form row: give it an empty nested
+  # author so the form renders a name input for the new pen name.
+  defp maybe_put_new_author(%__MODULE__{id: nil}, attrs) when is_map(attrs) do
+    has_author? = Map.has_key?(attrs, "author") or Map.has_key?(attrs, :author)
+    author_id = Map.get(attrs, "author_id") || Map.get(attrs, :author_id)
+
+    if has_author? or author_id not in [nil, ""] do
+      attrs
+    else
+      Map.put(attrs, "author", %{})
+    end
+  end
+
+  defp maybe_put_new_author(_author_person, attrs), do: attrs
+
+  # A row either links an existing author (author_id) or carries a nested
+  # author (new pen name / rename of a linked one).
+  defp validate_author(changeset) do
+    if get_field(changeset, :author_id) || get_change(changeset, :author) do
+      changeset
+    else
+      add_error(changeset, :author_id, "can't be blank")
+    end
+  end
+end

--- a/lib/ambry/people/person.ex
+++ b/lib/ambry/people/person.ex
@@ -10,12 +10,13 @@ defmodule Ambry.People.Person do
   import Ecto.Changeset
 
   alias Ambry.Paths
-  alias Ambry.People.Author
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.Narrator
   alias Ambry.Thumbnails
 
   schema "people" do
-    has_many :authors, Author, on_replace: :delete
+    has_many :author_people, AuthorPerson, on_replace: :delete
+    has_many :authors, through: [:author_people, :author]
     has_many :narrators, Narrator, on_replace: :delete
 
     embeds_one :thumbnails, Thumbnails, on_replace: :delete
@@ -24,6 +25,10 @@ defmodule Ambry.People.Person do
     field :description, :string
     field :image_path, :string
 
+    # form-only: staging input for linking an existing author, see
+    # AmbryWeb.Admin.PersonLive.Form
+    field :link_author_id, :integer, virtual: true
+
     timestamps(type: :utc_datetime)
   end
 
@@ -31,9 +36,9 @@ defmodule Ambry.People.Person do
   def changeset(person, attrs) do
     person
     |> cast(attrs, [:name, :description, :image_path])
-    |> cast_assoc(:authors,
-      sort_param: :authors_sort,
-      drop_param: :authors_drop
+    |> cast_assoc(:author_people,
+      sort_param: :author_people_sort,
+      drop_param: :author_people_drop
     )
     |> cast_assoc(:narrators,
       sort_param: :narrators_sort,
@@ -43,7 +48,6 @@ defmodule Ambry.People.Person do
     |> maybe_clear_thumbnails()
     |> validate_required([:name])
     |> validate_image_path()
-    |> foreign_key_constraint(:author, name: "authors_books_author_id_fkey")
     |> foreign_key_constraint(:narrator, name: "media_narrators_narrator_id_fkey")
     |> check_constraint(:thumbnails, name: "thumbnails_original_match_constraint")
   end

--- a/lib/ambry/search/index.ex
+++ b/lib/ambry/search/index.ex
@@ -107,7 +107,7 @@ defmodule Ambry.Search.Index do
       Repo.all(
         from book in Book,
           where: book.id in ^book_ids,
-          preload: [:series, authors: [:person], media: [narrators: [:person]]]
+          preload: [:series, authors: [:people], media: [narrators: [:person]]]
       )
 
     books
@@ -144,7 +144,7 @@ defmodule Ambry.Search.Index do
       Repo.all(
         from series in Series,
           where: series.id in ^series_ids,
-          preload: [:series_books, authors: [:person]]
+          preload: [:series_books, authors: [:people]]
       )
 
     {series_to_insert, series_to_delete} =
@@ -210,7 +210,7 @@ defmodule Ambry.Search.Index do
   defp series_record(series) do
     {secondary_names, secondary_dependencies} = names(series.authors)
     {tertiary_names, tertiary_dependencies} = person_names(series.authors)
-    book_dependencies = Enum.map(series.books, &reference/1)
+    book_dependencies = Enum.flat_map(series.books, &references/1)
     dependencies = Enum.uniq(book_dependencies ++ secondary_dependencies ++ tertiary_dependencies)
 
     %{
@@ -223,23 +223,33 @@ defmodule Ambry.Search.Index do
   end
 
   defp names(structs) do
-    structs
-    |> Enum.map(&{&1.name, reference(&1)})
-    |> Enum.uniq()
-    |> Enum.unzip()
+    names = structs |> Enum.map(& &1.name) |> Enum.uniq()
+    references = structs |> Enum.flat_map(&references/1) |> Enum.uniq()
+
+    {names, references}
   end
 
   defp person_names(authors_or_narrators) do
     authors_or_narrators
-    |> Enum.reject(&(&1.name == &1.person.name))
-    |> Enum.map(&{&1.person.name, reference(&1.person)})
+    |> Enum.flat_map(fn identity ->
+      identity
+      |> people_of()
+      |> Enum.reject(&(&1.name == identity.name))
+    end)
+    |> Enum.map(&{&1.name, Reference.new(&1)})
     |> Enum.uniq()
     |> Enum.unzip()
   end
 
-  defp reference(%Author{person: person}), do: Reference.new(person)
-  defp reference(%Narrator{person: person}), do: Reference.new(person)
-  defp reference(struct), do: Reference.new(struct)
+  defp people_of(%Author{people: people}), do: people
+  defp people_of(%Narrator{person: person}), do: [person]
+
+  defp references(%Author{} = author), do: author |> people_of() |> Enum.map(&Reference.new/1)
+
+  defp references(%Narrator{} = narrator),
+    do: narrator |> people_of() |> Enum.map(&Reference.new/1)
+
+  defp references(struct), do: [Reference.new(struct)]
 
   defp join([]), do: nil
   defp join(items), do: Enum.join(items, " ")

--- a/lib/ambry_schema/people.ex
+++ b/lib/ambry_schema/people.ex
@@ -4,7 +4,7 @@ defmodule AmbrySchema.People do
   use Absinthe.Schema.Notation
   use Absinthe.Relay.Schema.Notation, :modern
 
-  import Absinthe.Resolution.Helpers, only: [dataloader: 1, dataloader: 2]
+  import Absinthe.Resolution.Helpers, only: [dataloader: 1, dataloader: 2, dataloader: 3]
 
   alias AmbrySchema.Resolvers
 
@@ -41,11 +41,28 @@ defmodule AmbrySchema.People do
   node object(:author) do
     field :name, non_null(:string)
 
-    field :person, non_null(:person), resolve: dataloader(Resolvers)
+    field :person, non_null(:person),
+      deprecate: "use `people` instead; an author can be linked to multiple people",
+      resolve:
+        dataloader(Resolvers, :people,
+          args: %{order: :id},
+          callback: fn people, _parent, _args -> {:ok, List.first(people)} end
+        )
+
+    field :people, non_null(list_of(non_null(:person))),
+      resolve: dataloader(Resolvers, :people, args: %{order: :id})
 
     connection field :authored_books, node_type: :book do
       resolve &Resolvers.list_authored_books/3
     end
+
+    field :inserted_at, non_null(:datetime)
+    field :updated_at, non_null(:datetime)
+  end
+
+  node object(:author_person) do
+    field :author, non_null(:author), resolve: dataloader(Resolvers)
+    field :person, non_null(:person), resolve: dataloader(Resolvers)
 
     field :inserted_at, non_null(:datetime)
     field :updated_at, non_null(:datetime)

--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -15,6 +15,7 @@ defmodule AmbrySchema.Resolvers do
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
   alias Ambry.People.Author
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
   alias Ambry.People.Narrator
   alias Ambry.People.Person
@@ -78,6 +79,10 @@ defmodule AmbrySchema.Resolvers do
 
   def people_changed_since(args, _resolution), do: Sync.changes_since(Person, args[:since])
   def authors_changed_since(args, _resolution), do: Sync.changes_since(Author, args[:since])
+
+  def author_people_changed_since(args, _resolution),
+    do: Sync.changes_since(AuthorPerson, args[:since])
+
   def narrators_changed_since(args, _resolution), do: Sync.changes_since(Narrator, args[:since])
   def books_changed_since(args, _resolution), do: Sync.changes_since(Book, args[:since])
 
@@ -138,6 +143,9 @@ defmodule AmbrySchema.Resolvers do
   end
 
   def node(%{type: :author, id: id}, _resolution), do: {:ok, Repo.get(Author, id)}
+
+  def node(%{type: :author_person, id: id}, _resolution), do: {:ok, Repo.get(AuthorPerson, id)}
+
   def node(%{type: :book, id: id}, _resolution), do: {:ok, Repo.get(Book, id)}
   def node(%{type: :book_author, id: id}, _resolution), do: {:ok, Repo.get(BookAuthor, id)}
   def node(%{type: :deletion, id: id}, _resolution), do: {:ok, Repo.get(Deletion, id)}
@@ -149,6 +157,7 @@ defmodule AmbrySchema.Resolvers do
   def node(%{type: :series_book, id: id}, _resolution), do: {:ok, Repo.get(SeriesBook, id)}
 
   def type(%Author{}, _resolution), do: :author
+  def type(%AuthorPerson{}, _resolution), do: :author_person
   def type(%Book{}, _resolution), do: :book
   def type(%BookAuthor{}, _resolution), do: :book_author
   def type(%Deletion{}, _resolution), do: :deletion

--- a/lib/ambry_schema/sync.ex
+++ b/lib/ambry_schema/sync.ex
@@ -11,6 +11,7 @@ defmodule AmbrySchema.Sync do
   enum :deletion_type do
     value :person
     value :author
+    value :author_person
     value :narrator
     value :book
     value :book_author
@@ -46,6 +47,14 @@ defmodule AmbrySchema.Sync do
       middleware AmbrySchema.AuthMiddleware
 
       resolve &Resolvers.authors_changed_since/2
+    end
+
+    field :author_people_changed_since, non_null(list_of(non_null(:author_person))) do
+      arg :since, :datetime
+
+      middleware AmbrySchema.AuthMiddleware
+
+      resolve &Resolvers.author_people_changed_since/2
     end
 
     field :narrators_changed_since, non_null(list_of(non_null(:narrator))) do

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -16,6 +16,7 @@ defmodule AmbryWeb.CoreComponents do
   alias Ambry.Books.Book
   alias Ambry.Books.SeriesBook
   alias Ambry.Media.Media
+  alias Ambry.People.Author
   alias AmbryWeb.Admin.UploadHelpers
   alias AmbryWeb.Components.Autocomplete
   alias Phoenix.HTML.Form
@@ -1241,7 +1242,7 @@ defmodule AmbryWeb.CoreComponents do
   def all_people_links(assigns) do
     ~H"""
     <%= for person_ish <- @people do %>
-      <.link navigate={~p"/people/#{person_ish.person_id}"} class="hover:underline" phx-no-format>
+      <.link navigate={person_ish_path(person_ish)} class="hover:underline" phx-no-format>
         <%= person_ish.name %></.link><span
         class="last:hidden"
         phx-no-format
@@ -1274,7 +1275,7 @@ defmodule AmbryWeb.CoreComponents do
     assigns = assign(assigns, person: person)
 
     ~H"""
-    <.link navigate={~p"/people/#{@person.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person)} class="hover:underline" phx-no-format>
     <%= @person.name %></.link><span phx-no-format>, and a full cast</span>
     """
   end
@@ -1283,7 +1284,7 @@ defmodule AmbryWeb.CoreComponents do
     assigns = assign(assigns, person: person)
 
     ~H"""
-    <.link navigate={~p"/people/#{@person.person_id}"} class="hover:underline">
+    <.link navigate={person_ish_path(@person)} class="hover:underline">
       {@person.name}
     </.link>
     """
@@ -1293,9 +1294,9 @@ defmodule AmbryWeb.CoreComponents do
     assigns = assign(assigns, person1: person1, person2: person2)
 
     ~H"""
-    <.link navigate={~p"/people/#{@person1.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person1)} class="hover:underline" phx-no-format>
       <%= @person1.name %></.link><span phx-no-format>,</span>
-    <.link navigate={~p"/people/#{@person2.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person2)} class="hover:underline" phx-no-format>
       <%= @person2.name %></.link><span phx-no-format>, and a full cast</span>
     """
   end
@@ -1304,9 +1305,9 @@ defmodule AmbryWeb.CoreComponents do
     assigns = assign(assigns, person1: person1, person2: person2)
 
     ~H"""
-    <.link navigate={~p"/people/#{@person1.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person1)} class="hover:underline" phx-no-format>
       <%= @person1.name %></.link><span phx-no-format>,</span>
-    <.link navigate={~p"/people/#{@person2.person_id}"} class="hover:underline">
+    <.link navigate={person_ish_path(@person2)} class="hover:underline">
       {@person2.name}
     </.link>
     """
@@ -1316,9 +1317,9 @@ defmodule AmbryWeb.CoreComponents do
     assigns = assign(assigns, person1: person1, person2: person2, others: Enum.count(rest))
 
     ~H"""
-    <.link navigate={~p"/people/#{@person1.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person1)} class="hover:underline" phx-no-format>
       <%= @person1.name %></.link><span phx-no-format>,</span>
-    <.link navigate={~p"/people/#{@person2.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person2)} class="hover:underline" phx-no-format>
       <%= @person2.name %></.link><span phx-no-format>, <%= @others %> others, and a full cast</span>
     """
   end
@@ -1327,12 +1328,17 @@ defmodule AmbryWeb.CoreComponents do
     assigns = assign(assigns, person1: person1, person2: person2, others: Enum.count(rest))
 
     ~H"""
-    <.link navigate={~p"/people/#{@person1.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person1)} class="hover:underline" phx-no-format>
       <%= @person1.name %></.link><span phx-no-format>,</span>
-    <.link navigate={~p"/people/#{@person2.person_id}"} class="hover:underline" phx-no-format>
+    <.link navigate={person_ish_path(@person2)} class="hover:underline" phx-no-format>
       <%= @person2.name %></.link><span phx-no-format>, and <%= @others %> others</span>
     """
   end
+
+  # Authors can be linked to multiple people (composite pen names), so author
+  # links go to the author page; narrators link straight to their person.
+  defp person_ish_path(%Author{} = author), do: ~p"/authors/#{author}"
+  defp person_ish_path(person_ish), do: ~p"/people/#{person_ish.person_id}"
 
   @doc """
   Renders a list of links to series, each in its own p tag.

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
@@ -132,14 +132,19 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
   defp build_authors_params(matching_authors) do
     Enum.map(matching_authors, fn
       {imported, nil} ->
-        {:ok, %{authors: [author]}} =
-          Ambry.People.create_person(%{name: imported.name, authors: [%{name: imported.name}]})
+        {:ok, %{author_people: [%{author: author}]}} =
+          Ambry.People.create_person(%{
+            name: imported.name,
+            author_people: [%{author: %{name: imported.name}}]
+          })
 
         %{"author_id" => author.id}
 
       {_imported, %{authors: []} = existing} ->
-        {:ok, %{authors: [author]}} =
-          Ambry.People.update_person(existing, %{authors: [%{name: existing.name}]})
+        {:ok, %{author_people: [%{author: author}]}} =
+          Ambry.People.update_person(existing, %{
+            author_people: [%{author: %{name: existing.name}}]
+          })
 
         %{"author_id" => author.id}
 

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   alias Ambry.Metadata.Registry
   alias Ambry.People
+  alias Ambry.People.Author
   alias Ambry.People.Person
   alias AmbryWeb.Admin.PersonLive.Form.ImportForm
   alias Ecto.Changeset
@@ -15,7 +16,11 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     {:ok,
      socket
      |> allow_image_upload(:image)
-     |> assign(import: nil, providers: Registry.enabled(capability: :author_search))
+     |> assign(
+       import: nil,
+       providers: Registry.enabled(capability: :author_search),
+       authors: People.authors_for_select()
+     )
      |> apply_action(socket.assigns.live_action, params)}
   end
 
@@ -63,6 +68,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"person" => person_params}, socket) do
+    person_params = maybe_link_author(person_params)
+
     socket =
       if person_params["image_type"] == "upload" do
         socket
@@ -79,6 +86,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   def handle_event("submit", %{"person" => person_params}, socket) do
+    person_params = maybe_link_author(person_params)
+
     with {:ok, _person} <-
            socket.assigns.person
            |> People.change_person(person_params)
@@ -159,6 +168,62 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   defp assign_form(socket, %Changeset{} = changeset) do
     assign(socket, :form, to_form(changeset))
+  end
+
+  # Selecting an author in the "link an existing author" autocomplete stages an
+  # `author_people` row linking that author (unless it's already present).
+  defp maybe_link_author(%{"link_author_id" => id} = person_params) when id not in [nil, ""] do
+    author_people = person_params["author_people"] || %{}
+
+    linked_ids =
+      author_people
+      |> Map.values()
+      |> Enum.flat_map(&[&1["author_id"], get_in(&1, ["author", "id"])])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&to_string/1)
+
+    person_params = Map.put(person_params, "link_author_id", "")
+
+    if to_string(id) in linked_ids do
+      person_params
+    else
+      next_index =
+        author_people
+        |> Map.keys()
+        |> Enum.map(&String.to_integer/1)
+        |> Enum.max(fn -> -1 end)
+        |> Kernel.+(1)
+        |> to_string()
+
+      sort = person_params["author_people_sort"] || []
+
+      person_params
+      |> Map.put("author_people", Map.put(author_people, next_index, %{"author_id" => id}))
+      |> Map.put("author_people_sort", sort ++ [next_index])
+    end
+  end
+
+  defp maybe_link_author(person_params), do: person_params
+
+  defp linked_author_row?(author_person_form) do
+    is_nil(author_person_form.data.id) and
+      author_person_form[:author_id].value not in [nil, ""]
+  end
+
+  defp linked_author_name(authors, value) do
+    Enum.find_value(authors, fn {name, id} -> to_string(id) == to_string(value) && name end)
+  end
+
+  defp shared_with(author_person_form, person) do
+    case author_person_form.data.author do
+      %Author{people: people} when is_list(people) ->
+        people
+        |> Enum.reject(&(&1.id == person.id))
+        |> Enum.map(& &1.name)
+
+      _author ->
+        []
+    end
   end
 
   defp open_import_form(%Person{id: nil}, type),

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -54,17 +54,52 @@
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
         <div class="space-y-2">
           <.label>Writing as</.label>
-          <.inputs_for :let={author_form} field={@form[:authors]}>
-            <.sort_input field={@form[:authors_sort]} index={author_form.index} />
+          <.datalist id="all-authors" options={@authors} />
+          <.inputs_for :let={author_person_form} field={@form[:author_people]}>
+            <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
 
-            <div class="relative">
-              <.input field={author_form[:name]} />
-              <.delete_button field={@form[:authors_drop]} index={author_form.index} class="absolute top-3 right-2" />
-            </div>
+            <%= if linked_author_row?(author_person_form) do %>
+              <div class="relative">
+                <.input type="hidden" field={author_person_form[:author_id]} />
+                <.input
+                  type="text"
+                  name={"linked-author-#{author_person_form.index}"}
+                  value={linked_author_name(@authors, author_person_form[:author_id].value)}
+                  disabled
+                />
+                <.delete_button
+                  field={@form[:author_people_drop]}
+                  index={author_person_form.index}
+                  class="absolute top-3 right-2"
+                />
+              </div>
+            <% else %>
+              <.inputs_for :let={author_form} field={author_person_form[:author]}>
+                <div class="relative">
+                  <.input field={author_form[:name]} />
+                  <.delete_button
+                    field={@form[:author_people_drop]}
+                    index={author_person_form.index}
+                    class="absolute top-3 right-2"
+                  />
+                </div>
+                <p :if={shared_with(author_person_form, @person) != []} class="text-xs text-zinc-500">
+                  Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
+                </p>
+              </.inputs_for>
+            <% end %>
           </.inputs_for>
 
-          <.add_button field={@form[:authors_sort]}>Add author</.add_button>
-          <.delete_input field={@form[:authors_drop]} />
+          <.add_button field={@form[:author_people_sort]}>Add author</.add_button>
+          <.delete_input field={@form[:author_people_drop]} />
+
+          <.input
+            field={@form[:link_author_id]}
+            type="autocomplete"
+            options={@authors}
+            list="all-authors"
+            label="Or link an existing author"
+          />
         </div>
 
         <div class="space-y-2">

--- a/lib/ambry_web/live/author_live.ex
+++ b/lib/ambry_web/live/author_live.ex
@@ -15,18 +15,35 @@ defmodule AmbryWeb.AuthorLive do
     ~H"""
     <div class="mx-auto max-w-md space-y-8 p-4 sm:max-w-none sm:space-y-12 sm:p-10 md:max-w-screen-2xl md:p-12 lg:space-y-16 lg:p-16">
       <div class="flex items-center gap-4">
-        <.link :if={@author.person.thumbnails} navigate={~p"/people/#{@author.person}"} class="flex-none">
-          <img
-            src={@author.person.thumbnails.extra_large}
-            class="hidden rounded-full object-cover object-top shadow-lg sm:block sm:h-16 sm:w-16 xl:h-24 xl:w-24"
-          />
-        </.link>
-        <h1 class="text-3xl font-bold text-zinc-900 dark:text-zinc-100 sm:text-4xl xl:text-5xl">
-          Written by
-          <.link navigate={~p"/people/#{@author.person}"} class="hover:underline">
-            {@author.name}
+        <%= for person <- @author.people, person.thumbnails do %>
+          <.link navigate={~p"/people/#{person}"} class="flex-none">
+            <img
+              src={person.thumbnails.extra_large}
+              class="hidden rounded-full object-cover object-top shadow-lg sm:block sm:h-16 sm:w-16 xl:h-24 xl:w-24"
+            />
           </.link>
-        </h1>
+        <% end %>
+        <div>
+          <h1 class="text-3xl font-bold text-zinc-900 dark:text-zinc-100 sm:text-4xl xl:text-5xl">
+            Written by
+            <%= case @author.people do %>
+              <% [person] -> %>
+                <.link navigate={~p"/people/#{person}"} class="hover:underline">
+                  {@author.name}
+                </.link>
+              <% _people -> %>
+                {@author.name}
+            <% end %>
+          </h1>
+          <p :if={pen_name_people(@author) != []} class="mt-2 text-zinc-500">
+            a pen name of <.link
+              :for={person <- pen_name_people(@author)}
+              navigate={~p"/people/#{person}"}
+              class="hover:underline"
+              phx-no-format
+            ><%= person.name %></.link><span class="last:hidden">,</span>
+          </p>
+        </div>
       </div>
 
       <.book_tiles_stream id="books" stream={@streams.books} page={@page} end?={@end?} />
@@ -63,6 +80,15 @@ defmodule AmbryWeb.AuthorLive do
       {:noreply, paginate_books(socket, socket.assigns.page - 1)}
     else
       {:noreply, socket}
+    end
+  end
+
+  # People worth calling out under the heading: everyone, unless this is the
+  # simple case of a single person writing under their own name.
+  defp pen_name_people(author) do
+    case author.people do
+      [%{name: name}] when name == author.name -> []
+      people -> people
     end
   end
 

--- a/priv/repo/migrations/20260801201946_composite_authors.exs
+++ b/priv/repo/migrations/20260801201946_composite_authors.exs
@@ -1,0 +1,63 @@
+defmodule Ambry.Repo.Migrations.CompositeAuthors do
+  use Ecto.Migration
+  use Familiar
+
+  def up do
+    create table(:authors_people) do
+      add :author_id, references(:authors, on_delete: :delete_all), null: false
+      add :person_id, references(:people, on_delete: :delete_all), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:authors_people, [:author_id, :person_id])
+    create index(:authors_people, [:person_id])
+
+    execute """
+    INSERT INTO authors_people (author_id, person_id, inserted_at, updated_at)
+    SELECT id, person_id, inserted_at, updated_at FROM authors
+    """
+
+    execute """
+    CREATE TRIGGER track_delete_trigger
+    BEFORE DELETE ON authors_people
+    FOR EACH ROW
+    EXECUTE FUNCTION track_delete('author_person');
+    """
+
+    update_view("people_flat", version: 5)
+    update_view("books_flat", version: 9)
+    update_view("media_flat", version: 6)
+    update_view("series_flat", version: 4)
+
+    alter table(:authors) do
+      remove :person_id
+    end
+  end
+
+  def down do
+    alter table(:authors) do
+      add :person_id, references(:people, on_delete: :delete_all)
+    end
+
+    # Best-effort revert: an author linked to multiple people keeps only the
+    # earliest link.
+    execute """
+    UPDATE authors SET person_id = (
+      SELECT ap.person_id FROM authors_people AS ap
+      WHERE ap.author_id = authors.id
+      ORDER BY ap.id
+      LIMIT 1
+    )
+    """
+
+    execute "ALTER TABLE authors ALTER COLUMN person_id SET NOT NULL"
+
+    update_view("people_flat", version: 4)
+    update_view("books_flat", version: 8)
+    update_view("media_flat", version: 5)
+    update_view("series_flat", version: 3)
+
+    drop table(:authors_people)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -7,6 +7,7 @@ alias Ambry.Books.Book
 alias Ambry.Media.Media
 alias Ambry.Media.MediaNarrator
 alias Ambry.People.Author
+alias Ambry.People.AuthorPerson
 alias Ambry.People.BookAuthor
 alias Ambry.People.Narrator
 alias Ambry.People.Person
@@ -27,12 +28,10 @@ cwd = File.cwd!()
 Repo.transact(fn ->
   ## People ##
 
-  %{authors: [jules_verne]} =
+  %{author_people: [%{author: jules_verne}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Jules Verne"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Jules Verne"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/001a07ae-2bf5-484c-b7c2-c0b62084651d.jpg",
@@ -50,12 +49,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/001a07ae-2bf5-484c-b7c2-c0b62084651d.jpg"
     })
 
-  %{authors: [h_g_wells]} =
+  %{author_people: [%{author: h_g_wells}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "H.G. Wells"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "H.G. Wells"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/464c6305-f307-4504-8cdb-54ee523eb8c2.jpg",
@@ -73,12 +70,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/464c6305-f307-4504-8cdb-54ee523eb8c2.jpg"
     })
 
-  %{authors: [l_m_montgomery]} =
+  %{author_people: [%{author: l_m_montgomery}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "L.M. Montgomery"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "L.M. Montgomery"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/6330a96e-564a-4d43-b067-4594e0cb1620.jpg",
@@ -96,12 +91,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/6330a96e-564a-4d43-b067-4594e0cb1620.jpg"
     })
 
-  %{authors: [arthur_conan_doyle]} =
+  %{author_people: [%{author: arthur_conan_doyle}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Arthur Conan Doyle"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Arthur Conan Doyle"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/d4a1addc-e65b-4f90-8282-0fdc2e275d9f.jpg",
@@ -119,12 +112,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/d4a1addc-e65b-4f90-8282-0fdc2e275d9f.jpg"
     })
 
-  %{authors: [edgar_rice_burroughs]} =
+  %{author_people: [%{author: edgar_rice_burroughs}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Edgar Rice Burroughs"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Edgar Rice Burroughs"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/64e3c1dd-0c25-4889-98e9-f5756a279f04.jpg",
@@ -142,12 +133,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/64e3c1dd-0c25-4889-98e9-f5756a279f04.jpg"
     })
 
-  %{authors: [rudyard_kipling]} =
+  %{author_people: [%{author: rudyard_kipling}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Rudyard Kipling"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Rudyard Kipling"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/26c057fe-e508-48f9-9c1c-f0f1809465ae.jpg",
@@ -163,12 +152,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/26c057fe-e508-48f9-9c1c-f0f1809465ae.jpg"
     })
 
-  %{authors: [robert_louis_stevenson]} =
+  %{author_people: [%{author: robert_louis_stevenson}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Robert Louis Stevenson"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Robert Louis Stevenson"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/8472ffe9-d717-4319-9023-c983a05cfb4a.jpg",
@@ -186,12 +173,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/8472ffe9-d717-4319-9023-c983a05cfb4a.jpg"
     })
 
-  %{authors: [frances_hodgson_burnett]} =
+  %{author_people: [%{author: frances_hodgson_burnett}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Frances Hodgson Burnett"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Frances Hodgson Burnett"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/74e9d1e3-8db6-4c3b-9bcb-16693687490e.jpg",
@@ -209,12 +194,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/74e9d1e3-8db6-4c3b-9bcb-16693687490e.jpg"
     })
 
-  %{authors: [alexandre_dumas]} =
+  %{author_people: [%{author: alexandre_dumas}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Alexandre Dumas"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Alexandre Dumas"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/49350e87-cfd9-4884-af38-df935a26ab60.jpg",
@@ -232,12 +215,10 @@ Repo.transact(fn ->
       image_path: "/uploads/images/49350e87-cfd9-4884-af38-df935a26ab60.jpg"
     })
 
-  %{authors: [emmuska_orczy]} =
+  %{author_people: [%{author: emmuska_orczy}]} =
     Repo.insert!(%Person{
-      authors: [
-        %Author{
-          name: "Emmuska Orczy"
-        }
+      author_people: [
+        %AuthorPerson{author: %Author{name: "Emmuska Orczy"}}
       ],
       thumbnails: %Thumbnails{
         original: "/uploads/images/6574da90-c914-4ac9-8823-1d8d311d0d36.jpg",

--- a/priv/repo/views/books_flat_v9.sql
+++ b/priv/repo/views/books_flat_v9.sql
@@ -1,0 +1,74 @@
+SELECT
+  book.id,
+  book.title,
+  book.published,
+  book.published_format,
+  ARRAY(
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+      AND media.thumbnails IS NOT NULL
+    ORDER BY
+      media.published DESC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      universe.name
+    FROM
+      universes AS universe
+    WHERE
+      universe.id = book.universe_id
+  ) AS universe,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+  ) AS media,
+  book.inserted_at,
+  book.updated_at,
+  -- deprecated
+  book.image_path,
+  book.description IS NOT NULL AS has_description
+FROM
+  books AS book
+ORDER BY
+  book.title

--- a/priv/repo/views/media_flat_v6.sql
+++ b/priv/repo/views/media_flat_v6.sql
@@ -1,0 +1,76 @@
+SELECT
+  media.id,
+  media.status,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      universe.name
+    FROM
+      universes AS universe
+    WHERE
+      universe.id = book.universe_id
+  ) AS universe,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrator.name
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/priv/repo/views/people_flat_v5.sql
+++ b/priv/repo/views/people_flat_v5.sql
@@ -1,0 +1,39 @@
+SELECT
+  person.id,
+  person.name,
+  ARRAY(
+    SELECT
+      author.name
+    FROM
+      authors_people AS author_link
+      INNER JOIN authors AS author ON author.id = author_link.author_id
+    WHERE
+      author_link.person_id = person.id
+  ) AS writing_as,
+  ARRAY(
+    SELECT
+      narrator.name
+    FROM
+      narrators AS narrator
+    WHERE
+      narrator.person_id = person.id
+  ) AS narrating_as,
+  COUNT(author.id) > 0 AS is_author,
+  COUNT(distinct authored_book.id) AS authored_books,
+  COUNT(narrator.id) > 0 AS is_narrator,
+  COUNT(distinct narrated_media.id) AS narrated_media,
+  person.thumbnails -> 'small' AS thumbnail,
+  person.description IS NOT NULL AS has_description,
+  person.inserted_at,
+  person.updated_at
+FROM
+  people AS person
+  LEFT JOIN authors_people AS author_link ON person.id = author_link.person_id
+  LEFT JOIN authors AS author ON author.id = author_link.author_id
+  LEFT JOIN narrators AS narrator ON person.id = narrator.person_id
+  LEFT JOIN authors_books AS authored_book ON author.id = authored_book.author_id
+  LEFT JOIN media_narrators AS narrated_media ON narrator.id = narrated_media.narrator_id
+GROUP BY
+  person.id
+ORDER BY
+  person.name

--- a/priv/repo/views/series_flat_v4.sql
+++ b/priv/repo/views/series_flat_v4.sql
@@ -1,0 +1,64 @@
+SELECT
+  series.id,
+  series.name,
+  (
+    SELECT
+      COUNT(books_series.id)
+    FROM
+      books_series
+    WHERE
+      books_series.series_id = series.id
+  ) AS books,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN media ON media.book_id = book.id
+    WHERE
+      series_book.series_id = series.id
+  ) AS media,
+  ARRAY(
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN media ON media.book_id = book.id
+    WHERE
+      series_book.series_id = series.id
+      AND media.thumbnails IS NOT NULL
+    ORDER BY
+      media.published DESC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      DISTINCT (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name AS person_name
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN authors_books AS authored_by ON book.id = authored_by.book_id
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      series_book.series_id = series.id
+    ORDER BY
+      person_name
+  ) AS authors,
+  series.inserted_at,
+  series.updated_at
+FROM
+  series
+ORDER BY
+  series.name

--- a/test/ambry/books_test.exs
+++ b/test/ambry/books_test.exs
@@ -114,7 +114,7 @@ defmodule Ambry.BooksTest do
 
     test "can create nested book authors" do
       person = insert(:person, authors: [build(:author)])
-      [%{id: author_id}] = person.authors
+      [%{author: %{id: author_id}}] = person.author_people
 
       %{title: title} = params = params_for(:book, book_authors: [%{author_id: author_id}])
 
@@ -176,7 +176,7 @@ defmodule Ambry.BooksTest do
 
     test "updates nested book authors" do
       person = insert(:person, authors: [build(:author)])
-      [%{id: new_author_id}] = person.authors
+      [%{author: %{id: new_author_id}}] = person.author_people
 
       book =
         insert(:book,

--- a/test/ambry/factory_test.exs
+++ b/test/ambry/factory_test.exs
@@ -12,6 +12,7 @@ defmodule Ambry.FactoryTest do
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaNarrator
   alias Ambry.People.Author
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
   alias Ambry.People.Narrator
   alias Ambry.People.Person
@@ -26,7 +27,7 @@ defmodule Ambry.FactoryTest do
       assert is_binary(person.description)
       refute person.image_path
       refute person.thumbnails
-      assert person.authors == []
+      assert person.author_people == []
       assert person.narrators == []
     end
 
@@ -58,7 +59,7 @@ defmodule Ambry.FactoryTest do
 
       assert %Person{} = person
       assert "Real Name" = person.name
-      assert [%Author{name: "Pen Name"}] = person.authors
+      assert [%AuthorPerson{author: %Author{name: "Pen Name"}}] = person.author_people
     end
 
     test "creates a person that narrates as a narrator under an alias" do
@@ -82,7 +83,7 @@ defmodule Ambry.FactoryTest do
 
       assert %Person{} = person
       assert "Real Name" = person.name
-      assert 3 = length(person.authors)
+      assert 3 = length(person.author_people)
     end
   end
 
@@ -107,7 +108,7 @@ defmodule Ambry.FactoryTest do
       assert %Book{} = book
       assert [%BookAuthor{author: author}] = book.book_authors
       assert %Author{} = author
-      assert %Person{} = author.person
+      assert [%AuthorPerson{person: %Person{}}] = author.author_people
     end
 
     test "creates a book with multiple authors" do
@@ -121,9 +122,9 @@ defmodule Ambry.FactoryTest do
       assert 2 = length(book.book_authors)
       assert [%BookAuthor{author: author1}, %BookAuthor{author: author2}] = book.book_authors
       assert %Author{} = author1
-      assert %Person{} = author1.person
+      assert [%AuthorPerson{person: %Person{}}] = author1.author_people
       assert %Author{} = author2
-      assert %Person{} = author2.person
+      assert [%AuthorPerson{person: %Person{}}] = author2.author_people
     end
 
     test "creates a book that's part of a series" do

--- a/test/ambry/people_test.exs
+++ b/test/ambry/people_test.exs
@@ -140,11 +140,11 @@ defmodule Ambry.PeopleTest do
     test "can create nested authors" do
       %{name: person_name} = person_params = params_for(:person, image_path: nil)
       %{name: author_name} = author_params = params_for(:author)
-      params = Map.put(person_params, :authors, [author_params])
+      params = Map.put(person_params, :author_people, [%{author: author_params}])
 
       assert {:ok, person} = People.create_person(params)
 
-      assert %{name: ^person_name, authors: [%{name: ^author_name}]} = person
+      assert %{name: ^person_name, author_people: [%{author: %{name: ^author_name}}]} = person
     end
 
     test "can create nested narrators" do
@@ -205,56 +205,95 @@ defmodule Ambry.PeopleTest do
 
     test "updates nested authors" do
       person = insert(:person, authors: [build(:author)])
-      [%{id: author_id}] = person.authors
+      [%{id: join_id, author: %{id: author_id}}] = person.author_people
       new_name = Fake.full_name()
 
       {:ok, updated_person} =
         People.update_person(person, %{
           name: new_name,
-          authors: [%{id: author_id, name: new_name}]
+          author_people: [%{id: join_id, author: %{id: author_id, name: new_name}}]
         })
 
       assert %{
                name: ^new_name,
-               authors: [
+               author_people: [
                  %{
-                   name: ^new_name
+                   author: %{name: ^new_name}
                  }
                ]
              } = updated_person
     end
 
-    test "deletes nested authors" do
-      person = insert(:person, authors: [build(:author)])
-      [%{id: author_id}] = person.authors
+    test "links an existing author to another person (composite pen name)" do
+      author = insert(:author, person: build(:person))
+      other_person = insert(:person)
 
       {:ok, updated_person} =
-        People.update_person(person, %{authors_drop: [0], authors: %{0 => %{id: author_id}}})
+        People.update_person(other_person, %{author_people: [%{author_id: author.id}]})
 
-      assert %{authors: []} = updated_person
+      assert %{author_people: [%{author_id: author_id}]} = updated_person
+      assert author_id == author.id
+
+      assert %{people: people} = People.get_author!(author.id)
+      assert length(people) == 2
     end
 
-    @tag :skip
+    test "unlinking a shared author keeps the author" do
+      author = insert(:author, person: build(:person))
+      other_person = insert(:person)
+
+      {:ok, other_person} =
+        People.update_person(other_person, %{author_people: [%{author_id: author.id}]})
+
+      [%{id: join_id}] = other_person.author_people
+
+      {:ok, updated_person} =
+        People.update_person(other_person, %{
+          author_people_drop: [0],
+          author_people: %{0 => %{id: join_id}}
+        })
+
+      assert %{author_people: []} = updated_person
+      assert %{people: [_person]} = People.get_author!(author.id)
+    end
+
+    test "deletes nested authors" do
+      person = insert(:person, authors: [build(:author)])
+      [%{id: join_id, author: %{id: author_id}}] = person.author_people
+
+      {:ok, updated_person} =
+        People.update_person(person, %{
+          author_people_drop: [0],
+          author_people: %{0 => %{id: join_id}}
+        })
+
+      assert %{author_people: []} = updated_person
+
+      # the author lost its last person link, so it was deleted entirely
+      assert_raise Ecto.NoResultsError, fn -> People.get_author!(author_id) end
+    end
+
     test "cannot delete a nested author if they have authored a book" do
       book =
         insert(:book,
           book_authors: [build(:book_author, author: build(:author, person: build(:person)))]
         )
 
-      %{book_authors: [%{author: %{id: author_id, person: person}}]} = book
+      %{book_authors: [%{author: %{id: author_id, author_people: [%{person: person}]}}]} = book
+
+      %{author_people: [%{id: join_id}]} = person = People.get_person!(person.id)
 
       {:error, changeset} =
-        People.update_person(person, %{authors_drop: [0], authors: %{0 => %{id: author_id}}})
+        People.update_person(person, %{
+          author_people_drop: [0],
+          author_people: %{0 => %{id: join_id}}
+        })
 
-      assert %{
-               authors: [
-                 %{
-                   id: [
-                     "This author is in use by one or more books. You must first remove them as an author from any associated books."
-                   ]
-                 }
-               ]
-             } = errors_on(changeset)
+      assert %{author_people: [message]} = errors_on(changeset)
+      assert message =~ "This author is in use by one or more books."
+
+      # the author and its link both survive
+      assert %{author_people: [%{author_id: ^author_id}]} = People.get_person!(person.id)
     end
 
     test "updates nested narrators" do
@@ -553,7 +592,7 @@ defmodule Ambry.PeopleTest do
 
     test "returns the author with the given id" do
       person = insert(:person, authors: [build(:author)])
-      [%{id: id}] = person.authors
+      [%{author: %{id: id}}] = person.author_people
 
       assert %People.Author{id: ^id} = People.get_author!(id)
     end

--- a/test/ambry/search/index_test.exs
+++ b/test/ambry/search/index_test.exs
@@ -174,7 +174,7 @@ defmodule Ambry.Search.IndexTest do
     test "updates all index records that reference this person" do
       %{
         name: person_name,
-        authors: [author],
+        author_people: [%{id: author_person_id, author: author}],
         narrators: [narrator]
       } =
         person =
@@ -211,7 +211,9 @@ defmodule Ambry.Search.IndexTest do
       {:ok, _person} =
         People.update_person(person, %{
           name: "PersonName",
-          authors: [%{id: author.id, name: "AuthorName"}],
+          author_people: [
+            %{id: author_person_id, author: %{id: author.id, name: "AuthorName"}}
+          ],
           narrators: [%{id: narrator.id, name: "NarratorName"}]
         })
 

--- a/test/ambry/search_test.exs
+++ b/test/ambry/search_test.exs
@@ -47,7 +47,8 @@ defmodule Ambry.SearchTest do
         )
         |> with_search_index()
 
-      %{id: id, book_authors: [%{author: %{person: %{name: person_name}}}]} = book
+      %{id: id, book_authors: [%{author: %{author_people: [%{person: %{name: person_name}}]}}]} =
+        book
 
       assert [%{id: ^id}] = Search.search(person_name)
     end
@@ -91,7 +92,7 @@ defmodule Ambry.SearchTest do
     end
 
     test "returns person by author name" do
-      %{id: id, authors: [%{name: author_name}]} =
+      %{id: id, author_people: [%{author: %{name: author_name}}]} =
         :person |> insert(authors: [build(:author)]) |> with_search_index()
 
       assert [%{id: ^id}] = Search.search(author_name)
@@ -136,7 +137,7 @@ defmodule Ambry.SearchTest do
       %{
         id: book_id,
         series_books: [%{series: %{id: id}}],
-        book_authors: [%{author: %{person: %{name: person_name}}}]
+        book_authors: [%{author: %{author_people: [%{person: %{name: person_name}}]}}]
       } = book
 
       assert results = Search.search(person_name)
@@ -183,7 +184,8 @@ defmodule Ambry.SearchTest do
         )
         |> with_search_index()
 
-      %{id: id, book_authors: [%{author: %{person: %{name: person_name}}}]} = book
+      %{id: id, book_authors: [%{author: %{author_people: [%{person: %{name: person_name}}]}}]} =
+        book
 
       assert %{id: ^id} = Search.find_first(person_name, Book)
     end
@@ -230,7 +232,7 @@ defmodule Ambry.SearchTest do
     end
 
     test "returns person by author name" do
-      %{id: id, authors: [%{name: author_name}]} =
+      %{id: id, author_people: [%{author: %{name: author_name}}]} =
         :person |> insert(authors: [build(:author)]) |> with_search_index()
 
       assert %{id: ^id} = Search.find_first(author_name, Person)
@@ -282,7 +284,7 @@ defmodule Ambry.SearchTest do
 
       %{
         series_books: [%{series: %{id: id}}],
-        book_authors: [%{author: %{person: %{name: person_name}}}]
+        book_authors: [%{author: %{author_people: [%{person: %{name: person_name}}]}}]
       } = book
 
       assert %{id: ^id} = Search.find_first(person_name, Series)

--- a/test/ambry_schema/people_test.exs
+++ b/test/ambry_schema/people_test.exs
@@ -72,6 +72,10 @@ defmodule AmbrySchema.PeopleTest do
           person {
             __typename
           }
+          people {
+            __typename
+            name
+          }
           authoredBooks(first: 1) {
             __typename
           }
@@ -83,7 +87,8 @@ defmodule AmbrySchema.PeopleTest do
     """
     test "resolves Author fields", %{conn: conn} do
       person = insert(:person, authors: [build(:author)])
-      %{authors: [%{id: id, name: name}]} = person
+      %{author_people: [%{author: %{id: id, name: name}}]} = person
+      person_name = person.name
 
       gid = to_global_id("Author", id)
 
@@ -99,6 +104,7 @@ defmodule AmbrySchema.PeopleTest do
                    "id" => ^gid,
                    "name" => ^name,
                    "person" => %{"__typename" => "Person"},
+                   "people" => [%{"__typename" => "Person", "name" => ^person_name}],
                    "authoredBooks" => %{"__typename" => "BookConnection"},
                    "insertedAt" => "" <> _,
                    "updatedAt" => "" <> _

--- a/test/ambry_schema/search_test.exs
+++ b/test/ambry_schema/search_test.exs
@@ -132,7 +132,8 @@ defmodule AmbrySchema.SearchTest do
         )
         |> with_search_index()
 
-      %{id: id, book_authors: [%{author: %{person: %{name: person_name}}}]} = book
+      %{id: id, book_authors: [%{author: %{author_people: [%{person: %{name: person_name}}]}}]} =
+        book
 
       gid = to_global_id("Book", id)
 
@@ -251,7 +252,7 @@ defmodule AmbrySchema.SearchTest do
 
     test "returns person by author name", %{conn: conn} do
       person = :person |> insert(authors: [build(:author)]) |> with_search_index()
-      %{id: id, authors: [%{name: author_name}]} = person
+      %{id: id, author_people: [%{author: %{name: author_name}}]} = person
       gid = to_global_id("Person", id)
 
       conn =
@@ -386,7 +387,7 @@ defmodule AmbrySchema.SearchTest do
       %{
         id: book_id,
         series_books: [%{series: %{id: id}}],
-        book_authors: [%{author: %{person: %{name: person_name}}}]
+        book_authors: [%{author: %{author_people: [%{person: %{name: person_name}}]}}]
       } = book
 
       gid = to_global_id("Series", id)

--- a/test/ambry_schema/sync_test.exs
+++ b/test/ambry_schema/sync_test.exs
@@ -1,0 +1,84 @@
+defmodule AmbrySchema.SyncTest do
+  use AmbryWeb.ConnCase
+
+  import Ambry.GraphQLSigil
+
+  alias Ambry.People
+
+  setup :register_and_put_user_api_token
+
+  describe "authorPeopleChangedSince" do
+    @query ~G"""
+    query Sync($since: DateTime) {
+      authorPeopleChangedSince(since: $since) {
+        id
+        author {
+          name
+        }
+        person {
+          name
+        }
+        insertedAt
+        updatedAt
+      }
+      deletionsSince(since: $since) {
+        type
+        recordId
+      }
+    }
+    """
+    test "returns author-person links and tracks their deletions", %{conn: conn} do
+      person = insert(:person, name: "Real Name", authors: [build(:author, name: "Pen Name")])
+      %{author_people: [%{id: join_id}]} = person
+
+      conn =
+        post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{
+               "data" => %{
+                 "authorPeopleChangedSince" => [
+                   %{
+                     "author" => %{"name" => "Pen Name"},
+                     "person" => %{"name" => "Real Name"}
+                   }
+                 ],
+                 "deletionsSince" => []
+               }
+             } = json_response(conn, 200)
+
+      # unlinking (which here also deletes the orphaned author) records
+      # deletions for both the join row and the author
+      person = People.get_person!(person.id)
+
+      {:ok, _person} =
+        People.update_person(person, %{
+          author_people_drop: [0],
+          author_people: %{0 => %{id: join_id}}
+        })
+
+      conn =
+        post(build_conn_with_same_auth(conn), "/gql", %{
+          "query" => @query,
+          "variables" => %{"since" => "2000-01-01T00:00:00Z"}
+        })
+
+      assert %{
+               "data" => %{
+                 "authorPeopleChangedSince" => [],
+                 "deletionsSince" => deletions
+               }
+             } = json_response(conn, 200)
+
+      assert Enum.any?(deletions, &(&1["type"] == "AUTHOR_PERSON"))
+      assert Enum.any?(deletions, &(&1["type"] == "AUTHOR"))
+    end
+  end
+
+  defp build_conn_with_same_auth(conn) do
+    auth_header = Plug.Conn.get_req_header(conn, "authorization")
+
+    Enum.reduce(auth_header, build_conn(), fn value, conn ->
+      Plug.Conn.put_req_header(conn, "authorization", value)
+    end)
+  end
+end

--- a/test/ambry_web/live/admin/home_live/index_test.exs
+++ b/test/ambry_web/live/admin/home_live/index_test.exs
@@ -56,8 +56,8 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
 
       assert has_element?(view, "[data-role='author-count']", "0")
 
-      author = insert(:author, person: build(:person))
-      author.person |> Ambry.People.PubSub.PersonCreated.new() |> Ambry.PubSub.broadcast()
+      %{author_people: [%{person: person}]} = insert(:author, person: build(:person))
+      person |> Ambry.People.PubSub.PersonCreated.new() |> Ambry.PubSub.broadcast()
       ensure_all_messages_handled(view.pid)
 
       assert has_element?(view, "[data-role='author-count']", "1")

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -1,0 +1,70 @@
+defmodule AmbryWeb.Admin.PersonLive.FormTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Ambry.People
+
+  setup :register_and_log_in_admin_user
+
+  describe "linking an existing author (composite pen names)" do
+    test "links a shared author through the autocomplete", %{conn: conn} do
+      insert(:person, name: "Daniel Abraham", authors: [build(:author, name: "James S.A. Corey")])
+      person = insert(:person, name: "Ty Franck")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      # pick the author in the "link an existing author" autocomplete; in the
+      # browser the value-change hook then fires a form change event
+      view
+      |> element("input[name='autocomplete[person_link_author_id]']")
+      |> render_change(%{"autocomplete" => %{"person_link_author_id" => "James S.A. Corey"}})
+
+      html = view |> form("#person-form", %{"person" => %{}}) |> render_change()
+      assert html =~ "James S.A. Corey"
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      person = People.get_person!(person.id)
+      assert [%{author: %{name: "James S.A. Corey"} = author}] = person.author_people
+
+      assert [%{name: "Daniel Abraham"}, %{name: "Ty Franck"}] =
+               People.get_author!(author.id).people |> Enum.sort_by(& &1.name)
+    end
+
+    test "shows who a pen name is shared with", %{conn: conn} do
+      author =
+        insert(:author, name: "James S.A. Corey", person: build(:person, name: "Daniel Abraham"))
+
+      franck = insert(:person, name: "Ty Franck")
+      {:ok, _person} = People.update_person(franck, %{author_people: [%{author_id: author.id}]})
+
+      %{author_people: [%{person_id: abraham_id}, _]} =
+        People.get_author!(author.id) |> Ambry.Repo.preload(:author_people)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/people/#{abraham_id}/edit")
+
+      assert html =~ "Shared pen name with Ty Franck"
+    end
+
+    test "linking the same author twice adds only one row", %{conn: conn} do
+      insert(:person, name: "Daniel Abraham", authors: [build(:author, name: "James S.A. Corey")])
+      person = insert(:person, name: "Ty Franck")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      for _try <- 1..2 do
+        view
+        |> element("input[name='autocomplete[person_link_author_id]']")
+        |> render_change(%{"autocomplete" => %{"person_link_author_id" => "James S.A. Corey"}})
+
+        view |> form("#person-form", %{"person" => %{}}) |> render_change()
+      end
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      person = People.get_person!(person.id)
+      assert [%{author: %{name: "James S.A. Corey"}}] = person.author_people
+    end
+  end
+end

--- a/test/ambry_web/live/admin/person_live/index_test.exs
+++ b/test/ambry_web/live/admin/person_live/index_test.exs
@@ -73,18 +73,18 @@ defmodule AmbryWeb.Admin.PersonLive.IndexTest do
           book_authors: [build(:book_author, author: build(:author, person: build(:person)))]
         )
 
-      %{book_authors: [%{author: author}]} = book
+      %{book_authors: [%{author: %{author_people: [%{person: person}]}}]} = book
 
       {:ok, view, _html} = live(conn, ~p"/admin/people")
 
-      assert has_element?(view, "[data-role='person-name']", author.person.name)
+      assert has_element?(view, "[data-role='person-name']", person.name)
 
       view
       |> element("[data-role='delete-person']")
       |> render_click()
 
       # Person should still be visible
-      assert has_element?(view, "[data-role='person-name']", author.person.name)
+      assert has_element?(view, "[data-role='person-name']", person.name)
       assert render(view) =~ "Can&#39;t delete person because they have authored books"
     end
 
@@ -200,7 +200,7 @@ defmodule AmbryWeb.Admin.PersonLive.IndexTest do
 
   describe "Author and Narrator Counts" do
     test "shows book and media counts", %{conn: conn} do
-      %{authors: [author], narrators: [narrator]} =
+      %{author_people: [%{author: author}], narrators: [narrator]} =
         insert(:person,
           name: "Test Person",
           authors: [%{name: "Test Author"}],

--- a/test/ambry_web/live/person_live_test.exs
+++ b/test/ambry_web/live/person_live_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.PersonLiveTest do
         book_authors: [build(:book_author, author: build(:author, person: build(:person)))]
       )
 
-    %{book_authors: [%{author: %{person: person}}]} = book
+    %{book_authors: [%{author: %{author_people: [%{person: person}]}}]} = book
 
     {:ok, _view, html} = live(conn, ~p"/people/#{person.id}")
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -13,6 +13,7 @@ defmodule Ambry.Factory do
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
   alias Ambry.People.Author
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
   alias Ambry.People.Narrator
   alias Ambry.People.Person
@@ -50,20 +51,45 @@ defmodule Ambry.Factory do
 
   # People
 
-  def person_factory do
+  # `authors` is a through association; the factory translates it into
+  # `author_people` join rows so call sites can keep the natural shape.
+  def person_factory(attrs) do
+    {authors, attrs} = Map.pop(attrs, :authors)
+
+    author_people =
+      case authors do
+        nil -> []
+        authors -> Enum.map(authors, &%AuthorPerson{author: &1})
+      end
+
     %Person{
       name: Fake.full_name(),
       description: Fake.paragraph(),
-      authors: [],
+      author_people: author_people,
       narrators: []
     }
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes()
   end
 
-  def author_factory do
+  # `people` is a through association; the factory translates `person`/`people`
+  # into `author_people` join rows so call sites can keep the natural shape.
+  def author_factory(attrs) do
+    {person, attrs} = Map.pop(attrs, :person)
+    {people, attrs} = Map.pop(attrs, :people)
+
+    author_people =
+      case people || List.wrap(person) do
+        [] -> []
+        people -> Enum.map(people, &%AuthorPerson{person: &1})
+      end
+
     %Author{
       name: Fake.full_name(),
-      person: nil
+      author_people: author_people
     }
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes()
   end
 
   def narrator_factory do


### PR DESCRIPTION
First of the v1.9.0 data-model PRs (ROADMAP Phase 1a). An author (pen name) can now be linked to multiple people — James S.A. Corey = Daniel Abraham + Ty Franck. Narrators intentionally stay single-person (decided in the roadmap).

## Data model

- New `authors_people` join table (unique author+person, cascade FKs), backfilled 1:1 from `authors.person_id` with the author's timestamps; `authors.person_id` dropped in the same migration. Down migration is best-effort (an author with multiple people keeps the earliest link).
- `Author has_many :people through`, `Person has_many :authors through`; authors keep the invariant "≥ 1 person" app-side: unlinking a pen name's last person deletes the author (blocked with the existing in-use error if it has books); deleting a person deletes only its *exclusive* authors — shared pen names survive.
- All four flat views rebuilt (`people_flat` v5, `books_flat` v9, `media_flat` v6, `series_flat` v4); multi-person authors render aggregated person names in the `person_name` composite.
- Search index: an author's people are all indexed as name sources and dependencies, so renaming any person behind a pen name reindexes the right books/series.

## GraphQL — additive only (invariant 2)

- `author.people` (non-null list) plus new `AuthorPerson` node.
- `author.person` stays non-null but **deprecated**, resolving to the first linked person — deployed mobile clients keep working unchanged.
- Sync surface for the join table: `authorPeopleChangedSince`, `AUTHOR_PERSON` deletion type, and the Postgres delete trigger (covered end-to-end by a new `AmbrySchema.SyncTest`).

## Admin & web UI

- Person form: pen-name rows now edit the join; a new "link an existing author" autocomplete stages shared pen names (validated + deduped in the form transform, LiveView-tested). Renaming a shared pen name renames it for everyone, with a "Shared pen name with …" hint.
- Public UI: author links navigate to the author page (there is no single person to link for a composite author); the author page header shows and links every person behind the pen name.

## Notes for review

- The book provider-import form's create-person-on-the-fly path was mechanically adapted; its known create-before-submit wart is unchanged and tracked for 1g.
- Migration rehearsed both directions on the dev DB; `mix check` (format, credo, dialyzer) and the full suite (582 tests) are green.
- Mobile picks up `people` on its own schedule; nothing here requires a client release.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9