### PR TITLE
Phase 1a: media version fields — title override, language, translators

### DIFF
--- a/lib/ambry/deletions/deletion.ex
+++ b/lib/ambry/deletions/deletion.ex
@@ -8,7 +8,7 @@ defmodule Ambry.Deletions.Deletion do
   schema "deletions" do
     field :type, Ecto.Enum,
       values:
-        ~w(person author author_person narrator book book_author book_universe series series_book media media_narrator universe)a
+        ~w(person author author_person narrator book book_author book_universe series series_book media media_narrator media_translator universe)a
 
     field :record_id, :integer
     field :deleted_at, :utc_datetime

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -12,6 +12,7 @@ defmodule Ambry.Media do
       Media,
       Media.Chapter,
       MediaNarrator,
+      MediaTranslator,
       PubSub.MediaCreated,
       PubSub.MediaDeleted,
       PubSub.MediaProgress,
@@ -100,7 +101,8 @@ defmodule Ambry.Media do
       ** (Ecto.NoResultsError)
 
   """
-  def get_media!(id), do: Media |> preload([:book, :media_narrators]) |> Repo.get!(id)
+  def get_media!(id),
+    do: Media |> preload([:book, :media_narrators, :media_translators]) |> Repo.get!(id)
 
   @doc """
   Gets a media and the book with all its details.
@@ -129,6 +131,7 @@ defmodule Ambry.Media do
     Media
     |> preload([
       :narrators,
+      :translators,
       book: [
         :authors,
         series_books: :series,

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -11,6 +11,7 @@ defmodule Ambry.Media.Media do
   alias Ambry.Media.Media
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.MediaTranslator
   alias Ambry.Media.Processor
   alias Ambry.Repo.SupplementalFile
   alias Ambry.Thumbnails
@@ -20,8 +21,10 @@ defmodule Ambry.Media.Media do
   schema "media" do
     belongs_to :book, Book
     has_many :media_narrators, MediaNarrator, on_replace: :delete
+    has_many :media_translators, MediaTranslator, on_replace: :delete
     has_many :authors, through: [:book, :authors]
     has_many :narrators, through: [:media_narrators, :narrator]
+    has_many :translators, through: [:media_translators, :author]
 
     embeds_many :chapters, Chapter, on_replace: :delete
     embeds_many :supplemental_files, SupplementalFile, on_replace: :delete
@@ -30,6 +33,12 @@ defmodule Ambry.Media.Media do
     field :full_cast, :boolean, default: false
     field :status, Ecto.Enum, values: @statuses, default: :pending
     field :abridged, :boolean, default: false
+
+    # version fields: how this recording differs from the work — a
+    # display-title override (translated/regional/retail title), the
+    # recording's language, and translator credits (see :translators)
+    field :title, :string
+    field :language, :string
 
     field :source_path, :string
     field :source_files, {:array, :string}, default: []
@@ -60,6 +69,8 @@ defmodule Ambry.Media.Media do
       :abridged,
       :book_id,
       :full_cast,
+      :title,
+      :language,
       :source_path,
       :source_files,
       :published,
@@ -77,6 +88,10 @@ defmodule Ambry.Media.Media do
     |> cast_assoc(:media_narrators,
       sort_param: :media_narrators_sort,
       drop_param: :media_narrators_drop
+    )
+    |> cast_assoc(:media_translators,
+      sort_param: :media_translators_sort,
+      drop_param: :media_translators_drop
     )
     |> cast_embed(:chapters,
       sort_param: :chapters_sort,

--- a/lib/ambry/media/media_flat.ex
+++ b/lib/ambry/media/media_flat.ex
@@ -9,6 +9,8 @@ defmodule Ambry.Media.MediaFlat do
   alias Ambry.People.PersonName
 
   schema "media_flat" do
+    field :title, :string
+    field :language, :string
     field :status, Ecto.Enum, values: [:pending, :processing, :error, :ready]
     field :full_cast, :boolean
     field :abridged, :boolean
@@ -33,7 +35,8 @@ defmodule Ambry.Media.MediaFlat do
 
     from m in query,
       where:
-        ilike(m.book, ^search_string) or ilike(m.universes, ^search_string) or
+        ilike(m.book, ^search_string) or ilike(m.title, ^search_string) or
+          ilike(m.universes, ^search_string) or
           fragment(
             "EXISTS (SELECT FROM unnest(?) elem WHERE (elem).name ILIKE ?)",
             m.series,

--- a/lib/ambry/media/media_translator.ex
+++ b/lib/ambry/media/media_translator.ex
@@ -1,0 +1,31 @@
+defmodule Ambry.Media.MediaTranslator do
+  @moduledoc """
+  Join table between media and authors crediting the translator(s) of a
+  recording's text.
+
+  Translators are Author identities (reusing the pen-name machinery — a
+  translator like Ken Liu is also an author).
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Media.Media
+  alias Ambry.People.Author
+
+  schema "media_translators" do
+    belongs_to :media, Media
+    belongs_to :author, Author
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(media_translator, attrs) do
+    media_translator
+    |> cast(attrs, [:author_id])
+    |> validate_required(:author_id)
+    |> unique_constraint([:media_id, :author_id])
+  end
+end

--- a/lib/ambry/people/author.ex
+++ b/lib/ambry/people/author.ex
@@ -35,5 +35,10 @@ defmodule Ambry.People.Author do
       message:
         "This author is in use by one or more books. You must first remove them as an author from any associated books."
     )
+    |> foreign_key_constraint(:id,
+      name: "media_translators_author_id_fkey",
+      message:
+        "This author is credited as a translator on one or more recordings. You must first remove those credits."
+    )
   end
 end

--- a/lib/ambry/search/index.ex
+++ b/lib/ambry/search/index.ex
@@ -173,10 +173,14 @@ defmodule Ambry.Search.Index do
     dependencies =
       Enum.uniq(secondary_dependencies ++ tertiary_dependencies ++ media_dependencies)
 
+    # recording display-title overrides are searchable alongside the book
+    # title (e.g. find "Sorcerer's Stone" under the British-titled book)
+    media_titles = book.media |> Enum.map(& &1.title) |> Enum.filter(& &1)
+
     %{
       reference: Reference.new(book),
       dependencies: dependencies,
-      primary: book.title,
+      primary: join(Enum.uniq([book.title | media_titles])),
       secondary: join(secondary_names),
       tertiary: join(tertiary_names)
     }

--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -34,6 +34,14 @@ defmodule AmbrySchema.Media do
 
     field :full_cast, non_null(:boolean)
     field :abridged, non_null(:boolean)
+
+    @desc "Display-title override for this recording (translated/regional/retail title); null means the book's title applies"
+    field :title, :string
+    field :language, :string
+
+    field :translators, non_null(list_of(non_null(:author))),
+      resolve: dataloader(Resolvers, args: %{order: {:asc, :name}})
+
     field :duration, :float, resolve: Resolvers.resolve_decimal(:duration)
     field :mpd_path, :string
     field :hls_path, :string
@@ -66,6 +74,14 @@ defmodule AmbrySchema.Media do
   node object(:media_narrator) do
     field :media, non_null(:media), resolve: dataloader(Resolvers, args: %{allow_all_media: true})
     field :narrator, non_null(:narrator), resolve: dataloader(Resolvers)
+
+    field :inserted_at, non_null(:datetime)
+    field :updated_at, non_null(:datetime)
+  end
+
+  node object(:media_translator) do
+    field :media, non_null(:media), resolve: dataloader(Resolvers, args: %{allow_all_media: true})
+    field :author, non_null(:author), resolve: dataloader(Resolvers)
 
     field :inserted_at, non_null(:datetime)
     field :updated_at, non_null(:datetime)

--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -16,6 +16,7 @@ defmodule AmbrySchema.Resolvers do
   alias Ambry.Hashids
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.MediaTranslator
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
@@ -106,6 +107,9 @@ defmodule AmbrySchema.Resolvers do
   def media_narrators_changed_since(args, _resolution),
     do: Sync.changes_since(MediaNarrator, args[:since])
 
+  def media_translators_changed_since(args, _resolution),
+    do: Sync.changes_since(MediaTranslator, args[:since])
+
   def deletions_since(args, _resolution), do: Sync.deletions_since(args[:since])
 
   def list_series_books(%Series{} = series, args, _resolution) do
@@ -162,6 +166,10 @@ defmodule AmbrySchema.Resolvers do
   def node(%{type: :deletion, id: id}, _resolution), do: {:ok, Repo.get(Deletion, id)}
   def node(%{type: :media, id: id}, _resolution), do: {:ok, Repo.get(Media, id)}
   def node(%{type: :media_narrator, id: id}, _resolution), do: {:ok, Repo.get(MediaNarrator, id)}
+
+  def node(%{type: :media_translator, id: id}, _resolution),
+    do: {:ok, Repo.get(MediaTranslator, id)}
+
   def node(%{type: :narrator, id: id}, _resolution), do: {:ok, Repo.get(Narrator, id)}
   def node(%{type: :person, id: id}, _resolution), do: {:ok, Repo.get(Person, id)}
   def node(%{type: :series, id: id}, _resolution), do: {:ok, Repo.get(Series, id)}
@@ -176,6 +184,7 @@ defmodule AmbrySchema.Resolvers do
   def type(%Deletion{}, _resolution), do: :deletion
   def type(%Media{}, _resolution), do: :media
   def type(%MediaNarrator{}, _resolution), do: :media_narrator
+  def type(%MediaTranslator{}, _resolution), do: :media_translator
   def type(%Narrator{}, _resolution), do: :narrator
   def type(%Person{}, _resolution), do: :person
   def type(%Series{}, _resolution), do: :series

--- a/lib/ambry_schema/sync.ex
+++ b/lib/ambry_schema/sync.ex
@@ -20,6 +20,7 @@ defmodule AmbrySchema.Sync do
     value :series_book
     value :media
     value :media_narrator
+    value :media_translator
     value :universe
   end
 
@@ -129,6 +130,14 @@ defmodule AmbrySchema.Sync do
       middleware AmbrySchema.AuthMiddleware
 
       resolve &Resolvers.media_narrators_changed_since/2
+    end
+
+    field :media_translators_changed_since, non_null(list_of(non_null(:media_translator))) do
+      arg :since, :datetime
+
+      middleware AmbrySchema.AuthMiddleware
+
+      resolve &Resolvers.media_translators_changed_since/2
     end
 
     field :deletions_since, non_null(list_of(non_null(:deletion))) do

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1413,12 +1413,13 @@ defmodule AmbryWeb.CoreComponents do
 
   attr :book, Book, required: true
   attr :class, :string, default: nil
+  attr :title_override, :string, default: nil
 
   def book_header(assigns) do
     ~H"""
     <div>
       <h1 class={["text-3xl font-bold text-zinc-900 dark:text-zinc-100 sm:text-4xl", @class]}>
-        {@book.title}
+        {@title_override || @book.title}
       </h1>
       <p class="text-zinc-800 dark:text-zinc-200 sm:text-lg xl:text-xl">
         <span>by <.all_people_links people={@book.authors} /></span>

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -27,6 +27,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
        recording_providers: Registry.enabled(level: :recording, capability: :book_search),
        source_files_expanded: false,
        narrators: People.narrators_for_select(),
+       authors: People.authors_for_select(),
        books: Ambry.Books.books_for_select(),
        local_import_path: Ambry.Paths.local_import_path()
      )

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -15,6 +15,7 @@
 
   <.datalist id="narrators" options={@narrators} />
   <.datalist id="books" options={@books} />
+  <.datalist id="translators" options={@authors} />
 
   <div class="max-w-3xl">
     <.simple_form id="media-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
@@ -35,6 +36,15 @@
             </.button>
           </div>
         </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
+        <.input
+          field={@form[:title]}
+          label="Title override"
+          placeholder="defaults to the book's title"
+        />
+        <.input field={@form[:language]} label="Language" />
       </div>
 
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-3 sm:gap-2">
@@ -91,6 +101,30 @@
 
         <.add_button field={@form[:media_narrators_sort]}>Add narrator</.add_button>
         <.delete_input field={@form[:media_narrators_drop]} />
+      </div>
+
+      <div class="space-y-2">
+        <.label>Translated by</.label>
+        <.inputs_for :let={media_translator_form} field={@form[:media_translators]}>
+          <.sort_input field={@form[:media_translators_sort]} index={media_translator_form.index} />
+
+          <div class="relative">
+            <.input
+              field={media_translator_form[:author_id]}
+              type="autocomplete"
+              options={@authors}
+              list="translators"
+            />
+            <.delete_button
+              field={@form[:media_translators_drop]}
+              index={media_translator_form.index}
+              class="absolute top-3 right-2"
+            />
+          </div>
+        </.inputs_for>
+
+        <.add_button field={@form[:media_translators_sort]}>Add translator</.add_button>
+        <.delete_input field={@form[:media_translators_drop]} />
       </div>
 
       <div class="flex gap-4">

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -20,12 +20,15 @@ defmodule AmbryWeb.AudiobookLive do
       <div class="justify-center sm:flex sm:flex-row">
         <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
           <div class="mb-6 sm:hidden">
-            <.book_header book={@media.book} />
+            <.book_header book={@media.book} title_override={@media.title} />
             <p class="mt-4">
               Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
               <%= if @media.abridged do %>
                 <span>(Abridged)</span>
               <% end %>
+            </p>
+            <p :if={@media.translators != []}>
+              Translated by <.all_people_links people={@media.translators} />
             </p>
           </div>
 
@@ -44,9 +47,12 @@ defmodule AmbryWeb.AudiobookLive do
           <div class="mt-6 divide-y divide-zinc-300 rounded-sm border border-zinc-200 bg-zinc-50 px-3 text-zinc-800 shadow-md dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200">
             <div class="flex items-center gap-4 py-3">
               <div class="grow">
-                <p>{@media.book.title}</p>
+                <p>{@media.title || @media.book.title}</p>
                 <p class="text-zinc-600 dark:text-zinc-400">
                   {duration_display(@media.duration)}
+                </p>
+                <p :if={@media.language} class="text-zinc-600 dark:text-zinc-400">
+                  {@media.language}
                 </p>
               </div>
             </div>
@@ -93,12 +99,15 @@ defmodule AmbryWeb.AudiobookLive do
         </section>
 
         <section id="description" class="hidden max-w-md sm:ml-10 sm:block">
-          <.book_header book={@media.book} />
+          <.book_header book={@media.book} title_override={@media.title} />
           <p class="mt-4">
             Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
             <%= if @media.abridged do %>
               <span>(Abridged)</span>
             <% end %>
+          </p>
+          <p :if={@media.translators != []}>
+            Translated by <.all_people_links people={@media.translators} />
           </p>
           <.markdown
             :if={@media.description}

--- a/priv/repo/migrations/20260801223909_media_version_fields.exs
+++ b/priv/repo/migrations/20260801223909_media_version_fields.exs
@@ -1,0 +1,41 @@
+defmodule Ambry.Repo.Migrations.MediaVersionFields do
+  use Ecto.Migration
+  use Familiar
+
+  def up do
+    alter table(:media) do
+      add :title, :text
+      add :language, :text
+    end
+
+    create table(:media_translators) do
+      add :media_id, references(:media, on_delete: :delete_all), null: false
+      add :author_id, references(:authors), null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:media_translators, [:media_id, :author_id])
+    create index(:media_translators, [:author_id])
+
+    execute """
+    CREATE TRIGGER track_delete_trigger
+    BEFORE DELETE ON media_translators
+    FOR EACH ROW
+    EXECUTE FUNCTION track_delete('media_translator');
+    """
+
+    update_view("media_flat", version: 8)
+  end
+
+  def down do
+    update_view("media_flat", version: 7)
+
+    drop table(:media_translators)
+
+    alter table(:media) do
+      remove :title
+      remove :language
+    end
+  end
+end

--- a/priv/repo/views/media_flat_v8.sql
+++ b/priv/repo/views/media_flat_v8.sql
@@ -1,0 +1,79 @@
+SELECT
+  media.id,
+  media.status,
+  media.title,
+  media.language,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrator.name
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -352,6 +352,69 @@ defmodule Ambry.MediaTest do
     end
   end
 
+  describe "version fields" do
+    test "creates media with a title override, language, and translators" do
+      %{id: book_id} = insert(:book)
+      %{id: author_id} = insert(:author, person: build(:person))
+
+      params =
+        :media
+        |> params_for(
+          book_id: book_id,
+          title: "The Three-Body Problem (English)",
+          language: "English",
+          media_translators: [%{author_id: author_id}]
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :title,
+          :language,
+          :media_translators
+        ])
+
+      assert {:ok, media} = Media.create_media(params)
+
+      assert %{
+               title: "The Three-Body Problem (English)",
+               language: "English",
+               media_translators: [%{author_id: ^author_id}]
+             } = media
+
+      assert %{translators: [%{id: ^author_id}]} =
+               Ambry.Repo.preload(media, :translators)
+    end
+
+    test "an author credited as translator cannot be deleted" do
+      author = insert(:author, person: build(:person))
+      %{id: book_id} = insert(:book)
+
+      params =
+        :media
+        |> params_for(book_id: book_id, media_translators: [%{author_id: author.id}])
+        |> Map.take([:abridged, :full_cast, :source_path, :book_id, :media_translators])
+
+      {:ok, _media} = Media.create_media(params)
+
+      # unlinking the author's only person would orphan-delete the author,
+      # which the translator credit blocks
+      [%{id: person_id}] = Ambry.Repo.preload(author, :people).people
+      person = Ambry.People.get_person!(person_id)
+      [%{id: join_id}] = person.author_people
+
+      {:error, changeset} =
+        Ambry.People.update_person(person, %{
+          author_people_drop: [0],
+          author_people: %{0 => %{id: join_id}}
+        })
+
+      assert %{author_people: [message]} = errors_on(changeset)
+      assert message =~ "credited as a translator"
+    end
+  end
+
   describe "update_media/3" do
     test "allows updating a media's abridged value" do
       media = insert(:media, book: build(:book))

--- a/test/ambry/search_test.exs
+++ b/test/ambry/search_test.exs
@@ -26,6 +26,19 @@ defmodule Ambry.SearchTest do
       assert result_ids == Enum.sort([id, series_id])
     end
 
+    test "returns book by a recording's display-title override" do
+      book = insert(:book, title: "Harry Potter and the Philosopher's Stone")
+
+      :media
+      |> insert(book: book, title: "Harry Potter and the Sorcerer's Stone")
+      |> with_search_index()
+
+      %{id: id} = book
+
+      assert [%{id: ^id}] = Search.search("Sorcerer's Stone")
+      assert [%{id: ^id}] = Search.search("Philosopher's Stone")
+    end
+
     test "returns book by author name" do
       book =
         :book
@@ -161,6 +174,19 @@ defmodule Ambry.SearchTest do
       %{id: id, series_books: [%{series: %{name: series_name}}]} = book
 
       assert %{id: ^id} = Search.find_first(series_name, Book)
+    end
+
+    test "returns book by a recording's display-title override" do
+      book = insert(:book, title: "Harry Potter and the Philosopher's Stone")
+
+      :media
+      |> insert(book: book, title: "Harry Potter and the Sorcerer's Stone")
+      |> with_search_index()
+
+      %{id: id} = book
+
+      assert [%{id: ^id}] = Search.search("Sorcerer's Stone")
+      assert [%{id: ^id}] = Search.search("Philosopher's Stone")
     end
 
     test "returns book by author name" do

--- a/test/ambry_schema/sync_test.exs
+++ b/test/ambry_schema/sync_test.exs
@@ -140,6 +140,76 @@ defmodule AmbrySchema.SyncTest do
     end
   end
 
+  describe "mediaTranslatorsChangedSince" do
+    @query ~G"""
+    query Sync($since: DateTime) {
+      mediaTranslatorsChangedSince(since: $since) {
+        id
+        media {
+          title
+          language
+        }
+        author {
+          name
+        }
+      }
+      deletionsSince(since: $since) {
+        type
+        recordId
+      }
+    }
+    """
+    test "returns translator credits and tracks their deletions", %{conn: conn} do
+      author = insert(:author, name: "Ken Liu", person: build(:person))
+      book = insert(:book)
+
+      media =
+        insert(:media,
+          book: book,
+          title: "The Three-Body Problem (English)",
+          language: "English",
+          media_translators: [build(:media_translator, author: author)]
+        )
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{
+               "data" => %{
+                 "mediaTranslatorsChangedSince" => [
+                   %{
+                     "media" => %{
+                       "title" => "The Three-Body Problem (English)",
+                       "language" => "English"
+                     },
+                     "author" => %{"name" => "Ken Liu"}
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
+
+      {:ok, _media} =
+        Ambry.Media.update_media(Ambry.Media.get_media!(media.id), %{
+          media_translators_drop: [0],
+          media_translators: %{0 => %{id: List.first(media.media_translators).id}}
+        })
+
+      conn =
+        post(build_conn_with_same_auth(conn), "/gql", %{
+          "query" => @query,
+          "variables" => %{"since" => "2000-01-01T00:00:00Z"}
+        })
+
+      assert %{
+               "data" => %{
+                 "mediaTranslatorsChangedSince" => [],
+                 "deletionsSince" => deletions
+               }
+             } = json_response(conn, 200)
+
+      assert Enum.any?(deletions, &(&1["type"] == "MEDIA_TRANSLATOR"))
+    end
+  end
+
   defp build_conn_with_same_auth(conn) do
     auth_header = Plug.Conn.get_req_header(conn, "authorization")
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,7 @@ defmodule Ambry.Factory do
   alias Ambry.Media.Bookmark
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.MediaTranslator
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
@@ -186,6 +187,13 @@ defmodule Ambry.Factory do
       notes: Fake.sentence(),
       description: Fake.paragraph(),
       source_path: fn -> valid_source_path() end
+    }
+  end
+
+  def media_translator_factory do
+    %MediaTranslator{
+      media: nil,
+      author: nil
     }
   end
 


### PR DESCRIPTION
Third of the v1.9.0 data-model PRs (ROADMAP Phase 1a, the translations & title-variants decision): since Ambry is audio-only and Book is strictly a grouping node, any attribute that varies between recordings belongs on the recording. This adds the three version fields to Media.

## What's added

- **`media.title`** — nullable display-title override (translated / regional / retail title); null means the book's title applies. The two motivating cases both resolve to one Book with per-recording titles: The Three-Body Problem (Chinese original vs. Ken Liu's English translation) and Philosopher's vs. Sorcerer's Stone.
- **`media.language`** — freeform string.
- **Translator credits** — `media_translators` join to **Author** identities (reusing the pen-name machinery; Ken Liu is also an author). `Author.changeset` gains a second FK constraint so an author credited as a translator can't be deleted out from under a recording — including via the composite-authors orphan-cleanup path (tested).

## Companion behaviors (from the roadmap decision)

- **Override titles are searchable**: the book's search record now indexes its recordings' override titles, so searching "Sorcerer's Stone" finds the British-titled book (test included, both directions).
- **Public audiobook page** shows the override title, a "Translated by …" line, and the language in the details box.
- **Admin media form** gets Title override / Language inputs and a "Translated by" autocomplete section mirroring narrators; `media_flat` v8 exposes and filters the override title.

## GraphQL — additive only

`media.title`, `media.language`, `media.translators`, `media_translator` node, `mediaTranslatorsChangedSince`, `MEDIA_TRANSLATOR` deletion type + delete trigger — the full sync-contract checklist, covered end-to-end in `AmbrySchema.SyncTest`.

## Notes for review

- Provider auto-fill of these fields (work-level providers model editions) is deliberately not wired yet — it lands with 1g auto-match.
- Migration rehearsed both directions on dev; full suite (602 tests) + `mix check` green. No client impact.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9