### PR TITLE
Phase 1a: multi-part recordings — part fields + recording groups

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -244,7 +244,8 @@ defmodule Ambry.Books do
     |> preload([
       :authors,
       series_books: :series,
-      media: ^{media_query, [:narrators, book: [:authors, series_books: :series]]}
+      media:
+        ^{media_query, [:narrators, :recording_group, book: [:authors, series_books: :series]]}
     ])
     |> Repo.get!(book_id)
   end

--- a/lib/ambry/deletions/deletion.ex
+++ b/lib/ambry/deletions/deletion.ex
@@ -8,7 +8,7 @@ defmodule Ambry.Deletions.Deletion do
   schema "deletions" do
     field :type, Ecto.Enum,
       values:
-        ~w(person author author_person narrator book book_author book_universe series series_book media media_narrator universe)a
+        ~w(person author author_person narrator book book_author book_universe series series_book media media_narrator recording_group universe)a
 
     field :record_id, :integer
     field :deleted_at, :utc_datetime

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -142,7 +142,8 @@ defmodule Ambry.Media do
       book: [
         :authors,
         series_books: :series,
-        media: ^{media_query, [:narrators, book: [:authors, series_books: :series]]}
+        media:
+          ^{media_query, [:narrators, :recording_group, book: [:authors, series_books: :series]]}
       ]
     ])
   end

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -11,7 +11,9 @@ defmodule Ambry.Media do
       Chapters,
       Media,
       Media.Chapter,
+      MediaFlat,
       MediaNarrator,
+      RecordingGroup,
       PubSub.MediaCreated,
       PubSub.MediaDeleted,
       PubSub.MediaProgress,
@@ -34,6 +36,7 @@ defmodule Ambry.Media do
   alias Ambry.Media.PubSub.MediaDeleted
   alias Ambry.Media.PubSub.MediaProgress
   alias Ambry.Media.PubSub.MediaUpdated
+  alias Ambry.Media.RecordingGroup
   alias Ambry.Media.RunProcessor
   alias Ambry.Paths
   alias Ambry.PubSub
@@ -100,7 +103,8 @@ defmodule Ambry.Media do
       ** (Ecto.NoResultsError)
 
   """
-  def get_media!(id), do: Media |> preload([:book, :media_narrators]) |> Repo.get!(id)
+  def get_media!(id),
+    do: Media |> preload([:book, :media_narrators, :recording_group]) |> Repo.get!(id)
 
   @doc """
   Gets a media and the book with all its details.
@@ -129,6 +133,7 @@ defmodule Ambry.Media do
     Media
     |> preload([
       :narrators,
+      :recording_group,
       book: [
         :authors,
         series_books: :series,
@@ -201,6 +206,7 @@ defmodule Ambry.Media do
       changeset = Media.changeset(media, attrs)
 
       with {:ok, updated_media} <- Repo.update(changeset),
+           :ok <- delete_orphaned_recording_groups(),
            :ok <- Search.update(updated_media),
            {:ok, _job_or_noop} <- delete_unused_files_async(media, updated_media),
            {:ok, _job_or_noop} <- generate_thumbnails_async(updated_media),
@@ -253,6 +259,7 @@ defmodule Ambry.Media do
   def delete_media(%Media{} = media) do
     Repo.transact(fn ->
       with {:ok, deleted_media} <- Repo.delete(media),
+           :ok <- delete_orphaned_recording_groups(),
            :ok <- Search.delete(deleted_media),
            {:ok, _job} <- delete_all_files_async(deleted_media),
            {:ok, _job} <- broadcast_media_deleted(deleted_media) do
@@ -406,6 +413,42 @@ defmodule Ambry.Media do
   end
 
   @doc """
+  Returns the recording groups usable for the given book, for `Select`
+  components: every group already attached to one of the book's media.
+  """
+  def recording_groups_for_select(nil), do: []
+  def recording_groups_for_select(""), do: []
+
+  def recording_groups_for_select(book_id) do
+    query =
+      from g in RecordingGroup,
+        join: m in assoc(g, :media),
+        on: m.book_id == ^book_id,
+        distinct: true,
+        order_by: g.id,
+        select: {g.name, g.id}
+
+    query
+    |> Repo.all()
+    |> Enum.map(fn
+      {nil, id} -> {"Unnamed group ##{id}", id}
+      {name, id} -> {name, id}
+    end)
+  end
+
+  # Groups exist only to tie parts together; once no media references one it
+  # is deleted (the delete trigger records it for sync).
+  defp delete_orphaned_recording_groups do
+    Repo.delete_all(
+      from g in RecordingGroup,
+        as: :group,
+        where: not exists(from m in Media, where: m.recording_group_id == parent_as(:group).id)
+    )
+
+    :ok
+  end
+
+  @doc """
   Returns a paginated list of media narrated by the given narrator.
   """
   def get_narrated_media(narrator, offset \\ 0, limit \\ 10) do
@@ -478,11 +521,13 @@ defmodule Ambry.Media do
 
     description = Books.get_book_description(book)
 
-    # recordings with a display-title override are described by it
+    # recordings are described by their display title (override or part label)
     description =
-      if media.title,
-        do: String.replace_prefix(description, book.title, media.title),
-        else: description
+      String.replace_prefix(
+        description,
+        book.title,
+        Media.display_title(%{media | book: book})
+      )
 
     "#{description} • narrated by #{narrators}"
   end

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -130,10 +130,15 @@ defmodule Ambry.Media do
     media_query =
       from m in Media, where: m.status == :ready and m.id != ^id, order_by: {:desc, :published}
 
+    group_media_query =
+      from m in Media,
+        where: m.status == :ready,
+        order_by: [asc_nulls_last: m.part_number, asc: m.id]
+
     Media
     |> preload([
       :narrators,
-      :recording_group,
+      recording_group: [media: ^group_media_query],
       book: [
         :authors,
         series_books: :series,
@@ -474,16 +479,38 @@ defmodule Ambry.Media do
   def get_recent_media(offset \\ 0, limit \\ 10) do
     over_limit = limit + 1
 
+    # part sets collapse to one entry: only the first ready part of each
+    # recording group represents its set
     query =
       from m in Media,
         where: m.status == :ready,
+        where:
+          is_nil(m.recording_group_id) or
+            m.id ==
+              fragment(
+                """
+                (SELECT m2.id FROM media m2
+                 WHERE m2.recording_group_id = ? AND m2.status = 'ready'
+                 ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+                 LIMIT 1)
+                """,
+                m.recording_group_id
+              ),
         order_by: [desc: m.inserted_at],
         offset: ^offset,
         limit: ^over_limit
 
+    group_media_query =
+      from m in Media,
+        where: m.status == :ready,
+        order_by: [asc_nulls_last: m.part_number, asc: m.id]
+
     media =
       query
-      |> preload(book: [:authors, series_books: :series])
+      |> preload(
+        book: [:authors, series_books: :series],
+        recording_group: [media: ^group_media_query]
+      )
       |> Repo.all()
 
     media_to_return = Enum.slice(media, 0, limit)

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -45,6 +45,8 @@ defmodule Ambry.Media.Media do
     # form-only: recording-group picker staging, see apply_recording_group_choice/1
     field :recording_group_choice, :string, virtual: true
     field :recording_group_name, :string, virtual: true
+    field :recording_group_part_word, :string, virtual: true
+    field :recording_group_part_word_plural, :string, virtual: true
 
     field :source_path, :string
     field :source_files, {:array, :string}, default: []
@@ -106,7 +108,11 @@ defmodule Ambry.Media.Media do
       sort_param: :supplemental_files_sort,
       drop_param: :supplemental_files_drop
     )
-    |> cast(attrs, [:recording_group_name], empty_values: [])
+    |> cast(
+      attrs,
+      [:recording_group_name, :recording_group_part_word, :recording_group_part_word_plural],
+      empty_values: []
+    )
     |> apply_recording_group_choice()
     |> maybe_rename_recording_group()
     |> validate_part_fields()
@@ -131,8 +137,11 @@ defmodule Ambry.Media.Media do
         put_change(changeset, :recording_group_id, nil)
 
       "new" ->
-        name = presence(get_change(changeset, :recording_group_name))
-        put_assoc(changeset, :recording_group, %RecordingGroup{name: name})
+        put_assoc(changeset, :recording_group, %RecordingGroup{
+          name: presence(get_change(changeset, :recording_group_name)),
+          part_word: group_word_change(changeset, :recording_group_part_word),
+          part_word_plural: group_word_change(changeset, :recording_group_part_word_plural)
+        })
 
       id ->
         case Integer.parse(id) do
@@ -142,24 +151,38 @@ defmodule Ambry.Media.Media do
     end
   end
 
-  # Renames the currently-linked group (shared by all its parts) when the
-  # form's name field changed. Only applies while the media stays linked to
-  # that same group — picking a different or new group ignores it.
+  # Updates the currently-linked group's label/wording (shared by all its
+  # parts) when the form's fields changed. Only applies while the media stays
+  # linked to that same group — picking a different or new group ignores it.
   defp maybe_rename_recording_group(changeset) do
-    name = get_change(changeset, :recording_group_name)
     group = changeset.data.recording_group
 
-    with false <- is_nil(name),
+    updates =
+      [
+        name: get_change(changeset, :recording_group_name),
+        part_word: get_change(changeset, :recording_group_part_word),
+        part_word_plural: get_change(changeset, :recording_group_part_word_plural)
+      ]
+      |> Enum.reject(fn {_field, value} -> is_nil(value) end)
+      |> Map.new(fn {field, value} -> {field, presence(value)} end)
+
+    with false <- updates == %{},
          false <- get_change(changeset, :recording_group_choice) == "new",
          %RecordingGroup{} <- group,
          true <- get_field(changeset, :recording_group_id) == group.id,
-         new_name = presence(name),
-         true <- new_name != group.name do
-      put_assoc(changeset, :recording_group, RecordingGroup.changeset(group, %{name: new_name}))
+         true <- Enum.any?(updates, fn {field, value} -> Map.get(group, field) != value end) do
+      put_assoc(changeset, :recording_group, RecordingGroup.changeset(group, updates))
     else
-      _no_rename -> changeset
+      _no_update -> changeset
     end
   end
+
+  defp group_word_change(changeset, field) do
+    changeset |> get_change(field) |> presence_downcase()
+  end
+
+  defp presence_downcase(nil), do: nil
+  defp presence_downcase(string), do: string |> presence() |> then(&(&1 && String.downcase(&1)))
 
   defp presence(nil), do: nil
   defp presence(string) when is_binary(string), do: with("" <- String.trim(string), do: nil)
@@ -197,13 +220,32 @@ defmodule Ambry.Media.Media do
   end
 
   @doc """
-  A human label for a media's position in its part set, or nil for
-  single-release recordings. Works on anything with the part fields
-  (Media structs and MediaFlat rows alike).
+  A human label for a media's position in its part set ("Part 2 of 3",
+  "Episode 4" per the group's wording), or nil for single-release
+  recordings. Works on anything with the part fields (Media structs and
+  MediaFlat rows alike); the wording comes from the loaded recording group,
+  a flat row's part_word column, or an explicitly passed group.
   """
-  def part_label(%{part_number: nil}), do: nil
-  def part_label(%{part_number: n, parts_total: nil}), do: "Part #{n}"
-  def part_label(%{part_number: n, parts_total: total}), do: "Part #{n} of #{total}"
+  def part_label(media_ish, group \\ nil)
+  def part_label(%{part_number: nil}, _group), do: nil
+
+  def part_label(%{part_number: n} = media_ish, group) do
+    word = media_ish |> resolve_part_word(group) |> String.capitalize()
+
+    case media_ish.parts_total do
+      nil -> "#{word} #{n}"
+      total -> "#{word} #{n} of #{total}"
+    end
+  end
+
+  defp resolve_part_word(_media_ish, %RecordingGroup{} = group),
+    do: RecordingGroup.part_word(group)
+
+  defp resolve_part_word(%Media{recording_group: %RecordingGroup{} = group}, nil),
+    do: RecordingGroup.part_word(group)
+
+  defp resolve_part_word(%{part_word: word}, nil) when is_binary(word), do: word
+  defp resolve_part_word(_media_ish, nil), do: "part"
 
   defp status_based_validation(changeset) do
     changeset

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -44,7 +44,7 @@ defmodule Ambry.Media.Media do
 
     # form-only: recording-group picker staging, see apply_recording_group_choice/1
     field :recording_group_choice, :string, virtual: true
-    field :new_recording_group_name, :string, virtual: true
+    field :recording_group_name, :string, virtual: true
 
     field :source_path, :string
     field :source_files, {:array, :string}, default: []
@@ -80,7 +80,6 @@ defmodule Ambry.Media.Media do
       :parts_total,
       :recording_group_id,
       :recording_group_choice,
-      :new_recording_group_name,
       :source_path,
       :source_files,
       :published,
@@ -107,7 +106,9 @@ defmodule Ambry.Media.Media do
       sort_param: :supplemental_files_sort,
       drop_param: :supplemental_files_drop
     )
+    |> cast(attrs, [:recording_group_name], empty_values: [])
     |> apply_recording_group_choice()
+    |> maybe_rename_recording_group()
     |> validate_part_fields()
     |> maybe_clear_thumbnails()
     |> status_based_validation()
@@ -130,7 +131,7 @@ defmodule Ambry.Media.Media do
         put_change(changeset, :recording_group_id, nil)
 
       "new" ->
-        name = presence(get_change(changeset, :new_recording_group_name))
+        name = presence(get_change(changeset, :recording_group_name))
         put_assoc(changeset, :recording_group, %RecordingGroup{name: name})
 
       id ->
@@ -138,6 +139,25 @@ defmodule Ambry.Media.Media do
           {id, ""} -> put_change(changeset, :recording_group_id, id)
           _else -> add_error(changeset, :recording_group_choice, "is invalid")
         end
+    end
+  end
+
+  # Renames the currently-linked group (shared by all its parts) when the
+  # form's name field changed. Only applies while the media stays linked to
+  # that same group — picking a different or new group ignores it.
+  defp maybe_rename_recording_group(changeset) do
+    name = get_change(changeset, :recording_group_name)
+    group = changeset.data.recording_group
+
+    with false <- is_nil(name),
+         false <- get_change(changeset, :recording_group_choice) == "new",
+         %RecordingGroup{} <- group,
+         true <- get_field(changeset, :recording_group_id) == group.id,
+         new_name = presence(name),
+         true <- new_name != group.name do
+      put_assoc(changeset, :recording_group, RecordingGroup.changeset(group, %{name: new_name}))
+    else
+      _no_rename -> changeset
     end
   end
 

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -12,6 +12,7 @@ defmodule Ambry.Media.Media do
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaNarrator
   alias Ambry.Media.Processor
+  alias Ambry.Media.RecordingGroup
   alias Ambry.Repo.SupplementalFile
   alias Ambry.Thumbnails
 
@@ -19,6 +20,7 @@ defmodule Ambry.Media.Media do
 
   schema "media" do
     belongs_to :book, Book
+    belongs_to :recording_group, RecordingGroup
     has_many :media_narrators, MediaNarrator, on_replace: :delete
     has_many :authors, through: [:book, :authors]
     has_many :narrators, through: [:media_narrators, :narrator]
@@ -34,6 +36,15 @@ defmodule Ambry.Media.Media do
     # display-title override: how this recording's title differs from the
     # work's (translated/regional/retail title); nil means the book's title
     field :title, :string
+
+    # multi-part recordings: each part is a full media of the same book,
+    # optionally labeled "Part N of M" and grouped with its siblings
+    field :part_number, :integer
+    field :parts_total, :integer
+
+    # form-only: recording-group picker staging, see apply_recording_group_choice/1
+    field :recording_group_choice, :string, virtual: true
+    field :new_recording_group_name, :string, virtual: true
 
     field :source_path, :string
     field :source_files, {:array, :string}, default: []
@@ -65,6 +76,11 @@ defmodule Ambry.Media.Media do
       :book_id,
       :full_cast,
       :title,
+      :part_number,
+      :parts_total,
+      :recording_group_id,
+      :recording_group_choice,
+      :new_recording_group_name,
       :source_path,
       :source_files,
       :published,
@@ -91,12 +107,83 @@ defmodule Ambry.Media.Media do
       sort_param: :supplemental_files_sort,
       drop_param: :supplemental_files_drop
     )
+    |> apply_recording_group_choice()
+    |> validate_part_fields()
     |> maybe_clear_thumbnails()
     |> status_based_validation()
     |> validate_image_path()
     |> cast_embed(:thumbnails)
     |> check_constraint(:thumbnails, name: "thumbnails_original_match_constraint")
   end
+
+  # The media form stages the recording-group picker in a virtual field:
+  # "none" clears the group, "new" creates one (with the optional name from
+  # new_recording_group_name) atomically at save, and an id links it. ("" is
+  # unusable as the clear sentinel — Ecto casts it to nil, i.e. "untouched".)
+  # Callers that set recording_group_id directly bypass this entirely.
+  defp apply_recording_group_choice(changeset) do
+    case get_change(changeset, :recording_group_choice) do
+      nil ->
+        changeset
+
+      "none" ->
+        put_change(changeset, :recording_group_id, nil)
+
+      "new" ->
+        name = presence(get_change(changeset, :new_recording_group_name))
+        put_assoc(changeset, :recording_group, %RecordingGroup{name: name})
+
+      id ->
+        case Integer.parse(id) do
+          {id, ""} -> put_change(changeset, :recording_group_id, id)
+          _else -> add_error(changeset, :recording_group_choice, "is invalid")
+        end
+    end
+  end
+
+  defp presence(nil), do: nil
+  defp presence(string) when is_binary(string), do: with("" <- String.trim(string), do: nil)
+
+  defp validate_part_fields(changeset) do
+    changeset
+    |> validate_number(:part_number, greater_than_or_equal_to: 1)
+    |> validate_number(:parts_total, greater_than_or_equal_to: 1)
+    |> validate_part_number_within_total()
+  end
+
+  defp validate_part_number_within_total(changeset) do
+    part_number = get_field(changeset, :part_number)
+    parts_total = get_field(changeset, :parts_total)
+
+    if part_number && parts_total && part_number > parts_total do
+      add_error(changeset, :part_number, "can't be greater than the total number of parts")
+    else
+      changeset
+    end
+  end
+
+  @doc """
+  The title this recording displays as: the override verbatim when set
+  (retail overrides already carry their own part designation), otherwise the
+  book's title plus the part label. Requires `book` to be preloaded.
+  """
+  def display_title(%Media{title: title}) when is_binary(title), do: title
+
+  def display_title(%Media{} = media) do
+    case part_label(media) do
+      nil -> media.book.title
+      label -> "#{media.book.title} (#{label})"
+    end
+  end
+
+  @doc """
+  A human label for a media's position in its part set, or nil for
+  single-release recordings. Works on anything with the part fields
+  (Media structs and MediaFlat rows alike).
+  """
+  def part_label(%{part_number: nil}), do: nil
+  def part_label(%{part_number: n, parts_total: nil}), do: "Part #{n}"
+  def part_label(%{part_number: n, parts_total: total}), do: "Part #{n} of #{total}"
 
   defp status_based_validation(changeset) do
     changeset

--- a/lib/ambry/media/media_flat.ex
+++ b/lib/ambry/media/media_flat.ex
@@ -12,6 +12,7 @@ defmodule Ambry.Media.MediaFlat do
     field :title, :string
     field :part_number, :integer
     field :parts_total, :integer
+    field :part_word, :string
     field :status, Ecto.Enum, values: [:pending, :processing, :error, :ready]
     field :full_cast, :boolean
     field :abridged, :boolean

--- a/lib/ambry/media/media_flat.ex
+++ b/lib/ambry/media/media_flat.ex
@@ -10,6 +10,8 @@ defmodule Ambry.Media.MediaFlat do
 
   schema "media_flat" do
     field :title, :string
+    field :part_number, :integer
+    field :parts_total, :integer
     field :status, Ecto.Enum, values: [:pending, :processing, :error, :ready]
     field :full_cast, :boolean
     field :abridged, :boolean

--- a/lib/ambry/media/recording_group.ex
+++ b/lib/ambry/media/recording_group.ex
@@ -1,0 +1,30 @@
+defmodule Ambry.Media.RecordingGroup do
+  @moduledoc """
+  A set of separately-released recordings that together cover one work.
+
+  Examples: GraphicAudio's "Part 1 of 3" releases, or episodic full-cast
+  seasons ("The Audio Immersion Experience — Season One"). The group itself is
+  deliberately minimal — per-release facts (cover, date, chapters) live on
+  each Media; the group exists so parts can be displayed together and, for
+  episodic sets, carry a display name.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Media.Media
+
+  schema "recording_groups" do
+    has_many :media, Media, preload_order: [asc: :part_number]
+
+    field :name, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(recording_group, attrs) do
+    cast(recording_group, attrs, [:name])
+  end
+end

--- a/lib/ambry/media/recording_group.ex
+++ b/lib/ambry/media/recording_group.ex
@@ -18,13 +18,28 @@ defmodule Ambry.Media.RecordingGroup do
   schema "recording_groups" do
     has_many :media, Media, preload_order: [asc: :part_number]
 
+    # admin-only organizational label; never rendered in user-facing UI
     field :name, :string
+
+    # what one release in this set is called ("part" by default; "episode",
+    # "volume", ...). Stored lowercase; display capitalizes as needed. nil
+    # means the default wording.
+    field :part_word, :string
+    field :part_word_plural, :string
 
     timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(recording_group, attrs) do
-    cast(recording_group, attrs, [:name])
+    cast(recording_group, attrs, [:name, :part_word, :part_word_plural])
   end
+
+  @doc "The singular word for one release in this set, defaulting to \"part\"."
+  def part_word(nil), do: "part"
+  def part_word(%__MODULE__{} = group), do: group.part_word || "part"
+
+  @doc "The plural word for this set's releases, defaulting to \"parts\"."
+  def part_word_plural(nil), do: "parts"
+  def part_word_plural(%__MODULE__{} = group), do: group.part_word_plural || "parts"
 end

--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -74,7 +74,14 @@ defmodule AmbrySchema.Media do
   end
 
   node object(:recording_group) do
+    @desc "Admin-only organizational label; clients should not display it"
     field :name, :string
+
+    @desc "Wording for one release in this set; null means \"part\""
+    field :part_word, :string
+
+    @desc "Wording for several releases; null means \"parts\""
+    field :part_word_plural, :string
 
     field :media, non_null(list_of(non_null(:media))),
       resolve: dataloader(Resolvers, args: %{order: {:asc, :part_number}})

--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -38,6 +38,12 @@ defmodule AmbrySchema.Media do
     @desc "Display-title override for this recording (translated/regional/retail title); null means the book's title applies"
     field :title, :string
 
+    @desc "For multi-part recordings: this recording's position in its part set"
+    field :part_number, :integer
+    field :parts_total, :integer
+
+    field :recording_group, :recording_group, resolve: dataloader(Resolvers)
+
     field :duration, :float, resolve: Resolvers.resolve_decimal(:duration)
     field :mpd_path, :string
     field :hls_path, :string
@@ -65,6 +71,16 @@ defmodule AmbrySchema.Media do
     field :updated_at, non_null(:datetime)
 
     field :image_path, :string, deprecate: "use `thumbnails` instead"
+  end
+
+  node object(:recording_group) do
+    field :name, :string
+
+    field :media, non_null(list_of(non_null(:media))),
+      resolve: dataloader(Resolvers, args: %{order: {:asc, :part_number}})
+
+    field :inserted_at, non_null(:datetime)
+    field :updated_at, non_null(:datetime)
   end
 
   node object(:media_narrator) do

--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -16,6 +16,7 @@ defmodule AmbrySchema.Resolvers do
   alias Ambry.Hashids
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.RecordingGroup
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
@@ -106,6 +107,9 @@ defmodule AmbrySchema.Resolvers do
   def media_narrators_changed_since(args, _resolution),
     do: Sync.changes_since(MediaNarrator, args[:since])
 
+  def recording_groups_changed_since(args, _resolution),
+    do: Sync.changes_since(RecordingGroup, args[:since])
+
   def deletions_since(args, _resolution), do: Sync.deletions_since(args[:since])
 
   def list_series_books(%Series{} = series, args, _resolution) do
@@ -165,6 +169,10 @@ defmodule AmbrySchema.Resolvers do
 
   def node(%{type: :narrator, id: id}, _resolution), do: {:ok, Repo.get(Narrator, id)}
   def node(%{type: :person, id: id}, _resolution), do: {:ok, Repo.get(Person, id)}
+
+  def node(%{type: :recording_group, id: id}, _resolution),
+    do: {:ok, Repo.get(RecordingGroup, id)}
+
   def node(%{type: :series, id: id}, _resolution), do: {:ok, Repo.get(Series, id)}
   def node(%{type: :series_book, id: id}, _resolution), do: {:ok, Repo.get(SeriesBook, id)}
 
@@ -179,6 +187,7 @@ defmodule AmbrySchema.Resolvers do
   def type(%MediaNarrator{}, _resolution), do: :media_narrator
   def type(%Narrator{}, _resolution), do: :narrator
   def type(%Person{}, _resolution), do: :person
+  def type(%RecordingGroup{}, _resolution), do: :recording_group
   def type(%Series{}, _resolution), do: :series
   def type(%SeriesBook{}, _resolution), do: :series_book
 

--- a/lib/ambry_schema/sync.ex
+++ b/lib/ambry_schema/sync.ex
@@ -20,6 +20,7 @@ defmodule AmbrySchema.Sync do
     value :series_book
     value :media
     value :media_narrator
+    value :recording_group
     value :universe
   end
 
@@ -129,6 +130,14 @@ defmodule AmbrySchema.Sync do
       middleware AmbrySchema.AuthMiddleware
 
       resolve &Resolvers.media_narrators_changed_since/2
+    end
+
+    field :recording_groups_changed_since, non_null(list_of(non_null(:recording_group))) do
+      arg :since, :datetime
+
+      middleware AmbrySchema.AuthMiddleware
+
+      resolve &Resolvers.recording_groups_changed_since/2
     end
 
     field :deletions_since, non_null(list_of(non_null(:deletion))) do

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1409,16 +1409,12 @@ defmodule AmbryWeb.CoreComponents do
   end
 
   @doc """
-  A label for a part set: "Season One · 3 parts", or "3 parts" for unnamed
-  groups. The group's media must be loaded.
+  A user-facing label for a part set: "3 parts", "6 episodes" — count plus
+  the group's plural wording. The group's name is an admin-only label and is
+  deliberately never rendered here.
   """
   def part_set_label(%RecordingGroup{} = group, parts \\ nil) do
-    count = "#{length(parts || group.media)} parts"
-
-    case group.name do
-      nil -> count
-      name -> "#{name} · #{count}"
-    end
+    "#{length(parts || group.media)} #{RecordingGroup.part_word_plural(group)}"
   end
 
   @doc """

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -17,6 +17,7 @@ defmodule AmbryWeb.CoreComponents do
   alias Ambry.Books.SeriesBook
   alias Ambry.Media.Media
   alias Ambry.Media.MediaFlat
+  alias Ambry.Media.RecordingGroup
   alias Ambry.People.Author
   alias AmbryWeb.Admin.UploadHelpers
   alias AmbryWeb.Components.Autocomplete
@@ -1021,6 +1022,7 @@ defmodule AmbryWeb.CoreComponents do
   attr :stream, :any, required: true
   attr :next, :string, default: "next-page"
   attr :prev, :string, default: "prev-page"
+  attr :collapse_part_sets, :boolean, default: false
   attr :rest, :global
 
   def media_tiles_stream(assigns) do
@@ -1034,7 +1036,12 @@ defmodule AmbryWeb.CoreComponents do
       class={[if(@end?, do: "", else: "pb-[calc(200vh)]"), if(@page == 1, do: "", else: "pt-[calc(200vh)]")]}
       {@rest}
     >
-      <.media_tile :for={{id, media} <- @stream} media={media} id={id} />
+      <.media_tile
+        :for={{id, media} <- @stream}
+        media={media}
+        id={id}
+        collapse_part_sets={@collapse_part_sets}
+      />
     </.grid>
     """
   end
@@ -1064,7 +1071,9 @@ defmodule AmbryWeb.CoreComponents do
       <% end %>
       <div class="group">
         <.link navigate={~p"/books/#{@book}"}>
-          <.book_multi_image thumbnails={Enum.flat_map(@book.media, &if(&1.thumbnails, do: [&1.thumbnails], else: []))} />
+          <.book_multi_image thumbnails={
+            Enum.flat_map(part_set_stack_media(@book.media), &if(&1.thumbnails, do: [&1.thumbnails], else: []))
+          } />
         </.link>
         <p class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
           <.link navigate={~p"/books/#{@book}"}>
@@ -1107,6 +1116,46 @@ defmodule AmbryWeb.CoreComponents do
   attr :show_series, :boolean, default: true
   attr :show_narrators, :boolean, default: false
   attr :show_published, :boolean, default: false
+  attr :collapse_part_sets, :boolean, default: false
+
+  # A part set collapses into a single stacked tile (its parts' covers),
+  # titled with the book, and lands on the book page where the parts are
+  # listed in order.
+  def media_tile(
+        %{
+          collapse_part_sets: true,
+          media: %Media{recording_group: %RecordingGroup{media: [_, _ | _]}}
+        } = assigns
+      ) do
+    ~H"""
+    <div id={@id} class="text-center">
+      <div class="group">
+        <.link navigate={~p"/books/#{@media.book}"}>
+          <.book_multi_image thumbnails={
+            Enum.flat_map(@media.recording_group.media, &if(&1.thumbnails, do: [&1.thumbnails], else: []))
+          } />
+        </.link>
+        <p :if={@show_title} class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
+          <.link navigate={~p"/books/#{@media.book}"}>
+            {@media.book.title}
+          </.link>
+        </p>
+      </div>
+
+      <p class="text-sm text-zinc-600 dark:text-zinc-400">
+        {part_set_label(@media.recording_group)}
+      </p>
+
+      <p :if={@show_authors} class="text-sm text-zinc-800 dark:text-zinc-200 sm:text-base">
+        by <.people_links people={@media.book.authors} />
+      </p>
+
+      <div :if={@show_series} class="text-xs text-zinc-600 dark:text-zinc-400 sm:text-sm">
+        <.series_book_links series_books={@media.book.series_books} />
+      </div>
+    </div>
+    """
+  end
 
   def media_tile(assigns) do
     ~H"""
@@ -1356,6 +1405,49 @@ defmodule AmbryWeb.CoreComponents do
       flat.title -> flat.title
       label = Media.part_label(flat) -> "#{flat.book} (#{label})"
       true -> flat.book
+    end
+  end
+
+  @doc """
+  A label for a part set: "Season One · 3 parts", or "3 parts" for unnamed
+  groups. The group's media must be loaded.
+  """
+  def part_set_label(%RecordingGroup{} = group, parts \\ nil) do
+    count = "#{length(parts || group.media)} parts"
+
+    case group.name do
+      nil -> count
+      name -> "#{name} · #{count}"
+    end
+  end
+
+  @doc """
+  The media whose covers a book tile stacks: one per edition — part sets
+  contribute only their first part — unless the book's sole edition is a part
+  set, in which case its parts are the stack.
+  """
+  def part_set_stack_media(media_list) do
+    first_parts =
+      media_list
+      |> Enum.filter(& &1.recording_group_id)
+      |> Enum.group_by(& &1.recording_group_id)
+      |> Map.new(fn {group_id, parts} ->
+        {group_id, Enum.min_by(parts, &{&1.part_number || :infinity, &1.id}).id}
+      end)
+
+    representatives =
+      Enum.filter(media_list, fn media ->
+        is_nil(media.recording_group_id) or first_parts[media.recording_group_id] == media.id
+      end)
+
+    case representatives do
+      [%{recording_group_id: group_id}] when not is_nil(group_id) ->
+        media_list
+        |> Enum.filter(&(&1.recording_group_id == group_id))
+        |> Enum.sort_by(&{&1.part_number || :infinity, &1.id})
+
+      _multiple_editions ->
+        representatives
     end
   end
 

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -16,6 +16,7 @@ defmodule AmbryWeb.CoreComponents do
   alias Ambry.Books.Book
   alias Ambry.Books.SeriesBook
   alias Ambry.Media.Media
+  alias Ambry.Media.MediaFlat
   alias Ambry.People.Author
   alias AmbryWeb.Admin.UploadHelpers
   alias AmbryWeb.Components.Autocomplete
@@ -1116,7 +1117,15 @@ defmodule AmbryWeb.CoreComponents do
         </.link>
         <p :if={@show_title} class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
           <.link navigate={~p"/audiobooks/#{@media}"}>
-            {@media.title || @media.book.title}
+            {media_display_title(@media)}
+          </.link>
+        </p>
+        <p
+          :if={!@show_title && media_distinguisher(@media)}
+          class="text-sm text-zinc-800 group-hover:underline dark:text-zinc-200"
+        >
+          <.link navigate={~p"/audiobooks/#{@media}"}>
+            {media_distinguisher(@media)}
           </.link>
         </p>
       </div>
@@ -1333,6 +1342,27 @@ defmodule AmbryWeb.CoreComponents do
     <.link navigate={person_ish_path(@person2)} class="hover:underline" phx-no-format>
       <%= @person2.name %></.link><span phx-no-format>, and <%= @others %> others</span>
     """
+  end
+
+  @doc """
+  The title a recording displays as, for both Media structs (book preloaded)
+  and MediaFlat rows: the override verbatim, else the book title plus part
+  label.
+  """
+  def media_display_title(%Media{} = media), do: Media.display_title(media)
+
+  def media_display_title(%MediaFlat{} = flat) do
+    cond do
+      flat.title -> flat.title
+      label = Media.part_label(flat) -> "#{flat.book} (#{label})"
+      true -> flat.book
+    end
+  end
+
+  # When a tile hides its title (e.g. "other editions" lists), parts of a set
+  # still need telling apart: the override title or the part label.
+  defp media_distinguisher(%Media{} = media) do
+    media.title || Media.part_label(media)
   end
 
   # Authors can be linked to multiple people (composite pen names), so author

--- a/lib/ambry_web/controllers/preview/audiobook_html/show.html.heex
+++ b/lib/ambry_web/controllers/preview/audiobook_html/show.html.heex
@@ -2,7 +2,7 @@
   <div class="justify-center sm:flex sm:flex-row">
     <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
       <div class="mb-6 sm:hidden">
-        <.book_header book={@media.book} />
+        <.book_header book={@media.book} title_override={media_display_title(@media)} />
         <p class="mt-4">
           Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
           <%= if @media.abridged do %>
@@ -30,7 +30,7 @@
     </section>
     <section id="description" class="max-w-md sm:ml-10">
       <div class="hidden sm:block">
-        <.book_header book={@media.book} />
+        <.book_header book={@media.book} title_override={media_display_title(@media)} />
         <p class="mt-4">
           Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
           <%= if @media.abridged do %>

--- a/lib/ambry_web/live/admin/media_live/chapters.ex
+++ b/lib/ambry_web/live/admin/media_live/chapters.ex
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.MediaLive.Chapters do
      socket
      |> assign_form(changeset)
      |> assign(
-       page_title: "#{media.book.title} - Chapters",
+       page_title: "#{Ambry.Media.Media.display_title(media)} - Chapters",
        media: media,
        import: nil
      )}

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -406,6 +406,13 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     [{"(not part of a group)", "none"}, {"+ New group…", "new"} | groups]
   end
 
+  defp group_field_value(form, media, virtual_field, group_field) do
+    case {form[virtual_field].value, group_name_mode(form, media)} do
+      {nil, :edit} -> media.recording_group && Map.get(media.recording_group, group_field)
+      {value, _mode} -> value
+    end
+  end
+
   # :new — naming a group being created; :edit — renaming the currently
   # linked group; nil — no name input
   defp group_name_mode(form, media) do

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -45,8 +45,9 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     socket
     |> assign_form(changeset)
     |> assign(
-      page_title: media.book.title,
+      page_title: Media.Media.display_title(media),
       media: media,
+      recording_groups: Media.recording_groups_for_select(media.book_id),
       file_stats: Media.get_media_file_details(media)
     )
   end
@@ -65,6 +66,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     |> assign(
       page_title: "New Media",
       media: media,
+      recording_groups: [],
       file_stats: nil
     )
   end
@@ -110,6 +112,11 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       else
         cancel_all_uploads(socket, :image)
       end
+
+    socket =
+      assign(socket,
+        recording_groups: Media.recording_groups_for_select(media_params["book_id"])
+      )
 
     changeset =
       socket.assigns.media
@@ -394,4 +401,15 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   defp open_import_form(media, type), do: JS.patch(media_path(media, %{import: type}))
   defp open_file_browser(media), do: JS.patch(media_path(media, %{browse: :files}))
   defp close_modal(media), do: JS.patch(media_path(media), replace: true)
+
+  defp recording_group_options(groups) do
+    [{"(not part of a group)", "none"}, {"+ New group…", "new"} | groups]
+  end
+
+  defp recording_group_choice_value(form) do
+    case form[:recording_group_choice].value do
+      nil -> form[:recording_group_id].value || "none"
+      value -> value
+    end
+  end
 end

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -406,6 +406,18 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     [{"(not part of a group)", "none"}, {"+ New group…", "new"} | groups]
   end
 
+  # :new — naming a group being created; :edit — renaming the currently
+  # linked group; nil — no name input
+  defp group_name_mode(form, media) do
+    choice = to_string(recording_group_choice_value(form))
+
+    cond do
+      choice == "new" -> :new
+      media.recording_group_id && choice == to_string(media.recording_group_id) -> :edit
+      true -> nil
+    end
+  end
+
   defp recording_group_choice_value(form) do
     case form[:recording_group_choice].value do
       nil -> form[:recording_group_id].value || "none"

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -112,18 +112,25 @@
         />
       </div>
 
-      <.input
-        :if={group_name_mode(@form, @media) == :new}
-        field={@form[:recording_group_name]}
-        label="New group name (optional — e.g. a season name)"
-      />
-
-      <.input
-        :if={group_name_mode(@form, @media) == :edit}
-        field={@form[:recording_group_name]}
-        label="Group name (renames it for every part; optional)"
-        value={@form[:recording_group_name].value || (@media.recording_group && @media.recording_group.name)}
-      />
+      <div :if={group_name_mode(@form, @media)} class="grid grid-cols-1 gap-6 sm:grid-cols-3 sm:gap-2">
+        <.input
+          field={@form[:recording_group_name]}
+          label="Group label (admin-only; optional)"
+          value={group_field_value(@form, @media, :recording_group_name, :name)}
+        />
+        <.input
+          field={@form[:recording_group_part_word]}
+          label={~s(What's one release called? — default "part")}
+          placeholder="part"
+          value={group_field_value(@form, @media, :recording_group_part_word, :part_word)}
+        />
+        <.input
+          field={@form[:recording_group_part_word_plural]}
+          label={~s(…and several? — default "parts")}
+          placeholder="parts"
+          value={group_field_value(@form, @media, :recording_group_part_word_plural, :part_word_plural)}
+        />
+      </div>
 
       <.input type="hidden" field={@form[:image_type]} />
       <.input type="hidden" field={@form[:image_path]} />

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -100,6 +100,24 @@
         <.input field={@form[:full_cast]} label="Full cast" type="checkbox" />
       </div>
 
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-3 sm:gap-2">
+        <.input field={@form[:part_number]} type="number" min="1" label="Part number" />
+        <.input field={@form[:parts_total]} type="number" min="1" label="Total parts" />
+        <.input
+          field={@form[:recording_group_choice]}
+          type="select"
+          label="Recording group"
+          options={recording_group_options(@recording_groups)}
+          value={recording_group_choice_value(@form)}
+        />
+      </div>
+
+      <.input
+        :if={to_string(@form[:recording_group_choice].value) == "new"}
+        field={@form[:new_recording_group_name]}
+        label="New group name (optional — e.g. a season name)"
+      />
+
       <.input type="hidden" field={@form[:image_type]} />
       <.input type="hidden" field={@form[:image_path]} />
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -113,9 +113,16 @@
       </div>
 
       <.input
-        :if={to_string(@form[:recording_group_choice].value) == "new"}
-        field={@form[:new_recording_group_name]}
+        :if={group_name_mode(@form, @media) == :new}
+        field={@form[:recording_group_name]}
         label="New group name (optional — e.g. a season name)"
+      />
+
+      <.input
+        :if={group_name_mode(@form, @media) == :edit}
+        field={@form[:recording_group_name]}
+        label="Group name (renames it for every part; optional)"
+        value={@form[:recording_group_name].value || (@media.recording_group && @media.recording_group.name)}
       />
 
       <.input type="hidden" field={@form[:image_type]} />

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -43,7 +43,7 @@
       </div>
 
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis">{media.title || media.book}</p>
+        <p class="overflow-hidden text-ellipsis">{media_display_title(media)}</p>
         <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500">
           by {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -22,7 +22,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
      |> allow_audio_upload(:audio)
      |> assign_form(changeset)
      |> assign(
-       page_title: "#{media.book.title} - Replace audio",
+       page_title: "#{Ambry.Media.Media.display_title(media)} - Replace audio",
        media: media,
        local_import_path: local_import_path,
        select_files: false,

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -88,13 +88,13 @@ defmodule AmbryWeb.AudiobookLive do
                     <.book_multi_image thumbnails={if part.thumbnails, do: [part.thumbnails], else: []} />
                   </div>
                   <p class="mt-1 text-sm font-bold text-zinc-900 dark:text-zinc-100">
-                    {part_chip_label(part)}
+                    {part_chip_label(part, @part_set)}
                   </p>
                 <% else %>
                   <.link navigate={~p"/audiobooks/#{part}"} class="group">
                     <.book_multi_image thumbnails={if part.thumbnails, do: [part.thumbnails], else: []} />
                     <p class="mt-1 text-sm text-zinc-800 group-hover:underline dark:text-zinc-200">
-                      {part_chip_label(part)}
+                      {part_chip_label(part, @part_set)}
                     </p>
                   </.link>
                 <% end %>
@@ -171,21 +171,14 @@ defmodule AmbryWeb.AudiobookLive do
   end
 
   # short label under each cover in the part rail
-  defp part_chip_label(part) do
-    Ambry.Media.Media.part_label(part) || part.title || "Untitled"
+  defp part_chip_label(part, group) do
+    Ambry.Media.Media.part_label(part, group) || part.title || "Untitled"
   end
 
-  # "Season One — Part 2 of 3" / "Part 2 of 3" / nil
+  # "Part 2 of 3" / "Episode 4 of 6" / nil — the group name is admin-only
+  # and deliberately not shown
   defp part_set_line(media) do
-    label = Ambry.Media.Media.part_label(media)
-    group_name = media.recording_group && media.recording_group.name
-
-    case {group_name, label} do
-      {nil, nil} -> nil
-      {nil, label} -> label
-      {name, nil} -> name
-      {name, label} -> "#{name} — #{label}"
-    end
+    Ambry.Media.Media.part_label(media)
   end
 
   defp format_file_name(file), do: file.label || file.filename

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -77,13 +77,38 @@ defmodule AmbryWeb.AudiobookLive do
             <.markdown :if={@media.description} content={@media.description} class="mt-4" />
           </section>
 
-          <%= if @media.book.media != [] do %>
+          <%= if @part_set do %>
+            <h2 class="mt-6 mb-2 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+              {part_set_label(@part_set)}
+            </h2>
+            <div class="grid grid-cols-3 gap-4 sm:gap-6">
+              <div :for={part <- @part_set.media} class="text-center">
+                <%= if part.id == @media.id do %>
+                  <div class="ring-brand rounded-sm ring-2 dark:ring-brand-dark">
+                    <.book_multi_image thumbnails={if part.thumbnails, do: [part.thumbnails], else: []} />
+                  </div>
+                  <p class="mt-1 text-sm font-bold text-zinc-900 dark:text-zinc-100">
+                    {part_chip_label(part)}
+                  </p>
+                <% else %>
+                  <.link navigate={~p"/audiobooks/#{part}"} class="group">
+                    <.book_multi_image thumbnails={if part.thumbnails, do: [part.thumbnails], else: []} />
+                    <p class="mt-1 text-sm text-zinc-800 group-hover:underline dark:text-zinc-200">
+                      {part_chip_label(part)}
+                    </p>
+                  </.link>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <%= if @other_editions != [] do %>
             <h2 class="mt-6 mb-2 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
               Other Editions
             </h2>
             <div class="grid grid-cols-2 gap-4 sm:gap-6 md:gap-8">
               <.media_tile
-                :for={media <- @media.book.media}
+                :for={media <- @other_editions}
                 media={media}
                 show_title={false}
                 show_authors={false}
@@ -120,15 +145,34 @@ defmodule AmbryWeb.AudiobookLive do
          {:ok, media} <- Media.fetch_media_with_book_details(media_id) do
       global_id = to_global_id("Media", media.id, AmbrySchema)
 
+      part_set =
+        case media.recording_group do
+          %{media: [_, _ | _]} = group -> group
+          _no_set -> nil
+        end
+
+      other_editions =
+        Enum.reject(
+          media.book.media,
+          &(part_set && &1.recording_group_id == media.recording_group_id)
+        )
+
       {:ok,
        assign(socket,
          page_title: Books.get_book_description(media.book),
          media: media,
+         part_set: part_set,
+         other_editions: other_editions,
          global_id: global_id
        )}
     else
       _ -> {:ok, redirect(socket, to: ~p"/")}
     end
+  end
+
+  # short label under each cover in the part rail
+  defp part_chip_label(part) do
+    Ambry.Media.Media.part_label(part) || part.title || "Untitled"
   end
 
   # "Season One — Part 2 of 3" / "Part 2 of 3" / nil

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -20,7 +20,7 @@ defmodule AmbryWeb.AudiobookLive do
       <div class="justify-center sm:flex sm:flex-row">
         <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
           <div class="mb-6 sm:hidden">
-            <.book_header book={@media.book} title_override={@media.title} />
+            <.book_header book={@media.book} title_override={media_display_title(@media)} />
             <p class="mt-4">
               Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
               <%= if @media.abridged do %>
@@ -44,7 +44,10 @@ defmodule AmbryWeb.AudiobookLive do
           <div class="mt-6 divide-y divide-zinc-300 rounded-sm border border-zinc-200 bg-zinc-50 px-3 text-zinc-800 shadow-md dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-200">
             <div class="flex items-center gap-4 py-3">
               <div class="grow">
-                <p>{@media.title || @media.book.title}</p>
+                <p>{media_display_title(@media)}</p>
+                <p :if={part_set_line(@media)} class="text-zinc-600 dark:text-zinc-400">
+                  {part_set_line(@media)}
+                </p>
                 <p class="text-zinc-600 dark:text-zinc-400">
                   {duration_display(@media.duration)}
                 </p>
@@ -93,7 +96,7 @@ defmodule AmbryWeb.AudiobookLive do
         </section>
 
         <section id="description" class="hidden max-w-md sm:ml-10 sm:block">
-          <.book_header book={@media.book} title_override={@media.title} />
+          <.book_header book={@media.book} title_override={media_display_title(@media)} />
           <p class="mt-4">
             Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
             <%= if @media.abridged do %>
@@ -125,6 +128,19 @@ defmodule AmbryWeb.AudiobookLive do
        )}
     else
       _ -> {:ok, redirect(socket, to: ~p"/")}
+    end
+  end
+
+  # "Season One — Part 2 of 3" / "Part 2 of 3" / nil
+  defp part_set_line(media) do
+    label = Ambry.Media.Media.part_label(media)
+    group_name = media.recording_group && media.recording_group.name
+
+    case {group_name, label} do
+      {nil, nil} -> nil
+      {nil, label} -> label
+      {name, nil} -> name
+      {name, label} -> "#{name} — #{label}"
     end
   end
 

--- a/lib/ambry_web/live/book_live.ex
+++ b/lib/ambry_web/live/book_live.ex
@@ -24,8 +24,23 @@ defmodule AmbryWeb.BookLive do
         <div>
           <h1 class="mb-4 text-2xl font-bold sm:text-3xl lg:mb-8 lg:text-4xl">Editions</h1>
 
+          <div :for={%{group: group, parts: parts} <- @part_groups} class="mb-10">
+            <h2 class="mb-4 text-xl font-bold text-zinc-800 dark:text-zinc-200 sm:text-2xl">
+              {part_set_label(group, parts)}
+            </h2>
+            <.media_tiles
+              media={parts}
+              show_title={false}
+              show_authors={false}
+              show_series={false}
+              show_narrators={true}
+              show_published={true}
+            />
+          </div>
+
           <.media_tiles
-            media={@book.media}
+            :if={@ungrouped_media != []}
+            media={@ungrouped_media}
             show_title={false}
             show_authors={false}
             show_series={false}
@@ -47,10 +62,24 @@ defmodule AmbryWeb.BookLive do
         {:ok, push_navigate(socket, to: ~p"/audiobooks/#{media}")}
 
       _else ->
+        part_groups =
+          book.media
+          |> Enum.filter(& &1.recording_group_id)
+          |> Enum.group_by(& &1.recording_group_id)
+          |> Enum.map(fn {_group_id, parts} ->
+            %{
+              group: hd(parts).recording_group,
+              parts: Enum.sort_by(parts, &{&1.part_number || :infinity, &1.id})
+            }
+          end)
+          |> Enum.sort_by(& &1.group.id)
+
         {:ok,
          assign(socket,
            page_title: Books.get_book_description(book),
-           book: book
+           book: book,
+           part_groups: part_groups,
+           ungrouped_media: Enum.reject(book.media, & &1.recording_group_id)
          )}
     end
   end

--- a/lib/ambry_web/live/library_live.ex
+++ b/lib/ambry_web/live/library_live.ex
@@ -29,7 +29,7 @@ defmodule AmbryWeb.LibraryLive do
           </p>
         </div>
       <% else %>
-        <.media_tiles_stream id="media" stream={@streams.media} page={@page} end?={@end?} />
+        <.media_tiles_stream id="media" stream={@streams.media} page={@page} end?={@end?} collapse_part_sets />
       <% end %>
     </div>
     """

--- a/priv/repo/migrations/20260801232823_multi_part_recordings.exs
+++ b/priv/repo/migrations/20260801232823_multi_part_recordings.exs
@@ -1,0 +1,43 @@
+defmodule Ambry.Repo.Migrations.MultiPartRecordings do
+  use Ecto.Migration
+  use Familiar
+
+  def up do
+    create table(:recording_groups) do
+      add :name, :text
+
+      timestamps(type: :utc_datetime)
+    end
+
+    alter table(:media) do
+      add :part_number, :integer
+      add :parts_total, :integer
+      add :recording_group_id, references(:recording_groups, on_delete: :nilify_all)
+    end
+
+    create index(:media, [:recording_group_id])
+
+    execute """
+    CREATE TRIGGER track_delete_trigger
+    BEFORE DELETE ON recording_groups
+    FOR EACH ROW
+    EXECUTE FUNCTION track_delete('recording_group');
+    """
+
+    update_view("media_flat", version: 10)
+  end
+
+  def down do
+    update_view("media_flat", version: 9)
+
+    alter table(:media) do
+      remove :part_number
+      remove :parts_total
+      remove :recording_group_id
+    end
+
+    execute "DELETE FROM deletions WHERE type = 'recording_group'"
+
+    drop table(:recording_groups)
+  end
+end

--- a/priv/repo/migrations/20260802002945_recording_group_part_words.exs
+++ b/priv/repo/migrations/20260802002945_recording_group_part_words.exs
@@ -1,0 +1,22 @@
+defmodule Ambry.Repo.Migrations.RecordingGroupPartWords do
+  use Ecto.Migration
+  use Familiar
+
+  def up do
+    alter table(:recording_groups) do
+      add :part_word, :text
+      add :part_word_plural, :text
+    end
+
+    update_view("media_flat", version: 11)
+  end
+
+  def down do
+    update_view("media_flat", version: 10)
+
+    alter table(:recording_groups) do
+      remove :part_word
+      remove :part_word_plural
+    end
+  end
+end

--- a/priv/repo/views/media_flat_v10.sql
+++ b/priv/repo/views/media_flat_v10.sql
@@ -1,0 +1,80 @@
+SELECT
+  media.id,
+  media.status,
+  media.title,
+  media.part_number,
+  media.parts_total,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrator.name
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/priv/repo/views/media_flat_v11.sql
+++ b/priv/repo/views/media_flat_v11.sql
@@ -1,0 +1,88 @@
+SELECT
+  media.id,
+  media.status,
+  media.title,
+  media.part_number,
+  media.parts_total,
+  (
+    SELECT
+      recording_group.part_word
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS part_word,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrator.name
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -367,6 +367,146 @@ defmodule Ambry.MediaTest do
     end
   end
 
+  describe "multi-part recordings" do
+    test "creates media with part fields and a new named recording group" do
+      %{id: book_id} = insert(:book)
+
+      params =
+        :media
+        |> params_for(
+          book_id: book_id,
+          part_number: 1,
+          parts_total: 3,
+          recording_group_choice: "new",
+          new_recording_group_name: "Season One"
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :part_number,
+          :parts_total,
+          :recording_group_choice,
+          :new_recording_group_name
+        ])
+
+      assert {:ok, media} = Media.create_media(params)
+
+      assert %{part_number: 1, parts_total: 3, recording_group: %{name: "Season One"}} = media
+      assert [{"Season One", _id}] = Media.recording_groups_for_select(book_id)
+    end
+
+    test "links a sibling part to an existing group via the choice field" do
+      %{id: book_id} = insert(:book)
+
+      {:ok, part_one} =
+        :media
+        |> params_for(book_id: book_id, part_number: 1, recording_group_choice: "new")
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :part_number,
+          :recording_group_choice
+        ])
+        |> Media.create_media()
+
+      group_id = part_one.recording_group.id
+
+      {:ok, part_two} =
+        :media
+        |> params_for(
+          book_id: book_id,
+          part_number: 2,
+          recording_group_choice: to_string(group_id)
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :part_number,
+          :recording_group_choice
+        ])
+        |> Media.create_media()
+
+      assert part_two.recording_group_id == group_id
+
+      # unnamed groups get a readable select label
+      assert [{"Unnamed group #" <> _, ^group_id}] = Media.recording_groups_for_select(book_id)
+    end
+
+    test "clearing the last member deletes the orphaned group" do
+      %{id: book_id} = insert(:book)
+
+      {:ok, media} =
+        :media
+        |> params_for(book_id: book_id, recording_group_choice: "new")
+        |> Map.take([:abridged, :full_cast, :source_path, :book_id, :recording_group_choice])
+        |> Media.create_media()
+
+      assert media.recording_group_id
+
+      {:ok, updated} =
+        Media.update_media(Media.get_media!(media.id), %{recording_group_choice: "none"})
+
+      assert updated.recording_group_id == nil
+      assert [] = Media.recording_groups_for_select(book_id)
+      assert Ambry.Repo.aggregate(Ambry.Media.RecordingGroup, :count) == 0
+    end
+
+    test "validates part fields" do
+      %{id: book_id} = insert(:book)
+
+      params =
+        :media
+        |> params_for(book_id: book_id, part_number: 3, parts_total: 2)
+        |> Map.take([:abridged, :full_cast, :source_path, :book_id, :part_number, :parts_total])
+
+      {:error, changeset} = Media.create_media(params)
+
+      assert %{part_number: ["can't be greater than the total number of parts"]} =
+               errors_on(changeset)
+    end
+
+    test "part_label/1 and display_title/1" do
+      alias Ambry.Media.Media, as: MediaSchema
+
+      assert MediaSchema.part_label(%{part_number: nil, parts_total: nil}) == nil
+      assert MediaSchema.part_label(%{part_number: 2, parts_total: nil}) == "Part 2"
+      assert MediaSchema.part_label(%{part_number: 2, parts_total: 3}) == "Part 2 of 3"
+
+      book = build(:book, title: "The Way of Kings")
+
+      plain = build(:media, book: book, part_number: nil, parts_total: nil, title: nil)
+      assert MediaSchema.display_title(plain) == "The Way of Kings"
+
+      part = build(:media, book: book, part_number: 2, parts_total: 3, title: nil)
+      assert MediaSchema.display_title(part) == "The Way of Kings (Part 2 of 3)"
+
+      override =
+        build(:media,
+          book: book,
+          part_number: 2,
+          parts_total: 3,
+          title: "The Way of Kings (2 of 3)"
+        )
+
+      assert MediaSchema.display_title(override) == "The Way of Kings (2 of 3)"
+    end
+
+    test "get_media_description/1 includes the part label" do
+      book = insert(:book, title: "The Way of Kings")
+      media = insert(:media, book: book, part_number: 1, parts_total: 3)
+
+      description = media.id |> Media.get_media!() |> Media.get_media_description()
+
+      assert description =~ "The Way of Kings (Part 1 of 3)"
+    end
+  end
+
   describe "update_media/3" do
     test "allows updating a media's abridged value" do
       media = insert(:media, book: build(:book))

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -378,7 +378,7 @@ defmodule Ambry.MediaTest do
           part_number: 1,
           parts_total: 3,
           recording_group_choice: "new",
-          new_recording_group_name: "Season One"
+          recording_group_name: "Season One"
         )
         |> Map.take([
           :abridged,
@@ -388,7 +388,7 @@ defmodule Ambry.MediaTest do
           :part_number,
           :parts_total,
           :recording_group_choice,
-          :new_recording_group_name
+          :recording_group_name
         ])
 
       assert {:ok, media} = Media.create_media(params)
@@ -455,6 +455,97 @@ defmodule Ambry.MediaTest do
       assert updated.recording_group_id == nil
       assert [] = Media.recording_groups_for_select(book_id)
       assert Ambry.Repo.aggregate(Ambry.Media.RecordingGroup, :count) == 0
+    end
+
+    test "renames the linked group from any part (shared by all parts)" do
+      %{id: book_id} = insert(:book)
+
+      {:ok, part_one} =
+        :media
+        |> params_for(book_id: book_id, recording_group_choice: "new")
+        |> Map.take([:abridged, :full_cast, :source_path, :book_id, :recording_group_choice])
+        |> Media.create_media()
+
+      group_id = part_one.recording_group.id
+
+      {:ok, updated} =
+        Media.update_media(Media.get_media!(part_one.id), %{
+          recording_group_choice: to_string(group_id),
+          recording_group_name: "Season One"
+        })
+
+      assert %{recording_group: %{name: "Season One"}} = updated
+      assert [{"Season One", ^group_id}] = Media.recording_groups_for_select(book_id)
+    end
+
+    test "clears a group's name with an empty string" do
+      %{id: book_id} = insert(:book)
+
+      {:ok, media} =
+        :media
+        |> params_for(
+          book_id: book_id,
+          recording_group_choice: "new",
+          recording_group_name: "Typo Name"
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :recording_group_choice,
+          :recording_group_name
+        ])
+        |> Media.create_media()
+
+      group_id = media.recording_group.id
+
+      {:ok, updated} =
+        Media.update_media(Media.get_media!(media.id), %{
+          recording_group_choice: to_string(group_id),
+          recording_group_name: ""
+        })
+
+      assert %{recording_group: %{name: nil}} = updated
+    end
+
+    test "the name field is ignored when switching to a different group" do
+      %{id: book_id} = insert(:book)
+
+      {:ok, first} =
+        :media
+        |> params_for(
+          book_id: book_id,
+          recording_group_choice: "new",
+          recording_group_name: "Keep Me"
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :recording_group_choice,
+          :recording_group_name
+        ])
+        |> Media.create_media()
+
+      {:ok, second} =
+        :media
+        |> params_for(book_id: book_id, recording_group_choice: "new")
+        |> Map.take([:abridged, :full_cast, :source_path, :book_id, :recording_group_choice])
+        |> Media.create_media()
+
+      keep_me_id = first.recording_group.id
+
+      # switch `second` over to the first group while a stale name value posts
+      {:ok, moved} =
+        Media.update_media(Media.get_media!(second.id), %{
+          recording_group_choice: to_string(keep_me_id),
+          recording_group_name: "Keep Me"
+        })
+
+      assert moved.recording_group_id == keep_me_id
+      assert [{"Keep Me", ^keep_me_id}] = Media.recording_groups_for_select(book_id)
     end
 
     test "validates part fields" do

--- a/test/ambry_schema/sync_test.exs
+++ b/test/ambry_schema/sync_test.exs
@@ -170,7 +170,7 @@ defmodule AmbrySchema.SyncTest do
           part_number: 1,
           parts_total: 3,
           recording_group_choice: "new",
-          new_recording_group_name: "Season One"
+          recording_group_name: "Season One"
         )
         |> Map.take([
           :abridged,
@@ -180,7 +180,7 @@ defmodule AmbrySchema.SyncTest do
           :part_number,
           :parts_total,
           :recording_group_choice,
-          :new_recording_group_name
+          :recording_group_name
         ])
         |> Ambry.Media.create_media()
 

--- a/test/ambry_schema/sync_test.exs
+++ b/test/ambry_schema/sync_test.exs
@@ -140,6 +140,88 @@ defmodule AmbrySchema.SyncTest do
     end
   end
 
+  describe "recordingGroupsChangedSince" do
+    @query ~G"""
+    query Sync($since: DateTime) {
+      recordingGroupsChangedSince(since: $since) {
+        id
+        name
+      }
+      mediaChangedSince(since: $since) {
+        partNumber
+        partsTotal
+        recordingGroup {
+          name
+        }
+      }
+      deletionsSince(since: $since) {
+        type
+        recordId
+      }
+    }
+    """
+    test "returns groups, part fields, and tracks group deletions", %{conn: conn} do
+      book = insert(:book)
+
+      {:ok, media} =
+        :media
+        |> params_for(
+          book_id: book.id,
+          part_number: 1,
+          parts_total: 3,
+          recording_group_choice: "new",
+          new_recording_group_name: "Season One"
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :part_number,
+          :parts_total,
+          :recording_group_choice,
+          :new_recording_group_name
+        ])
+        |> Ambry.Media.create_media()
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{
+               "data" => %{
+                 "recordingGroupsChangedSince" => [%{"name" => "Season One"}],
+                 "mediaChangedSince" => [
+                   %{
+                     "partNumber" => 1,
+                     "partsTotal" => 3,
+                     "recordingGroup" => %{"name" => "Season One"}
+                   }
+                 ]
+               }
+             } = json_response(conn, 200)
+
+      # clearing the last member orphan-deletes the group, tracked for sync
+      {:ok, _media} =
+        Ambry.Media.update_media(Ambry.Media.get_media!(media.id), %{
+          recording_group_choice: "none"
+        })
+
+      conn =
+        post(build_conn_with_same_auth(conn), "/gql", %{
+          "query" => @query,
+          "variables" => %{"since" => "2000-01-01T00:00:00Z"}
+        })
+
+      assert %{
+               "data" => %{
+                 "recordingGroupsChangedSince" => [],
+                 "deletionsSince" => deletions
+               }
+             } = json_response(conn, 200)
+
+      assert Enum.any?(deletions, &(&1["type"] == "RECORDING_GROUP"))
+    end
+  end
+
   defp build_conn_with_same_auth(conn) do
     auth_header = Plug.Conn.get_req_header(conn, "authorization")
 

--- a/test/ambry_web/live/audiobook_live_part_test.exs
+++ b/test/ambry_web/live/audiobook_live_part_test.exs
@@ -1,0 +1,36 @@
+defmodule AmbryWeb.AudiobookLivePartTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_user
+
+  test "shows the part label and group name on the audiobook page", %{conn: conn} do
+    book = insert(:book, title: "Dungeon Crawler Carl")
+    group = insert(:recording_group, name: "Season One")
+
+    media =
+      insert(:media,
+        book: book,
+        part_number: 2,
+        parts_total: 3,
+        recording_group: group,
+        status: :ready
+      )
+
+    {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
+
+    assert html =~ "Dungeon Crawler Carl (Part 2 of 3)"
+    assert html =~ "Season One — Part 2 of 3"
+  end
+
+  test "tiles show composed titles for parts", %{conn: conn} do
+    book = insert(:book, title: "The Way of Kings")
+
+    insert(:media, book: book, part_number: 1, parts_total: 3, status: :ready)
+
+    {:ok, _view, html} = live(conn, ~p"/")
+
+    assert html =~ "The Way of Kings (Part 1 of 3)"
+  end
+end

--- a/test/ambry_web/live/audiobook_live_part_test.exs
+++ b/test/ambry_web/live/audiobook_live_part_test.exs
@@ -21,7 +21,8 @@ defmodule AmbryWeb.AudiobookLivePartTest do
     {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
 
     assert html =~ "Dungeon Crawler Carl (Part 2 of 3)"
-    assert html =~ "Season One — Part 2 of 3"
+    assert html =~ "Part 2 of 3"
+    refute html =~ "Season One"
   end
 
   test "tiles show composed titles for parts", %{conn: conn} do

--- a/test/ambry_web/live/part_set_ux_test.exs
+++ b/test/ambry_web/live/part_set_ux_test.exs
@@ -29,7 +29,8 @@ defmodule AmbryWeb.PartSetUxTest do
       {:ok, _view, html} = live(conn, ~p"/")
 
       assert html =~ "Dungeon Crawler Carl"
-      assert html =~ "Season One · 3 parts"
+      assert html =~ "3 parts"
+      refute html =~ "Season One"
       # the individual part labels don't appear as separate tiles
       refute html =~ "(Part 1 of 3)"
       assert html =~ ~p"/books/#{book.id}"
@@ -56,7 +57,8 @@ defmodule AmbryWeb.PartSetUxTest do
       {:ok, _view, html} = live(conn, ~p"/books/#{book.id}")
 
       assert html =~ "Editions"
-      assert html =~ "Season One · 2 parts"
+      assert html =~ "2 parts"
+      refute html =~ "Season One"
 
       # parts render in part order despite publication-date ordering elsewhere
       assert [i1, i2] =
@@ -75,8 +77,9 @@ defmodule AmbryWeb.PartSetUxTest do
 
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{part_two.id}")
 
-      # rail with heading and links to sibling parts
-      assert html =~ "Season One · 3 parts"
+      # rail with heading and links to sibling parts (group name is admin-only)
+      assert html =~ "3 parts"
+      refute html =~ "Season One"
       assert html =~ ~p"/audiobooks/#{part_one.id}"
 
       # the true alternate edition still shows under Other Editions
@@ -95,6 +98,41 @@ defmodule AmbryWeb.PartSetUxTest do
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
 
       refute html =~ "Other Editions"
+    end
+  end
+
+  describe "custom part wording" do
+    test "episode wording flows through labels and titles", %{conn: conn} do
+      book = insert(:book, title: "Dungeon Crawler Carl")
+
+      group =
+        insert(:recording_group,
+          name: "Admin Label",
+          part_word: "episode",
+          part_word_plural: "episodes"
+        )
+
+      parts =
+        for n <- 1..2 do
+          insert(:media,
+            book: book,
+            part_number: n,
+            parts_total: 2,
+            recording_group: group,
+            status: :ready
+          )
+        end
+
+      # library: collapsed tile counts in episodes
+      {:ok, _view, html} = live(conn, ~p"/")
+      assert html =~ "2 episodes"
+      refute html =~ "Admin Label"
+
+      # audiobook page: composed title, details line, and rail chips all say Episode
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{hd(parts).id}")
+      assert html =~ "Dungeon Crawler Carl (Episode 1 of 2)"
+      assert html =~ "Episode 2"
+      refute html =~ "Admin Label"
     end
   end
 

--- a/test/ambry_web/live/part_set_ux_test.exs
+++ b/test/ambry_web/live/part_set_ux_test.exs
@@ -1,0 +1,121 @@
+defmodule AmbryWeb.PartSetUxTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias AmbryWeb.CoreComponents
+
+  setup :register_and_log_in_user
+
+  defp insert_part_set(book, opts \\ []) do
+    group = insert(:recording_group, name: opts[:name])
+
+    for n <- 1..Keyword.get(opts, :count, 3) do
+      insert(:media,
+        book: book,
+        part_number: n,
+        parts_total: Keyword.get(opts, :count, 3),
+        recording_group: group,
+        status: :ready
+      )
+    end
+  end
+
+  describe "library page" do
+    test "collapses a part set into one stacked tile linking to the book", %{conn: conn} do
+      book = insert(:book, title: "Dungeon Crawler Carl")
+      insert_part_set(book, name: "Season One")
+
+      {:ok, _view, html} = live(conn, ~p"/")
+
+      assert html =~ "Dungeon Crawler Carl"
+      assert html =~ "Season One · 3 parts"
+      # the individual part labels don't appear as separate tiles
+      refute html =~ "(Part 1 of 3)"
+      assert html =~ ~p"/books/#{book.id}"
+    end
+
+    test "single-release media are unaffected", %{conn: conn} do
+      book = insert(:book, title: "Standalone Book")
+      insert(:media, book: book, status: :ready)
+
+      {:ok, _view, html} = live(conn, ~p"/")
+
+      assert html =~ "Standalone Book"
+    end
+  end
+
+  describe "book page" do
+    test "renders part sets as titled sections with parts in order, ungrouped below", %{
+      conn: conn
+    } do
+      book = insert(:book, title: "Dungeon Crawler Carl")
+      insert_part_set(book, name: "Season One", count: 2)
+      insert(:media, book: book, status: :ready)
+
+      {:ok, _view, html} = live(conn, ~p"/books/#{book.id}")
+
+      assert html =~ "Editions"
+      assert html =~ "Season One · 2 parts"
+
+      # parts render in part order despite publication-date ordering elsewhere
+      assert [i1, i2] =
+               Regex.scan(~r/Part \d of 2/, html) |> List.flatten() |> Enum.take(2)
+
+      assert i1 == "Part 1 of 2"
+      assert i2 == "Part 2 of 2"
+    end
+  end
+
+  describe "audiobook page" do
+    test "shows the part rail and excludes siblings from Other Editions", %{conn: conn} do
+      book = insert(:book, title: "Dungeon Crawler Carl")
+      [part_one, part_two, _part_three] = insert_part_set(book, name: "Season One")
+      other_edition = insert(:media, book: book, status: :ready, publisher: "Solo Narration Inc")
+
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{part_two.id}")
+
+      # rail with heading and links to sibling parts
+      assert html =~ "Season One · 3 parts"
+      assert html =~ ~p"/audiobooks/#{part_one.id}"
+
+      # the true alternate edition still shows under Other Editions
+      assert html =~ "Other Editions"
+      assert html =~ ~p"/audiobooks/#{other_edition.id}"
+
+      # sibling parts are not duplicated in Other Editions: their links appear
+      # exactly once (in the rail)
+      assert html |> String.split(~p"/audiobooks/#{part_one.id}") |> length() == 2
+    end
+
+    test "no rail or Other Editions for a lone single-part recording", %{conn: conn} do
+      book = insert(:book)
+      media = insert(:media, book: book, status: :ready)
+
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
+
+      refute html =~ "Other Editions"
+    end
+  end
+
+  describe "part_set_stack_media/1 (book tile stacks)" do
+    test "a part set contributes only its first part when other editions exist" do
+      book = insert(:book)
+      [part_one | rest] = insert_part_set(book)
+      solo = insert(:media, book: book, status: :ready)
+
+      stacked = CoreComponents.part_set_stack_media([solo, part_one | rest])
+
+      assert Enum.map(stacked, & &1.id) == [solo.id, part_one.id]
+    end
+
+    test "a sole part-set edition stacks all of its parts in order" do
+      book = insert(:book)
+      parts = insert_part_set(book)
+
+      stacked = CoreComponents.part_set_stack_media(Enum.shuffle(parts))
+
+      assert Enum.map(stacked, & &1.id) == Enum.map(parts, & &1.id)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,7 @@ defmodule Ambry.Factory do
   alias Ambry.Media.Bookmark
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.RecordingGroup
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
   alias Ambry.People.BookAuthor
@@ -186,6 +187,12 @@ defmodule Ambry.Factory do
       notes: Fake.sentence(),
       description: Fake.paragraph(),
       source_path: fn -> valid_source_path() end
+    }
+  end
+
+  def recording_group_factory do
+    %RecordingGroup{
+      name: nil
     }
   end
 


### PR DESCRIPTION
Fourth v1.9.0 data-model PR (ROADMAP Phase 1a): multi-part recordings — each part **is** a full Media (own cover, date, chapters, playthroughs unchanged), plus `part_number`, `parts_total`, and membership in a minimal named `recording_groups` table. Covers GraphicAudio part-sets and episodic full-cast seasons.

## Display rule (single source of truth)

`Media.display_title/1`: the override title verbatim when set (retail overrides already carry their own "(1 of 3)"), otherwise book title + part label ("The Way of Kings (Part 2 of 3)"). `Media.part_label/1` works on structs and flat rows alike.

## Part-set UX (designed with operator sign-off: cover rail + book-page landing)

A part set reads as **one thing** wherever media are listed:

- **Library page**: a set collapses into a single stacked tile (its parts' covers), subtitled "Season One · 3 parts", clicking through to the book page. Collapse happens in SQL (first ready part represents the set) so pagination stays correct.
- **Book page**: each set is a titled sub-section under Editions ("Season One · 3 parts") with parts in **part order**; loose editions keep the flat, date-ordered list.
- **Audiobook page**: sibling parts leave Other Editions (which returns to meaning true alternates) and get a **cover rail** — all parts in order, current highlighted, each clickable, labeled "Part N of M" (or episode title).
- **Book tiles** (author/series pages): a set contributes only its **first part's cover** to the image stack so sets don't dominate — unless the set is the book's sole edition, in which case its parts *are* the stack.

## Surface checklist (every media render/edit surface)

- [x] media tiles → library home, book page, narrator page, person page, series page (composed titles; hidden-title tiles get a distinguisher line)
- [x] collapsed part-set tiles + stack rules (above)
- [x] audiobook page — header, details box ("Season One — Part 2 of 3" line), part rail, filtered Other Editions
- [x] link-preview page (also picked up the previously missed title override)
- [x] `get_media_description` — tab titles / social previews
- [x] admin media index (media_flat v10 carries part fields)
- [x] admin media form — part inputs + recording-group picker (existing groups of the book, "+ New group…" with optional name, atomic at save; orphaned groups auto-deleted)
- [x] admin chapters + replace page titles
- [x] GraphQL: `media.partNumber/partsTotal/recordingGroup`, `recording_group` node, `recordingGroupsChangedSince`, `RECORDING_GROUP` deletion type + trigger (tested end-to-end incl. orphan deletion sync)
- [x] narrator/person page media lists — **decided: parts stay split there, by design.** Narrator credits are per-part and genuinely non-uniform in large-cast productions (a narrator might perform on parts 1, 3, and 5 only), so listing the individual parts a narrator is credited on — with composed titles — is the honest representation. Collapsing would misstate their work.
- [ ] mobile — deliberately untouched (standing instruction); grouped shelf display + auto-advance are the roadmap's mobile player features, no further schema needed

## Notes

- Ecto gotcha handled: `""` can't be the "clear group" select sentinel (cast folds it to nil = untouched); the picker uses `"none"`.
- Migration rehearsed both directions; full suite (620 tests) + `mix check` green.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9
