### PR TITLE
Phase 1d: field-level metadata provenance and locks

### DIFF
--- a/lib/ambry.ex
+++ b/lib/ambry.ex
@@ -20,6 +20,7 @@ defmodule Ambry do
       {Paths, []},
       {People, []},
       {Playback, []},
+      {Provenance, []},
       {PubSub, []},
       {Repo, []},
       {Thumbnails, []},

--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -131,10 +131,12 @@ defmodule Ambry.Books do
       iex> create_book(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
+  Accepts `provenance: %{"field" => source}` in `opts` to record where
+  provider-fillable field values came from — see `Ambry.Provenance`.
   """
-  def create_book(attrs \\ %{}) do
+  def create_book(attrs \\ %{}, opts \\ []) do
     Repo.transact(fn ->
-      changeset = change_book(%Book{}, attrs)
+      changeset = Book.changeset(%Book{}, attrs, opts)
 
       with {:ok, book} <- Repo.insert(changeset),
            :ok <- Search.insert(book),
@@ -161,11 +163,13 @@ defmodule Ambry.Books do
       iex> update_book(book, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
+  Accepts `provenance: %{"field" => source}` in `opts` to record where
+  provider-fillable field values came from — see `Ambry.Provenance`.
   """
-  def update_book(%Book{} = book, attrs) do
+  def update_book(%Book{} = book, attrs, opts \\ []) do
     Repo.transact(fn ->
       book = Repo.preload(book, @book_direct_assoc_preloads)
-      changeset = change_book(book, attrs)
+      changeset = Book.changeset(book, attrs, opts)
 
       with {:ok, updated_book} <- Repo.update(changeset),
            :ok <- Search.update(updated_book),

--- a/lib/ambry/books/book.ex
+++ b/lib/ambry/books/book.ex
@@ -11,6 +11,10 @@ defmodule Ambry.Books.Book do
   alias Ambry.Books.SeriesBook
   alias Ambry.Media.Media
   alias Ambry.People.BookAuthor
+  alias Ambry.Provenance
+
+  # provider-fillable scalar fields tracked by field-level provenance
+  @provenance_fields [:title, :published, :published_format]
 
   schema "books" do
     has_many :media, Media, preload_order: [desc: :published]
@@ -25,11 +29,15 @@ defmodule Ambry.Books.Book do
     field :published, :date
     field :published_format, Ecto.Enum, values: [:full, :year_month, :year]
 
+    field :field_provenance, :map, default: %{}
+
     timestamps(type: :utc_datetime)
   end
 
+  def provenance_fields, do: @provenance_fields
+
   @doc false
-  def changeset(book, attrs) do
+  def changeset(book, attrs, opts \\ []) do
     book
     |> cast(attrs, [:title, :published, :published_format])
     |> cast_assoc(:series_books,
@@ -48,5 +56,6 @@ defmodule Ambry.Books.Book do
     )
     |> validate_required([:title, :published])
     |> foreign_key_constraint(:media, name: "media_book_id_fkey")
+    |> Provenance.track_changes(@provenance_fields, opts[:provenance] || %{})
   end
 end

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -175,10 +175,12 @@ defmodule Ambry.Media do
       iex> create_media(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
+  Accepts `provenance: %{"field" => source}` in `opts` to record where
+  provider-fillable field values came from — see `Ambry.Provenance`.
   """
-  def create_media(attrs \\ %{}) do
+  def create_media(attrs \\ %{}, opts \\ []) do
     Repo.transact(fn ->
-      changeset = Media.changeset(%Media{}, attrs)
+      changeset = Media.changeset(%Media{}, attrs, opts)
 
       with {:ok, media} <- Repo.insert(changeset),
            :ok <- Search.insert(media),
@@ -206,10 +208,12 @@ defmodule Ambry.Media do
       iex> update_media(media, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
+  Accepts `provenance: %{"field" => source}` in `opts` to record where
+  provider-fillable field values came from — see `Ambry.Provenance`.
   """
-  def update_media(%Media{} = media, attrs) do
+  def update_media(%Media{} = media, attrs, opts \\ []) do
     Repo.transact(fn ->
-      changeset = Media.changeset(media, attrs)
+      changeset = Media.changeset(media, attrs, opts)
 
       with {:ok, updated_media} <- Repo.update(changeset),
            :ok <- delete_orphaned_recording_groups(),

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -13,10 +13,14 @@ defmodule Ambry.Media.Media do
   alias Ambry.Media.MediaNarrator
   alias Ambry.Media.Processor
   alias Ambry.Media.RecordingGroup
+  alias Ambry.Provenance
   alias Ambry.Repo.SupplementalFile
   alias Ambry.Thumbnails
 
   @statuses [:pending, :processing, :error, :ready]
+
+  # provider-fillable scalar fields tracked by field-level provenance
+  @provenance_fields [:published, :published_format, :publisher, :description, :image_path]
 
   schema "media" do
     belongs_to :book, Book
@@ -65,13 +69,17 @@ defmodule Ambry.Media.Media do
     field :description, :string
     field :publisher, :string
 
+    field :field_provenance, :map, default: %{}
+
     timestamps(type: :utc_datetime)
   end
 
   def statuses, do: @statuses
 
+  def provenance_fields, do: @provenance_fields
+
   @doc false
-  def changeset(media, attrs) do
+  def changeset(media, attrs, opts \\ []) do
     media
     |> cast(attrs, [
       :abridged,
@@ -121,6 +129,7 @@ defmodule Ambry.Media.Media do
     |> validate_image_path()
     |> cast_embed(:thumbnails)
     |> check_constraint(:thumbnails, name: "thumbnails_original_match_constraint")
+    |> Provenance.track_changes(@provenance_fields, opts[:provenance] || %{})
   end
 
   # The media form stages the recording-group picker in a virtual field:

--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -125,10 +125,12 @@ defmodule Ambry.People do
       iex> create_person(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
+  Accepts `provenance: %{"field" => source}` in `opts` to record where
+  provider-fillable field values came from — see `Ambry.Provenance`.
   """
-  def create_person(attrs \\ %{}) do
+  def create_person(attrs \\ %{}, opts \\ []) do
     Repo.transact(fn ->
-      changeset = Person.changeset(%Person{}, attrs)
+      changeset = Person.changeset(%Person{}, attrs, opts)
 
       with {:ok, person} <- Repo.insert(changeset),
            :ok <- Search.insert(person),
@@ -156,11 +158,13 @@ defmodule Ambry.People do
       iex> update_person(person, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
+  Accepts `provenance: %{"field" => source}` in `opts` to record where
+  provider-fillable field values came from — see `Ambry.Provenance`.
   """
-  def update_person(%Person{} = person, attrs) do
+  def update_person(%Person{} = person, attrs, opts \\ []) do
     Repo.transact(fn ->
       person = Repo.preload(person, @person_direct_assoc_preloads)
-      changeset = Person.changeset(person, attrs)
+      changeset = Person.changeset(person, attrs, opts)
 
       with {:ok, updated_person} <- Repo.update(changeset),
            :ok <- delete_orphaned_authors(person, changeset),

--- a/lib/ambry/people/person.ex
+++ b/lib/ambry/people/person.ex
@@ -12,7 +12,11 @@ defmodule Ambry.People.Person do
   alias Ambry.Paths
   alias Ambry.People.AuthorPerson
   alias Ambry.People.Narrator
+  alias Ambry.Provenance
   alias Ambry.Thumbnails
+
+  # provider-fillable scalar fields tracked by field-level provenance
+  @provenance_fields [:name, :description, :image_path]
 
   schema "people" do
     has_many :author_people, AuthorPerson, on_replace: :delete
@@ -25,6 +29,8 @@ defmodule Ambry.People.Person do
     field :description, :string
     field :image_path, :string
 
+    field :field_provenance, :map, default: %{}
+
     # form-only: staging input for linking an existing author, see
     # AmbryWeb.Admin.PersonLive.Form
     field :link_author_id, :integer, virtual: true
@@ -32,8 +38,10 @@ defmodule Ambry.People.Person do
     timestamps(type: :utc_datetime)
   end
 
+  def provenance_fields, do: @provenance_fields
+
   @doc false
-  def changeset(person, attrs) do
+  def changeset(person, attrs, opts \\ []) do
     person
     |> cast(attrs, [:name, :description, :image_path])
     |> cast_assoc(:author_people,
@@ -50,6 +58,7 @@ defmodule Ambry.People.Person do
     |> validate_image_path()
     |> foreign_key_constraint(:narrator, name: "media_narrators_narrator_id_fkey")
     |> check_constraint(:thumbnails, name: "thumbnails_original_match_constraint")
+    |> Provenance.track_changes(@provenance_fields, opts[:provenance] || %{})
   end
 
   # if the image_path changes, clear the thumbnails embed

--- a/lib/ambry/provenance.ex
+++ b/lib/ambry/provenance.ex
@@ -1,0 +1,133 @@
+defmodule Ambry.Provenance do
+  @moduledoc """
+  Field-level metadata provenance and locks.
+
+  Every provider-fillable scalar field on a schema records where its current
+  value came from and whether it's locked against automated overwrite. The
+  provenance lives in a `field_provenance` jsonb map on the record itself,
+  keyed by field name:
+
+      %{"description" => %{"source" => "provider:audible", "locked" => false, "at" => "..."}}
+
+  Sources:
+
+    * `"manual"` — the operator typed/edited the value. Always locked.
+    * `"provider:<id>"` — an accepted metadata-provider suggestion. Unlocked,
+      so future refresh may update it; accepting a suggestion is a choice of
+      source, not curation of the value itself.
+    * `"legacy"` — a value that predates provenance tracking (set by the
+      backfill migration, locked) or had no recorded origin when it was
+      first locked.
+
+  Locks gate **automated writers only** (the future inbox approval and
+  background refresh — they must route their updates through
+  `reject_locked/2`). Operator-driven forms may always write any field; what
+  varies is the provenance they record: schemas call `track_changes/3` from
+  their changeset with the per-field source hints the form collected, and
+  any tracked change without a hint is a manual edit — locked.
+
+  Each schema owns its tracked-field list (its provider-fillable scalars)
+  and passes it in; structural associations are operator-owned by definition
+  and never carry provenance.
+  """
+
+  import Ecto.Changeset
+
+  alias Ambry.Repo
+
+  @manual "manual"
+  @legacy "legacy"
+
+  @type source :: String.t()
+  @type entry :: %{String.t() => String.t() | boolean()}
+
+  @doc "The provenance source string for a metadata provider id."
+  @spec provider_source(String.t()) :: source()
+  def provider_source(provider_id) when is_binary(provider_id), do: "provider:" <> provider_id
+
+  @doc "The provenance entry for a field, or nil if none was ever recorded."
+  @spec entry(struct(), atom() | String.t()) :: entry() | nil
+  def entry(record, field) do
+    Map.get(record.field_provenance || %{}, to_string(field))
+  end
+
+  @doc "Whether a field is locked against automated overwrite."
+  @spec locked?(struct(), atom() | String.t()) :: boolean()
+  def locked?(record, field) do
+    match?(%{"locked" => true}, entry(record, field))
+  end
+
+  @doc """
+  Records provenance for every tracked field the changeset is changing.
+
+  `sources` maps field names (strings) to the source the pending value came
+  from (e.g. `"provider:audible"`); a changed field with a source hint
+  records that source unlocked, a changed field without one is a manual
+  edit — recorded `"manual"` and locked. Unchanged fields keep whatever
+  provenance they had.
+  """
+  @spec track_changes(Ecto.Changeset.t(), [atom()], %{String.t() => source()}) ::
+          Ecto.Changeset.t()
+  def track_changes(%Ecto.Changeset{} = changeset, tracked_fields, sources) do
+    existing = changeset.data.field_provenance || %{}
+
+    updated =
+      Enum.reduce(tracked_fields, existing, fn field, acc ->
+        if Map.has_key?(changeset.changes, field) do
+          Map.put(acc, to_string(field), new_entry(Map.get(sources, to_string(field))))
+        else
+          acc
+        end
+      end)
+
+    if updated == existing do
+      changeset
+    else
+      put_change(changeset, :field_provenance, updated)
+    end
+  end
+
+  defp new_entry(nil), do: %{"source" => @manual, "locked" => true, "at" => now()}
+
+  defp new_entry(source) when is_binary(source),
+    do: %{"source" => source, "locked" => false, "at" => now()}
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+  @doc """
+  Drops every locked field from a proposed attrs map (string or atom keys).
+
+  This is the gate all automated writers (inbox approval, background
+  refresh, auto-match) must route proposed updates through before calling a
+  context update function — it's what makes re-syncing facts safe for
+  curated records. Operator-driven forms do NOT use this; explicit operator
+  action may always write.
+  """
+  @spec reject_locked(struct(), map()) :: map()
+  def reject_locked(record, attrs) when is_map(attrs) do
+    locked_fields =
+      for {field, %{"locked" => true}} <- record.field_provenance || %{}, do: field
+
+    Map.drop(attrs, locked_fields ++ Enum.map(locked_fields, &String.to_existing_atom/1))
+  end
+
+  @doc """
+  Flips a field's lock, persisting immediately.
+
+  Locking a field that never had provenance recorded protects its current
+  value under the `"legacy"` (unknown-origin) source. The lock flag is
+  provenance metadata, not entity data — no search/broadcast side effects
+  apply.
+  """
+  @spec toggle_lock(struct(), atom() | String.t()) :: {:ok, struct()} | {:error, term()}
+  def toggle_lock(record, field) do
+    field = to_string(field)
+    current = entry(record, field) || %{"source" => @legacy, "at" => now()}
+    updated_entry = Map.put(current, "locked", !current["locked"])
+    updated_map = Map.put(record.field_provenance || %{}, field, updated_entry)
+
+    record
+    |> change(field_provenance: updated_map)
+    |> Repo.update()
+  end
+end

--- a/lib/ambry/provenance.ex
+++ b/lib/ambry/provenance.ex
@@ -58,13 +58,15 @@ defmodule Ambry.Provenance do
   end
 
   @doc """
-  Records provenance for every tracked field the changeset is changing.
+  Records provenance for the tracked fields a save touches.
 
   `sources` maps field names (strings) to the source the pending value came
-  from (e.g. `"provider:audible"`); a changed field with a source hint
-  records that source unlocked, a changed field without one is a manual
-  edit — recorded `"manual"` and locked. Unchanged fields keep whatever
-  provenance they had.
+  from (e.g. `"provider:audible"`): a hinted field records that source
+  unlocked — even when the accepted value happens to equal what was already
+  stored (the operator's acceptance is a statement about where the current
+  value comes from, and it's what lets refresh update the field later). A
+  changed field without a hint is a manual edit — recorded `"manual"` and
+  locked. Unchanged, unhinted fields keep whatever provenance they had.
   """
   @spec track_changes(Ecto.Changeset.t(), [atom()], %{String.t() => source()}) ::
           Ecto.Changeset.t()
@@ -73,10 +75,17 @@ defmodule Ambry.Provenance do
 
     updated =
       Enum.reduce(tracked_fields, existing, fn field, acc ->
-        if Map.has_key?(changeset.changes, field) do
-          Map.put(acc, to_string(field), new_entry(Map.get(sources, to_string(field))))
-        else
-          acc
+        source = Map.get(sources, to_string(field))
+
+        cond do
+          Map.has_key?(changeset.changes, field) ->
+            Map.put(acc, to_string(field), new_entry(source))
+
+          source && get_field(changeset, field) not in [nil, ""] ->
+            Map.put(acc, to_string(field), new_entry(source))
+
+          true ->
+            acc
         end
       end)
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -497,8 +497,14 @@ defmodule AmbryWeb.Admin.Components do
   provider-fillable fields (see `Ambry.Provenance`). Renders nothing for
   unsaved records. The parent LiveView must handle the
   `"toggle-provenance-lock"` event (field name in `phx-value-field`).
+
+  Pass the form's `changeset` and the pending accepted-value sources
+  (field-string → source-string) so rows can also show what the *next
+  save* will record — without them the panel only reflects saved state.
   """
   attr :record, :any, required: true
+  attr :changeset, :any, default: nil
+  attr :pending_sources, :map, default: %{}
 
   def provenance_panel(assigns) do
     assigns = assign(assigns, :fields, assigns.record.__struct__.provenance_fields())
@@ -513,6 +519,14 @@ defmodule AmbryWeb.Admin.Components do
           </span>
           <span class="grow text-zinc-600 dark:text-zinc-400">
             {provenance_description(@record, field)}
+            <span
+              :if={pending = provenance_pending(@record, @changeset, @pending_sources, field)}
+              class="text-amber-600 dark:text-amber-500"
+            >
+              → after save: {provenance_source_label(pending["source"])} ({(pending["locked"] &&
+                                                                              "locked") ||
+                "unlocked"})
+            </span>
           </span>
           <button
             type="button"
@@ -521,7 +535,7 @@ defmodule AmbryWeb.Admin.Components do
             title={provenance_lock_title(Provenance.locked?(@record, field))}
           >
             <.icon
-              name={if Provenance.locked?(@record, field), do: "fa-lock", else: "fa-lock-open"}
+              name={if Provenance.locked?(@record, field), do: "fa-lock", else: "fa-unlock"}
               class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-lime-600"
             />
           </button>
@@ -545,6 +559,28 @@ defmodule AmbryWeb.Admin.Components do
           nil -> provenance_source_label(source)
           at -> "#{provenance_source_label(source)} · #{String.slice(at, 0, 10)}"
         end
+    end
+  end
+
+  # What the next save will record for this field, mirroring
+  # Ambry.Provenance.track_changes/3: an accepted (hinted) value records
+  # its source unlocked; an edited value without a hint is a manual edit,
+  # locked. Nil when nothing pending or when it matches the saved entry.
+  defp provenance_pending(record, changeset, pending_sources, field) do
+    source = Map.get(pending_sources, to_string(field))
+    changed? = changeset != nil and Map.has_key?(changeset.changes, field)
+
+    pending =
+      cond do
+        is_binary(source) -> %{"source" => source, "locked" => false}
+        changed? -> %{"source" => "manual", "locked" => true}
+        true -> nil
+      end
+
+    saved = Provenance.entry(record, field)
+
+    if pending != nil and (saved == nil or Map.take(saved, ["source", "locked"]) != pending) do
+      pending
     end
   end
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -6,6 +6,8 @@ defmodule AmbryWeb.Admin.Components do
   import AmbryWeb.Gravatar
 
   alias Ambry.Accounts.User
+  alias Ambry.Metadata.Registry
+  alias Ambry.Provenance
   alias Phoenix.HTML.Form
   alias Phoenix.HTML.FormField
 
@@ -489,6 +491,80 @@ defmodule AmbryWeb.Admin.Components do
     </div>
     """
   end
+
+  @doc """
+  Provenance display + lock toggles for a persisted record's
+  provider-fillable fields (see `Ambry.Provenance`). Renders nothing for
+  unsaved records. The parent LiveView must handle the
+  `"toggle-provenance-lock"` event (field name in `phx-value-field`).
+  """
+  attr :record, :any, required: true
+
+  def provenance_panel(assigns) do
+    assigns = assign(assigns, :fields, assigns.record.__struct__.provenance_fields())
+
+    ~H"""
+    <div :if={@record.id} class="max-w-lg space-y-2">
+      <.label>Metadata provenance</.label>
+      <div class="divide-y divide-zinc-200 rounded-sm border border-zinc-200 text-sm dark:divide-zinc-800 dark:border-zinc-800">
+        <div :for={field <- @fields} class="flex items-center gap-2 px-3 py-2">
+          <span class="w-36 shrink-0 font-semibold text-zinc-800 dark:text-zinc-200">
+            {Phoenix.Naming.humanize(field)}
+          </span>
+          <span class="grow text-zinc-600 dark:text-zinc-400">
+            {provenance_description(@record, field)}
+          </span>
+          <button
+            type="button"
+            phx-click="toggle-provenance-lock"
+            phx-value-field={field}
+            title={provenance_lock_title(Provenance.locked?(@record, field))}
+          >
+            <.icon
+              name={if Provenance.locked?(@record, field), do: "fa-lock", else: "fa-lock-open"}
+              class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-lime-600"
+            />
+          </button>
+        </div>
+      </div>
+      <p class="text-xs text-zinc-500">
+        Locked fields are never overwritten by metadata refresh or auto-match. Editing a field by
+        hand locks it; accepting a provider suggestion records the provider and stays unlocked.
+      </p>
+    </div>
+    """
+  end
+
+  defp provenance_description(record, field) do
+    case Provenance.entry(record, field) do
+      nil ->
+        "no provenance recorded"
+
+      %{"source" => source} = entry ->
+        case entry["at"] do
+          nil -> provenance_source_label(source)
+          at -> "#{provenance_source_label(source)} · #{String.slice(at, 0, 10)}"
+        end
+    end
+  end
+
+  defp provenance_source_label("manual"), do: "manually edited"
+  defp provenance_source_label("legacy"), do: "legacy (pre-provenance)"
+
+  defp provenance_source_label("provider:" <> provider_id) do
+    case Registry.fetch(provider_id) do
+      {:ok, entry} -> entry.display_name
+      {:error, :unknown_provider} -> provider_id
+    end
+  end
+
+  defp provenance_source_label(other), do: other
+
+  defp provenance_lock_title(true),
+    do: "Locked — automated refresh will never overwrite this field. Click to unlock."
+
+  defp provenance_lock_title(false),
+    do: "Unlocked — automated refresh may update this field. Click to lock."
 
   @doc """
   Book Card for displaying normalized metadata-provider results.

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -6,7 +6,9 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   alias Ambry.Books.Book
   alias Ambry.Metadata.Registry
   alias Ambry.People
+  alias Ambry.Provenance
   alias AmbryWeb.Admin.BookLive.Form.ProviderImportForm
+  alias AmbryWeb.Admin.ProvenanceHints
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -15,6 +17,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
      socket
      |> assign(
        import: nil,
+       provenance_hints: %{},
        # work-level providers plus Audible: its normalized results carry
        # title/authors/series too, and the generic form is provider-agnostic
        import_providers: Registry.enabled(capability: :book_search),
@@ -74,10 +77,20 @@ defmodule AmbryWeb.Admin.BookLive.Form do
       |> Books.change_book(book_params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign_form(socket, changeset)}
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, book_params)
+     )}
   end
 
   def handle_event("submit", %{"book" => book_params}, socket) do
+    socket =
+      assign(socket,
+        provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, book_params)
+      )
+
     socket.assigns.book
     |> Books.change_book(book_params)
     |> Changeset.apply_action(:insert)
@@ -87,12 +100,17 @@ defmodule AmbryWeb.Admin.BookLive.Form do
     end
   end
 
+  def handle_event("toggle-provenance-lock", %{"field" => field}, socket) do
+    {:ok, book} = Provenance.toggle_lock(socket.assigns.book, field)
+    {:noreply, assign(socket, book: book)}
+  end
+
   def handle_event("open-import-form", %{"type" => type}, socket) do
     {:noreply, handle_import_form_params(socket, %{"import" => type})}
   end
 
   @impl Phoenix.LiveView
-  def handle_info({:import, %{"book" => book_params}}, socket) do
+  def handle_info({:import, %{"book" => book_params}, source}, socket) do
     # authors and/or series could have been created, reload the data-lists
     socket =
       assign(socket,
@@ -100,14 +118,23 @@ defmodule AmbryWeb.Admin.BookLive.Form do
         series: Books.series_for_select()
       )
 
+    hints = ProvenanceHints.from_import(book_params, source)
     new_params = Map.merge(socket.assigns.form.params, book_params)
     changeset = Books.change_book(socket.assigns.book, new_params)
 
-    {:noreply, socket |> assign_form(changeset) |> assign(import: nil)}
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       import: nil,
+       provenance_hints: Map.merge(socket.assigns.provenance_hints, hints)
+     )}
   end
 
   defp save_book(socket, :edit, book_params) do
-    case Books.update_book(socket.assigns.book, book_params) do
+    opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
+
+    case Books.update_book(socket.assigns.book, book_params, opts) do
       {:ok, book} ->
         {:noreply,
          socket
@@ -120,7 +147,9 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   end
 
   defp save_book(socket, :new, book_params) do
-    case Books.create_book(book_params) do
+    opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
+
+    case Books.create_book(book_params, opts) do
       {:ok, book} ->
         {:noreply,
          socket

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -118,6 +118,8 @@
         <.delete_input field={@form[:book_universes_drop]} />
       </div>
 
+      <.provenance_panel record={@book} />
+
       <:actions>
         <.button>Save</.button>
       </:actions>

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -118,7 +118,11 @@
         <.delete_input field={@form[:book_universes_drop]} />
       </div>
 
-      <.provenance_panel record={@book} />
+      <.provenance_panel
+        record={@book}
+        changeset={@form.source}
+        pending_sources={ProvenanceHints.sources(@provenance_hints)}
+      />
 
       <:actions>
         <.button>Save</.button>

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
@@ -15,6 +15,7 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
   alias Ambry.Books.Series
   alias Ambry.Metadata.Providers
   alias Ambry.People.Person
+  alias Ambry.Provenance
   alias Ambry.Search
   alias Phoenix.LiveView.AsyncResult
 
@@ -88,6 +89,7 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
 
   def handle_event("import", %{"import" => import_params}, socket) do
     book = socket.assigns.selected_book
+    source = Provenance.provider_source(socket.assigns.provider.id)
 
     params =
       Enum.reduce(import_params, %{}, fn
@@ -101,7 +103,11 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
           })
 
         {"use_authors", "true"}, acc ->
-          Map.put(acc, "book_authors", build_authors_params(socket.assigns.matching_authors))
+          Map.put(
+            acc,
+            "book_authors",
+            build_authors_params(socket.assigns.matching_authors, source)
+          )
 
         {"use_series", "true"}, acc ->
           Map.put(acc, "series_books", build_series_params(socket.assigns.matching_series))
@@ -110,7 +116,7 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
           acc
       end)
 
-    send(self(), {:import, %{"book" => params}})
+    send(self(), {:import, %{"book" => params}, source})
 
     {:noreply, socket}
   end
@@ -129,14 +135,17 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
     )
   end
 
-  defp build_authors_params(matching_authors) do
+  defp build_authors_params(matching_authors, source) do
     Enum.map(matching_authors, fn
       {imported, nil} ->
         {:ok, %{author_people: [%{author: author}]}} =
-          Ambry.People.create_person(%{
-            name: imported.name,
-            author_people: [%{author: %{name: imported.name}}]
-          })
+          Ambry.People.create_person(
+            %{
+              name: imported.name,
+              author_people: [%{author: %{name: imported.name}}]
+            },
+            provenance: %{"name" => source}
+          )
 
         %{"author_id" => author.id}
 

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -9,8 +9,10 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   alias Ambry.Media
   alias Ambry.Metadata.Registry
   alias Ambry.People
+  alias Ambry.Provenance
   alias AmbryWeb.Admin.MediaLive.Form.FileBrowser
   alias AmbryWeb.Admin.MediaLive.Form.ProviderImportForm
+  alias AmbryWeb.Admin.ProvenanceHints
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -22,6 +24,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
      |> allow_supplemental_file_upload(:supplemental)
      |> assign(
        import: nil,
+       provenance_hints: %{},
        select_files: false,
        selected_files: MapSet.new(),
        recording_providers: Registry.enabled(level: :recording, capability: :book_search),
@@ -123,10 +126,20 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       |> Media.change_media(media_params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign_form(socket, changeset)}
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, media_params)
+     )}
   end
 
   def handle_event("submit", %{"media" => media_params}, socket) do
+    socket =
+      assign(socket,
+        provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, media_params)
+      )
+
     with :ok <- changeset_valid?(socket, media_params),
          {:ok, media_params} <- handle_image_upload(socket, media_params, :image),
          {:ok, media_params} <-
@@ -143,6 +156,11 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     end
   end
 
+  def handle_event("toggle-provenance-lock", %{"field" => field}, socket) do
+    {:ok, media} = Provenance.toggle_lock(socket.assigns.media, field)
+    {:noreply, assign(socket, media: media)}
+  end
+
   def handle_event("cancel-upload", %{"ref" => ref}, socket) do
     {:noreply, cancel_upload(socket, :audio, ref)}
   end
@@ -152,19 +170,26 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   end
 
   @impl Phoenix.LiveView
-  def handle_info({:import, %{"media" => media_params}}, socket) do
+  def handle_info({:import, %{"media" => media_params}, source}, socket) do
     # narrators could have been created, reload the data-lists
     socket =
       assign(socket,
         narrators: People.narrators_for_select()
       )
 
+    hints = ProvenanceHints.from_import(media_params, source)
     new_params = Map.merge(socket.assigns.form.params, media_params)
 
     changeset =
       Media.change_media(socket.assigns.media, new_params)
 
-    {:noreply, socket |> assign_form(changeset) |> assign(import: nil)}
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       import: nil,
+       provenance_hints: Map.merge(socket.assigns.provenance_hints, hints)
+     )}
   end
 
   def handle_info({:files_selected, files}, socket) do
@@ -269,7 +294,9 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   end
 
   defp save_media(socket, :edit, media_params) do
-    case Media.update_media(socket.assigns.media, media_params) do
+    opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
+
+    case Media.update_media(socket.assigns.media, media_params, opts) do
       {:ok, media} ->
         maybe_start_processor!(media, media_params, :edit)
 
@@ -284,7 +311,9 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   end
 
   defp save_media(socket, :new, media_params) do
-    case Media.create_media(media_params) do
+    opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
+
+    case Media.create_media(media_params, opts) do
       {:ok, media} ->
         media = Media.get_media!(media.id)
         maybe_start_processor!(media, media_params, :new)

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -371,6 +371,8 @@
         />
       </div>
 
+      <.provenance_panel record={@media} />
+
       <:actions>
         <.button>Save</.button>
       </:actions>

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -371,7 +371,11 @@
         />
       </div>
 
-      <.provenance_panel record={@media} />
+      <.provenance_panel
+        record={@media}
+        changeset={@form.source}
+        pending_sources={ProvenanceHints.sources(@provenance_hints)}
+      />
 
       <:actions>
         <.button>Save</.button>

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.ex
@@ -10,6 +10,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
 
   alias Ambry.Metadata.Providers
   alias Ambry.People.Person
+  alias Ambry.Provenance
   alias Ambry.Search
   alias Phoenix.LiveView.AsyncResult
 
@@ -82,6 +83,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
 
   def handle_event("import", %{"import" => import_params}, socket) do
     book = socket.assigns.selected_book
+    source = Provenance.provider_source(socket.assigns.provider.id)
 
     params =
       Enum.reduce(import_params, %{}, fn
@@ -101,7 +103,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
           Map.put(
             acc,
             "media_narrators",
-            build_narrators_params(socket.assigns.matching_narrators)
+            build_narrators_params(socket.assigns.matching_narrators, source)
           )
 
         {"use_cover_image", "true"}, acc ->
@@ -115,7 +117,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
           acc
       end)
 
-    send(self(), {:import, %{"media" => params}})
+    send(self(), {:import, %{"media" => params}, source})
 
     {:noreply, socket}
   end
@@ -130,11 +132,14 @@ defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
     )
   end
 
-  defp build_narrators_params(matching_narrators) do
+  defp build_narrators_params(matching_narrators, source) do
     Enum.map(matching_narrators, fn
       {imported, nil} ->
         {:ok, %{narrators: [narrator]}} =
-          Ambry.People.create_person(%{name: imported.name, narrators: [%{name: imported.name}]})
+          Ambry.People.create_person(
+            %{name: imported.name, narrators: [%{name: imported.name}]},
+            provenance: %{"name" => source}
+          )
 
         %{"narrator_id" => narrator.id}
 

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -8,7 +8,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   alias Ambry.People
   alias Ambry.People.Author
   alias Ambry.People.Person
+  alias Ambry.Provenance
   alias AmbryWeb.Admin.PersonLive.Form.ImportForm
+  alias AmbryWeb.Admin.ProvenanceHints
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -18,6 +20,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
      |> allow_image_upload(:image)
      |> assign(
        import: nil,
+       provenance_hints: %{},
        providers: Registry.enabled(capability: :author_search),
        authors: People.authors_for_select()
      )
@@ -82,11 +85,21 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
       |> People.change_person(person_params)
       |> Map.put(:action, :validate)
 
-    {:noreply, assign_form(socket, changeset)}
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, person_params)
+     )}
   end
 
   def handle_event("submit", %{"person" => person_params}, socket) do
     person_params = maybe_link_author(person_params)
+
+    socket =
+      assign(socket,
+        provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, person_params)
+      )
 
     with {:ok, _person} <-
            socket.assigns.person
@@ -103,6 +116,11 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     end
   end
 
+  def handle_event("toggle-provenance-lock", %{"field" => field}, socket) do
+    {:ok, person} = Provenance.toggle_lock(socket.assigns.person, field)
+    {:noreply, assign(socket, person: person)}
+  end
+
   def handle_event("open-import-form", %{"type" => provider_id}, socket) do
     {:noreply, handle_import_form_params(socket, %{"import" => provider_id})}
   end
@@ -112,10 +130,18 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   @impl Phoenix.LiveView
-  def handle_info({:import, %{"person" => person_params}}, socket) do
+  def handle_info({:import, %{"person" => person_params}, source}, socket) do
+    hints = ProvenanceHints.from_import(person_params, source)
     new_params = Map.merge(socket.assigns.form.params, person_params)
     changeset = People.change_person(socket.assigns.person, new_params)
-    {:noreply, socket |> assign_form(changeset) |> assign(import: nil)}
+
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       import: nil,
+       provenance_hints: Map.merge(socket.assigns.provenance_hints, hints)
+     )}
   end
 
   defp cancel_all_uploads(socket, upload) do
@@ -141,7 +167,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   defp save_person(socket, :edit, person_params) do
-    case People.update_person(socket.assigns.person, person_params) do
+    opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
+
+    case People.update_person(socket.assigns.person, person_params, opts) do
       {:ok, person} ->
         {:noreply,
          socket
@@ -154,7 +182,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   defp save_person(socket, :new, person_params) do
-    case People.create_person(person_params) do
+    opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
+
+    case People.create_person(person_params, opts) do
       {:ok, person} ->
         {:noreply,
          socket

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -184,7 +184,11 @@
         </div>
       <% end %>
 
-      <.provenance_panel record={@person} />
+      <.provenance_panel
+        record={@person}
+        changeset={@form.source}
+        pending_sources={ProvenanceHints.sources(@provenance_hints)}
+      />
 
       <:actions>
         <.button>Save</.button>

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -184,6 +184,8 @@
         </div>
       <% end %>
 
+      <.provenance_panel record={@person} />
+
       <:actions>
         <.button>Save</.button>
       </:actions>

--- a/lib/ambry_web/live/admin/person_live/form/import_form.ex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.ex
@@ -5,6 +5,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
   import AmbryWeb.Admin.Components
 
   alias Ambry.Metadata.Providers
+  alias Ambry.Provenance
   alias Phoenix.LiveView.AsyncResult
 
   @impl Phoenix.LiveComponent
@@ -125,7 +126,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImportForm do
           acc
       end)
 
-    send(self(), {:import, %{"person" => params}})
+    source = Provenance.provider_source(socket.assigns.provider.id)
+    send(self(), {:import, %{"person" => params}, source})
 
     {:noreply, socket}
   end

--- a/lib/ambry_web/live/admin/provenance_hints.ex
+++ b/lib/ambry_web/live/admin/provenance_hints.ex
@@ -1,0 +1,77 @@
+defmodule AmbryWeb.Admin.ProvenanceHints do
+  @moduledoc """
+  Server-side tracking of which pending form values were accepted from a
+  metadata provider, so that saving records provider provenance (unlocked)
+  for accepted suggestions and manual provenance (locked) for typed edits —
+  see `Ambry.Provenance`.
+
+  Hints live in socket assigns, never in browser params. Each hint watches
+  the form param carrying its value and dies the moment the operator edits
+  that value: the field then saves as an ordinary manual edit.
+  """
+
+  # import-payload keys that never map to a tracked scalar field themselves
+  @non_field_keys ~w(image_path image_type image_import_url)
+
+  @doc """
+  Builds hints from a provider-import payload: one per scalar param (watched
+  under its own name), plus — when the payload carries an image URL import —
+  one for `image_path` watching `image_import_url` (the actual path is only
+  set at submit time, after the download). List params (associations) are
+  structural and never hinted.
+  """
+  def from_import(params, source) do
+    scalar_hints =
+      for {key, value} <- params,
+          not is_list(value),
+          not is_map(value),
+          key not in @non_field_keys,
+          into: %{} do
+        {key, %{source: source, watch: key, value: normalize(value)}}
+      end
+
+    case params do
+      %{"image_type" => "url_import", "image_import_url" => url} ->
+        Map.put(scalar_hints, "image_path", %{
+          source: source,
+          watch: "image_import_url",
+          value: normalize(url)
+        })
+
+      _params ->
+        scalar_hints
+    end
+  end
+
+  @doc """
+  Drops hints whose watched param no longer carries the accepted value.
+  Call on every validate and once more with the submit params.
+  """
+  def prune(hints, form_params) do
+    hints
+    |> Enum.reject(fn {field, hint} ->
+      edited?(hint, form_params) or
+        (field == "image_path" and image_source_changed?(form_params))
+    end)
+    |> Map.new()
+  end
+
+  defp edited?(hint, params) do
+    case Map.fetch(params, hint.watch) do
+      {:ok, value} -> normalize(value) != hint.value
+      :error -> false
+    end
+  end
+
+  defp image_source_changed?(params) do
+    case params do
+      %{"image_type" => type} -> type != "url_import"
+      _params -> false
+    end
+  end
+
+  @doc "The `provenance:` opts value for a save: field name → source."
+  def sources(hints), do: Map.new(hints, fn {field, hint} -> {field, hint.source} end)
+
+  defp normalize(value), do: to_string(value)
+end

--- a/priv/repo/migrations/20260802011809_add_field_provenance.exs
+++ b/priv/repo/migrations/20260802011809_add_field_provenance.exs
@@ -1,0 +1,79 @@
+defmodule Ambry.Repo.Migrations.AddFieldProvenance do
+  use Ecto.Migration
+
+  # Field-level metadata provenance (roadmap 1d): a jsonb map on each
+  # provider-fillable table recording, per scalar field, where its current
+  # value came from ("manual" | "legacy" | "provider:<id>") and whether it's
+  # locked against automated overwrite.
+  #
+  # Backfill: every non-null tracked field on existing rows is marked
+  # source=legacy and locked — years of hand-curation must never be clobbered
+  # by future refresh/auto-match; the operator unlocks per field where
+  # freshness is wanted. (published_format piggybacks on published: it always
+  # has a default value, so it only gets an entry when a date is actually
+  # set.)
+
+  def up do
+    alter table(:people) do
+      add :field_provenance, :map, default: %{}, null: false
+    end
+
+    alter table(:books) do
+      add :field_provenance, :map, default: %{}, null: false
+    end
+
+    alter table(:media) do
+      add :field_provenance, :map, default: %{}, null: false
+    end
+
+    execute """
+    UPDATE people SET field_provenance = jsonb_strip_nulls(jsonb_build_object(
+      'name', CASE WHEN name IS NOT NULL THEN #{legacy_entry()} END,
+      'description', CASE WHEN description IS NOT NULL THEN #{legacy_entry()} END,
+      'image_path', CASE WHEN image_path IS NOT NULL THEN #{legacy_entry()} END
+    ))
+    """
+
+    execute """
+    UPDATE books SET field_provenance = jsonb_strip_nulls(jsonb_build_object(
+      'title', CASE WHEN title IS NOT NULL THEN #{legacy_entry()} END,
+      'published', CASE WHEN published IS NOT NULL THEN #{legacy_entry()} END,
+      'published_format', CASE WHEN published IS NOT NULL THEN #{legacy_entry()} END
+    ))
+    """
+
+    execute """
+    UPDATE media SET field_provenance = jsonb_strip_nulls(jsonb_build_object(
+      'published', CASE WHEN published IS NOT NULL THEN #{legacy_entry()} END,
+      'published_format', CASE WHEN published IS NOT NULL THEN #{legacy_entry()} END,
+      'publisher', CASE WHEN publisher IS NOT NULL THEN #{legacy_entry()} END,
+      'description', CASE WHEN description IS NOT NULL THEN #{legacy_entry()} END,
+      'image_path', CASE WHEN image_path IS NOT NULL THEN #{legacy_entry()} END
+    ))
+    """
+  end
+
+  def down do
+    alter table(:people) do
+      remove :field_provenance
+    end
+
+    alter table(:books) do
+      remove :field_provenance
+    end
+
+    alter table(:media) do
+      remove :field_provenance
+    end
+  end
+
+  defp legacy_entry do
+    """
+    jsonb_build_object(
+      'source', 'legacy',
+      'locked', true,
+      'at', to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+    )
+    """
+  end
+end

--- a/test/ambry/provenance_test.exs
+++ b/test/ambry/provenance_test.exs
@@ -44,6 +44,29 @@ defmodule Ambry.ProvenanceTest do
       assert %{"source" => "manual", "locked" => true} = Provenance.entry(updated, :description)
     end
 
+    test "an accepted value records its source even when it equals the stored value" do
+      # re-importing the same name must still flip legacy/manual → provider:
+      # acceptance is a statement about where the current value comes from
+      {:ok, person} = People.create_person(%{name: "Arthur Conan Doyle"})
+
+      {:ok, updated} =
+        People.update_person(person, %{name: "Arthur Conan Doyle"},
+          provenance: %{"name" => "provider:wikidata"}
+        )
+
+      assert %{"source" => "provider:wikidata", "locked" => false} =
+               Provenance.entry(updated, :name)
+    end
+
+    test "a hint for a field that stays empty records nothing" do
+      {:ok, person} =
+        People.create_person(%{name: "Somebody"},
+          provenance: %{"description" => "provider:hardcover"}
+        )
+
+      assert Provenance.entry(person, :description) == nil
+    end
+
     test "a manual edit over a provider value re-records it as manual and locks it" do
       {:ok, person} =
         People.create_person(

--- a/test/ambry/provenance_test.exs
+++ b/test/ambry/provenance_test.exs
@@ -1,0 +1,162 @@
+defmodule Ambry.ProvenanceTest do
+  use Ambry.DataCase
+
+  alias Ambry.Books
+  alias Ambry.Media
+  alias Ambry.People
+  alias Ambry.Provenance
+
+  describe "recording provenance through context create/update" do
+    test "changed fields without a source hint are manual edits — locked" do
+      {:ok, person} = People.create_person(%{name: "Ty Franck"})
+
+      assert %{"source" => "manual", "locked" => true, "at" => at} =
+               Provenance.entry(person, :name)
+
+      assert {:ok, _at, 0} = DateTime.from_iso8601(at)
+      assert Provenance.locked?(person, :name)
+    end
+
+    test "changed fields with a provider hint record that source — unlocked" do
+      {:ok, person} =
+        People.create_person(
+          %{name: "Ty Franck", description: "Half of James S.A. Corey."},
+          provenance: %{"description" => "provider:hardcover"}
+        )
+
+      # accepted suggestion: provider source, refresh may update it later
+      assert %{"source" => "provider:hardcover", "locked" => false} =
+               Provenance.entry(person, :description)
+
+      # the name had no hint: typed by the operator, locked
+      assert %{"source" => "manual", "locked" => true} = Provenance.entry(person, :name)
+    end
+
+    test "unchanged fields keep their existing provenance" do
+      {:ok, person} =
+        People.create_person(%{name: "Somebody"}, provenance: %{"name" => "provider:audnexus"})
+
+      {:ok, updated} = People.update_person(person, %{description: "New bio."})
+
+      assert %{"source" => "provider:audnexus", "locked" => false} =
+               Provenance.entry(updated, :name)
+
+      assert %{"source" => "manual", "locked" => true} = Provenance.entry(updated, :description)
+    end
+
+    test "a manual edit over a provider value re-records it as manual and locks it" do
+      {:ok, person} =
+        People.create_person(
+          %{name: "Somebody", description: "Provider bio."},
+          provenance: %{"description" => "provider:hardcover"}
+        )
+
+      {:ok, updated} = People.update_person(person, %{description: "Curated bio."})
+
+      assert %{"source" => "manual", "locked" => true} = Provenance.entry(updated, :description)
+    end
+
+    test "books and media track their provider-fillable scalars" do
+      author = insert(:author)
+
+      {:ok, book} =
+        Books.create_book(
+          %{
+            title: "Leviathan Wakes",
+            published: ~D[2011-06-15],
+            published_format: :full,
+            book_authors: [%{author_id: author.id}]
+          },
+          provenance: %{
+            "title" => "provider:rreading_glasses",
+            "published" => "provider:rreading_glasses",
+            "published_format" => "provider:rreading_glasses"
+          }
+        )
+
+      assert %{"source" => "provider:rreading_glasses", "locked" => false} =
+               Provenance.entry(book, :title)
+
+      media = insert(:media, book: book)
+
+      {:ok, updated_media} =
+        Media.update_media(
+          media,
+          %{publisher: "Recorded Books", description: "From Audible."},
+          provenance: %{"description" => "provider:audible"}
+        )
+
+      assert %{"source" => "manual", "locked" => true} =
+               Provenance.entry(updated_media, :publisher)
+
+      assert %{"source" => "provider:audible", "locked" => false} =
+               Provenance.entry(updated_media, :description)
+    end
+
+    test "untracked fields never get provenance entries" do
+      {:ok, book} =
+        Books.create_book(%{
+          title: "Some Book",
+          published: ~D[2020-01-01],
+          book_authors: [%{author_id: insert(:author).id}]
+        })
+
+      refute Map.has_key?(book.field_provenance, "book_authors")
+
+      media = insert(:media, book: build(:book))
+      {:ok, updated} = Media.update_media(media, %{notes: "operator note"})
+
+      assert Provenance.entry(updated, :notes) == nil
+    end
+  end
+
+  describe "reject_locked/2 — the gate for automated writers" do
+    test "drops locked fields from proposed attrs, string or atom keys" do
+      {:ok, person} =
+        People.create_person(
+          %{name: "Somebody", description: "Provider bio."},
+          provenance: %{"description" => "provider:hardcover"}
+        )
+
+      # name is manual+locked, description is provider+unlocked
+      proposed = %{"name" => "Refreshed Name", "description" => "Refreshed bio."}
+      assert Provenance.reject_locked(person, proposed) == %{"description" => "Refreshed bio."}
+
+      proposed_atoms = %{name: "Refreshed Name", description: "Refreshed bio."}
+      assert Provenance.reject_locked(person, proposed_atoms) == %{description: "Refreshed bio."}
+    end
+
+    test "passes everything through for records with no provenance" do
+      person = insert(:person)
+      proposed = %{"name" => "New Name"}
+      assert Provenance.reject_locked(person, proposed) == proposed
+    end
+  end
+
+  describe "toggle_lock/2" do
+    test "flips the lock on an existing entry, keeping its source" do
+      {:ok, person} =
+        People.create_person(%{name: "Somebody"}, provenance: %{"name" => "provider:audnexus"})
+
+      {:ok, locked} = Provenance.toggle_lock(person, :name)
+
+      assert %{"source" => "provider:audnexus", "locked" => true} =
+               Provenance.entry(locked, :name)
+
+      {:ok, unlocked} = Provenance.toggle_lock(locked, "name")
+
+      assert %{"source" => "provider:audnexus", "locked" => false} =
+               Provenance.entry(unlocked, :name)
+    end
+
+    test "locking a field with no recorded provenance protects it as legacy" do
+      person = insert(:person)
+      assert Provenance.entry(person, :description) == nil
+
+      {:ok, updated} = Provenance.toggle_lock(person, :description)
+
+      assert %{"source" => "legacy", "locked" => true} = Provenance.entry(updated, :description)
+      assert Provenance.locked?(updated, :description)
+    end
+  end
+end

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -4,8 +4,72 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
   import Phoenix.LiveViewTest
 
   alias Ambry.People
+  alias Ambry.Provenance
 
   setup :register_and_log_in_admin_user
+
+  describe "field-level provenance" do
+    test "manually edited fields save with manual provenance, locked", %{conn: conn} do
+      person = insert(:person, name: "Old Name")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view |> form("#person-form", %{"person" => %{"name" => "New Name"}}) |> render_submit()
+
+      updated = People.get_person!(person.id)
+      assert %{"source" => "manual", "locked" => true} = Provenance.entry(updated, :name)
+
+      # untouched fields get no provenance entry
+      assert Provenance.entry(updated, :image_path) == nil
+    end
+
+    test "the provenance panel shows sources and toggles locks", %{conn: conn} do
+      person =
+        insert(:person,
+          field_provenance: %{
+            "name" => %{
+              "source" => "provider:audible",
+              "locked" => false,
+              "at" => "2026-08-01T00:00:00Z"
+            }
+          }
+        )
+
+      {:ok, view, html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      assert html =~ "Metadata provenance"
+      assert html =~ "Audible"
+
+      view
+      |> element(~s{button[phx-click="toggle-provenance-lock"][phx-value-field="name"]})
+      |> render_click()
+
+      updated = People.get_person!(person.id)
+
+      assert %{"source" => "provider:audible", "locked" => true} =
+               Provenance.entry(updated, :name)
+    end
+
+    test "locking a field that has no provenance protects it as legacy", %{conn: conn} do
+      person = insert(:person)
+
+      {:ok, view, html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+      assert html =~ "no provenance recorded"
+
+      view
+      |> element(~s{button[phx-click="toggle-provenance-lock"][phx-value-field="description"]})
+      |> render_click()
+
+      updated = People.get_person!(person.id)
+      assert %{"source" => "legacy", "locked" => true} = Provenance.entry(updated, :description)
+    end
+
+    test "the panel is not rendered for new records", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/people/new")
+
+      refute html =~ "Metadata provenance"
+    end
+  end
 
   describe "linking an existing author (composite pen names)" do
     test "links a shared author through the autocomplete", %{conn: conn} do

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -69,6 +69,20 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       refute html =~ "Metadata provenance"
     end
+
+    test "the panel previews what the next save will record", %{conn: conn} do
+      person = insert(:person, name: "Old Name")
+
+      {:ok, view, html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+      refute html =~ "after save:"
+
+      html =
+        view
+        |> form("#person-form", %{"person" => %{"name" => "New Name"}})
+        |> render_change()
+
+      assert html =~ "after save: manually edited (locked)"
+    end
   end
 
   describe "linking an existing author (composite pen names)" do

--- a/test/ambry_web/live/admin/person_live/import_test.exs
+++ b/test/ambry_web/live/admin/person_live/import_test.exs
@@ -65,6 +65,64 @@ defmodule AmbryWeb.Admin.PersonLive.ImportTest do
     assert html =~ ~s(value="https://images.gr-assets.com/authors/999015.jpg")
   end
 
+  test "accepted provider values save with provider provenance, unlocked", %{conn: conn} do
+    patch_rreading_glasses()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new?import=rreading_glasses")
+    render_chained_async(view)
+
+    view
+    |> form("form[phx-submit='import']", %{
+      "import" => %{"use_name" => "true", "use_description" => "true", "use_image" => "false"}
+    })
+    |> render_submit()
+
+    view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+    person = person_by_name("Matt Dinniman")
+
+    assert %{"source" => "provider:rreading_glasses", "locked" => false} =
+             Ambry.Provenance.entry(person, :name)
+
+    assert %{"source" => "provider:rreading_glasses", "locked" => false} =
+             Ambry.Provenance.entry(person, :description)
+  end
+
+  test "editing an accepted value before saving makes it a manual edit again", %{conn: conn} do
+    patch_rreading_glasses()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new?import=rreading_glasses")
+    render_chained_async(view)
+
+    view
+    |> form("form[phx-submit='import']", %{
+      "import" => %{"use_name" => "true", "use_description" => "true", "use_image" => "false"}
+    })
+    |> render_submit()
+
+    view
+    |> form("#person-form", %{"person" => %{"description" => "My own curated bio."}})
+    |> render_change()
+
+    view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+    person = person_by_name("Matt Dinniman")
+
+    # untouched accepted value keeps its provider provenance…
+    assert %{"source" => "provider:rreading_glasses", "locked" => false} =
+             Ambry.Provenance.entry(person, :name)
+
+    # …but the edited one is operator curation now — manual and locked
+    assert %{"source" => "manual", "locked" => true} =
+             Ambry.Provenance.entry(person, :description)
+  end
+
+  defp person_by_name(name) do
+    import Ecto.Query, only: [from: 2]
+
+    Ambry.Repo.one!(from p in Ambry.People.Person, where: p.name == ^name)
+  end
+
   test "unknown provider in the URL just closes the import modal", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/admin/people/new?import=bogus")
 


### PR DESCRIPTION
The last v1.9.0 data-model PR (roadmap 1d): every provider-fillable scalar field on people/books/media records where its value came from and whether it's locked against automated overwrite.

## Design (operator-confirmed before implementation)

- **Storage**: `field_provenance` jsonb map per table — `"description" => {source, locked, at}`, sources `manual | legacy | provider:<id>`. No flat-view changes (views enumerate columns), no GraphQL/sync surface (admin-only).
- **Model-layer merge machinery, not form UX**: the real consumers are the future inbox approval (3b) and background refresh. `Ambry.Provenance.reject_locked/2` is the gate all automated writers must route proposed updates through; operator-driven forms may always write — what varies is the provenance recorded.
- **Lock semantics**: typing/editing a value locks it (`manual`); *accepting* a provider suggestion via checkbox-merge records that provider as source and stays **unlocked**, so refresh stays useful. Explicit lock/unlock toggle in the admin UI regardless.
- **Scalars only**: tracked fields are Person `name/description/image_path`, Book `title/published/published_format`, Media `published/published_format/publisher/description/image_path`. Structural associations are operator-owned by definition and carry no provenance. Chapters wait for 1h's per-half provenance.
- **Backfill**: all existing non-null tracked fields → `legacy` + locked. The curated back catalog is untouchable until explicitly unlocked per field.

## Implementation

- `Ambry.Provenance` (core boundary, exported): `track_changes/3` (called from each schema's changeset with per-field source hints), `reject_locked/2`, `toggle_lock/2`, `provider_source/1`. Schemas own their tracked-field lists.
- Contexts: `create_/update_` for person/book/media accept `provenance: %{"field" => source}` opts (arity-compatible — all existing callers unchanged).
- Import forms send their provider source with accepted values; People auto-created from author/narrator matches get `name` recorded as provider-sourced.
- `AmbryWeb.Admin.ProvenanceHints`: server-side hint tracking in socket assigns (never browser params); a hint dies the moment the operator edits the accepted value, making the field a manual edit again. Handles the image URL-import indirection (hint on `image_path` watching `image_import_url`).
- Admin person/book/media forms: provenance panel (per-field source label via provider registry, date, lock toggle) shown for persisted records.

## Tests

- Context-level: recording via create/update (hinted vs manual), provenance preservation on unchanged fields, `reject_locked` (string+atom keys), `toggle_lock` incl. legacy-entry creation.
- LiveView e2e: accepted provider values save provider-sourced + unlocked; editing an accepted value before saving reverts it to manual + locked; panel lock toggles persist; panel hidden on new records.
- Full suite 640 passed; `mix check` clean (format, credo, dialyzer).

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9