### PR TITLE
Phase 1c: Wikidata/Wikipedia person-level provider

### DIFF
--- a/lib/ambry/metadata.ex
+++ b/lib/ambry/metadata.ex
@@ -8,7 +8,7 @@ defmodule Ambry.Metadata do
   # inherited from the parent boundary anyway; it's listed to make the
   # dependency visible.
   use Boundary,
-    deps: [Ambry.Repo, AmbryScraping],
+    deps: [Ambry.Repo, Ambry.Utils, AmbryScraping],
     exports: [
       {Provider, []},
       Providers,

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -9,6 +9,10 @@ defmodule Ambry.Metadata.Provider do
       audiobook releases.
     * `:recording` — the concrete side: audiobook releases with narrators,
       square cover art, chapters. ASIN is the natural key at this level.
+    * `:person` — the humans behind author and narrator identities: bios
+      and profile photos, keyed on real people rather than published-as
+      names (covers narrate-only people and the halves of composite pen
+      names that book catalogs can't see).
 
   All callbacks return normalized structs defined in this module, so the web
   layer never depends on any provider's upstream payload shape. Capabilities
@@ -149,7 +153,7 @@ defmodule Ambry.Metadata.Provider do
   @callback display_name() :: String.t()
 
   @doc "Which level of the data model this provider speaks to."
-  @callback level() :: :work | :recording
+  @callback level() :: :work | :recording | :person
 
   @doc "The optional callbacks this provider actually implements."
   @callback capabilities() :: [capability()]

--- a/lib/ambry/metadata/providers/wikidata.ex
+++ b/lib/ambry/metadata/providers/wikidata.ex
@@ -11,8 +11,11 @@ defmodule Ambry.Metadata.Providers.Wikidata do
   Flow: Wikidata entity search, hydrated and filtered to humans (P31 = Q5)
   → bio from the Wikipedia summary-extract API (the article's lead
   section; falls back to the terse Wikidata description when a person has
-  no English article) → freely-licensed photo from Commons (P18), served
-  scaled through Special:FilePath.
+  no English article) → freely-licensed photo, preferring the summary's
+  direct `originalimage` URL (a plain upload.wikimedia.org file — no
+  MediaWiki redirect or on-demand thumbnailer in the path) and falling
+  back to the Commons P18 claim via Special:FilePath for article-less
+  people.
 
   Zero-config and free, no API key. Registered with the author-search
   capabilities, so the person form offers it alongside the book-keyed
@@ -139,12 +142,14 @@ defmodule Ambry.Metadata.Providers.Wikidata do
   end
 
   defp entity_details(entity) do
+    summary = fetch_summary(get_in(entity, ["sitelinks", "enwiki", "title"]))
+
     %Provider.Author{
       provider: id(),
       id: entity["id"],
       name: label(entity),
-      description: bio(entity),
-      image_url: image_url(entity)
+      description: presence(summary["extract"]) || description(entity),
+      image_url: get_in(summary, ["originalimage", "source"]) || p18_image_url(entity)
     }
   end
 
@@ -152,22 +157,18 @@ defmodule Ambry.Metadata.Providers.Wikidata do
 
   defp description(entity), do: get_in(entity, ["descriptions", "en", "value"])
 
-  defp bio(entity) do
-    wikipedia_extract(get_in(entity, ["sitelinks", "enwiki", "title"])) || description(entity)
-  end
+  defp fetch_summary(nil), do: %{}
 
-  defp wikipedia_extract(nil), do: nil
-
-  defp wikipedia_extract(title) do
+  defp fetch_summary(title) do
     url = @wikipedia_summary_url <> URI.encode(title, &URI.char_unreserved?/1)
 
     case Client.get_json(url, []) do
-      {:ok, %{"extract" => extract}} when is_binary(extract) and extract != "" -> extract
-      _no_usable_summary -> nil
+      {:ok, summary} when is_map(summary) -> summary
+      _no_usable_summary -> %{}
     end
   end
 
-  defp image_url(entity) do
+  defp p18_image_url(entity) do
     case claim_values(entity, "P18") do
       [filename | _rest] when is_binary(filename) ->
         @commons_file_path_url <>
@@ -177,6 +178,10 @@ defmodule Ambry.Metadata.Providers.Wikidata do
         nil
     end
   end
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
 
   defp claim_values(entity, property) do
     for claim <- get_in(entity, ["claims", property]) || [],

--- a/lib/ambry/metadata/providers/wikidata.ex
+++ b/lib/ambry/metadata/providers/wikidata.ex
@@ -1,0 +1,187 @@
+defmodule Ambry.Metadata.Providers.Wikidata do
+  @moduledoc """
+  Person-level provider backed by Wikidata + Wikipedia + Wikimedia Commons.
+
+  The anchor of the person level: providers keyed on *real people* rather
+  than published-as author identities. Book-catalog providers can't see
+  people who barely exist as catalog authors — half of a composite pen name
+  (Ty Franck, of James S.A. Corey) or narrate-only people — while Wikidata
+  models the humans themselves.
+
+  Flow: Wikidata entity search, hydrated and filtered to humans (P31 = Q5)
+  → bio from the Wikipedia summary-extract API (the article's lead
+  section; falls back to the terse Wikidata description when a person has
+  no English article) → freely-licensed photo from Commons (P18), served
+  scaled through Special:FilePath.
+
+  Zero-config and free, no API key. Registered with the author-search
+  capabilities, so the person form offers it alongside the book-keyed
+  author sources.
+  """
+
+  @behaviour Ambry.Metadata.Provider
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.Wikidata.Client
+
+  @wikidata_api "https://www.wikidata.org/w/api.php"
+  @wikipedia_summary_url "https://en.wikipedia.org/api/rest_v1/page/summary/"
+  @commons_file_path_url "https://commons.wikimedia.org/wiki/Special:FilePath/"
+
+  # Commons originals can be enormous (tens of MB); Special:FilePath scales
+  # server-side. 1200px is plenty for the thumbnail pipeline and on par
+  # with the best book-provider image sources.
+  @image_width 1200
+
+  @search_limit 10
+  @human "Q5"
+
+  @impl Provider
+  def id, do: "wikidata"
+
+  @impl Provider
+  def display_name, do: "Wikipedia"
+
+  @impl Provider
+  def level, do: :person
+
+  @impl Provider
+  def capabilities, do: [:author_search, :author_details]
+
+  @impl Provider
+  def config_fields, do: []
+
+  @impl Provider
+  def search_authors(query, _config) do
+    with {:ok, results} <- search_entities(query) do
+      results |> Enum.map(& &1["id"]) |> hydrate_people()
+    end
+  end
+
+  @impl Provider
+  def author_details(qid, _config) do
+    with {:ok, entities} <- get_entities([qid], "claims|labels|descriptions|sitelinks") do
+      case entities[qid] do
+        %{"missing" => _missing} -> {:error, :not_found}
+        nil -> {:error, :not_found}
+        entity -> {:ok, entity_details(entity)}
+      end
+    end
+  end
+
+  defp search_entities(query) do
+    params = [
+      action: "wbsearchentities",
+      search: query,
+      language: "en",
+      uselang: "en",
+      type: "item",
+      limit: @search_limit,
+      format: "json"
+    ]
+
+    case Client.get_json(@wikidata_api, params) do
+      {:ok, %{"search" => results}} -> {:ok, results}
+      {:ok, _other} -> {:error, :unexpected_response_payload}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp get_entities(ids, props) do
+    params = [
+      action: "wbgetentities",
+      ids: Enum.join(ids, "|"),
+      props: props,
+      languages: "en",
+      sitefilter: "enwiki",
+      format: "json"
+    ]
+
+    case Client.get_json(@wikidata_api, params) do
+      {:ok, %{"entities" => entities}} -> {:ok, entities}
+      {:ok, _other} -> {:error, :unexpected_response_payload}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Entity search matches organizations, works, and disambiguation pages
+  # too; hydrating the hits' claims lets us keep only actual humans, in
+  # the search's relevance order.
+  defp hydrate_people([]), do: {:ok, []}
+
+  defp hydrate_people(ids) do
+    with {:ok, entities} <- get_entities(ids, "claims|labels|descriptions") do
+      {:ok,
+       ids
+       |> Enum.map(&entities[&1])
+       |> Enum.filter(&human?/1)
+       |> Enum.map(&entity_summary/1)}
+    end
+  end
+
+  defp human?(nil), do: false
+
+  defp human?(entity) do
+    entity
+    |> claim_values("P31")
+    |> Enum.any?(&match?(%{"id" => @human}, &1))
+  end
+
+  # search listing: name + the terse Wikidata description ("American
+  # science fiction author") is enough to pick the right person
+  defp entity_summary(entity) do
+    %Provider.Author{
+      provider: id(),
+      id: entity["id"],
+      name: label(entity),
+      description: description(entity)
+    }
+  end
+
+  defp entity_details(entity) do
+    %Provider.Author{
+      provider: id(),
+      id: entity["id"],
+      name: label(entity),
+      description: bio(entity),
+      image_url: image_url(entity)
+    }
+  end
+
+  defp label(entity), do: get_in(entity, ["labels", "en", "value"]) || entity["id"]
+
+  defp description(entity), do: get_in(entity, ["descriptions", "en", "value"])
+
+  defp bio(entity) do
+    wikipedia_extract(get_in(entity, ["sitelinks", "enwiki", "title"])) || description(entity)
+  end
+
+  defp wikipedia_extract(nil), do: nil
+
+  defp wikipedia_extract(title) do
+    url = @wikipedia_summary_url <> URI.encode(title, &URI.char_unreserved?/1)
+
+    case Client.get_json(url, []) do
+      {:ok, %{"extract" => extract}} when is_binary(extract) and extract != "" -> extract
+      _no_usable_summary -> nil
+    end
+  end
+
+  defp image_url(entity) do
+    case claim_values(entity, "P18") do
+      [filename | _rest] when is_binary(filename) ->
+        @commons_file_path_url <>
+          URI.encode(filename, &URI.char_unreserved?/1) <> "?width=#{@image_width}"
+
+      _no_image ->
+        nil
+    end
+  end
+
+  defp claim_values(entity, property) do
+    for claim <- get_in(entity, ["claims", property]) || [],
+        value = get_in(claim, ["mainsnak", "datavalue", "value"]),
+        not is_nil(value),
+        do: value
+  end
+end

--- a/lib/ambry/metadata/providers/wikidata/client.ex
+++ b/lib/ambry/metadata/providers/wikidata/client.ex
@@ -36,7 +36,5 @@ defmodule Ambry.Metadata.Providers.Wikidata.Client do
 
   defp decode(_body), do: {:error, :unexpected_response_payload}
 
-  defp user_agent do
-    "Ambry/#{Application.spec(:ambry, :vsn)} (https://github.com/ambry-app/ambry)"
-  end
+  defp user_agent, do: Ambry.Utils.http_user_agent()
 end

--- a/lib/ambry/metadata/providers/wikidata/client.ex
+++ b/lib/ambry/metadata/providers/wikidata/client.ex
@@ -1,0 +1,42 @@
+defmodule Ambry.Metadata.Providers.Wikidata.Client do
+  @moduledoc """
+  Thin HTTP client for the Wikimedia APIs (the Wikidata action API and the
+  Wikipedia REST summary endpoint).
+
+  Wikimedia's API etiquette requires a descriptive User-Agent identifying
+  the application and a contact point — generic library UAs risk being
+  throttled or blocked.
+  """
+
+  @receive_timeout 30_000
+
+  def get_json(url, params) do
+    case Req.get(
+           url: url,
+           params: params,
+           headers: [{"user-agent", user_agent()}],
+           receive_timeout: @receive_timeout,
+           retry: false
+         ) do
+      {:ok, %{status: 200, body: body}} -> decode(body)
+      {:ok, %{status: 404}} -> {:error, :not_found}
+      {:ok, response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode(body) when is_map(body), do: {:ok, body}
+
+  defp decode(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _reason} -> {:error, :unexpected_response_payload}
+    end
+  end
+
+  defp decode(_body), do: {:error, :unexpected_response_payload}
+
+  defp user_agent do
+    "Ambry/#{Application.spec(:ambry, :vsn)} (https://github.com/ambry-app/ambry)"
+  end
+end

--- a/lib/ambry/metadata/registry.ex
+++ b/lib/ambry/metadata/registry.ex
@@ -15,9 +15,10 @@ defmodule Ambry.Metadata.Registry do
   alias Ambry.Metadata.Providers.Audnexus
   alias Ambry.Metadata.Providers.Hardcover
   alias Ambry.Metadata.Providers.RreadingGlasses
+  alias Ambry.Metadata.Providers.Wikidata
   alias Ambry.Repo
 
-  @known_providers [RreadingGlasses, Hardcover, Audible, Audnexus]
+  @known_providers [RreadingGlasses, Hardcover, Audible, Audnexus, Wikidata]
 
   defmodule Entry do
     @moduledoc "A provider module joined with its runtime configuration."

--- a/lib/ambry/utils.ex
+++ b/lib/ambry/utils.ex
@@ -11,6 +11,18 @@ defmodule Ambry.Utils do
   @byte_units ["B", "kB", "MB", "GB", "TB", "PB"]
 
   @doc """
+  Descriptive User-Agent for outbound HTTP requests.
+
+  Some services (notably the Wikimedia family) throttle or block generic
+  library UAs; their API etiquette asks for an identifying agent with a
+  contact point.
+  """
+  @spec http_user_agent() :: String.t()
+  def http_user_agent do
+    "Ambry/#{Application.spec(:ambry, :vsn)} (https://github.com/ambry-app/ambry)"
+  end
+
+  @doc """
   Formats a byte count as a human-readable string using SI (1000-based) units,
   rounded to a whole number.
 

--- a/lib/ambry_web/controllers/admin/image_proxy_controller.ex
+++ b/lib/ambry_web/controllers/admin/image_proxy_controller.ex
@@ -21,7 +21,13 @@ defmodule AmbryWeb.Admin.ImageProxyController do
   def show(conn, %{"url" => url}) do
     with %URI{scheme: scheme} when scheme in ["http", "https"] <- URI.parse(url),
          {:ok, %{status: 200, body: body} = response} when is_binary(body) <-
-           Req.get(url: url, receive_timeout: @receive_timeout, retry: false, decode_body: false),
+           Req.get(
+             url: url,
+             headers: [{"user-agent", Ambry.Utils.http_user_agent()}],
+             receive_timeout: @receive_timeout,
+             retry: false,
+             decode_body: false
+           ),
          [content_type | _rest] <- Req.Response.get_header(response, "content-type"),
          true <- String.starts_with?(content_type, @allowed_content_types) do
       conn

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -200,7 +200,9 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
       {:work, "Work-level providers",
        "Books, authors, and series — the abstract side of the library."},
       {:recording, "Recording-level providers",
-       "Audiobook releases — narrators, square covers, and chapters, keyed by ASIN."}
+       "Audiobook releases — narrators, square covers, and chapters, keyed by ASIN."},
+      {:person, "Person-level providers",
+       "Bios and photos for the humans behind authors and narrators — keyed on real people, not published-as names."}
     ]
   end
 

--- a/lib/ambry_web/live/admin/upload_helpers.ex
+++ b/lib/ambry_web/live/admin/upload_helpers.ex
@@ -97,7 +97,7 @@ defmodule AmbryWeb.Admin.UploadHelpers do
   end
 
   defp do_image_import(url) do
-    with {:ok, response} <- Req.get(url),
+    with {:ok, response} <- Req.get(url: url, headers: [{"user-agent", http_user_agent()}]),
          [mime | _rest] when mime in @accepted_mime <-
            Req.Response.get_header(response, "content-type") do
       filename = generate_filename(mime)
@@ -122,7 +122,7 @@ defmodule AmbryWeb.Admin.UploadHelpers do
   def valid_image_url?(_term), do: false
 
   def valid_image?(uri) do
-    case Req.head(uri) do
+    case Req.head(url: uri, headers: [{"user-agent", http_user_agent()}]) do
       {:ok, response} ->
         [mime | _rest] = Req.Response.get_header(response, "content-type")
         image?(mime)
@@ -131,6 +131,8 @@ defmodule AmbryWeb.Admin.UploadHelpers do
         false
     end
   end
+
+  defp http_user_agent, do: Ambry.Utils.http_user_agent()
 
   def image?("image/" <> _rest), do: true
   def image?(_mime), do: false

--- a/test/ambry/metadata/providers/mocks/wikidata_entities_search.json
+++ b/test/ambry/metadata/providers/mocks/wikidata_entities_search.json
@@ -1,0 +1,56 @@
+{
+  "entities": {
+    "Q18608460": {
+      "type": "item",
+      "id": "Q18608460",
+      "labels": { "en": { "language": "en", "value": "Ty Franck" } },
+      "descriptions": { "en": { "language": "en", "value": "American science fiction writer" } },
+      "claims": {
+        "P31": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P31",
+              "datavalue": { "value": { "entity-type": "item", "id": "Q5" }, "type": "wikibase-entityid" }
+            }
+          }
+        ]
+      }
+    },
+    "Q3107329": {
+      "type": "item",
+      "id": "Q3107329",
+      "labels": { "en": { "language": "en", "value": "Leviathan Wakes" } },
+      "descriptions": { "en": { "language": "en", "value": "2011 novel by James S. A. Corey" } },
+      "claims": {
+        "P31": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P31",
+              "datavalue": { "value": { "entity-type": "item", "id": "Q7725634" }, "type": "wikibase-entityid" }
+            }
+          }
+        ]
+      }
+    },
+    "Q99999999": {
+      "type": "item",
+      "id": "Q99999999",
+      "labels": { "en": { "language": "en", "value": "Obscure Narrator" } },
+      "descriptions": { "en": { "language": "en", "value": "audiobook narrator" } },
+      "claims": {
+        "P31": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P31",
+              "datavalue": { "value": { "entity-type": "item", "id": "Q5" }, "type": "wikibase-entityid" }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "success": 1
+}

--- a/test/ambry/metadata/providers/mocks/wikidata_entity_details.json
+++ b/test/ambry/metadata/providers/mocks/wikidata_entity_details.json
@@ -1,0 +1,34 @@
+{
+  "entities": {
+    "Q18608460": {
+      "type": "item",
+      "id": "Q18608460",
+      "labels": { "en": { "language": "en", "value": "Ty Franck" } },
+      "descriptions": { "en": { "language": "en", "value": "American science fiction writer" } },
+      "claims": {
+        "P31": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P31",
+              "datavalue": { "value": { "entity-type": "item", "id": "Q5" }, "type": "wikibase-entityid" }
+            }
+          }
+        ],
+        "P18": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P18",
+              "datavalue": { "value": "Ty Franck (36166643166).jpg", "type": "string" }
+            }
+          }
+        ]
+      },
+      "sitelinks": {
+        "enwiki": { "site": "enwiki", "title": "Ty Franck", "badges": [] }
+      }
+    }
+  },
+  "success": 1
+}

--- a/test/ambry/metadata/providers/mocks/wikidata_entity_details_no_article.json
+++ b/test/ambry/metadata/providers/mocks/wikidata_entity_details_no_article.json
@@ -1,0 +1,23 @@
+{
+  "entities": {
+    "Q99999999": {
+      "type": "item",
+      "id": "Q99999999",
+      "labels": { "en": { "language": "en", "value": "Obscure Narrator" } },
+      "descriptions": { "en": { "language": "en", "value": "audiobook narrator" } },
+      "claims": {
+        "P31": [
+          {
+            "mainsnak": {
+              "snaktype": "value",
+              "property": "P31",
+              "datavalue": { "value": { "entity-type": "item", "id": "Q5" }, "type": "wikibase-entityid" }
+            }
+          }
+        ]
+      },
+      "sitelinks": {}
+    }
+  },
+  "success": 1
+}

--- a/test/ambry/metadata/providers/mocks/wikidata_search.json
+++ b/test/ambry/metadata/providers/mocks/wikidata_search.json
@@ -1,0 +1,27 @@
+{
+  "searchinfo": { "search": "ty franck" },
+  "search": [
+    {
+      "id": "Q18608460",
+      "title": "Q18608460",
+      "label": "Ty Franck",
+      "description": "American science fiction writer",
+      "match": { "type": "label", "language": "en", "text": "Ty Franck" }
+    },
+    {
+      "id": "Q3107329",
+      "title": "Q3107329",
+      "label": "Leviathan Wakes",
+      "description": "2011 novel by James S. A. Corey",
+      "match": { "type": "label", "language": "en", "text": "Leviathan Wakes" }
+    },
+    {
+      "id": "Q99999999",
+      "title": "Q99999999",
+      "label": "Obscure Narrator",
+      "description": "audiobook narrator",
+      "match": { "type": "label", "language": "en", "text": "Obscure Narrator" }
+    }
+  ],
+  "success": 1
+}

--- a/test/ambry/metadata/providers/mocks/wikipedia_summary.json
+++ b/test/ambry/metadata/providers/mocks/wikipedia_summary.json
@@ -1,0 +1,5 @@
+{
+  "type": "standard",
+  "title": "Ty Franck",
+  "extract": "Tyler Corey Franck is an American science fiction writer, best known as one half of James S. A. Corey, the joint pen name under which he and Daniel Abraham wrote The Expanse."
+}

--- a/test/ambry/metadata/providers/mocks/wikipedia_summary.json
+++ b/test/ambry/metadata/providers/mocks/wikipedia_summary.json
@@ -1,5 +1,15 @@
 {
   "type": "standard",
   "title": "Ty Franck",
+  "thumbnail": {
+    "source": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/85/Ty_Franck_%2836166643166%29.jpg/320px-Ty_Franck_%2836166643166%29.jpg",
+    "width": 320,
+    "height": 427
+  },
+  "originalimage": {
+    "source": "https://upload.wikimedia.org/wikipedia/commons/8/85/Ty_Franck_%2836166643166%29.jpg",
+    "width": 1536,
+    "height": 2048
+  },
   "extract": "Tyler Corey Franck is an American science fiction writer, best known as one half of James S. A. Corey, the joint pen name under which he and Daniel Abraham wrote The Expanse."
 }

--- a/test/ambry/metadata/providers/wikidata_test.exs
+++ b/test/ambry/metadata/providers/wikidata_test.exs
@@ -1,0 +1,114 @@
+defmodule Ambry.Metadata.Providers.WikidataTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.Wikidata
+  alias Ambry.Metadata.Providers.Wikidata.Client
+
+  @mocks Path.join(__DIR__, "mocks")
+
+  @wikidata_api "https://www.wikidata.org/w/api.php"
+  @summary_prefix "https://en.wikipedia.org/api/rest_v1/page/summary/"
+
+  defp fixture(name) do
+    @mocks |> Path.join(name) |> File.read!() |> Jason.decode!()
+  end
+
+  describe "search_authors/2" do
+    test "searches entities, hydrates, and keeps only humans in search order" do
+      search = fixture("wikidata_search.json")
+      entities = fixture("wikidata_entities_search.json")
+
+      patch(Client, :get_json, fn @wikidata_api, params ->
+        case params[:action] do
+          "wbsearchentities" -> {:ok, search}
+          "wbgetentities" -> {:ok, entities}
+        end
+      end)
+
+      assert {:ok, authors} = Wikidata.search_authors("ty franck", %{})
+
+      # the novel (non-human) hit is filtered out; humans keep search order
+      assert [
+               %Provider.Author{
+                 provider: "wikidata",
+                 id: "Q18608460",
+                 name: "Ty Franck",
+                 description: "American science fiction writer"
+               },
+               %Provider.Author{id: "Q99999999", name: "Obscure Narrator"}
+             ] = authors
+
+      # all search hits go into one batched hydration call
+      assert_called(Client.get_json(@wikidata_api, params))
+      assert params[:ids] == "Q18608460|Q3107329|Q99999999"
+    end
+
+    test "returns empty list when the search has no hits" do
+      patch(Client, :get_json, fn @wikidata_api, _params ->
+        {:ok, %{"search" => [], "success" => 1}}
+      end)
+
+      assert {:ok, []} = Wikidata.search_authors("zzz", %{})
+    end
+
+    test "passes through client errors" do
+      patch(Client, :get_json, fn @wikidata_api, _params -> {:error, :nxdomain} end)
+
+      assert {:error, :nxdomain} = Wikidata.search_authors("q", %{})
+    end
+  end
+
+  describe "author_details/2" do
+    test "combines the Wikipedia lead extract with the Commons photo" do
+      details = fixture("wikidata_entity_details.json")
+      summary = fixture("wikipedia_summary.json")
+
+      patch(Client, :get_json, fn
+        @wikidata_api, _params -> {:ok, details}
+        @summary_prefix <> title, [] -> if title == "Ty%20Franck", do: {:ok, summary}
+      end)
+
+      assert {:ok, author} = Wikidata.author_details("Q18608460", %{})
+
+      assert %Provider.Author{provider: "wikidata", id: "Q18608460", name: "Ty Franck"} = author
+      assert author.description =~ "one half of James S. A. Corey"
+
+      # P18 filename → scaled Special:FilePath URL, fully encoded
+      assert author.image_url ==
+               "https://commons.wikimedia.org/wiki/Special:FilePath/Ty%20Franck%20%2836166643166%29.jpg?width=1200"
+    end
+
+    test "falls back to the Wikidata description when there is no English article" do
+      details = fixture("wikidata_entity_details_no_article.json")
+
+      patch(Client, :get_json, fn @wikidata_api, _params -> {:ok, details} end)
+
+      assert {:ok, author} = Wikidata.author_details("Q99999999", %{})
+
+      assert author.description == "audiobook narrator"
+      assert author.image_url == nil
+    end
+
+    test "a failing summary fetch degrades to the Wikidata description" do
+      details = fixture("wikidata_entity_details.json")
+
+      patch(Client, :get_json, fn
+        @wikidata_api, _params -> {:ok, details}
+        @summary_prefix <> _title, [] -> {:error, :not_found}
+      end)
+
+      assert {:ok, author} = Wikidata.author_details("Q18608460", %{})
+      assert author.description == "American science fiction writer"
+    end
+
+    test "missing entities are :not_found" do
+      patch(Client, :get_json, fn @wikidata_api, _params ->
+        {:ok, %{"entities" => %{"Q0" => %{"id" => "Q0", "missing" => ""}}, "success" => 1}}
+      end)
+
+      assert {:error, :not_found} = Wikidata.author_details("Q0", %{})
+    end
+  end
+end

--- a/test/ambry/metadata/providers/wikidata_test.exs
+++ b/test/ambry/metadata/providers/wikidata_test.exs
@@ -61,7 +61,7 @@ defmodule Ambry.Metadata.Providers.WikidataTest do
   end
 
   describe "author_details/2" do
-    test "combines the Wikipedia lead extract with the Commons photo" do
+    test "combines the Wikipedia lead extract with the article's direct original image" do
       details = fixture("wikidata_entity_details.json")
       summary = fixture("wikipedia_summary.json")
 
@@ -74,6 +74,23 @@ defmodule Ambry.Metadata.Providers.WikidataTest do
 
       assert %Provider.Author{provider: "wikidata", id: "Q18608460", name: "Ty Franck"} = author
       assert author.description =~ "one half of James S. A. Corey"
+
+      # the summary's originalimage is a direct upload.wikimedia.org file —
+      # preferred over Special:FilePath (no redirect / on-demand thumbnailer)
+      assert author.image_url ==
+               "https://upload.wikimedia.org/wikipedia/commons/8/85/Ty_Franck_%2836166643166%29.jpg"
+    end
+
+    test "falls back to the P18 FilePath URL when the summary has no image" do
+      details = fixture("wikidata_entity_details.json")
+      summary = fixture("wikipedia_summary.json") |> Map.drop(["originalimage", "thumbnail"])
+
+      patch(Client, :get_json, fn
+        @wikidata_api, _params -> {:ok, details}
+        @summary_prefix <> _title, [] -> {:ok, summary}
+      end)
+
+      assert {:ok, author} = Wikidata.author_details("Q18608460", %{})
 
       # P18 filename → scaled Special:FilePath URL, fully encoded
       assert author.image_url ==
@@ -91,7 +108,7 @@ defmodule Ambry.Metadata.Providers.WikidataTest do
       assert author.image_url == nil
     end
 
-    test "a failing summary fetch degrades to the Wikidata description" do
+    test "a failing summary fetch degrades to the Wikidata description and P18 image" do
       details = fixture("wikidata_entity_details.json")
 
       patch(Client, :get_json, fn
@@ -101,6 +118,7 @@ defmodule Ambry.Metadata.Providers.WikidataTest do
 
       assert {:ok, author} = Wikidata.author_details("Q18608460", %{})
       assert author.description == "American science fiction writer"
+      assert author.image_url =~ "Special:FilePath"
     end
 
     test "missing entities are :not_found" do

--- a/test/ambry/metadata/registry_test.exs
+++ b/test/ambry/metadata/registry_test.exs
@@ -6,7 +6,9 @@ defmodule Ambry.Metadata.RegistryTest do
   test "all/0 returns every known provider enabled by default, in priority order" do
     entries = Registry.all()
 
-    assert Enum.map(entries, & &1.id) == ["rreading_glasses", "hardcover", "audible", "audnexus"]
+    assert Enum.map(entries, & &1.id) ==
+             ["rreading_glasses", "hardcover", "audible", "audnexus", "wikidata"]
+
     assert Enum.all?(entries, & &1.enabled)
   end
 
@@ -33,8 +35,10 @@ defmodule Ambry.Metadata.RegistryTest do
 
     assert ["audnexus"] = Enum.map(Registry.enabled(capability: :chapters), & &1.id)
 
-    assert ["rreading_glasses", "audnexus"] =
+    assert ["rreading_glasses", "audnexus", "wikidata"] =
              Enum.map(Registry.enabled(capability: :author_search), & &1.id)
+
+    assert ["wikidata"] = Enum.map(Registry.enabled(level: :person), & &1.id)
   end
 
   test "update/2 persists enabled flag and priority" do

--- a/test/ambry_web/live/admin/metadata_live/providers_test.exs
+++ b/test/ambry_web/live/admin/metadata_live/providers_test.exs
@@ -13,6 +13,8 @@ defmodule AmbryWeb.Admin.MetadataLive.ProvidersTest do
     assert html =~ "rreading-glasses"
     assert html =~ "Audible"
     assert html =~ "Audnexus"
+    assert html =~ "Person-level providers"
+    assert html =~ "Wikipedia"
   end
 
   test "toggles a provider off and on", %{conn: conn} do

--- a/test/ambry_web/live/admin/person_live/import_test.exs
+++ b/test/ambry_web/live/admin/person_live/import_test.exs
@@ -42,6 +42,7 @@ defmodule AmbryWeb.Admin.PersonLive.ImportTest do
 
     assert html =~ "rreading-glasses"
     assert html =~ "Audnexus"
+    assert html =~ "Wikipedia"
     refute html =~ "GoodReads"
   end
 


### PR DESCRIPTION
**Stacked on #1155** (provenance/locks) — merge that first, and merge this one *without* deleting the base branch until this is retargeted/merged (GitHub closes stacked PRs when their base branch is deleted).

The anchor of the person-level provider tier (roadmap 1c): providers keyed on **real people**, not published-as author identities. Book-catalog providers can't see people who barely exist as catalog authors — Ty Franck (half of James S.A. Corey) gets no bio and no photo from any book-keyed source. Wikidata models the humans themselves.

## What's here

- **New `:person` provider level** in the behaviour, registry, and admin settings page (its own section: "Person-level providers").
- **`Ambry.Metadata.Providers.Wikidata`** (display name "Wikipedia", zero-config, no API key):
  - Search: Wikidata entity search → one batched hydration → filtered to humans (P31=Q5), search order preserved. Search listing shows the terse Wikidata description ("American science fiction writer") for disambiguation.
  - Details: bio from the Wikipedia summary-extract API (the article lead; falls back to the Wikidata description when no English article exists) + freely-licensed Commons photo (P18) served scaled via `Special:FilePath?width=1200`.
  - Descriptive User-Agent per Wikimedia API etiquette.
- Registered with `author_search`/`author_details` capabilities, so the **person form offers it automatically** with zero new UI, and accepted values record `provider:wikidata` provenance (unlocked) via #1155's machinery.

## Verified live

`search_authors("ty franck")` → exactly one result, Q18608460 (the novel hit is filtered as non-human); details return the full Wikipedia lead ("…best known for co-authoring The Expanse…") and a Commons photo URL that resolves to `image/jpeg`.

## Tests

Provider unit tests with recorded-shape fixtures (human filtering + order, batched hydration, bio fallback chains, URL encoding of Commons filenames, missing entities); registry/settings/person-form integration assertions updated. Full suite 647 passed; `mix check` clean.

## Not in this PR (next 1c increments)

TMDB person search (needs API key config), the aggregated image-picker grid + assisted manual flow, and pen-name structural proposals from Wikidata (1g inbox material).

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9