### PR TITLE
Phase 1c: TMDB person-level provider

### DIFF
--- a/lib/ambry/metadata/providers/tmdb.ex
+++ b/lib/ambry/metadata/providers/tmdb.ex
@@ -58,7 +58,9 @@ defmodule Ambry.Metadata.Providers.Tmdb do
     if available?(config) do
       []
     else
-      [{:warning, "No API key configured — get a free key at #{@signup_url}."}]
+      # info, not warning: this provider is a purely optional extra — an
+      # unkeyed TMDB is a fine steady state, not a misconfiguration
+      [{:info, "Optional — paste a free API key from #{@signup_url} to enable TMDB headshots."}]
     end
   end
 

--- a/lib/ambry/metadata/providers/tmdb.ex
+++ b/lib/ambry/metadata/providers/tmdb.ex
@@ -1,0 +1,119 @@
+defmodule Ambry.Metadata.Providers.Tmdb do
+  @moduledoc """
+  Person-level provider backed by TMDB (themoviedb.org).
+
+  Headshots (and often bios) for anyone with screen credits — many
+  narrators are working actors, and it covers authors with TV/film
+  credits too (Ty Franck again, via The Expanse). Complements the
+  Wikidata/Wikipedia provider: TMDB's profile photos are high-quality
+  and plentiful where Commons often has nothing.
+
+  Needs a free API key (unavailable until configured — visible in the
+  admin settings with a setup notice, not offered in import forms).
+  """
+
+  @behaviour Ambry.Metadata.Provider
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Provider.ConfigField
+  alias Ambry.Metadata.Providers.Tmdb.Client
+
+  @signup_url "https://www.themoviedb.org/settings/api"
+
+  # original-size profile images; TMDB profiles are typically ~2000px tall
+  @image_base_url "https://image.tmdb.org/t/p/original"
+
+  @impl Provider
+  def id, do: "tmdb"
+
+  @impl Provider
+  def display_name, do: "TMDB"
+
+  @impl Provider
+  def level, do: :person
+
+  @impl Provider
+  def capabilities, do: [:author_search, :author_details]
+
+  @impl Provider
+  def config_fields do
+    [
+      %ConfigField{
+        key: :api_key,
+        label: "API key",
+        type: :secret,
+        default: nil,
+        help:
+          "Free key from #{@signup_url} — either the v3 API key or the " <>
+            "v4 read access token works."
+      }
+    ]
+  end
+
+  @impl Provider
+  def available?(config), do: is_binary(config[:api_key]) and config[:api_key] != ""
+
+  @impl Provider
+  def config_notices(config) do
+    if available?(config) do
+      []
+    else
+      [{:warning, "No API key configured — get a free key at #{@signup_url}."}]
+    end
+  end
+
+  @impl Provider
+  def search_authors(query, config) do
+    with {:ok, %{"results" => results}} <-
+           Client.get_json("/search/person", [query: query, include_adult: false], config) do
+      {:ok, Enum.map(results, &result_summary/1)}
+    end
+  end
+
+  @impl Provider
+  def author_details(person_id, config) do
+    with {:ok, person} <- Client.get_json("/person/#{person_id}", [], config) do
+      {:ok,
+       %Provider.Author{
+         provider: id(),
+         id: to_string(person["id"]),
+         name: person["name"],
+         description: presence(person["biography"]),
+         image_url: image_url(person["profile_path"])
+       }}
+    end
+  end
+
+  # search listing: the person's known-for credits are the disambiguator
+  # ("Acting — The Expanse, Avenue 5")
+  defp result_summary(result) do
+    %Provider.Author{
+      provider: id(),
+      id: to_string(result["id"]),
+      name: result["name"],
+      description: known_for(result),
+      image_url: image_url(result["profile_path"])
+    }
+  end
+
+  defp known_for(result) do
+    titles =
+      for entry <- result["known_for"] || [],
+          title = presence(entry["title"] || entry["name"]),
+          do: title
+
+    case {presence(result["known_for_department"]), titles} do
+      {nil, []} -> nil
+      {department, []} -> department
+      {nil, titles} -> Enum.join(titles, ", ")
+      {department, titles} -> "#{department} — #{Enum.join(titles, ", ")}"
+    end
+  end
+
+  defp image_url(nil), do: nil
+  defp image_url(profile_path), do: @image_base_url <> profile_path
+
+  defp presence(nil), do: nil
+  defp presence(""), do: nil
+  defp presence(value), do: value
+end

--- a/lib/ambry/metadata/providers/tmdb/client.ex
+++ b/lib/ambry/metadata/providers/tmdb/client.ex
@@ -1,0 +1,41 @@
+defmodule Ambry.Metadata.Providers.Tmdb.Client do
+  @moduledoc """
+  Thin HTTP client for the TMDB v3 API.
+
+  TMDB hands out two credential shapes and both are accepted here: the
+  short v3 "API key" (sent as an `api_key` query param) and the long v4
+  "API Read Access Token" (a JWT, sent as a Bearer header). Operators
+  paste whichever their account page gave them.
+  """
+
+  @base_url "https://api.themoviedb.org/3"
+  @receive_timeout 30_000
+
+  def get_json(path, params, config) do
+    {params, headers} = authorize(params, config)
+
+    case Req.get(
+           url: @base_url <> path,
+           params: params,
+           headers: headers,
+           receive_timeout: @receive_timeout,
+           retry: false
+         ) do
+      {:ok, %{status: 200, body: body}} when is_map(body) -> {:ok, body}
+      {:ok, %{status: 401}} -> {:error, :unauthorized}
+      {:ok, %{status: 404}} -> {:error, :not_found}
+      {:ok, response} -> {:error, response}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp authorize(params, config) do
+    api_key = config[:api_key] || ""
+
+    if String.starts_with?(api_key, "eyJ") do
+      {params, [{"authorization", "Bearer " <> api_key}]}
+    else
+      {Keyword.put(params, :api_key, api_key), []}
+    end
+  end
+end

--- a/lib/ambry/metadata/registry.ex
+++ b/lib/ambry/metadata/registry.ex
@@ -15,10 +15,11 @@ defmodule Ambry.Metadata.Registry do
   alias Ambry.Metadata.Providers.Audnexus
   alias Ambry.Metadata.Providers.Hardcover
   alias Ambry.Metadata.Providers.RreadingGlasses
+  alias Ambry.Metadata.Providers.Tmdb
   alias Ambry.Metadata.Providers.Wikidata
   alias Ambry.Repo
 
-  @known_providers [RreadingGlasses, Hardcover, Audible, Audnexus, Wikidata]
+  @known_providers [RreadingGlasses, Hardcover, Audible, Audnexus, Wikidata, Tmdb]
 
   defmodule Entry do
     @moduledoc "A provider module joined with its runtime configuration."

--- a/test/ambry/metadata/providers/mocks/tmdb_person.json
+++ b/test/ambry/metadata/providers/mocks/tmdb_person.json
@@ -1,0 +1,11 @@
+{
+  "adult": false,
+  "biography": "Tyler Corey Franck is an American writer and television producer, best known as one half of James S. A. Corey.",
+  "birthday": "1969-03-16",
+  "deathday": null,
+  "id": 1252351,
+  "known_for_department": "Writing",
+  "name": "Ty Franck",
+  "place_of_birth": "Portland, Oregon, USA",
+  "profile_path": "/tyfranck-profile.jpg"
+}

--- a/test/ambry/metadata/providers/mocks/tmdb_search.json
+++ b/test/ambry/metadata/providers/mocks/tmdb_search.json
@@ -1,0 +1,32 @@
+{
+  "page": 1,
+  "results": [
+    {
+      "adult": false,
+      "gender": 2,
+      "id": 1252351,
+      "known_for_department": "Writing",
+      "name": "Ty Franck",
+      "original_name": "Ty Franck",
+      "popularity": 1.4,
+      "profile_path": "/tyfranck-profile.jpg",
+      "known_for": [
+        { "id": 63639, "media_type": "tv", "name": "The Expanse" },
+        { "id": 99999, "media_type": "movie", "title": "Some Film" }
+      ]
+    },
+    {
+      "adult": false,
+      "gender": 0,
+      "id": 555,
+      "known_for_department": null,
+      "name": "Ty Franck Lookalike",
+      "original_name": "Ty Franck Lookalike",
+      "popularity": 0.1,
+      "profile_path": null,
+      "known_for": []
+    }
+  ],
+  "total_pages": 1,
+  "total_results": 2
+}

--- a/test/ambry/metadata/providers/tmdb_test.exs
+++ b/test/ambry/metadata/providers/tmdb_test.exs
@@ -1,0 +1,82 @@
+defmodule Ambry.Metadata.Providers.TmdbTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers.Tmdb
+  alias Ambry.Metadata.Providers.Tmdb.Client
+
+  @mocks Path.join(__DIR__, "mocks")
+
+  defp fixture(name) do
+    @mocks |> Path.join(name) |> File.read!() |> Jason.decode!()
+  end
+
+  describe "availability" do
+    test "unavailable until an API key is configured, with a setup notice" do
+      refute Tmdb.available?(%{})
+      refute Tmdb.available?(%{api_key: ""})
+      assert Tmdb.available?(%{api_key: "abc123"})
+
+      assert [{:warning, notice}] = Tmdb.config_notices(%{})
+      assert notice =~ "themoviedb.org"
+
+      assert [] = Tmdb.config_notices(%{api_key: "abc123"})
+    end
+  end
+
+  describe "search_authors/2" do
+    test "normalizes results with known-for credits as the description" do
+      search = fixture("tmdb_search.json")
+
+      patch(Client, :get_json, fn "/search/person", params, _config ->
+        assert params[:query] == "ty franck"
+        {:ok, search}
+      end)
+
+      assert {:ok, [franck, lookalike]} = Tmdb.search_authors("ty franck", %{api_key: "k"})
+
+      assert %Provider.Author{
+               provider: "tmdb",
+               id: "1252351",
+               name: "Ty Franck",
+               description: "Writing — The Expanse, Some Film",
+               image_url: "https://image.tmdb.org/t/p/original/tyfranck-profile.jpg"
+             } = franck
+
+      # no credits and no photo: still listed, just bare
+      assert %Provider.Author{id: "555", description: nil, image_url: nil} = lookalike
+    end
+
+    test "passes through client errors" do
+      patch(Client, :get_json, fn "/search/person", _params, _config ->
+        {:error, :unauthorized}
+      end)
+
+      assert {:error, :unauthorized} = Tmdb.search_authors("q", %{api_key: "bad"})
+    end
+  end
+
+  describe "author_details/2" do
+    test "returns biography and original-size profile image" do
+      person = fixture("tmdb_person.json")
+
+      patch(Client, :get_json, fn "/person/1252351", [], _config -> {:ok, person} end)
+
+      assert {:ok, author} = Tmdb.author_details("1252351", %{api_key: "k"})
+
+      assert %Provider.Author{provider: "tmdb", id: "1252351", name: "Ty Franck"} = author
+      assert author.description =~ "one half of James S. A. Corey"
+      assert author.image_url == "https://image.tmdb.org/t/p/original/tyfranck-profile.jpg"
+    end
+
+    test "empty biography becomes nil" do
+      person = fixture("tmdb_person.json") |> Map.put("biography", "")
+
+      patch(Client, :get_json, fn "/person/1252351", [], _config -> {:ok, person} end)
+
+      assert {:ok, %Provider.Author{description: nil}} =
+               Tmdb.author_details("1252351", %{api_key: "k"})
+    end
+  end
+end

--- a/test/ambry/metadata/providers/tmdb_test.exs
+++ b/test/ambry/metadata/providers/tmdb_test.exs
@@ -18,8 +18,9 @@ defmodule Ambry.Metadata.Providers.TmdbTest do
       refute Tmdb.available?(%{api_key: ""})
       assert Tmdb.available?(%{api_key: "abc123"})
 
-      assert [{:warning, notice}] = Tmdb.config_notices(%{})
+      assert [{:info, notice}] = Tmdb.config_notices(%{})
       assert notice =~ "themoviedb.org"
+      assert notice =~ "Optional"
 
       assert [] = Tmdb.config_notices(%{api_key: "abc123"})
     end

--- a/test/ambry/metadata/registry_test.exs
+++ b/test/ambry/metadata/registry_test.exs
@@ -7,7 +7,7 @@ defmodule Ambry.Metadata.RegistryTest do
     entries = Registry.all()
 
     assert Enum.map(entries, & &1.id) ==
-             ["rreading_glasses", "hardcover", "audible", "audnexus", "wikidata"]
+             ["rreading_glasses", "hardcover", "audible", "audnexus", "wikidata", "tmdb"]
 
     assert Enum.all?(entries, & &1.enabled)
   end
@@ -38,7 +38,11 @@ defmodule Ambry.Metadata.RegistryTest do
     assert ["rreading_glasses", "audnexus", "wikidata"] =
              Enum.map(Registry.enabled(capability: :author_search), & &1.id)
 
+    # tmdb is person-level too but unavailable until an API key is stored
     assert ["wikidata"] = Enum.map(Registry.enabled(level: :person), & &1.id)
+
+    {:ok, _row} = Registry.update("tmdb", %{config: %{"api_key" => "k"}})
+    assert ["wikidata", "tmdb"] = Enum.map(Registry.enabled(level: :person), & &1.id)
   end
 
   test "update/2 persists enabled flag and priority" do

--- a/test/ambry_web/live/admin/metadata_live/providers_test.exs
+++ b/test/ambry_web/live/admin/metadata_live/providers_test.exs
@@ -20,7 +20,7 @@ defmodule AmbryWeb.Admin.MetadataLive.ProvidersTest do
     # the settings page is where the key gets pasted
     assert html =~ "TMDB"
     assert html =~ ~s(name="config[api_key]")
-    assert html =~ "No API key configured"
+    assert html =~ "Optional — paste a free API key"
   end
 
   test "toggles a provider off and on", %{conn: conn} do

--- a/test/ambry_web/live/admin/metadata_live/providers_test.exs
+++ b/test/ambry_web/live/admin/metadata_live/providers_test.exs
@@ -15,6 +15,12 @@ defmodule AmbryWeb.Admin.MetadataLive.ProvidersTest do
     assert html =~ "Audnexus"
     assert html =~ "Person-level providers"
     assert html =~ "Wikipedia"
+
+    # TMDB renders in the person-level section even while unavailable:
+    # the settings page is where the key gets pasted
+    assert html =~ "TMDB"
+    assert html =~ ~s(name="config[api_key]")
+    assert html =~ "No API key configured"
   end
 
   test "toggles a provider off and on", %{conn: conn} do


### PR DESCRIPTION
**Stacked on #1156** (Wikidata provider), which stacks on #1155. Same merge discipline: merge bases first, no branch deletion until the stack is settled.

Second person-level provider (roadmap 1c): **TMDB person search** — headshots for anyone with screen credits. Many narrators are working actors, and it covers authors with TV/film credits too (Ty Franck again, via The Expanse). Complements Wikipedia: TMDB's profile photos are high-quality and plentiful where Commons often has nothing.

## What's here

- `Ambry.Metadata.Providers.Tmdb` (person level, `author_search`/`author_details`):
  - Search via `/search/person`; listings show known-for credits as the disambiguator ("Writing — The Expanse, Some Film").
  - Details via `/person/{id}`: biography (empty → nil) + original-size profile image from `image.tmdb.org`.
- **Availability gating** (Hardcover pattern): unavailable until a free API key is configured — visible in admin settings with a setup notice pointing at themoviedb.org, not offered in the person form until then. The client accepts both credential shapes TMDB hands out: the v3 API key (query param) and the v4 read access token (Bearer header), detected automatically.
- Registry/settings/tests updated; a registry test covers the unavailable→available flip when a key is stored.

## Not verified live

I don't have a TMDB API key — @chris supplies one later. The client is exercised against recorded-shape fixtures; once a key is pasted into the settings page, the provider appears in the person form automatically. Suggested first live test: import Ty Franck or a narrator like Jefferson Mays from TMDB.

Full suite 652 passed; `mix check` clean.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9