### PR TITLE
Phase 1c: aggregated image picker + assisted manual flow

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -26,6 +26,7 @@ import { HeaderScrollspyHook } from "./hooks/header-scrollspy"
 import { ImageSizeHook } from "./hooks/image-size"
 import { InfiniteScrollHook } from "./hooks/infinite-scroll"
 import { MainTainAttrsHook } from "./hooks/maintain-attrs"
+import { PasteImageHook } from "./hooks/paste-image"
 import { ReadMoreHook } from "./hooks/read-more"
 import { ScrollIntoViewHook } from "./hooks/scroll-into-view"
 import { ScrollMatchHook } from "./hooks/scroll-match"
@@ -45,6 +46,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     "dispatch-value-change": DispatchValueChangeHook,
     "image-size": ImageSizeHook,
     "scroll-match": ScrollMatchHook,
+    "paste-image": PasteImageHook,
   },
 })
 

--- a/assets/js/hooks/paste-image.js
+++ b/assets/js/hooks/paste-image.js
@@ -1,0 +1,25 @@
+// Lets an image upload area accept images pasted from the clipboard
+// (screenshots, copied web images). Attached to a drop-target div with
+// `data-upload-name` naming the LiveView upload config; pasted image files
+// are piped into the same upload pipeline as drag-and-drop or the file
+// picker.
+export const PasteImageHook = {
+  mounted() {
+    this.handler = (event) => {
+      const files = Array.from(event.clipboardData?.files || []).filter((file) =>
+        file.type.startsWith("image/"),
+      )
+
+      if (files.length > 0) {
+        event.preventDefault()
+        this.uploadTo(this.el, this.el.dataset.uploadName, files.slice(0, 1))
+      }
+    }
+
+    window.addEventListener("paste", this.handler)
+  },
+
+  destroyed() {
+    window.removeEventListener("paste", this.handler)
+  },
+}

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -482,6 +482,10 @@ defmodule AmbryWeb.CoreComponents do
   attr :errors, :list, default: []
   attr :image_preview_class, :string, default: nil
 
+  attr :paste_upload, :boolean,
+    default: false,
+    doc: "also accept an image pasted from the clipboard (adds a JS hook to the drop area)"
+
   def file_input(assigns) do
     ~H"""
     <div>
@@ -500,10 +504,16 @@ defmodule AmbryWeb.CoreComponents do
         />
       </div>
       <div
+        id={"#{@upload.ref}-drop-area"}
         class="space-y-4 rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4"
         phx-drop-target={@upload.ref}
+        phx-hook={if @paste_upload, do: "paste-image"}
+        data-upload-name={if @paste_upload, do: @upload.name}
       >
         <.icon :if={@upload.entries == []} name="fa-upload" class="mx-auto my-4 block h-8 w-8 text-current" />
+        <p :if={@paste_upload && @upload.entries == []} class="text-center text-xs text-zinc-500">
+          drop, or paste from the clipboard
+        </p>
         <div :if={@upload.entries != []} class="flex flex-wrap gap-4">
           <article :for={entry <- @upload.entries} class="inline-block">
             <figure>

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -9,6 +9,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   alias Ambry.People.Author
   alias Ambry.People.Person
   alias Ambry.Provenance
+  alias AmbryWeb.Admin.PersonLive.Form.ImagePicker
   alias AmbryWeb.Admin.PersonLive.Form.ImportForm
   alias AmbryWeb.Admin.ProvenanceHints
   alias Ecto.Changeset
@@ -20,6 +21,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
      |> allow_image_upload(:image)
      |> assign(
        import: nil,
+       image_picker: false,
        provenance_hints: %{},
        providers: Registry.enabled(capability: :author_search),
        authors: People.authors_for_select()
@@ -121,6 +123,14 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     {:noreply, assign(socket, person: person)}
   end
 
+  def handle_event("open-image-picker", _params, socket) do
+    {:noreply, assign(socket, image_picker: true)}
+  end
+
+  def handle_event("close-image-picker", _params, socket) do
+    {:noreply, assign(socket, image_picker: false)}
+  end
+
   def handle_event("open-import-form", %{"type" => provider_id}, socket) do
     {:noreply, handle_import_form_params(socket, %{"import" => provider_id})}
   end
@@ -130,6 +140,21 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   @impl Phoenix.LiveView
+  def handle_info({:image_picked, url, source}, socket) do
+    picked = %{"image_path" => "", "image_type" => "url_import", "image_import_url" => url}
+    hints = ProvenanceHints.from_import(picked, source)
+    new_params = Map.merge(socket.assigns.form.params, picked)
+    changeset = People.change_person(socket.assigns.person, new_params)
+
+    {:noreply,
+     socket
+     |> assign_form(changeset)
+     |> assign(
+       image_picker: false,
+       provenance_hints: Map.merge(socket.assigns.provenance_hints, hints)
+     )}
+  end
+
   def handle_info({:import, %{"person" => person_params}, source}, socket) do
     hints = ProvenanceHints.from_import(person_params, source)
     new_params = Map.merge(socket.assigns.form.params, person_params)
@@ -255,6 +280,8 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
         []
     end
   end
+
+  defp picker_query(form, person), do: form.params["name"] || person.name
 
   defp open_import_form(%Person{id: nil}, type),
     do: JS.patch(~p"/admin/people/new?import=#{type}")

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -9,6 +9,10 @@
     />
   </.modal>
 
+  <.modal :if={@image_picker} id="image-picker-modal" show on_cancel={JS.push("close-image-picker")}>
+    <.live_component id="image-picker" module={ImagePicker} query={picker_query(@form, @person)} />
+  </.modal>
+
   <div class="max-w-3xl">
     <.simple_form id="person-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
@@ -159,20 +163,32 @@
         </div>
       <% else %>
         <div class="space-y-2">
-          <.tabs
-            field={@form[:image_type]}
-            options={[
-              {"Upload file", "upload"},
-              {"Import image from URL", "url_import"}
-            ]}
-          >
-            <.label>Image</.label>
-          </.tabs>
+          <div class="flex flex-wrap items-center gap-4">
+            <.tabs
+              field={@form[:image_type]}
+              options={[
+                {"Upload file", "upload"},
+                {"Import image from URL", "url_import"}
+              ]}
+            >
+              <.label>Image</.label>
+            </.tabs>
+
+            <.button
+              type="button"
+              color={:zinc}
+              phx-click="open-image-picker"
+              disabled={picker_query(@form, @person) in [nil, ""]}
+            >
+              Find images…
+            </.button>
+          </div>
 
           <.file_input
             :if={@form[:image_type].value == "upload"}
             upload={@uploads.image}
             on_cancel="cancel-upload"
+            paste_upload
             image_preview_class="h-40 w-40 rounded-full object-cover object-top"
           />
 

--- a/lib/ambry_web/live/admin/person_live/form/image_picker.ex
+++ b/lib/ambry_web/live/admin/person_live/form/image_picker.ex
@@ -1,0 +1,154 @@
+defmodule AmbryWeb.Admin.PersonLive.Form.ImagePicker do
+  @moduledoc """
+  Aggregated profile-image picker for the person form.
+
+  Searches every enabled author-search provider for the person's name in
+  parallel and collects each provider's best-match photo into a one-click
+  grid; picking a candidate stages it as a URL import in the parent form,
+  with that provider recorded as the image's provenance source. External
+  image-search links cover the genuinely obscure — manual-but-assisted is
+  the accepted floor.
+  """
+  use AmbryWeb, :live_component
+
+  alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Registry
+  alias Ambry.Provenance
+  alias Phoenix.LiveView.AsyncResult
+
+  @impl Phoenix.LiveComponent
+  def update(assigns, socket) do
+    providers = Registry.enabled(capability: :author_search)
+    query = assigns.query
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(
+        providers: providers,
+        candidates: Map.new(providers, &{&1.id, AsyncResult.loading()})
+      )
+
+    {:ok,
+     Enum.reduce(providers, socket, fn provider, socket ->
+       start_async(socket, {:candidate, provider.id}, fn -> find_candidate(provider, query) end)
+     end)}
+  end
+
+  @impl Phoenix.LiveComponent
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-4">
+      <h2 class="text-2xl font-bold">Find images</h2>
+      <p class="text-sm text-zinc-600 dark:text-zinc-400">
+        Best match for “{@query}” from every enabled provider. Pick a photo to stage it as a URL
+        import — it uploads when you save.
+      </p>
+
+      <div class="flex flex-wrap gap-4">
+        <div :for={provider <- @providers} class="w-40 space-y-1">
+          <div class="text-sm font-semibold">{provider.display_name}</div>
+          <% candidate = @candidates[provider.id] %>
+          <%= cond do %>
+            <% candidate.loading -> %>
+              <div class="h-40 w-40 animate-pulse rounded-sm bg-zinc-200 dark:bg-zinc-800" />
+            <% is_nil(candidate.result) -> %>
+              <div class="flex h-40 w-40 items-center justify-center rounded-sm bg-zinc-100 text-sm text-zinc-500 dark:bg-zinc-900">
+                No match
+              </div>
+            <% true -> %>
+              <button
+                type="button"
+                class="block"
+                phx-click="pick"
+                phx-target={@myself}
+                phx-value-url={candidate.result.image_url}
+                phx-value-source={Provenance.provider_source(provider.id)}
+              >
+                <img
+                  src={proxied_remote_image_url(candidate.result.image_url)}
+                  alt={candidate.result.name}
+                  class="h-40 w-40 cursor-pointer rounded-sm object-cover object-top transition hover:ring-2 hover:ring-lime-500"
+                />
+              </button>
+              <div class="truncate text-xs text-zinc-500" title={candidate.result.name}>
+                {candidate.result.name}
+              </div>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="space-y-1 border-t border-zinc-200 pt-4 text-sm dark:border-zinc-800">
+        <p class="font-semibold">Search the web instead:</p>
+        <div class="flex gap-4">
+          <a
+            href={"https://www.google.com/search?tbm=isch&q=#{URI.encode_www_form(@query)}"}
+            target="_blank"
+            rel="noopener"
+            class="text-brand hover:underline dark:text-brand-dark"
+          >
+            Google Images
+          </a>
+          <a
+            href={"https://duckduckgo.com/?ia=images&iax=images&q=#{URI.encode_www_form(@query)}"}
+            target="_blank"
+            rel="noopener"
+            class="text-brand hover:underline dark:text-brand-dark"
+          >
+            DuckDuckGo Images
+          </a>
+        </div>
+        <p class="text-xs text-zinc-500">
+          Then paste the image URL into “Import image from URL” — or copy the image itself and
+          paste it straight onto the upload area.
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_async({:candidate, provider_id}, {:ok, candidate}, socket) do
+    {:noreply, put_candidate(socket, provider_id, candidate)}
+  end
+
+  # a provider blowing up just means no candidate from it
+  def handle_async({:candidate, provider_id}, {:exit, _reason}, socket) do
+    {:noreply, put_candidate(socket, provider_id, nil)}
+  end
+
+  defp put_candidate(socket, provider_id, candidate) do
+    candidates =
+      Map.update!(socket.assigns.candidates, provider_id, &AsyncResult.ok(&1, candidate))
+
+    assign(socket, candidates: candidates)
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("pick", %{"url" => url, "source" => source}, socket) do
+    send(self(), {:image_picked, url, source})
+    {:noreply, socket}
+  end
+
+  # top search hit only: providers already order by relevance/similarity,
+  # and the operator judges the photo (name captioned) — a wrong match is
+  # one glance, not a wrong import
+  defp find_candidate(provider, query) do
+    with {:ok, [top | _rest]} <- Providers.search_authors(provider.id, query, []),
+         {:ok, image_url} <- candidate_image(provider, top) do
+      %{name: top.name, image_url: image_url}
+    else
+      _no_candidate -> nil
+    end
+  end
+
+  defp candidate_image(_provider, %{image_url: url}) when is_binary(url) and url != "",
+    do: {:ok, url}
+
+  defp candidate_image(provider, top) do
+    case Providers.author_details(provider.id, top.id, []) do
+      {:ok, %{image_url: url}} when is_binary(url) and url != "" -> {:ok, url}
+      _no_image -> :no_image
+    end
+  end
+end

--- a/lib/ambry_web/live/admin/person_live/form/image_picker.ex
+++ b/lib/ambry_web/live/admin/person_live/form/image_picker.ex
@@ -38,7 +38,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImagePicker do
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
-    <div class="space-y-4">
+    <div class="mx-auto max-w-3xl space-y-4 p-6">
       <h2 class="text-2xl font-bold">Find images</h2>
       <p class="text-sm text-zinc-600 dark:text-zinc-400">
         Best match for “{@query}” from every enabled provider. Pick a photo to stage it as a URL
@@ -135,11 +135,32 @@ defmodule AmbryWeb.Admin.PersonLive.Form.ImagePicker do
   # one glance, not a wrong import
   defp find_candidate(provider, query) do
     with {:ok, [top | _rest]} <- Providers.search_authors(provider.id, query, []),
+         true <- name_plausible?(query, top.name),
          {:ok, image_url} <- candidate_image(provider, top) do
       %{name: top.name, image_url: image_url}
     else
       _no_candidate -> nil
     end
+  end
+
+  # Guards against confidently-wrong candidates: rreading-glasses author
+  # search is book-relevance driven, so searching a narrator can surface
+  # the book's *author* instead (Jefferson Mays → James S.A. Corey). Jaro
+  # distance can't separate that case from legitimate name variants
+  # ("Ty Franck" vs "Tyler Corey Franck" scores lower than the Corey
+  # mismatch) — but sharing a name token does.
+  defp name_plausible?(query, name) do
+    not MapSet.disjoint?(name_tokens(query), name_tokens(name))
+  end
+
+  defp name_tokens(nil), do: MapSet.new()
+
+  defp name_tokens(string) do
+    string
+    |> String.downcase()
+    |> String.split(~r/[^\p{L}\p{N}]+/u, trim: true)
+    |> Enum.filter(&(String.length(&1) >= 2))
+    |> MapSet.new()
   end
 
   defp candidate_image(_provider, %{image_url: url}) when is_binary(url) and url != "",

--- a/test/ambry_web/live/admin/person_live/image_picker_test.exs
+++ b/test/ambry_web/live/admin/person_live/image_picker_test.exs
@@ -126,6 +126,39 @@ defmodule AmbryWeb.Admin.PersonLive.ImagePickerTest do
     assert %{"source" => "manual", "locked" => true} = Provenance.entry(person, :name)
   end
 
+  test "a top hit sharing no name token with the query is not offered", %{conn: conn} do
+    # rreading-glasses author search is book-relevance driven: searching
+    # the narrator "Jefferson Mays" surfaces the *author* James S.A. Corey
+    patch(Providers, :search_authors, fn
+      "rreading_glasses", _query, [] ->
+        {:ok,
+         [
+           %Provider.Author{
+             provider: "rreading_glasses",
+             id: "1",
+             name: "James S.A. Corey",
+             image_url: @gr_image
+           }
+         ]}
+
+      _other, _query, [] ->
+        {:ok, []}
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new")
+
+    view
+    |> form("#person-form", %{"person" => %{"name" => "Jefferson Mays"}})
+    |> render_change()
+
+    view |> element("button[phx-click='open-image-picker']") |> render_click()
+    html = render_async(view)
+
+    refute html =~ URI.encode_www_form(@gr_image)
+    refute html =~ "James S.A. Corey"
+    assert html =~ "No match"
+  end
+
   test "the find-images button is disabled until the person has a name", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/admin/people/new")
 

--- a/test/ambry_web/live/admin/person_live/image_picker_test.exs
+++ b/test/ambry_web/live/admin/person_live/image_picker_test.exs
@@ -1,0 +1,140 @@
+defmodule AmbryWeb.Admin.PersonLive.ImagePickerTest do
+  use AmbryWeb.ConnCase, async: false
+  use Patch
+
+  import Phoenix.ConnTest, except: [patch: 3]
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers
+  alias Ambry.Provenance
+
+  setup :register_and_log_in_admin_user
+
+  @gr_image "https://images.gr-assets.com/authors/999015.jpg"
+  @commons_image "https://commons.wikimedia.org/wiki/Special:FilePath/Matt%20Dinniman.jpg?width=1200"
+
+  # the picker fans out over the enabled author-search providers
+  # (rreading_glasses, audnexus, wikidata in the zero-config test env):
+  # one with an image on the search hit, one with no results, and one that
+  # needs the details round-trip for its image
+  defp patch_providers do
+    patch(Providers, :search_authors, fn
+      "rreading_glasses", _query, [] ->
+        {:ok,
+         [
+           %Provider.Author{
+             provider: "rreading_glasses",
+             id: "999015",
+             name: "Matt Dinniman",
+             image_url: @gr_image
+           }
+         ]}
+
+      "audnexus", _query, [] ->
+        {:ok, []}
+
+      "wikidata", _query, [] ->
+        {:ok, [%Provider.Author{provider: "wikidata", id: "Q110191067", name: "Matt Dinniman"}]}
+    end)
+
+    patch(Providers, :author_details, fn "wikidata", "Q110191067", [] ->
+      {:ok,
+       %Provider.Author{
+         provider: "wikidata",
+         id: "Q110191067",
+         name: "Matt Dinniman",
+         image_url: @commons_image
+       }}
+    end)
+  end
+
+  defp open_picker(conn) do
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new")
+
+    view
+    |> form("#person-form", %{"person" => %{"name" => "Matt Dinniman"}})
+    |> render_change()
+
+    view |> element("button[phx-click='open-image-picker']") |> render_click()
+    render_async(view)
+
+    view
+  end
+
+  test "collects each provider's best-match photo into a grid", %{conn: conn} do
+    patch_providers()
+
+    view = open_picker(conn)
+    html = render(view)
+
+    # both image candidates present (proxied), the empty provider says so
+    assert html =~ URI.encode_www_form(@gr_image)
+    assert html =~ URI.encode_www_form(@commons_image)
+    assert html =~ "No match"
+
+    # external search links are always offered
+    assert html =~ "google.com/search?tbm=isch&amp;q=Matt+Dinniman"
+    assert html =~ "duckduckgo.com"
+  end
+
+  test "picking a candidate stages a URL import in the form", %{conn: conn} do
+    patch_providers()
+
+    view = open_picker(conn)
+
+    view
+    |> element(~s{button[phx-value-source="provider:wikidata"]})
+    |> render_click()
+
+    html = render(view)
+
+    # modal closed, form switched to url_import with the picked URL staged
+    refute html =~ "Find images</h2>"
+
+    assert view |> element("#person-form input[name='person[image_import_url]']") |> render() =~
+             "Special:FilePath"
+  end
+
+  test "saving a picked image records the provider as image provenance", %{conn: conn} do
+    patch_providers()
+
+    %{web_path: web_path} = Ambry.Factory.valid_image(:person)
+
+    patch(AmbryWeb.Admin.UploadHelpers, :handle_image_import, fn url ->
+      assert url == @commons_image
+      {:ok, web_path}
+    end)
+
+    view = open_picker(conn)
+
+    view
+    |> element(~s{button[phx-value-source="provider:wikidata"]})
+    |> render_click()
+
+    view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+    person = Ambry.Repo.get_by!(Ambry.People.Person, name: "Matt Dinniman")
+
+    assert person.image_path == web_path
+
+    # picked from a provider: provider source, unlocked
+    assert %{"source" => "provider:wikidata", "locked" => false} =
+             Provenance.entry(person, :image_path)
+
+    # typed by hand: manual, locked
+    assert %{"source" => "manual", "locked" => true} = Provenance.entry(person, :name)
+  end
+
+  test "the find-images button is disabled until the person has a name", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/people/new")
+
+    assert has_element?(view, "button[phx-click='open-image-picker'][disabled]")
+
+    view
+    |> form("#person-form", %{"person" => %{"name" => "Somebody"}})
+    |> render_change()
+
+    refute has_element?(view, "button[phx-click='open-image-picker'][disabled]")
+  end
+end


### PR DESCRIPTION
**Stacked on #1157** (TMDB), which stacks on #1156 → #1155. Merge from the bottom of the stack up, no branch deletion until settled.

The last piece of the person-level provider work (roadmap 1c): the person form's **"Find images" picker** — one click aggregates photo candidates from every source that knows the person.

## What's here

- **`ImagePicker` LiveComponent**: fans out over all enabled author-search providers in parallel (`start_async` per provider), takes each provider's top match, fetches details when the search hit carries no image (Wikidata, Audnexus), and renders the results as a grid — photo, name caption, provider label, loading skeletons while providers race, "No match" where a source came up empty. With everything configured that's rreading-glasses, Hardcover, Audnexus, Wikipedia, and TMDB feeding one grid.
- **Picking a candidate** stages it as a URL import in the form (downloads at save, as before) and records that provider as the image's provenance source — unlocked, per the #1155 semantics.
- **Assisted manual floor**: pre-filled Google Images / DuckDuckGo external search links always offered; the upload drop area now also accepts **images pasted from the clipboard** (new `paste-image` JS hook → existing LiveView upload pipeline; drag-and-drop already worked). `file_input` gains an opt-in `paste_upload` attr — only the person form uses it for now.
- Button is disabled until the person has a name (it's the search query).

## Tests

Grid aggregation (image-on-search-hit, details-round-trip, and empty-provider cases), pick→staged-URL-import flow, save-path provenance (`provider:wikidata` on `image_path`, unlocked; typed name manual+locked), disabled-button gating, external links. Full suite 656 passed; `mix check` clean.

JS paste hook is not unit-tested (no JS test infra) — verify by copying any image and pressing Ctrl+V on the upload tab.

## This completes the 1c person-level roadmap section

Wikidata/Wikipedia anchor (#1156) + TMDB (#1157) + this picker = every bullet of "person-level providers" except future 1g inbox material (Wikidata pseudonym-structure proposals). The "polish the link-author UI" note stays parked.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9