### PR TITLE
v1.9.0 punch list: the bug fixes

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -142,8 +142,15 @@ defmodule Ambry.Media do
       book: [
         :authors,
         series_books: :series,
+        # sibling editions carry their group's (ready) media too, so a
+        # sibling part set can render as one stacked tile
         media:
-          ^{media_query, [:narrators, :recording_group, book: [:authors, series_books: :series]]}
+          ^{media_query,
+           [
+             :narrators,
+             recording_group: [media: group_media_query],
+             book: [:authors, series_books: :series]
+           ]}
       ]
     ])
   end

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1428,11 +1428,13 @@ defmodule AmbryWeb.CoreComponents do
   end
 
   @doc """
-  The media whose covers a book tile stacks: one per edition — part sets
-  contribute only their first part — unless the book's sole edition is a part
-  set, in which case its parts are the stack.
+  One media per edition, ready only: ungrouped media pass through, a part
+  set is represented by its first ready part. The shared collapse rule for
+  every user-facing surface that lists editions.
   """
-  def part_set_stack_media(media_list) do
+  def part_set_representatives(media_list) do
+    media_list = ready_media(media_list)
+
     first_parts =
       media_list
       |> Enum.filter(& &1.recording_group_id)
@@ -1441,10 +1443,19 @@ defmodule AmbryWeb.CoreComponents do
         {group_id, Enum.min_by(parts, &{&1.part_number || :infinity, &1.id}).id}
       end)
 
-    representatives =
-      Enum.filter(media_list, fn media ->
-        is_nil(media.recording_group_id) or first_parts[media.recording_group_id] == media.id
-      end)
+    Enum.filter(media_list, fn media ->
+      is_nil(media.recording_group_id) or first_parts[media.recording_group_id] == media.id
+    end)
+  end
+
+  @doc """
+  The media whose covers a book tile stacks, ready only: one per edition —
+  part sets contribute only their first part — unless the book's sole
+  edition is a part set, in which case its parts are the stack.
+  """
+  def part_set_stack_media(media_list) do
+    media_list = ready_media(media_list)
+    representatives = part_set_representatives(media_list)
 
     case representatives do
       [%{recording_group_id: group_id}] when not is_nil(group_id) ->
@@ -1456,6 +1467,10 @@ defmodule AmbryWeb.CoreComponents do
         representatives
     end
   end
+
+  # tile stacks must never leak pending/processing/errored media — several
+  # callers preload a book's media unfiltered
+  defp ready_media(media_list), do: Enum.filter(media_list, &(&1.status == :ready))
 
   # When a tile hides its title (e.g. "other editions" lists), parts of a set
   # still need telling apart: the override title or the part label.

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.ex
@@ -157,9 +157,28 @@ defmodule AmbryWeb.Admin.BookLive.Form.ProviderImportForm do
 
         %{"author_id" => author.id}
 
-      {_imported, %{authors: [author | _rest]}} ->
-        %{"author_id" => author.id}
+      {imported, existing} ->
+        %{"author_id" => pick_author(existing, imported.name).id}
     end)
+  end
+
+  # The author identity that gets linked for a matched person: the pen name
+  # the imported credit actually names — a person can write under several
+  # (composite pen names), and their first identity is not necessarily the
+  # credited one. Falls back to the first identity for fuzzy matches.
+  defp pick_author(%Person{authors: authors}, imported_name) do
+    Enum.find(authors, &(String.downcase(&1.name) == String.downcase(imported_name))) ||
+      List.first(authors)
+  end
+
+  # what the "Existing author" row shows: the identity being linked (or, for
+  # a person with no author identities yet, the person whose new identity
+  # will carry their name) — never the person behind a pen name
+  defp existing_author_label(person, imported) do
+    case pick_author(person, imported.name) do
+      nil -> person.name
+      author -> author.name
+    end
   end
 
   defp build_series_params(matching_series) do

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
@@ -56,7 +56,7 @@
             <p class="flex items-center gap-2">
               <.icon name="fa-circle-check" class="text-brand h-4 w-4 flex-none dark:text-brand-dark" />
               <span class="font-semibold">Existing author</span>
-              {existing_author.name}
+              {existing_author_label(existing_author, imported_author)}
             </p>
           <% else %>
             <p class="flex items-center gap-2">

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.ex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.ex
@@ -149,9 +149,28 @@ defmodule AmbryWeb.Admin.MediaLive.Form.ProviderImportForm do
 
         %{"narrator_id" => narrator.id}
 
-      {_imported, %{narrators: [narrator | _rest]}} ->
-        %{"narrator_id" => narrator.id}
+      {imported, existing} ->
+        %{"narrator_id" => pick_narrator(existing, imported.name).id}
     end)
+  end
+
+  # The narrator identity that gets linked for a matched person: the stage
+  # name the imported credit actually names (a person can narrate under a
+  # different name than they're known by), falling back to their first
+  # identity for fuzzy matches.
+  defp pick_narrator(%Person{narrators: narrators}, imported_name) do
+    Enum.find(narrators, &(String.downcase(&1.name) == String.downcase(imported_name))) ||
+      List.first(narrators)
+  end
+
+  # what the "Existing narrator" row shows: the identity being linked (or,
+  # for a person with no narrator identities yet, the person whose new
+  # identity will carry their name) — never the person behind a stage name
+  defp existing_narrator_label(person, imported) do
+    case pick_narrator(person, imported.name) do
+      nil -> person.name
+      narrator -> narrator.name
+    end
   end
 
   defp search(provider_id, query, refresh \\ false) do

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
@@ -63,7 +63,7 @@
             <p class="flex items-center gap-2">
               <.icon name="fa-circle-check" class="text-brand h-4 w-4 flex-none dark:text-brand-dark" />
               <span class="font-semibold">Existing narrator</span>
-              {existing_narrator.name}
+              {existing_narrator_label(existing_narrator, imported_narrator)}
             </p>
           <% else %>
             <p class="flex items-center gap-2">

--- a/lib/ambry_web/live/admin/provenance_hints.ex
+++ b/lib/ambry_web/live/admin/provenance_hints.ex
@@ -23,8 +23,7 @@ defmodule AmbryWeb.Admin.ProvenanceHints do
   def from_import(params, source) do
     scalar_hints =
       for {key, value} <- params,
-          not is_list(value),
-          not is_map(value),
+          scalar?(value),
           key not in @non_field_keys,
           into: %{} do
         {key, %{source: source, watch: key, value: normalize(value)}}
@@ -72,6 +71,11 @@ defmodule AmbryWeb.Admin.ProvenanceHints do
 
   @doc "The `provenance:` opts value for a save: field name → source."
   def sources(hints), do: Map.new(hints, fn {field, hint} -> {field, hint.source} end)
+
+  # association params arrive as lists/maps and are never hinted — but
+  # structs (%Date{} from published imports) are maps too, and ARE scalar
+  # values (dropping them recorded accepted dates as manual edits)
+  defp scalar?(value), do: not is_list(value) and (not is_map(value) or is_struct(value))
 
   defp normalize(value), do: to_string(value)
 end

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -110,6 +110,7 @@ defmodule AmbryWeb.AudiobookLive do
               <.media_tile
                 :for={media <- @other_editions}
                 media={media}
+                collapse_part_sets
                 show_title={false}
                 show_authors={false}
                 show_series={false}
@@ -151,11 +152,15 @@ defmodule AmbryWeb.AudiobookLive do
           _no_set -> nil
         end
 
+      # true alternates only: drop this media's own part-set siblings, then
+      # collapse sibling part sets to one representative each — the tile
+      # stacks the set's covers (a set is one edition, not N tiles)
       other_editions =
-        Enum.reject(
-          media.book.media,
-          &(part_set && &1.recording_group_id == media.recording_group_id)
+        media.book.media
+        |> Enum.reject(
+          &(&1.recording_group_id && &1.recording_group_id == media.recording_group_id)
         )
+        |> part_set_representatives()
 
       {:ok,
        assign(socket,

--- a/priv/repo/migrations/20260802174951_flat_view_stack_tile_rules.exs
+++ b/priv/repo/migrations/20260802174951_flat_view_stack_tile_rules.exs
@@ -1,0 +1,22 @@
+defmodule Ambry.Repo.Migrations.FlatViewStackTileRules do
+  use Ecto.Migration
+  use Familiar
+
+  # Admin books/series/universes list cover-stacks now follow the same
+  # part-set rules as the user-facing tiles (one cover per edition — a part
+  # set contributes its first part — sole-edition sets stack their parts),
+  # while deliberately keeping non-ready media visible (admin lists are ops
+  # views). v1.9.0 punch list.
+
+  def up do
+    update_view("books_flat", version: 11)
+    update_view("series_flat", version: 5)
+    update_view("universes_flat", version: 2)
+  end
+
+  def down do
+    update_view("books_flat", version: 10)
+    update_view("series_flat", version: 4)
+    update_view("universes_flat", version: 1)
+  end
+end

--- a/priv/repo/views/books_flat_v11.sql
+++ b/priv/repo/views/books_flat_v11.sql
@@ -1,0 +1,107 @@
+SELECT
+  book.id,
+  book.title,
+  book.published,
+  book.published_format,
+  ARRAY(
+    -- one cover per edition (a part set contributes its first part), unless
+    -- the book's sole edition is a part set — then its parts are the stack,
+    -- in part order. Mirrors AmbryWeb.CoreComponents.part_set_stack_media/1
+    -- (admin lists deliberately include non-ready media).
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+      AND media.thumbnails IS NOT NULL
+      AND (
+        media.recording_group_id IS NULL
+        OR media.id = (
+          SELECT m2.id
+          FROM media m2
+          WHERE m2.recording_group_id = media.recording_group_id
+          ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+          LIMIT 1
+        )
+        OR (
+          SELECT COUNT(DISTINCT m3.recording_group_id) = 1
+            AND COUNT(*) FILTER (WHERE m3.recording_group_id IS NULL) = 0
+          FROM media m3
+          WHERE m3.book_id = book.id
+        )
+      )
+    ORDER BY
+      CASE WHEN (
+        SELECT COUNT(DISTINCT m3.recording_group_id) = 1
+          AND COUNT(*) FILTER (WHERE m3.recording_group_id IS NULL) = 0
+        FROM media m3
+        WHERE m3.book_id = book.id
+      ) THEN media.part_number END ASC NULLS LAST,
+      CASE WHEN (
+        SELECT COUNT(DISTINCT m3.recording_group_id) = 1
+          AND COUNT(*) FILTER (WHERE m3.recording_group_id IS NULL) = 0
+        FROM media m3
+        WHERE m3.book_id = book.id
+      ) THEN media.id END ASC,
+      media.published DESC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+  ) AS media,
+  book.inserted_at,
+  book.updated_at,
+  -- deprecated
+  book.image_path,
+  book.description IS NOT NULL AS has_description
+FROM
+  books AS book
+ORDER BY
+  book.title

--- a/priv/repo/views/series_flat_v5.sql
+++ b/priv/repo/views/series_flat_v5.sql
@@ -1,0 +1,84 @@
+SELECT
+  series.id,
+  series.name,
+  (
+    SELECT
+      COUNT(books_series.id)
+    FROM
+      books_series
+    WHERE
+      books_series.series_id = series.id
+  ) AS books,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN media ON media.book_id = book.id
+    WHERE
+      series_book.series_id = series.id
+  ) AS media,
+  ARRAY(
+    -- one cover per edition per book (a part set contributes its first
+    -- part), unless a book's sole edition is a part set — then all its
+    -- parts contribute. Mirrors part_set_stack_media/1; admin lists
+    -- deliberately include non-ready media.
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN media ON media.book_id = book.id
+    WHERE
+      series_book.series_id = series.id
+      AND media.thumbnails IS NOT NULL
+      AND (
+        media.recording_group_id IS NULL
+        OR media.id = (
+          SELECT m2.id
+          FROM media m2
+          WHERE m2.recording_group_id = media.recording_group_id
+          ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+          LIMIT 1
+        )
+        OR (
+          SELECT COUNT(DISTINCT m3.recording_group_id) = 1
+            AND COUNT(*) FILTER (WHERE m3.recording_group_id IS NULL) = 0
+          FROM media m3
+          WHERE m3.book_id = media.book_id
+        )
+      )
+    ORDER BY
+      media.published DESC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      DISTINCT (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name AS person_name
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN authors_books AS authored_by ON book.id = authored_by.book_id
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      series_book.series_id = series.id
+    ORDER BY
+      person_name
+  ) AS authors,
+  series.inserted_at,
+  series.updated_at
+FROM
+  series
+ORDER BY
+  series.name

--- a/priv/repo/views/universes_flat_v2.sql
+++ b/priv/repo/views/universes_flat_v2.sql
@@ -1,0 +1,50 @@
+SELECT
+  universe.id,
+  universe.name,
+  (
+    SELECT
+      COUNT(books_universes.id)
+    FROM
+      books_universes
+    WHERE
+      books_universes.universe_id = universe.id
+  ) AS books,
+  ARRAY(
+    -- one cover per edition per book (a part set contributes its first
+    -- part), unless a book's sole edition is a part set — then all its
+    -- parts contribute. Mirrors part_set_stack_media/1; admin lists
+    -- deliberately include non-ready media.
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      books_universes AS book_universe
+      INNER JOIN books AS book ON book.id = book_universe.book_id
+      INNER JOIN media ON media.book_id = book.id
+    WHERE
+      book_universe.universe_id = universe.id
+      AND media.thumbnails IS NOT NULL
+      AND (
+        media.recording_group_id IS NULL
+        OR media.id = (
+          SELECT m2.id
+          FROM media m2
+          WHERE m2.recording_group_id = media.recording_group_id
+          ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+          LIMIT 1
+        )
+        OR (
+          SELECT COUNT(DISTINCT m3.recording_group_id) = 1
+            AND COUNT(*) FILTER (WHERE m3.recording_group_id IS NULL) = 0
+          FROM media m3
+          WHERE m3.book_id = media.book_id
+        )
+      )
+    ORDER BY
+      media.published DESC
+  ) AS thumbnails,
+  universe.inserted_at,
+  universe.updated_at
+FROM
+  universes AS universe
+ORDER BY
+  universe.name

--- a/test/ambry/flat_view_stack_test.exs
+++ b/test/ambry/flat_view_stack_test.exs
@@ -1,0 +1,122 @@
+defmodule Ambry.FlatViewStackTest do
+  @moduledoc """
+  The admin list cover-stacks (books/series/universes flat views) follow the
+  same part-set rules as the user-facing tiles — one cover per edition, a
+  part set contributes its first part, a sole-edition part set stacks all
+  its parts — but deliberately include non-ready media (admin lists are ops
+  views).
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Books.BookFlat
+  alias Ambry.Books.SeriesFlat
+  alias Ambry.Books.UniverseFlat
+  alias Ambry.Repo
+
+  # the thumbnails constraint only requires original == image_path, so fake
+  # covers are enough to drive the views' ARRAY subqueries
+  defp insert_media_with_cover(book, tag, attrs) do
+    path = "/uploads/images/#{tag}.webp"
+
+    thumbnails = %Ambry.Thumbnails{
+      original: path,
+      extra_small: "#{path}-xs",
+      small: "#{path}-sm",
+      medium: "#{path}-md",
+      large: "#{path}-lg",
+      extra_large: "#{path}-xl"
+    }
+
+    insert(:media, [book: book, image_path: path, thumbnails: thumbnails] ++ attrs)
+  end
+
+  defp small_thumb(media), do: media.thumbnails.small
+
+  test "a part set contributes only its first part when other editions exist" do
+    book = insert(:book)
+    group = insert(:recording_group)
+
+    solo = insert_media_with_cover(book, "solo", status: :ready, published: ~D[2020-01-01])
+
+    [part_one, _part_two, _part_three] =
+      for n <- 1..3 do
+        insert_media_with_cover(book, "part#{n}",
+          part_number: n,
+          parts_total: 3,
+          recording_group: group,
+          status: :ready,
+          published: ~D[2021-01-01]
+        )
+      end
+
+    flat = Repo.get!(BookFlat, book.id)
+
+    # newest edition first (published desc): the set's first part, then solo
+    assert flat.thumbnails == [small_thumb(part_one), small_thumb(solo)]
+  end
+
+  test "a sole part-set edition stacks all of its parts in part order" do
+    book = insert(:book)
+    group = insert(:recording_group)
+
+    parts =
+      for n <- [2, 1, 3] do
+        insert_media_with_cover(book, "part#{n}",
+          part_number: n,
+          parts_total: 3,
+          recording_group: group,
+          status: :ready
+        )
+      end
+
+    flat = Repo.get!(BookFlat, book.id)
+
+    expected =
+      parts
+      |> Enum.sort_by(& &1.part_number)
+      |> Enum.map(&small_thumb/1)
+
+    assert flat.thumbnails == expected
+  end
+
+  test "non-ready media still contribute covers (admin lists are ops views)" do
+    book = insert(:book)
+    pending = insert_media_with_cover(book, "pending", status: :pending)
+
+    flat = Repo.get!(BookFlat, book.id)
+
+    assert flat.thumbnails == [small_thumb(pending)]
+  end
+
+  test "series and universe rows apply the same per-book collapse" do
+    series = insert(:series)
+    universe = insert(:universe)
+
+    book =
+      insert(:book,
+        series_books: [%{series: series, book_number: 1}],
+        book_universes: [%{universe: universe}]
+      )
+
+    group = insert(:recording_group)
+
+    solo = insert_media_with_cover(book, "solo", status: :ready, published: ~D[2020-01-01])
+
+    [part_one | _rest] =
+      for n <- 1..2 do
+        insert_media_with_cover(book, "part#{n}",
+          part_number: n,
+          parts_total: 2,
+          recording_group: group,
+          status: :ready,
+          published: ~D[2021-01-01]
+        )
+      end
+
+    assert Repo.get!(SeriesFlat, series.id).thumbnails ==
+             [small_thumb(part_one), small_thumb(solo)]
+
+    assert Repo.get!(UniverseFlat, universe.id).thumbnails ==
+             [small_thumb(part_one), small_thumb(solo)]
+  end
+end

--- a/test/ambry_web/live/admin/book_live/provider_import_test.exs
+++ b/test/ambry_web/live/admin/book_live/provider_import_test.exs
@@ -80,4 +80,60 @@ defmodule AmbryWeb.Admin.BookLive.ProviderImportTest do
     assert html =~ "Existing author"
     assert html =~ "Existing series"
   end
+
+  test "a composite pen name shows and links the credited author identity, not the person",
+       %{conn: conn} do
+    # Ty Franck writes as himself AND as half of James S.A. Corey; a book
+    # credited to the pen name must render and link the pen name — never
+    # the person behind it, and never his first identity
+    import Ecto.Query, only: [from: 2]
+
+    person =
+      insert(:person,
+        name: "Ty Franck",
+        authors: [build(:author, name: "Ty Franck"), build(:author, name: "James S.A. Corey")]
+      )
+
+    with_search_index(person)
+
+    book = %{
+      result_book()
+      | authors: [%Provider.Contributor{id: "1", name: "James S.A. Corey", role: "author"}]
+    }
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
+      {:ok, [book]}
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/new?import=rreading_glasses")
+
+    html = render_async(view)
+    assert html =~ ~r|Existing author</span>\s*James S\.A\. Corey|
+    refute html =~ ~r|Existing author</span>\s*Ty Franck|
+
+    view
+    |> form("form[phx-submit='import']", %{
+      "import" => %{
+        "use_title" => "true",
+        "use_published" => "true",
+        "use_authors" => "true",
+        "use_series" => "false"
+      }
+    })
+    |> render_submit()
+
+    view |> form("#book-form", %{"book" => %{}}) |> render_submit()
+
+    saved_book =
+      Ambry.Repo.one!(from b in Ambry.Books.Book, where: b.title == "Dungeon Crawler Carl")
+
+    corey = Ambry.Repo.one!(from a in Ambry.People.Author, where: a.name == "James S.A. Corey")
+
+    assert [%{id: author_id}] = Ambry.Repo.preload(saved_book, :authors).authors
+    assert author_id == corey.id
+
+    # no duplicate person or identity was created
+    assert [_ty_franck] = Ambry.Repo.all(Ambry.People.Person)
+    assert length(Ambry.Repo.all(Ambry.People.Author)) == 2
+  end
 end

--- a/test/ambry_web/live/admin/provenance_hints_test.exs
+++ b/test/ambry_web/live/admin/provenance_hints_test.exs
@@ -1,0 +1,37 @@
+defmodule AmbryWeb.Admin.ProvenanceHintsTest do
+  use ExUnit.Case, async: true
+
+  alias AmbryWeb.Admin.ProvenanceHints
+
+  describe "from_import/2" do
+    test "date structs are scalar hint values (associations stay excluded)" do
+      # %Date{} is a map — the association filter must not swallow it, or
+      # accepted published dates save as manual edits (v1.9.0 punch list)
+      params = %{
+        "published" => ~D[2011-06-15],
+        "published_format" => "full",
+        "book_authors" => [%{"author_id" => 1}]
+      }
+
+      hints = ProvenanceHints.from_import(params, "provider:hardcover")
+
+      assert %{value: "2011-06-15", watch: "published"} = hints["published"]
+      assert %{value: "full"} = hints["published_format"]
+      refute Map.has_key?(hints, "book_authors")
+
+      assert ProvenanceHints.sources(hints) == %{
+               "published" => "provider:hardcover",
+               "published_format" => "provider:hardcover"
+             }
+    end
+  end
+
+  describe "prune/2" do
+    test "a date hint survives the form echoing the rendered value and dies on edit" do
+      hints = ProvenanceHints.from_import(%{"published" => ~D[2011-06-15]}, "provider:x")
+
+      assert ProvenanceHints.prune(hints, %{"published" => "2011-06-15"}) == hints
+      assert ProvenanceHints.prune(hints, %{"published" => "2012-01-01"}) == %{}
+    end
+  end
+end

--- a/test/ambry_web/live/part_set_ux_test.exs
+++ b/test/ambry_web/live/part_set_ux_test.exs
@@ -70,6 +70,54 @@ defmodule AmbryWeb.PartSetUxTest do
   end
 
   describe "audiobook page" do
+    test "a sibling part set stacks as one tile under Other Editions", %{conn: conn} do
+      book = insert(:book, title: "Dungeon Crawler Carl")
+      [part_one, part_two, part_three] = insert_part_set(book, name: "Season One")
+      solo = insert(:media, book: book, status: :ready)
+
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{solo.id}")
+
+      # one stacked tile for the whole set, landing on the book page —
+      # never one tile per part
+      assert html =~ "Other Editions"
+      assert html =~ "3 parts"
+      assert html =~ ~p"/books/#{book.id}"
+
+      for part <- [part_one, part_two, part_three] do
+        refute html =~ ~p"/audiobooks/#{part.id}"
+      end
+    end
+
+    test "a sibling set with non-ready parts stacks only its ready parts", %{conn: conn} do
+      book = insert(:book)
+      group = insert(:recording_group)
+
+      insert(:media,
+        book: book,
+        part_number: 1,
+        parts_total: 3,
+        recording_group: group,
+        status: :pending
+      )
+
+      for n <- 2..3 do
+        insert(:media,
+          book: book,
+          part_number: n,
+          parts_total: 3,
+          recording_group: group,
+          status: :ready
+        )
+      end
+
+      solo = insert(:media, book: book, status: :ready)
+
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{solo.id}")
+
+      # the pending first part neither counts nor represents
+      assert html =~ "2 parts"
+    end
+
     test "shows the part rail and excludes siblings from Other Editions", %{conn: conn} do
       book = insert(:book, title: "Dungeon Crawler Carl")
       [part_one, part_two, _part_three] = insert_part_set(book, name: "Season One")
@@ -154,6 +202,37 @@ defmodule AmbryWeb.PartSetUxTest do
       stacked = CoreComponents.part_set_stack_media(Enum.shuffle(parts))
 
       assert Enum.map(stacked, & &1.id) == Enum.map(parts, & &1.id)
+    end
+
+    test "non-ready media never contribute to stacks" do
+      book = insert(:book)
+      parts = insert_part_set(book)
+      pending = insert(:media, book: book, status: :pending)
+
+      # the pending solo is invisible — the set is still the sole (ready)
+      # edition and stacks its parts
+      stacked = CoreComponents.part_set_stack_media([pending | parts])
+
+      assert Enum.map(stacked, & &1.id) == Enum.map(parts, & &1.id)
+    end
+
+    test "part_set_representatives/1 keeps one ready media per edition" do
+      book = insert(:book)
+      group = insert(:recording_group)
+
+      pending_first =
+        insert(:media, book: book, part_number: 1, recording_group: group, status: :pending)
+
+      ready_second =
+        insert(:media, book: book, part_number: 2, recording_group: group, status: :ready)
+
+      solo = insert(:media, book: book, status: :ready)
+
+      representatives =
+        CoreComponents.part_set_representatives([pending_first, ready_second, solo])
+
+      # the set is represented by its first READY part
+      assert Enum.map(representatives, & &1.id) == [ready_second.id, solo.id]
     end
   end
 end


### PR DESCRIPTION
The four items from the roadmap's v1.9.0 punch list that were plainly bugs, in one PR as requested. Left for later: the per-group show-label flag (reversed decision — schema/feature work) and the rreading-glasses original-publication-date investigation.

## Fixes

1. **Accepted `published` dates saved as "manually edited"** (punch list #1): `ProvenanceHints.from_import` excluded associations by skipping list/map params — but `%Date{}` structs are maps, so the published hint silently never existed while `published_format` (a string) recorded fine. Structs now count as scalar hint values. Unit tests cover the Date round-trip through hint → prune → sources.

2. **Non-ready media leaked into cover stacks** (#2): `part_set_stack_media/1` — feeding book tiles on series/author/person/search pages from unfiltered preloads — now filters to ready media first. Every other user-facing surface (library SQL, book page, audiobook rail) already did.

3. **Sibling part sets now stack under "Other Editions"** (#4): on a normal edition's audiobook page, a sibling multi-part set rendered one bare tile per part. Now the mount collapses each sibling set to its first ready part via the new shared `part_set_representatives/1` and renders the existing collapsed tile (stacked covers + "N parts", landing on the book page — same behavior as library stacks). Sibling editions preload their group's ready media so the collapsed clause can match. Includes the edge case where a set's first part isn't ready (the first *ready* part represents, and the label counts only ready parts).

4. **Admin books/series/universes lists follow the stack-tile rules** (#3): the flat views' `ARRAY(...)` thumbnail subqueries had no part-set awareness. Per the two decisions taken during this fix: they now apply the exact user-facing collapse rules (one cover per edition; sole-edition part set stacks its parts in part order) while **deliberately including non-ready media** — admin lists are ops views, and a book whose only media is still processing keeps its cover visible. New view versions: `books_flat` v11, `series_flat` v5, `universes_flat` v2; reversible migration.

## Tests

New `flat_view_stack_test.exs` (collapse, sole-edition ordering, non-ready inclusion, series/universe parity), `provenance_hints_test.exs` (Date-struct hints), and four new part-set UX cases (stacked Other Editions, partially-ready sets, ready-only stacks, representatives). Full suite 671 passed; `mix check` clean.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9