### PR TITLE
Other Editions stacked tiles navigate into the set

### DIFF
--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1128,9 +1128,18 @@ defmodule AmbryWeb.CoreComponents do
   attr :show_published, :boolean, default: false
   attr :collapse_part_sets, :boolean, default: false
 
+  attr :collapse_navigate, :atom,
+    values: [:book, :representative],
+    default: :book,
+    doc: """
+    where a collapsed part-set tile lands: the book page (library listings —
+    the parts are listed there in order) or the representative part's own
+    audiobook page (Other Editions — the book page is already one click away,
+    so the stack takes you into the set instead)
+    """
+
   # A part set collapses into a single stacked tile (its parts' covers),
-  # titled with the book, and lands on the book page where the parts are
-  # listed in order.
+  # titled with the book.
   def media_tile(
         %{
           collapse_part_sets: true,
@@ -1140,13 +1149,13 @@ defmodule AmbryWeb.CoreComponents do
     ~H"""
     <div id={@id} class="text-center">
       <div class="group">
-        <.link navigate={~p"/books/#{@media.book}"}>
+        <.link navigate={collapsed_tile_path(@collapse_navigate, @media)}>
           <.book_multi_image thumbnails={
             Enum.flat_map(@media.recording_group.media, &if(&1.thumbnails, do: [&1.thumbnails], else: []))
           } />
         </.link>
         <p :if={@show_title} class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
-          <.link navigate={~p"/books/#{@media.book}"}>
+          <.link navigate={collapsed_tile_path(@collapse_navigate, @media)}>
             {@media.book.title}
           </.link>
         </p>
@@ -1471,6 +1480,11 @@ defmodule AmbryWeb.CoreComponents do
   # tile stacks must never leak pending/processing/errored media — several
   # callers preload a book's media unfiltered
   defp ready_media(media_list), do: Enum.filter(media_list, &(&1.status == :ready))
+
+  # the media on a collapsed tile is the set's representative (its first
+  # ready part), so :representative navigation is just its own page
+  defp collapsed_tile_path(:book, media), do: ~p"/books/#{media.book}"
+  defp collapsed_tile_path(:representative, media), do: ~p"/audiobooks/#{media}"
 
   # When a tile hides its title (e.g. "other editions" lists), parts of a set
   # still need telling apart: the override title or the part label.

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -111,6 +111,7 @@ defmodule AmbryWeb.AudiobookLive do
                 :for={media <- @other_editions}
                 media={media}
                 collapse_part_sets
+                collapse_navigate={:representative}
                 show_title={false}
                 show_authors={false}
                 show_series={false}

--- a/test/ambry_web/live/part_set_ux_test.exs
+++ b/test/ambry_web/live/part_set_ux_test.exs
@@ -77,13 +77,14 @@ defmodule AmbryWeb.PartSetUxTest do
 
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{solo.id}")
 
-      # one stacked tile for the whole set, landing on the book page —
-      # never one tile per part
+      # one stacked tile for the whole set — never one tile per part — and
+      # it navigates into the set: the first part's page (the book page is
+      # already one click away from here)
       assert html =~ "Other Editions"
       assert html =~ "3 parts"
-      assert html =~ ~p"/books/#{book.id}"
+      assert html =~ ~p"/audiobooks/#{part_one.id}"
 
-      for part <- [part_one, part_two, part_three] do
+      for part <- [part_two, part_three] do
         refute html =~ ~p"/audiobooks/#{part.id}"
       end
     end
@@ -100,22 +101,25 @@ defmodule AmbryWeb.PartSetUxTest do
         status: :pending
       )
 
-      for n <- 2..3 do
-        insert(:media,
-          book: book,
-          part_number: n,
-          parts_total: 3,
-          recording_group: group,
-          status: :ready
-        )
-      end
+      [part_two, _part_three] =
+        for n <- 2..3 do
+          insert(:media,
+            book: book,
+            part_number: n,
+            parts_total: 3,
+            recording_group: group,
+            status: :ready
+          )
+        end
 
       solo = insert(:media, book: book, status: :ready)
 
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{solo.id}")
 
-      # the pending first part neither counts nor represents
+      # the pending first part neither counts nor represents — the first
+      # READY part is the stack's landing target
       assert html =~ "2 parts"
+      assert html =~ ~p"/audiobooks/#{part_two.id}"
     end
 
     test "shows the part rail and excludes siblings from Other Editions", %{conn: conn} do


### PR DESCRIPTION
Follow-up to #1160, from staging verification: the collapsed part-set tile hardcoded its landing to the book page. That's the signed-off behavior for **library** stacks (the book page lists the parts in order), but circular for **Other Editions** — you're on a sibling edition's page, so the book page is already one click away.

The collapsed `media_tile` clause gains a `collapse_navigate` attr (`:book` default | `:representative`); the Other Editions section passes `:representative`. Since the media rendered on a collapsed tile is already the set's first *ready* part (from `part_set_representatives/1`), the stack now lands directly on that part's audiobook page — including the partially-ready case, where the first ready part (not the pending part 1) is the landing target. Library stacks are unchanged.

Tests updated to assert the stacked tile links to the first ready part and not to the other parts. Full suite 672 passed; `mix check` clean.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9