### PR TITLE
Tile system v2: the Edition model (user-facing surfaces)

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -298,8 +298,13 @@ defmodule Ambry.Books do
   def get_authored_books(author, offset \\ 0, limit \\ 10) do
     over_limit = limit + 1
 
+    # books with zero ready editions are hidden from users entirely
+    # (tile system v2) — filtered here so pagination stays correct
     query =
       from b in Ecto.assoc(author, :books),
+        as: :book,
+        where:
+          exists(from m in Media, where: m.book_id == parent_as(:book).id and m.status == :ready),
         order_by: [desc: b.published],
         offset: ^offset,
         limit: ^over_limit,

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -9,6 +9,8 @@ defmodule Ambry.Media do
       Audit,
       Bookmark,
       Chapters,
+      Editions,
+      Editions.Edition,
       Media,
       Media.Chapter,
       MediaFlat,
@@ -142,15 +144,8 @@ defmodule Ambry.Media do
       book: [
         :authors,
         series_books: :series,
-        # sibling editions carry their group's (ready) media too, so a
-        # sibling part set can render as one stacked tile
         media:
-          ^{media_query,
-           [
-             :narrators,
-             recording_group: [media: group_media_query],
-             book: [:authors, series_books: :series]
-           ]}
+          ^{media_query, [:narrators, :recording_group, book: [:authors, series_books: :series]]}
       ]
     ])
   end
@@ -471,8 +466,10 @@ defmodule Ambry.Media do
   def get_narrated_media(narrator, offset \\ 0, limit \\ 10) do
     over_limit = limit + 1
 
+    # users never see non-ready audiobooks (tile system v2, rule 1)
     query =
       from b in Ecto.assoc(narrator, :media),
+        where: b.status == :ready,
         order_by: [desc: b.published],
         offset: ^offset,
         limit: ^over_limit,

--- a/lib/ambry/media/editions.ex
+++ b/lib/ambry/media/editions.ex
@@ -1,0 +1,114 @@
+defmodule Ambry.Media.Editions do
+  @moduledoc """
+  Editions — the first-class "Audiobook or Group" union (tile system v2).
+
+  An edition is one recorded edition of a book: either a single audiobook
+  or a recording group (a multi-part set). This module is the one
+  implementation of grouping, representative choice, and ordering for
+  every tile surface; the library listing and the admin flat views carry
+  an SQL twin of the representative rule for pagination, held in lockstep
+  by tests.
+
+  The rules (ROADMAP "Tile system v2", operator-authored):
+
+    * parts order within a group: part number (nulls last), then id
+    * a group with only one visible part presents as a single edition —
+      a one-part "set" is noise, not a stack
+    * representative: the first part / the audiobook itself
+    * editions order: representative publish date, newest first (a
+      group's date IS its first part's date), nulls last, id tiebreak
+  """
+
+  alias Ambry.Media.Media
+  alias Ambry.Media.RecordingGroup
+
+  defmodule Edition do
+    @moduledoc "One recorded edition of a book: a single audiobook or a part set."
+
+    defstruct [:kind, :media, :representative, :group]
+
+    @type t :: %__MODULE__{
+            kind: :single | :group,
+            media: [struct()],
+            representative: struct(),
+            group: struct() | nil
+          }
+  end
+
+  @doc """
+  Partitions a book's media list into editions, newest first.
+
+  Only ready media are considered unless `all_statuses: true` (admin
+  surfaces — operators always see non-ready). A book whose media are all
+  filtered out yields `[]` — user-facing surfaces hide such books
+  entirely.
+  """
+  def from_media(media_list, opts \\ []) do
+    media_list =
+      if opts[:all_statuses],
+        do: media_list,
+        else: Enum.filter(media_list, &(&1.status == :ready))
+
+    {grouped, singles} = Enum.split_with(media_list, & &1.recording_group_id)
+
+    group_editions =
+      grouped
+      |> Enum.group_by(& &1.recording_group_id)
+      |> Enum.map(fn {_group_id, parts} ->
+        parts
+        |> Enum.sort_by(&{&1.part_number || :infinity, &1.id})
+        |> group_edition()
+      end)
+
+    single_editions = Enum.map(singles, &single_edition/1)
+
+    sort_newest_first(group_editions ++ single_editions)
+  end
+
+  @doc """
+  Wraps one listing row into its edition, for surfaces that select
+  representatives SQL-side (the library): a grouped row must arrive with
+  its recording group's visible media preloaded in part order. The row
+  itself stays the representative — the SQL already chose the first ready
+  part, and the row carries the preloads (book, narrators) the tile needs.
+  """
+  def from_representative(%Media{} = media) do
+    case media do
+      %{recording_group: %RecordingGroup{media: [_, _ | _] = parts} = group} ->
+        %Edition{kind: :group, media: parts, representative: media, group: group}
+
+      _single_or_lone_part ->
+        single_edition(media)
+    end
+  end
+
+  defp group_edition([only_part]), do: single_edition(only_part)
+
+  defp group_edition([representative | _rest] = parts) do
+    %Edition{
+      kind: :group,
+      media: parts,
+      representative: representative,
+      group: loaded_group(representative)
+    }
+  end
+
+  defp single_edition(media) do
+    %Edition{kind: :single, media: [media], representative: media, group: nil}
+  end
+
+  defp loaded_group(%Media{recording_group: %RecordingGroup{} = group}), do: group
+  defp loaded_group(_media), do: nil
+
+  @epoch {0, 1, 1}
+
+  defp sort_newest_first(editions) do
+    Enum.sort_by(
+      editions,
+      fn %Edition{representative: rep} ->
+        {(rep.published && Date.to_erl(rep.published)) || @epoch, rep.id}
+      end,
+      :desc
+    )
+  end
+end

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -15,6 +15,8 @@ defmodule AmbryWeb.CoreComponents do
 
   alias Ambry.Books.Book
   alias Ambry.Books.SeriesBook
+  alias Ambry.Media.Editions
+  alias Ambry.Media.Editions.Edition
   alias Ambry.Media.Media
   alias Ambry.Media.MediaFlat
   alias Ambry.Media.RecordingGroup
@@ -1032,7 +1034,6 @@ defmodule AmbryWeb.CoreComponents do
   attr :stream, :any, required: true
   attr :next, :string, default: "next-page"
   attr :prev, :string, default: "prev-page"
-  attr :collapse_part_sets, :boolean, default: false
   attr :rest, :global
 
   def media_tiles_stream(assigns) do
@@ -1046,12 +1047,36 @@ defmodule AmbryWeb.CoreComponents do
       class={[if(@end?, do: "", else: "pb-[calc(200vh)]"), if(@page == 1, do: "", else: "pt-[calc(200vh)]")]}
       {@rest}
     >
-      <.media_tile
-        :for={{id, media} <- @stream}
-        media={media}
-        id={id}
-        collapse_part_sets={@collapse_part_sets}
-      />
+      <.media_tile :for={{id, media} <- @stream} media={media} id={id} />
+    </.grid>
+    """
+  end
+
+  @doc """
+  Streams a listing of editions: each streamed row is a representative
+  media (grouped rows arrive with their recording group's visible media
+  preloaded) rendered as its edition tile.
+  """
+  attr :id, :string, required: true
+  attr :page, :integer, required: true
+  attr :end?, :boolean, required: true
+  attr :stream, :any, required: true
+  attr :next, :string, default: "next-page"
+  attr :prev, :string, default: "prev-page"
+  attr :rest, :global
+
+  def edition_tiles_stream(assigns) do
+    ~H"""
+    <.grid
+      id={@id}
+      phx-update="stream"
+      phx-viewport-top={@page > 1 && @prev}
+      phx-viewport-bottom={!@end? && @next}
+      phx-page-loading
+      class={[if(@end?, do: "", else: "pb-[calc(200vh)]"), if(@page == 1, do: "", else: "pt-[calc(200vh)]")]}
+      {@rest}
+    >
+      <.edition_tile :for={{id, media} <- @stream} edition={Editions.from_representative(media)} id={id} />
     </.grid>
     """
   end
@@ -1073,20 +1098,37 @@ defmodule AmbryWeb.CoreComponents do
   attr :book, Book, required: true
   attr :number, Decimal, default: nil
 
+  # Recursive collapse (tile system v2): one cover per edition, newest
+  # edition first and in front; each edition contributes its
+  # representative's cover. One edition → the tile links straight to that
+  # edition's target; multiple → the book page.
   def book_tile(assigns) do
+    editions = Editions.from_media(assigns.book.media)
+
+    link =
+      case editions do
+        [only_edition] -> ~p"/audiobooks/#{only_edition.representative}"
+        _multiple_or_none -> ~p"/books/#{assigns.book}"
+      end
+
+    thumbnails =
+      editions
+      |> Enum.map(& &1.representative.thumbnails)
+      |> Enum.filter(& &1)
+
+    assigns = assign(assigns, link: link, tile_thumbnails: thumbnails)
+
     ~H"""
     <div id={@id} class="text-center">
       <%= if @number do %>
         <p class="font-bold text-zinc-900 dark:text-zinc-100 sm:text-lg">Book {@number}</p>
       <% end %>
       <div class="group">
-        <.link navigate={~p"/books/#{@book}"}>
-          <.book_multi_image thumbnails={
-            Enum.flat_map(part_set_stack_media(@book.media), &if(&1.thumbnails, do: [&1.thumbnails], else: []))
-          } />
+        <.link navigate={@link}>
+          <.book_multi_image thumbnails={@tile_thumbnails} />
         </.link>
         <p class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
-          <.link navigate={~p"/books/#{@book}"}>
+          <.link navigate={@link}>
             {@book.title}
           </.link>
         </p>
@@ -1118,6 +1160,63 @@ defmodule AmbryWeb.CoreComponents do
     """
   end
 
+  @doc """
+  Renders one edition (tile system v2): a single audiobook as its media
+  tile, a part set as one stacked tile of its parts' covers. A group tile
+  always navigates to its first part's page.
+  """
+  attr :id, :string, default: nil
+  attr :edition, Edition, required: true
+
+  attr :show_title, :boolean, default: true
+  attr :show_authors, :boolean, default: true
+  attr :show_series, :boolean, default: true
+  attr :show_narrators, :boolean, default: false
+  attr :show_published, :boolean, default: false
+
+  def edition_tile(%{edition: %Edition{kind: :single}} = assigns) do
+    ~H"""
+    <.media_tile
+      id={@id}
+      media={@edition.representative}
+      show_title={@show_title}
+      show_authors={@show_authors}
+      show_series={@show_series}
+      show_narrators={@show_narrators}
+      show_published={@show_published}
+    />
+    """
+  end
+
+  def edition_tile(%{edition: %Edition{kind: :group}} = assigns) do
+    ~H"""
+    <div id={@id} class="text-center">
+      <div class="group">
+        <.link navigate={~p"/audiobooks/#{@edition.representative}"}>
+          <.book_multi_image thumbnails={Enum.flat_map(@edition.media, &if(&1.thumbnails, do: [&1.thumbnails], else: []))} />
+        </.link>
+        <p :if={@show_title} class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
+          <.link navigate={~p"/audiobooks/#{@edition.representative}"}>
+            {@edition.representative.book.title}
+          </.link>
+        </p>
+      </div>
+
+      <p class="text-sm text-zinc-600 dark:text-zinc-400">
+        {part_set_label(@edition.group, @edition.media)}
+      </p>
+
+      <p :if={@show_authors} class="text-sm text-zinc-800 dark:text-zinc-200 sm:text-base">
+        by <.people_links people={@edition.representative.book.authors} />
+      </p>
+
+      <div :if={@show_series} class="text-xs text-zinc-600 dark:text-zinc-400 sm:text-sm">
+        <.series_book_links series_books={@edition.representative.book.series_books} />
+      </div>
+    </div>
+    """
+  end
+
   attr :id, :string, default: nil
   attr :media, Media, required: true
 
@@ -1126,55 +1225,6 @@ defmodule AmbryWeb.CoreComponents do
   attr :show_series, :boolean, default: true
   attr :show_narrators, :boolean, default: false
   attr :show_published, :boolean, default: false
-  attr :collapse_part_sets, :boolean, default: false
-
-  attr :collapse_navigate, :atom,
-    values: [:book, :representative],
-    default: :book,
-    doc: """
-    where a collapsed part-set tile lands: the book page (library listings —
-    the parts are listed there in order) or the representative part's own
-    audiobook page (Other Editions — the book page is already one click away,
-    so the stack takes you into the set instead)
-    """
-
-  # A part set collapses into a single stacked tile (its parts' covers),
-  # titled with the book.
-  def media_tile(
-        %{
-          collapse_part_sets: true,
-          media: %Media{recording_group: %RecordingGroup{media: [_, _ | _]}}
-        } = assigns
-      ) do
-    ~H"""
-    <div id={@id} class="text-center">
-      <div class="group">
-        <.link navigate={collapsed_tile_path(@collapse_navigate, @media)}>
-          <.book_multi_image thumbnails={
-            Enum.flat_map(@media.recording_group.media, &if(&1.thumbnails, do: [&1.thumbnails], else: []))
-          } />
-        </.link>
-        <p :if={@show_title} class="font-bold text-zinc-900 group-hover:underline dark:text-zinc-100 sm:text-lg">
-          <.link navigate={collapsed_tile_path(@collapse_navigate, @media)}>
-            {@media.book.title}
-          </.link>
-        </p>
-      </div>
-
-      <p class="text-sm text-zinc-600 dark:text-zinc-400">
-        {part_set_label(@media.recording_group)}
-      </p>
-
-      <p :if={@show_authors} class="text-sm text-zinc-800 dark:text-zinc-200 sm:text-base">
-        by <.people_links people={@media.book.authors} />
-      </p>
-
-      <div :if={@show_series} class="text-xs text-zinc-600 dark:text-zinc-400 sm:text-sm">
-        <.series_book_links series_books={@media.book.series_books} />
-      </div>
-    </div>
-    """
-  end
 
   def media_tile(assigns) do
     ~H"""
@@ -1429,62 +1479,19 @@ defmodule AmbryWeb.CoreComponents do
 
   @doc """
   A user-facing label for a part set: "3 parts", "6 episodes" — count plus
-  the group's plural wording. The group's name is an admin-only label and is
-  deliberately never rendered here.
+  the group's plural wording (default wording when the group struct isn't
+  loaded). The group's name is an admin-only label and is deliberately
+  never rendered here.
   """
-  def part_set_label(%RecordingGroup{} = group, parts \\ nil) do
+  def part_set_label(group, parts \\ nil)
+
+  def part_set_label(%RecordingGroup{} = group, parts) do
     "#{length(parts || group.media)} #{RecordingGroup.part_word_plural(group)}"
   end
 
-  @doc """
-  One media per edition, ready only: ungrouped media pass through, a part
-  set is represented by its first ready part. The shared collapse rule for
-  every user-facing surface that lists editions.
-  """
-  def part_set_representatives(media_list) do
-    media_list = ready_media(media_list)
-
-    first_parts =
-      media_list
-      |> Enum.filter(& &1.recording_group_id)
-      |> Enum.group_by(& &1.recording_group_id)
-      |> Map.new(fn {group_id, parts} ->
-        {group_id, Enum.min_by(parts, &{&1.part_number || :infinity, &1.id}).id}
-      end)
-
-    Enum.filter(media_list, fn media ->
-      is_nil(media.recording_group_id) or first_parts[media.recording_group_id] == media.id
-    end)
+  def part_set_label(nil, parts) when is_list(parts) do
+    "#{length(parts)} parts"
   end
-
-  @doc """
-  The media whose covers a book tile stacks, ready only: one per edition —
-  part sets contribute only their first part — unless the book's sole
-  edition is a part set, in which case its parts are the stack.
-  """
-  def part_set_stack_media(media_list) do
-    media_list = ready_media(media_list)
-    representatives = part_set_representatives(media_list)
-
-    case representatives do
-      [%{recording_group_id: group_id}] when not is_nil(group_id) ->
-        media_list
-        |> Enum.filter(&(&1.recording_group_id == group_id))
-        |> Enum.sort_by(&{&1.part_number || :infinity, &1.id})
-
-      _multiple_editions ->
-        representatives
-    end
-  end
-
-  # tile stacks must never leak pending/processing/errored media — several
-  # callers preload a book's media unfiltered
-  defp ready_media(media_list), do: Enum.filter(media_list, &(&1.status == :ready))
-
-  # the media on a collapsed tile is the set's representative (its first
-  # ready part), so :representative navigation is just its own page
-  defp collapsed_tile_path(:book, media), do: ~p"/books/#{media.book}"
-  defp collapsed_tile_path(:representative, media), do: ~p"/audiobooks/#{media}"
 
   # When a tile hides its title (e.g. "other editions" lists), parts of a set
   # still need telling apart: the override title or the part label.

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -12,6 +12,7 @@ defmodule AmbryWeb.AudiobookLive do
   alias Ambry.Books
   alias Ambry.Hashids
   alias Ambry.Media
+  alias Ambry.Media.Editions
 
   @impl Phoenix.LiveView
   def render(assigns) do
@@ -107,11 +108,9 @@ defmodule AmbryWeb.AudiobookLive do
               Other Editions
             </h2>
             <div class="grid grid-cols-2 gap-4 sm:gap-6 md:gap-8">
-              <.media_tile
-                :for={media <- @other_editions}
-                media={media}
-                collapse_part_sets
-                collapse_navigate={:representative}
+              <.edition_tile
+                :for={edition <- @other_editions}
+                edition={edition}
                 show_title={false}
                 show_authors={false}
                 show_series={false}
@@ -153,15 +152,14 @@ defmodule AmbryWeb.AudiobookLive do
           _no_set -> nil
         end
 
-      # true alternates only: drop this media's own part-set siblings, then
-      # collapse sibling part sets to one representative each — the tile
-      # stacks the set's covers (a set is one edition, not N tiles)
+      # true alternates only: every other edition of the book, minus this
+      # media's own part set (its parts live in the rail above)
       other_editions =
         media.book.media
+        |> Editions.from_media()
         |> Enum.reject(
-          &(&1.recording_group_id && &1.recording_group_id == media.recording_group_id)
+          &(&1.kind == :group and &1.group != nil and &1.group.id == media.recording_group_id)
         )
-        |> part_set_representatives()
 
       {:ok,
        assign(socket,

--- a/lib/ambry_web/live/book_live.ex
+++ b/lib/ambry_web/live/book_live.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.BookLive do
   use AmbryWeb, :live_view
 
   alias Ambry.Books
+  alias Ambry.Media.Editions
 
   @impl Phoenix.LiveView
   def render(assigns) do
@@ -18,37 +19,21 @@ defmodule AmbryWeb.BookLive do
         </p>
       </div>
 
-      <%= if @book.media == [] do %>
-        <p class="mt-4 font-bold">Sorry, there are currently no audiobooks uploaded for this book.</p>
-      <% else %>
-        <div>
-          <h1 class="mb-4 text-2xl font-bold sm:text-3xl lg:mb-8 lg:text-4xl">Editions</h1>
+      <div>
+        <h1 class="mb-4 text-2xl font-bold sm:text-3xl lg:mb-8 lg:text-4xl">Editions</h1>
 
-          <div :for={%{group: group, parts: parts} <- @part_groups} class="mb-10">
-            <h2 class="mb-4 text-xl font-bold text-zinc-800 dark:text-zinc-200 sm:text-2xl">
-              {part_set_label(group, parts)}
-            </h2>
-            <.media_tiles
-              media={parts}
-              show_title={false}
-              show_authors={false}
-              show_series={false}
-              show_narrators={true}
-              show_published={true}
-            />
-          </div>
-
-          <.media_tiles
-            :if={@ungrouped_media != []}
-            media={@ungrouped_media}
+        <.grid>
+          <.edition_tile
+            :for={edition <- @editions}
+            edition={edition}
             show_title={false}
             show_authors={false}
             show_series={false}
             show_narrators={true}
             show_published={true}
           />
-        </div>
-      <% end %>
+        </.grid>
+      </div>
     </div>
     """
   end
@@ -57,29 +42,23 @@ defmodule AmbryWeb.BookLive do
   def mount(%{"id" => book_id}, _session, socket) do
     book = Books.get_book_with_media!(book_id)
 
-    case book.media do
-      [media] ->
-        {:ok, push_navigate(socket, to: ~p"/audiobooks/#{media}")}
+    # tile system v2: the page is a flat grid of edition tiles; a book with
+    # exactly one edition redirects to that edition's target (a group's
+    # target is its first part), and a book with no ready editions is
+    # hidden from users entirely
+    case Editions.from_media(book.media) do
+      [] ->
+        {:ok, redirect(socket, to: ~p"/")}
 
-      _else ->
-        part_groups =
-          book.media
-          |> Enum.filter(& &1.recording_group_id)
-          |> Enum.group_by(& &1.recording_group_id)
-          |> Enum.map(fn {_group_id, parts} ->
-            %{
-              group: hd(parts).recording_group,
-              parts: Enum.sort_by(parts, &{&1.part_number || :infinity, &1.id})
-            }
-          end)
-          |> Enum.sort_by(& &1.group.id)
+      [only_edition] ->
+        {:ok, push_navigate(socket, to: ~p"/audiobooks/#{only_edition.representative}")}
 
+      editions ->
         {:ok,
          assign(socket,
            page_title: Books.get_book_description(book),
            book: book,
-           part_groups: part_groups,
-           ungrouped_media: Enum.reject(book.media, & &1.recording_group_id)
+           editions: editions
          )}
     end
   end

--- a/lib/ambry_web/live/library_live.ex
+++ b/lib/ambry_web/live/library_live.ex
@@ -29,7 +29,7 @@ defmodule AmbryWeb.LibraryLive do
           </p>
         </div>
       <% else %>
-        <.media_tiles_stream id="media" stream={@streams.media} page={@page} end?={@end?} collapse_part_sets />
+        <.edition_tiles_stream id="media" stream={@streams.media} page={@page} end?={@end?} />
       <% end %>
     </div>
     """

--- a/lib/ambry_web/live/search_live.ex
+++ b/lib/ambry_web/live/search_live.ex
@@ -7,6 +7,9 @@ defmodule AmbryWeb.SearchLive do
 
   import AmbryWeb.SearchLive.Components
 
+  alias Ambry.Books.Book
+  alias Ambry.Books.Series
+  alias Ambry.Media.Editions
   alias Ambry.Search
 
   @impl Phoenix.LiveView
@@ -29,7 +32,10 @@ defmodule AmbryWeb.SearchLive do
   @impl Phoenix.LiveView
   def mount(%{"query" => query}, _session, socket) do
     query = String.trim(query)
-    results = Search.search(query)
+
+    # tile system v2: books with no ready editions are hidden from users,
+    # and a series is hidden when none of its books are visible
+    results = query |> Search.search() |> Enum.filter(&visible?/1)
 
     {:ok,
      socket
@@ -37,4 +43,10 @@ defmodule AmbryWeb.SearchLive do
      |> assign(:query, query)
      |> assign(:results, results)}
   end
+
+  defp visible?(%Book{} = book), do: Editions.from_media(book.media) != []
+
+  defp visible?(%Series{} = series), do: Enum.any?(series.series_books, &visible?(&1.book))
+
+  defp visible?(_person), do: true
 end

--- a/lib/ambry_web/live/search_live/components.ex
+++ b/lib/ambry_web/live/search_live/components.ex
@@ -7,6 +7,7 @@ defmodule AmbryWeb.SearchLive.Components do
 
   alias Ambry.Books.Book
   alias Ambry.Books.Series
+  alias Ambry.Media.Editions
   alias Ambry.People.Person
 
   def result_tile(%{result: %Book{}} = assigns) do
@@ -93,14 +94,18 @@ defmodule AmbryWeb.SearchLive.Components do
     """
   end
 
+  # Series tile rule (tile system v2): up to 3 covers — the books in
+  # series order, each contributing its representative (the newest
+  # edition's cover); books with no ready edition are skipped.
   defp thumbnails(series) do
-    # use the first non-nil image path from each book in the series
     series.series_books
-    |> Enum.map(fn series_book ->
-      Enum.find_value(series_book.book.media, fn media ->
-        media.thumbnails
-      end)
+    |> Enum.sort_by(& &1.book_number, Decimal)
+    |> Enum.flat_map(fn series_book ->
+      case Editions.from_media(series_book.book.media) do
+        [newest | _rest] -> List.wrap(newest.representative.thumbnails)
+        [] -> []
+      end
     end)
-    |> Enum.filter(& &1)
+    |> Enum.take(3)
   end
 end

--- a/lib/ambry_web/live/series_live.ex
+++ b/lib/ambry_web/live/series_live.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.SeriesLive do
   use AmbryWeb, :live_view
 
   alias Ambry.Books
+  alias Ambry.Media.Editions
 
   @impl Phoenix.LiveView
   def render(assigns) do
@@ -21,7 +22,7 @@ defmodule AmbryWeb.SeriesLive do
         </p>
       </div>
 
-      <.book_tiles books={@series.series_books} />
+      <.book_tiles books={@series_books} />
     </div>
     """
   end
@@ -30,8 +31,16 @@ defmodule AmbryWeb.SeriesLive do
   def mount(%{"id" => series_id}, _session, socket) do
     series = Books.get_series_with_books!(series_id)
 
-    authors =
+    # tile system v2: books with no ready editions are hidden from users
+    # entirely (series show gaps while a book processes); explicit series
+    # ordering, which the association never guaranteed
+    series_books =
       series.series_books
+      |> Enum.filter(&(Editions.from_media(&1.book.media) != []))
+      |> Enum.sort_by(& &1.book_number, Decimal)
+
+    authors =
+      series_books
       |> Enum.flat_map(& &1.book.authors)
       |> Enum.uniq()
 
@@ -39,6 +48,7 @@ defmodule AmbryWeb.SeriesLive do
      socket
      |> assign(:page_title, series.name)
      |> assign(:series, series)
+     |> assign(:series_books, series_books)
      |> assign(:authors, authors)}
   end
 end

--- a/test/ambry/media/editions_test.exs
+++ b/test/ambry/media/editions_test.exs
@@ -1,0 +1,108 @@
+defmodule Ambry.Media.EditionsTest do
+  use Ambry.DataCase
+
+  alias Ambry.Media.Editions
+  alias Ambry.Media.Editions.Edition
+
+  describe "from_media/2" do
+    test "partitions media into editions: singles pass through, groups collapse" do
+      book = insert(:book)
+      group = insert(:recording_group)
+
+      solo = insert(:media, book: book, status: :ready, published: ~D[2020-01-01])
+
+      [part_two, part_one] =
+        for n <- [2, 1] do
+          insert(:media,
+            book: book,
+            part_number: n,
+            recording_group: group,
+            status: :ready,
+            published: ~D[2021-01-01]
+          )
+        end
+
+      assert [group_edition, single_edition] = Editions.from_media([solo, part_two, part_one])
+
+      # newest first: the group's date is its first part's date (2021)
+      assert %Edition{kind: :group, representative: %{id: rep_id}, media: parts} = group_edition
+      assert rep_id == part_one.id
+      assert Enum.map(parts, & &1.id) == [part_one.id, part_two.id]
+
+      assert %Edition{kind: :single, representative: %{id: solo_id}} = single_edition
+      assert solo_id == solo.id
+    end
+
+    test "only ready media count unless all_statuses" do
+      book = insert(:book)
+      group = insert(:recording_group)
+
+      pending_first =
+        insert(:media, book: book, part_number: 1, recording_group: group, status: :pending)
+
+      ready_second =
+        insert(:media, book: book, part_number: 2, recording_group: group, status: :ready)
+
+      media_list = [pending_first, ready_second]
+
+      # the group has one visible part → presents as a single edition,
+      # represented by the first READY part
+      assert [%Edition{kind: :single, representative: %{id: rep_id}}] =
+               Editions.from_media(media_list)
+
+      assert rep_id == ready_second.id
+
+      # admin surfaces see everything: two parts, pending part represents
+      assert [%Edition{kind: :group, representative: %{id: admin_rep_id}}] =
+               Editions.from_media(media_list, all_statuses: true)
+
+      assert admin_rep_id == pending_first.id
+    end
+
+    test "a book with nothing ready yields no editions" do
+      book = insert(:book)
+      insert(:media, book: book, status: :pending)
+
+      assert Editions.from_media([insert(:media, book: book, status: :processing)]) == []
+    end
+
+    test "editions order newest first, nulls last, id tiebreak" do
+      book = insert(:book)
+
+      old = insert(:media, book: book, status: :ready, published: ~D[2010-01-01])
+      new = insert(:media, book: book, status: :ready, published: ~D[2022-01-01])
+      undated_a = insert(:media, book: book, status: :ready, published: nil)
+      undated_b = insert(:media, book: book, status: :ready, published: nil)
+
+      editions = Editions.from_media([undated_a, old, new, undated_b])
+
+      assert Enum.map(editions, & &1.representative.id) ==
+               [new.id, old.id, undated_b.id, undated_a.id]
+    end
+  end
+
+  describe "from_representative/1" do
+    test "a grouped listing row becomes a group edition; a lone row a single" do
+      book = insert(:book)
+      group = insert(:recording_group)
+
+      parts =
+        for n <- 1..2 do
+          insert(:media, book: book, part_number: n, recording_group: group, status: :ready)
+        end
+
+      [part_one, _part_two] = parts
+      loaded = Ambry.Repo.preload(part_one, recording_group: :media)
+
+      assert %Edition{kind: :group, representative: %{id: rep_id}} =
+               Editions.from_representative(loaded)
+
+      assert rep_id == part_one.id
+
+      solo = insert(:media, book: book, status: :ready)
+
+      assert %Edition{kind: :single} =
+               solo |> Ambry.Repo.preload(:recording_group) |> Editions.from_representative()
+    end
+  end
+end

--- a/test/ambry_web/live/author_live_test.exs
+++ b/test/ambry_web/live/author_live_test.exs
@@ -12,6 +12,7 @@ defmodule AmbryWeb.AuthorLiveTest do
       )
 
     %{book_authors: [%{author: author}]} = book
+    insert(:media, book: book, status: :ready)
 
     {:ok, _view, html} = live(conn, ~p"/authors/#{author.id}")
 

--- a/test/ambry_web/live/editions_ux_test.exs
+++ b/test/ambry_web/live/editions_ux_test.exs
@@ -1,9 +1,11 @@
-defmodule AmbryWeb.PartSetUxTest do
+defmodule AmbryWeb.EditionsUxTest do
+  @moduledoc """
+  Behavioral spec for tile system v2 (ROADMAP "Tile system v2"): recursive
+  collapse, ready-only for users, editions-based click targets.
+  """
   use AmbryWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
-
-  alias AmbryWeb.CoreComponents
 
   setup :register_and_log_in_user
 
@@ -16,24 +18,31 @@ defmodule AmbryWeb.PartSetUxTest do
         part_number: n,
         parts_total: Keyword.get(opts, :count, 3),
         recording_group: group,
-        status: :ready
+        status: :ready,
+        published: opts[:published]
       )
     end
   end
 
   describe "library page" do
-    test "collapses a part set into one stacked tile linking to the book", %{conn: conn} do
+    test "a group renders as one stacked tile navigating to its first part", %{conn: conn} do
       book = insert(:book, title: "Dungeon Crawler Carl")
-      insert_part_set(book, name: "Season One")
+      [part_one, part_two, part_three] = insert_part_set(book, name: "Season One")
 
       {:ok, _view, html} = live(conn, ~p"/")
 
       assert html =~ "Dungeon Crawler Carl"
       assert html =~ "3 parts"
       refute html =~ "Season One"
-      # the individual part labels don't appear as separate tiles
       refute html =~ "(Part 1 of 3)"
-      assert html =~ ~p"/books/#{book.id}"
+
+      # group tiles land on the first part — never the book page
+      assert html =~ ~p"/audiobooks/#{part_one.id}"
+      refute html =~ ~p"/books/#{book.id}"
+
+      for part <- [part_two, part_three] do
+        refute html =~ ~p"/audiobooks/#{part.id}"
+      end
     end
 
     test "single-release media are unaffected", %{conn: conn} do
@@ -47,12 +56,10 @@ defmodule AmbryWeb.PartSetUxTest do
   end
 
   describe "book page" do
-    test "renders part sets as titled sections with parts in order, ungrouped below", %{
-      conn: conn
-    } do
+    test "renders a flat grid of edition tiles — groups stack, no sub-sections", %{conn: conn} do
       book = insert(:book, title: "Dungeon Crawler Carl")
-      insert_part_set(book, name: "Season One", count: 2)
-      insert(:media, book: book, status: :ready)
+      [part_one, _part_two] = insert_part_set(book, name: "Season One", count: 2)
+      solo = insert(:media, book: book, status: :ready)
 
       {:ok, _view, html} = live(conn, ~p"/books/#{book.id}")
 
@@ -60,26 +67,38 @@ defmodule AmbryWeb.PartSetUxTest do
       assert html =~ "2 parts"
       refute html =~ "Season One"
 
-      # parts render in part order despite publication-date ordering elsewhere
-      assert [i1, i2] =
-               Regex.scan(~r/Part \d of 2/, html) |> List.flatten() |> Enum.take(2)
+      # the group is ONE tile linking to its first part; parts are not
+      # individually tiled
+      assert html =~ ~p"/audiobooks/#{part_one.id}"
+      assert html =~ ~p"/audiobooks/#{solo.id}"
+      refute html =~ "Part 2 of 2"
+    end
 
-      assert i1 == "Part 1 of 2"
-      assert i2 == "Part 2 of 2"
+    test "a book whose only edition is a group redirects to the first part", %{conn: conn} do
+      book = insert(:book)
+      [part_one | _rest] = insert_part_set(book)
+
+      assert {:error, {:live_redirect, %{to: to}}} = live(conn, ~p"/books/#{book.id}")
+      assert to == ~p"/audiobooks/#{part_one.id}"
+    end
+
+    test "a book with nothing ready redirects home", %{conn: conn} do
+      book = insert(:book)
+      insert(:media, book: book, status: :pending)
+
+      assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/books/#{book.id}")
     end
   end
 
   describe "audiobook page" do
-    test "a sibling part set stacks as one tile under Other Editions", %{conn: conn} do
+    test "a sibling group is one stacked tile under Other Editions, landing on its first part",
+         %{conn: conn} do
       book = insert(:book, title: "Dungeon Crawler Carl")
       [part_one, part_two, part_three] = insert_part_set(book, name: "Season One")
       solo = insert(:media, book: book, status: :ready)
 
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{solo.id}")
 
-      # one stacked tile for the whole set — never one tile per part — and
-      # it navigates into the set: the first part's page (the book page is
-      # already one click away from here)
       assert html =~ "Other Editions"
       assert html =~ "3 parts"
       assert html =~ ~p"/audiobooks/#{part_one.id}"
@@ -89,7 +108,7 @@ defmodule AmbryWeb.PartSetUxTest do
       end
     end
 
-    test "a sibling set with non-ready parts stacks only its ready parts", %{conn: conn} do
+    test "a sibling group with non-ready parts stacks only its ready parts", %{conn: conn} do
       book = insert(:book)
       group = insert(:recording_group)
 
@@ -116,8 +135,7 @@ defmodule AmbryWeb.PartSetUxTest do
 
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{solo.id}")
 
-      # the pending first part neither counts nor represents — the first
-      # READY part is the stack's landing target
+      # the pending first part neither counts nor represents
       assert html =~ "2 parts"
       assert html =~ ~p"/audiobooks/#{part_two.id}"
     end
@@ -138,8 +156,7 @@ defmodule AmbryWeb.PartSetUxTest do
       assert html =~ "Other Editions"
       assert html =~ ~p"/audiobooks/#{other_edition.id}"
 
-      # sibling parts are not duplicated in Other Editions: their links appear
-      # exactly once (in the rail)
+      # sibling parts appear exactly once (in the rail)
       assert html |> String.split(~p"/audiobooks/#{part_one.id}") |> length() == 2
     end
 
@@ -150,6 +167,79 @@ defmodule AmbryWeb.PartSetUxTest do
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
 
       refute html =~ "Other Editions"
+    end
+  end
+
+  describe "series page (book tiles)" do
+    test "a sole-group book links into its first part; multi-edition books to the book page",
+         %{conn: conn} do
+      series = insert(:series, name: "Test Series")
+
+      sole_group_book =
+        insert(:book, title: "Sole Group Book", series_books: [%{series: series, book_number: 1}])
+
+      [part_one | _rest] = insert_part_set(sole_group_book)
+
+      multi_book =
+        insert(:book,
+          title: "Multi Edition Book",
+          series_books: [%{series: series, book_number: 2}]
+        )
+
+      insert(:media, book: multi_book, status: :ready)
+      insert(:media, book: multi_book, status: :ready)
+
+      {:ok, _view, html} = live(conn, ~p"/series/#{series.id}")
+
+      # editions-based click rule: one edition → its target (the group's
+      # first part), multiple → the book page
+      assert html =~ ~p"/audiobooks/#{part_one.id}"
+      assert html =~ ~p"/books/#{multi_book.id}"
+      refute html =~ ~p"/books/#{sole_group_book.id}"
+    end
+
+    test "books with nothing ready are hidden entirely", %{conn: conn} do
+      series = insert(:series)
+
+      visible =
+        insert(:book, title: "Visible Book", series_books: [%{series: series, book_number: 1}])
+
+      insert(:media, book: visible, status: :ready)
+
+      hidden =
+        insert(:book, title: "Hidden Book", series_books: [%{series: series, book_number: 2}])
+
+      insert(:media, book: hidden, status: :pending)
+
+      {:ok, _view, html} = live(conn, ~p"/series/#{series.id}")
+
+      assert html =~ "Visible Book"
+      refute html =~ "Hidden Book"
+    end
+  end
+
+  describe "narrator page" do
+    test "never shows non-ready media", %{conn: conn} do
+      narrator = insert(:narrator, person: build(:person))
+
+      ready =
+        insert(:media,
+          book: insert(:book, title: "Ready Book"),
+          status: :ready,
+          media_narrators: [build(:media_narrator, narrator: narrator)]
+        )
+
+      pending =
+        insert(:media,
+          book: insert(:book, title: "Pending Book"),
+          status: :pending,
+          media_narrators: [build(:media_narrator, narrator: narrator)]
+        )
+
+      {:ok, _view, html} = live(conn, ~p"/narrators/#{narrator.id}")
+
+      assert html =~ ~p"/audiobooks/#{ready.id}"
+      refute html =~ ~p"/audiobooks/#{pending.id}"
     end
   end
 
@@ -175,7 +265,7 @@ defmodule AmbryWeb.PartSetUxTest do
           )
         end
 
-      # library: collapsed tile counts in episodes
+      # library: the group tile counts in episodes
       {:ok, _view, html} = live(conn, ~p"/")
       assert html =~ "2 episodes"
       refute html =~ "Admin Label"
@@ -185,58 +275,6 @@ defmodule AmbryWeb.PartSetUxTest do
       assert html =~ "Dungeon Crawler Carl (Episode 1 of 2)"
       assert html =~ "Episode 2"
       refute html =~ "Admin Label"
-    end
-  end
-
-  describe "part_set_stack_media/1 (book tile stacks)" do
-    test "a part set contributes only its first part when other editions exist" do
-      book = insert(:book)
-      [part_one | rest] = insert_part_set(book)
-      solo = insert(:media, book: book, status: :ready)
-
-      stacked = CoreComponents.part_set_stack_media([solo, part_one | rest])
-
-      assert Enum.map(stacked, & &1.id) == [solo.id, part_one.id]
-    end
-
-    test "a sole part-set edition stacks all of its parts in order" do
-      book = insert(:book)
-      parts = insert_part_set(book)
-
-      stacked = CoreComponents.part_set_stack_media(Enum.shuffle(parts))
-
-      assert Enum.map(stacked, & &1.id) == Enum.map(parts, & &1.id)
-    end
-
-    test "non-ready media never contribute to stacks" do
-      book = insert(:book)
-      parts = insert_part_set(book)
-      pending = insert(:media, book: book, status: :pending)
-
-      # the pending solo is invisible — the set is still the sole (ready)
-      # edition and stacks its parts
-      stacked = CoreComponents.part_set_stack_media([pending | parts])
-
-      assert Enum.map(stacked, & &1.id) == Enum.map(parts, & &1.id)
-    end
-
-    test "part_set_representatives/1 keeps one ready media per edition" do
-      book = insert(:book)
-      group = insert(:recording_group)
-
-      pending_first =
-        insert(:media, book: book, part_number: 1, recording_group: group, status: :pending)
-
-      ready_second =
-        insert(:media, book: book, part_number: 2, recording_group: group, status: :ready)
-
-      solo = insert(:media, book: book, status: :ready)
-
-      representatives =
-        CoreComponents.part_set_representatives([pending_first, ready_second, solo])
-
-      # the set is represented by its first READY part
-      assert Enum.map(representatives, & &1.id) == [ready_second.id, solo.id]
     end
   end
 end

--- a/test/ambry_web/live/person_live_test.exs
+++ b/test/ambry_web/live/person_live_test.exs
@@ -12,6 +12,7 @@ defmodule AmbryWeb.PersonLiveTest do
       )
 
     %{book_authors: [%{author: %{author_people: [%{person: person}]}}]} = book
+    insert(:media, book: book, status: :ready)
 
     {:ok, _view, html} = live(conn, ~p"/people/#{person.id}")
 
@@ -23,6 +24,7 @@ defmodule AmbryWeb.PersonLiveTest do
     media =
       insert(:media,
         book: build(:book),
+        status: :ready,
         media_narrators: [
           build(:media_narrator, narrator: build(:narrator, person: build(:person)))
         ]

--- a/test/ambry_web/live/series_live_test.exs
+++ b/test/ambry_web/live/series_live_test.exs
@@ -8,6 +8,7 @@ defmodule AmbryWeb.SeriesLiveTest do
   test "renders a series show page", %{conn: conn} do
     series = insert(:series)
     book = insert(:book, series_books: [%{series: series, book_number: 1}])
+    insert(:media, book: book, status: :ready)
 
     {:ok, _view, html} = live(conn, ~p"/series/#{series.id}")
 


### PR DESCRIPTION
**Stacked on #1161.** PR 1 of the tile-rules redesign — implements the operator-authored spec in ROADMAP "Tile system v2" (input analysis: `TILE-BEHAVIORS.md`).

## The Edition model

`Ambry.Media.Editions` is the new single implementation of "which covers, which order, which link": it partitions a book's media into `%Edition{kind: :single | :group, media, representative, group}` — ready-only for users, `all_statuses: true` for admin. Rules: parts in part order, representative = first part, editions newest-first by representative date (a group's date IS its first part's date), a group with one visible part presents as a single.

## Behavior changes (all per the confirmed spec)

- **Recursive collapse**: group tile alone = parts stacked; inside any stack = one representative cover. **The sole-edition exception is deleted** — a book whose only edition is a 3-part group shows ONE cover on book/series tiles.
- **Clicks**: Group tiles land on their **first part** everywhere — including the library (was: book page). Book tiles + the book-page redirect are **editions-based**: one edition → straight to its target (a sole group → its first part); multiple → book page.
- **Book page**: flat grid of edition tiles, replacing the #1154 titled sub-sections (decided reversal). Zero ready editions → redirect home.
- **Ready-only, everywhere**: fixes the narrator page and person narrated section (previously showed pending media — real bug), and the series search tile (previously any-status, any-part covers). **Books with zero ready editions are hidden entirely** from series/author/person pages and search (query-level on paginated surfaces so pagination stays correct).
- **Ordering fixed**: book-tile cover order was literally unspecified; now newest-first. Series pages sort by book number (previously association order).

## Deleted

`part_set_stack_media/1`, `part_set_representatives/1`, the collapsed `media_tile` clause + `collapse_part_sets`/`collapse_navigate` attrs, the book-page `group_by`, the search `thumbnails/1` heuristic. Four of the six implementations from the report are gone; the remaining two SQL twins (library listing — already conformant; admin flat views) are PR 2, which also deletes the sole-edition SQL branch.

## Tests

`editions_test.exs` (module rules: grouping, ready/all-statuses, ordering, one-part groups) + `editions_ux_test.exs` (behavioral spec replacing `part_set_ux_test.exs`: library/book/audiobook/series/narrator surfaces, redirects, hiding). Existing page tests updated where fixtures relied on pending-only books being visible. Full suite 678 passed; `mix check` clean.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9