### PR TITLE
Tile system v2: admin flat views (PR 2)

### DIFF
--- a/priv/repo/migrations/20260802194859_flat_views_edition_rules.exs
+++ b/priv/repo/migrations/20260802194859_flat_views_edition_rules.exs
@@ -1,0 +1,22 @@
+defmodule Ambry.Repo.Migrations.FlatViewsEditionRules do
+  use Ecto.Migration
+  use Familiar
+
+  # Tile system v2, admin side: list cover-stacks adopt the Edition rules —
+  # one cover per edition (books view) / one cover per book, its newest
+  # edition's representative (series & universes views). The sole-edition
+  # exception is deleted; non-ready media stay visible (admin lists are ops
+  # views). Mirrors Ambry.Media.Editions; parity-tested.
+
+  def up do
+    update_view("books_flat", version: 12)
+    update_view("series_flat", version: 6)
+    update_view("universes_flat", version: 3)
+  end
+
+  def down do
+    update_view("books_flat", version: 11)
+    update_view("series_flat", version: 5)
+    update_view("universes_flat", version: 2)
+  end
+end

--- a/priv/repo/views/books_flat_v12.sql
+++ b/priv/repo/views/books_flat_v12.sql
@@ -1,0 +1,90 @@
+SELECT
+  book.id,
+  book.title,
+  book.published,
+  book.published_format,
+  ARRAY(
+    -- tile system v2: one cover per edition — a part set contributes its
+    -- first part — newest edition first. Mirrors Ambry.Media.Editions
+    -- (all_statuses: admin lists deliberately include non-ready media);
+    -- held in lockstep by test/ambry/flat_view_stack_test.exs.
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+      AND media.thumbnails IS NOT NULL
+      AND (
+        media.recording_group_id IS NULL
+        OR media.id = (
+          SELECT m2.id
+          FROM media m2
+          WHERE m2.recording_group_id = media.recording_group_id
+          ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+          LIMIT 1
+        )
+      )
+    ORDER BY
+      media.published DESC NULLS LAST,
+      media.id DESC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      author.name
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.book_number ASC
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+  ) AS media,
+  book.inserted_at,
+  book.updated_at,
+  -- deprecated
+  book.image_path,
+  book.description IS NOT NULL AS has_description
+FROM
+  books AS book
+ORDER BY
+  book.title

--- a/priv/repo/views/series_flat_v6.sql
+++ b/priv/repo/views/series_flat_v6.sql
@@ -1,0 +1,88 @@
+SELECT
+  series.id,
+  series.name,
+  (
+    SELECT
+      COUNT(books_series.id)
+    FROM
+      books_series
+    WHERE
+      books_series.series_id = series.id
+  ) AS books,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN media ON media.book_id = book.id
+    WHERE
+      series_book.series_id = series.id
+  ) AS media,
+  ARRAY(
+    -- tile system v2 series rule: one cover per book, in series order —
+    -- each book contributes its representative (the newest edition's
+    -- first part / audiobook; all statuses on admin lists). Mirrors the
+    -- Series-tile logic over Ambry.Media.Editions.
+    SELECT
+      rep.thumb
+    FROM
+      books_series AS series_book
+      CROSS JOIN LATERAL (
+        SELECT
+          media.thumbnails -> 'small' AS thumb
+        FROM
+          media
+        WHERE
+          media.book_id = series_book.book_id
+          AND (
+            media.recording_group_id IS NULL
+            OR media.id = (
+              SELECT m2.id
+              FROM media m2
+              WHERE m2.recording_group_id = media.recording_group_id
+              ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+              LIMIT 1
+            )
+          )
+        ORDER BY
+          media.published DESC NULLS LAST,
+          media.id DESC
+        LIMIT 1
+      ) rep
+    WHERE
+      series_book.series_id = series.id
+      AND rep.thumb IS NOT NULL
+    ORDER BY
+      series_book.book_number ASC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      DISTINCT (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name AS person_name
+    FROM
+      books_series AS series_book
+      INNER JOIN books AS book ON book.id = series_book.book_id
+      INNER JOIN authors_books AS authored_by ON book.id = authored_by.book_id
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      series_book.series_id = series.id
+    ORDER BY
+      person_name
+  ) AS authors,
+  series.inserted_at,
+  series.updated_at
+FROM
+  series
+ORDER BY
+  series.name

--- a/priv/repo/views/universes_flat_v3.sql
+++ b/priv/repo/views/universes_flat_v3.sql
@@ -1,0 +1,54 @@
+SELECT
+  universe.id,
+  universe.name,
+  (
+    SELECT
+      COUNT(books_universes.id)
+    FROM
+      books_universes
+    WHERE
+      books_universes.universe_id = universe.id
+  ) AS books,
+  ARRAY(
+    -- tile system v2: one cover per book — its newest edition's
+    -- representative (all statuses on admin lists). Universe membership is
+    -- unnumbered, so books order by title.
+    SELECT
+      rep.thumb
+    FROM
+      books_universes AS book_universe
+      INNER JOIN books AS book ON book.id = book_universe.book_id
+      CROSS JOIN LATERAL (
+        SELECT
+          media.thumbnails -> 'small' AS thumb
+        FROM
+          media
+        WHERE
+          media.book_id = book.id
+          AND (
+            media.recording_group_id IS NULL
+            OR media.id = (
+              SELECT m2.id
+              FROM media m2
+              WHERE m2.recording_group_id = media.recording_group_id
+              ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+              LIMIT 1
+            )
+          )
+        ORDER BY
+          media.published DESC NULLS LAST,
+          media.id DESC
+        LIMIT 1
+      ) rep
+    WHERE
+      book_universe.universe_id = universe.id
+      AND rep.thumb IS NOT NULL
+    ORDER BY
+      book.title ASC
+  ) AS thumbnails,
+  universe.inserted_at,
+  universe.updated_at
+FROM
+  universes AS universe
+ORDER BY
+  universe.name

--- a/test/ambry/flat_view_stack_test.exs
+++ b/test/ambry/flat_view_stack_test.exs
@@ -1,16 +1,18 @@
 defmodule Ambry.FlatViewStackTest do
   @moduledoc """
-  The admin list cover-stacks (books/series/universes flat views) follow the
-  same part-set rules as the user-facing tiles — one cover per edition, a
-  part set contributes its first part, a sole-edition part set stacks all
-  its parts — but deliberately include non-ready media (admin lists are ops
-  views).
+  The admin list cover-stacks (books/series/universes flat views) follow
+  the tile-system-v2 Edition rules — one cover per edition (books view),
+  one cover per book via its newest edition's representative (series and
+  universes views) — while deliberately including non-ready media (admin
+  lists are ops views). The SQL is a twin of `Ambry.Media.Editions`; the
+  parity tests here are what hold the two in lockstep.
   """
   use Ambry.DataCase
 
   alias Ambry.Books.BookFlat
   alias Ambry.Books.SeriesFlat
   alias Ambry.Books.UniverseFlat
+  alias Ambry.Media.Editions
   alias Ambry.Repo
 
   # the thumbnails constraint only requires original == image_path, so fake
@@ -32,13 +34,24 @@ defmodule Ambry.FlatViewStackTest do
 
   defp small_thumb(media), do: media.thumbnails.small
 
-  test "a part set contributes only its first part when other editions exist" do
+  defp elixir_edition_thumbs(media_list) do
+    media_list
+    |> Editions.from_media(all_statuses: true)
+    |> Enum.map(& &1.representative.thumbnails)
+    |> Enum.filter(& &1)
+    |> Enum.map(& &1.small)
+  end
+
+  test "books view: one cover per edition, newest first, groups collapse to first part" do
     book = insert(:book)
     group = insert(:recording_group)
 
     solo = insert_media_with_cover(book, "solo", status: :ready, published: ~D[2020-01-01])
 
-    [part_one, _part_two, _part_three] =
+    pending =
+      insert_media_with_cover(book, "pending", status: :pending, published: ~D[2022-01-01])
+
+    parts =
       for n <- 1..3 do
         insert_media_with_cover(book, "part#{n}",
           part_number: n,
@@ -49,18 +62,24 @@ defmodule Ambry.FlatViewStackTest do
         )
       end
 
+    [part_one | _rest] = parts
+
     flat = Repo.get!(BookFlat, book.id)
 
-    # newest edition first (published desc): the set's first part, then solo
-    assert flat.thumbnails == [small_thumb(part_one), small_thumb(solo)]
+    # newest edition first; non-ready included (ops view); the group is one
+    # cover — its first part
+    assert flat.thumbnails == [small_thumb(pending), small_thumb(part_one), small_thumb(solo)]
+
+    # parity with the Elixir Editions rules (the lockstep contract)
+    assert flat.thumbnails == elixir_edition_thumbs([solo, pending | parts])
   end
 
-  test "a sole part-set edition stacks all of its parts in part order" do
+  test "books view: the sole-edition exception is gone — a lone group is ONE cover" do
     book = insert(:book)
     group = insert(:recording_group)
 
-    parts =
-      for n <- [2, 1, 3] do
+    [part_one | _rest] =
+      for n <- 1..3 do
         insert_media_with_cover(book, "part#{n}",
           part_number: n,
           parts_total: 3,
@@ -71,40 +90,35 @@ defmodule Ambry.FlatViewStackTest do
 
     flat = Repo.get!(BookFlat, book.id)
 
-    expected =
-      parts
-      |> Enum.sort_by(& &1.part_number)
-      |> Enum.map(&small_thumb/1)
-
-    assert flat.thumbnails == expected
+    assert flat.thumbnails == [small_thumb(part_one)]
   end
 
-  test "non-ready media still contribute covers (admin lists are ops views)" do
-    book = insert(:book)
-    pending = insert_media_with_cover(book, "pending", status: :pending)
-
-    flat = Repo.get!(BookFlat, book.id)
-
-    assert flat.thumbnails == [small_thumb(pending)]
-  end
-
-  test "series and universe rows apply the same per-book collapse" do
+  test "series and universe views: one cover per book (newest edition's representative), in order" do
     series = insert(:series)
     universe = insert(:universe)
 
-    book =
+    book_two =
       insert(:book,
+        title: "B Book",
+        series_books: [%{series: series, book_number: 2}],
+        book_universes: [%{universe: universe}]
+      )
+
+    book_one =
+      insert(:book,
+        title: "A Book",
         series_books: [%{series: series, book_number: 1}],
         book_universes: [%{universe: universe}]
       )
 
+    # book one: an old solo and a newer group — its cover is the group's
+    # first part (the newest edition's representative)
     group = insert(:recording_group)
+    insert_media_with_cover(book_one, "solo", status: :ready, published: ~D[2019-01-01])
 
-    solo = insert_media_with_cover(book, "solo", status: :ready, published: ~D[2020-01-01])
-
-    [part_one | _rest] =
+    [g_part_one | _rest] =
       for n <- 1..2 do
-        insert_media_with_cover(book, "part#{n}",
+        insert_media_with_cover(book_one, "part#{n}",
           part_number: n,
           parts_total: 2,
           recording_group: group,
@@ -113,10 +127,20 @@ defmodule Ambry.FlatViewStackTest do
         )
       end
 
-    assert Repo.get!(SeriesFlat, series.id).thumbnails ==
-             [small_thumb(part_one), small_thumb(solo)]
+    # book two: a single pending edition — still visible on admin lists
+    b2_media = insert_media_with_cover(book_two, "b2", status: :pending)
 
-    assert Repo.get!(UniverseFlat, universe.id).thumbnails ==
-             [small_thumb(part_one), small_thumb(solo)]
+    # a book with no media contributes nothing
+    insert(:book,
+      title: "C Book",
+      series_books: [%{series: series, book_number: 3}],
+      book_universes: [%{universe: universe}]
+    )
+
+    expected = [small_thumb(g_part_one), small_thumb(b2_media)]
+
+    # series order (book number) and universe order (title) agree here
+    assert Repo.get!(SeriesFlat, series.id).thumbnails == expected
+    assert Repo.get!(UniverseFlat, universe.id).thumbnails == expected
   end
 end


### PR DESCRIPTION
**Stacked on #1162** (← #1161). PR 2 of the tile redesign: the admin SQL twins adopt the Edition rules.

- **books_flat v12**: one cover per edition — part sets contribute their first part — newest edition first (`published DESC NULLS LAST, id DESC`, matching the Elixir ordering exactly). **The sole-edition SQL branch is deleted** (the big simplification this redesign bought).
- **series_flat v6 / universes_flat v3**: one cover per **book** — its newest edition's representative — in series order / title order (universes are unnumbered). This replaces the old "every cover across all books, published desc" aggregation, so admin series rows now look like the user-facing Series tile with non-ready media included.
- Non-ready media remain visible everywhere (admin = ops views, per the earlier decision).
- `flat_view_stack_test` rewritten as the **SQL↔Elixir parity contract**: the books-view test asserts the flat row equals `Editions.from_media(..., all_statuses: true)` over the same fixtures.

Reversible migration (down → v11/v5/v2). Full suite 677 passed; `mix check` clean.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9