### PR TITLE
Recording groups: per-group show-label choice (PR 3)

### DIFF
--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -49,6 +49,7 @@ defmodule Ambry.Media.Media do
     # form-only: recording-group picker staging, see apply_recording_group_choice/1
     field :recording_group_choice, :string, virtual: true
     field :recording_group_name, :string, virtual: true
+    field :recording_group_show_label, :boolean, virtual: true
     field :recording_group_part_word, :string, virtual: true
     field :recording_group_part_word_plural, :string, virtual: true
 
@@ -90,6 +91,7 @@ defmodule Ambry.Media.Media do
       :parts_total,
       :recording_group_id,
       :recording_group_choice,
+      :recording_group_show_label,
       :source_path,
       :source_files,
       :published,
@@ -148,6 +150,7 @@ defmodule Ambry.Media.Media do
       "new" ->
         put_assoc(changeset, :recording_group, %RecordingGroup{
           name: presence(get_change(changeset, :recording_group_name)),
+          show_label: get_change(changeset, :recording_group_show_label) == true,
           part_word: group_word_change(changeset, :recording_group_part_word),
           part_word_plural: group_word_change(changeset, :recording_group_part_word_plural)
         })
@@ -169,11 +172,12 @@ defmodule Ambry.Media.Media do
     updates =
       [
         name: get_change(changeset, :recording_group_name),
+        show_label: get_change(changeset, :recording_group_show_label),
         part_word: get_change(changeset, :recording_group_part_word),
         part_word_plural: get_change(changeset, :recording_group_part_word_plural)
       ]
       |> Enum.reject(fn {_field, value} -> is_nil(value) end)
-      |> Map.new(fn {field, value} -> {field, presence(value)} end)
+      |> Map.new(fn {field, value} -> {field, group_update_value(field, value)} end)
 
     with false <- updates == %{},
          false <- get_change(changeset, :recording_group_choice) == "new",
@@ -185,6 +189,11 @@ defmodule Ambry.Media.Media do
       _no_update -> changeset
     end
   end
+
+  # the label-visibility flag is a boolean — everything else is a string
+  # that folds empty to nil
+  defp group_update_value(:show_label, value), do: value
+  defp group_update_value(_field, value), do: presence(value)
 
   defp group_word_change(changeset, field) do
     changeset |> get_change(field) |> presence_downcase()

--- a/lib/ambry/media/recording_group.ex
+++ b/lib/ambry/media/recording_group.ex
@@ -18,8 +18,11 @@ defmodule Ambry.Media.RecordingGroup do
   schema "recording_groups" do
     has_many :media, Media, preload_order: [asc: :part_number]
 
-    # admin-only organizational label; never rendered in user-facing UI
+    # organizational label; rendered on the set's stacked tile only when
+    # the operator opts in via show_label (an explicit choice — label
+    # presence alone never triggers user-facing rendering)
     field :name, :string
+    field :show_label, :boolean, default: false
 
     # what one release in this set is called ("part" by default; "episode",
     # "volume", ...). Stored lowercase; display capitalizes as needed. nil
@@ -32,7 +35,7 @@ defmodule Ambry.Media.RecordingGroup do
 
   @doc false
   def changeset(recording_group, attrs) do
-    cast(recording_group, attrs, [:name, :part_word, :part_word_plural])
+    cast(recording_group, attrs, [:name, :show_label, :part_word, :part_word_plural])
   end
 
   @doc "The singular word for one release in this set, defaulting to \"part\"."

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1202,6 +1202,13 @@ defmodule AmbryWeb.CoreComponents do
         </p>
       </div>
 
+      <p
+        :if={@edition.group && @edition.group.show_label && @edition.group.name}
+        class="text-sm text-zinc-800 dark:text-zinc-200"
+      >
+        {@edition.group.name}
+      </p>
+
       <p class="text-sm text-zinc-600 dark:text-zinc-400">
         {part_set_label(@edition.group, @edition.media)}
       </p>
@@ -1480,8 +1487,8 @@ defmodule AmbryWeb.CoreComponents do
   @doc """
   A user-facing label for a part set: "3 parts", "6 episodes" — count plus
   the group's plural wording (default wording when the group struct isn't
-  loaded). The group's name is an admin-only label and is deliberately
-  never rendered here.
+  loaded). The group's *name* renders separately, and only when the group
+  opts in via `show_label` (see `edition_tile/1`).
   """
   def part_set_label(group, parts \\ nil)
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -132,6 +132,14 @@
         />
       </div>
 
+      <.input
+        :if={group_name_mode(@form, @media)}
+        field={@form[:recording_group_show_label]}
+        type="checkbox"
+        label="Show the group label to listeners on this set's stacked tile"
+        value={group_field_value(@form, @media, :recording_group_show_label, :show_label)}
+      />
+
       <.input type="hidden" field={@form[:image_type]} />
       <.input type="hidden" field={@form[:image_path]} />
 

--- a/priv/repo/migrations/20260802195208_add_recording_group_show_label.exs
+++ b/priv/repo/migrations/20260802195208_add_recording_group_show_label.exs
@@ -1,0 +1,12 @@
+defmodule Ambry.Repo.Migrations.AddRecordingGroupShowLabel do
+  use Ecto.Migration
+
+  # Reversed decision (v1.9.0 punch list): whether a group's label renders
+  # on its stacked tile is an explicit per-group operator choice — a
+  # dedicated flag, never inferred from label presence.
+  def change do
+    alter table(:recording_groups) do
+      add :show_label, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -395,6 +395,46 @@ defmodule Ambry.MediaTest do
 
       assert %{part_number: 1, parts_total: 3, recording_group: %{name: "Season One"}} = media
       assert [{"Season One", _id}] = Media.recording_groups_for_select(book_id)
+
+      # label visibility defaults to off — an explicit choice, never
+      # inferred from the label's presence
+      assert media.recording_group.show_label == false
+    end
+
+    test "the group's show_label flag is set at creation and toggled on rename" do
+      %{id: book_id} = insert(:book)
+
+      params =
+        :media
+        |> params_for(
+          book_id: book_id,
+          recording_group_choice: "new",
+          recording_group_name: "Season One",
+          recording_group_show_label: "true"
+        )
+        |> Map.take([
+          :abridged,
+          :full_cast,
+          :source_path,
+          :book_id,
+          :recording_group_choice,
+          :recording_group_name,
+          :recording_group_show_label
+        ])
+
+      assert {:ok, media} = Media.create_media(params)
+      assert media.recording_group.show_label == true
+
+      group_id = media.recording_group.id
+
+      # toggling off through the linked-group edit path
+      assert {:ok, _updated} =
+               Media.update_media(Media.get_media!(media.id), %{
+                 recording_group_choice: to_string(group_id),
+                 recording_group_show_label: "false"
+               })
+
+      assert Ambry.Repo.get!(Ambry.Media.RecordingGroup, group_id).show_label == false
     end
 
     test "links a sibling part to an existing group via the choice field" do

--- a/test/ambry_web/live/editions_ux_test.exs
+++ b/test/ambry_web/live/editions_ux_test.exs
@@ -243,6 +243,46 @@ defmodule AmbryWeb.EditionsUxTest do
     end
   end
 
+  describe "group label visibility" do
+    test "the label renders on group tiles only when the group opts in", %{conn: conn} do
+      book = insert(:book, title: "Dungeon Crawler Carl")
+
+      group =
+        insert(:recording_group,
+          name: "The Audio Immersion Experience — Season One",
+          show_label: true
+        )
+
+      [part_one | _rest] =
+        for n <- 1..2 do
+          insert(:media,
+            book: book,
+            part_number: n,
+            parts_total: 2,
+            recording_group: group,
+            status: :ready
+          )
+        end
+
+      other = insert(:media, book: book, status: :ready)
+
+      # library group tile shows the label
+      {:ok, _view, html} = live(conn, ~p"/")
+      assert html =~ "The Audio Immersion Experience — Season One"
+
+      # book page group tile shows it too
+      {:ok, _view, html} = live(conn, ~p"/books/#{book.id}")
+      assert html =~ "The Audio Immersion Experience — Season One"
+
+      # the audiobook page rail heading stays label-free (tile-only choice)
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{part_one.id}")
+      refute html =~ "The Audio Immersion Experience — Season One"
+
+      # sanity: another edition exists so the book page didn't redirect
+      assert other.status == :ready
+    end
+  end
+
   describe "custom part wording" do
     test "episode wording flows through labels and titles", %{conn: conn} do
       book = insert(:book, title: "Dungeon Crawler Carl")


### PR DESCRIPTION
**Stacked on #1163** (← #1162 ← #1161). The last piece of the tile redesign, implementing the reversed decision from the v1.9.0 punch list.

- `recording_groups.show_label` boolean (default **off**) — rendering the group label to listeners is an **active choice**, never a side effect of naming a group (the admin-organizational use of names stays free).
- Media form: the group section gains a "Show the group label to listeners on this set's stacked tile" checkbox, wired through both the create-group and linked-group-edit virtual paths (with the boolean handled alongside the existing fold-empty-to-nil string semantics).
- Edition tile: when the flag is on, the group name ("The Audio Immersion Experience — Season One") renders above the "N parts" line on the stacked tile — library, book page, Other Editions alike. The audiobook page's parts rail stays label-free (the decision is scoped to stacked tiles).
- Tests: changeset paths (create with flag, toggle via linked-group edit, default-off), and a UX test asserting the label appears on library + book-page tiles when opted in and nowhere when not (all pre-existing `refute "Season One"` assertions double as the default-off regression guard).

Full suite 679 passed; `mix check` clean.

## The full verification stack, bottom-up

#1161 (Other Editions landing) → #1162 (Edition model, user surfaces) → #1163 (admin flat views) → this. Merge in that order, no branch deletion mid-stack.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9