### PR TITLE
v1.9.0 punch list: sibling-part leak, rail group label, first-publication dates

### DIFF
--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -48,6 +48,25 @@ defmodule Ambry.Metadata.Provider do
       end
     end
 
+    @doc """
+    Demotes a full January-1st date to year-only display.
+
+    Goodreads-shaped sources (and Hardcover) encode "we only know the
+    year" as a literal `YYYY-01-01`, indistinguishable in the payload
+    from a real date — so a full Jan-1 date is far more likely year-only
+    knowledge than a genuine release day. The underlying date is kept;
+    the operator can flip the display format back per book when a
+    release really was January 1st.
+    """
+    def assume_jan1_is_year_only(nil), do: nil
+
+    def assume_jan1_is_year_only(
+          %__MODULE__{display_format: :full, date: %Date{month: 1, day: 1}} = published
+        ),
+        do: %{published | display_format: :year}
+
+    def assume_jan1_is_year_only(%__MODULE__{} = published), do: published
+
     defp new(year, month, day, display_format) do
       case Date.from_iso8601("#{year}-#{pad(month)}-#{pad(day)}") do
         {:ok, date} -> %__MODULE__{date: date, display_format: display_format}

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -62,8 +62,7 @@ defmodule Ambry.Metadata.Provider do
 
     def assume_jan1_is_year_only(
           %__MODULE__{display_format: :full, date: %Date{month: 1, day: 1}} = published
-        ),
-        do: %{published | display_format: :year}
+        ), do: %{published | display_format: :year}
 
     def assume_jan1_is_year_only(%__MODULE__{} = published), do: published
 

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -104,7 +104,7 @@ defmodule Ambry.Metadata.Providers.Hardcover do
          title: book["title"],
          description: presence(book["description"]),
          cover_url: get_in(book, ["image", "url"]),
-         published: Provider.PublishedDate.from_string(book["release_date"]),
+         published: published_date(book["release_date"]),
          authors: contributions_to_authors(book["contributions"]),
          series: book_series(book["book_series"])
        }}
@@ -225,7 +225,7 @@ defmodule Ambry.Metadata.Providers.Hardcover do
         title: doc["title"],
         description: presence(doc["description"]),
         cover_url: get_in(doc, ["image", "url"]),
-        published: Provider.PublishedDate.from_string(doc["release_date"]),
+        published: published_date(doc["release_date"]),
         authors: contributions_to_authors(doc["contributions"]),
         series: featured_series(doc["featured_series"])
       }
@@ -233,6 +233,12 @@ defmodule Ambry.Metadata.Providers.Hardcover do
   end
 
   defp search_hit_to_book(_hit), do: nil
+
+  defp published_date(raw) do
+    raw
+    |> Provider.PublishedDate.from_string()
+    |> Provider.PublishedDate.assume_jan1_is_year_only()
+  end
 
   # a null contribution role means "Author"; anything else (Cover Artist,
   # Illustrator, Translator, …) is not an author credit

--- a/lib/ambry/metadata/providers/rreading_glasses.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses.ex
@@ -199,8 +199,7 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
       description: best["Description"] || first_present(editions, "Description"),
       cover_url:
         full_size_image(presence(best["ImageUrl"]) || first_present(editions, "ImageUrl")),
-      published:
-        Provider.PublishedDate.from_string(work["ReleaseDateRaw"] || best["ReleaseDateRaw"]),
+      published: work_published(work, editions),
       publisher: presence(best["Publisher"]),
       language: presence(best["Language"]),
       format: presence(best["Format"]),
@@ -209,6 +208,19 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
       series: series(work),
       editions: Enum.map(editions, &edition/1)
     }
+  end
+
+  # Book.published means the work's ORIGINAL publication date, never a
+  # specific edition's. The work-level ReleaseDateRaw carries it (verified
+  # live 2026-08-02: The Hobbit 1937-09-21, The Martian 2011-09-27 self-pub
+  # vs its 2014 Crown edition, Eragon 2002-06-01 vs 2005 hits); when a work
+  # lacks one, the earliest edition date is the closest safe approximation.
+  defp work_published(work, editions) do
+    Provider.PublishedDate.from_string(work["ReleaseDateRaw"]) ||
+      editions
+      |> Enum.map(&Provider.PublishedDate.from_string(&1["ReleaseDateRaw"]))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.min_by(& &1.date, Date, fn -> nil end)
   end
 
   defp best_edition(editions, preferred_edition_id, best_book_id) do

--- a/lib/ambry/metadata/providers/rreading_glasses.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses.ex
@@ -216,11 +216,17 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
   # vs its 2014 Crown edition, Eragon 2002-06-01 vs 2005 hits); when a work
   # lacks one, the earliest edition date is the closest safe approximation.
   defp work_published(work, editions) do
-    Provider.PublishedDate.from_string(work["ReleaseDateRaw"]) ||
+    published_date(work["ReleaseDateRaw"]) ||
       editions
-      |> Enum.map(&Provider.PublishedDate.from_string(&1["ReleaseDateRaw"]))
+      |> Enum.map(&published_date(&1["ReleaseDateRaw"]))
       |> Enum.reject(&is_nil/1)
       |> Enum.min_by(& &1.date, Date, fn -> nil end)
+  end
+
+  defp published_date(raw) do
+    raw
+    |> Provider.PublishedDate.from_string()
+    |> Provider.PublishedDate.assume_jan1_is_year_only()
   end
 
   defp best_edition(editions, preferred_edition_id, best_book_id) do
@@ -268,7 +274,7 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
       language: presence(edition["Language"]),
       format: presence(edition["Format"]),
       publisher: presence(edition["Publisher"]),
-      published: Provider.PublishedDate.from_string(edition["ReleaseDateRaw"]),
+      published: published_date(edition["ReleaseDateRaw"]),
       cover_url: edition["ImageUrl"] |> presence() |> full_size_image()
     }
   end

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -115,7 +115,7 @@
       <div :if={group_name_mode(@form, @media)} class="grid grid-cols-1 gap-6 sm:grid-cols-3 sm:gap-2">
         <.input
           field={@form[:recording_group_name]}
-          label="Group label (optional; admin-only unless shown below)"
+          label="Group label (optional)"
           value={group_field_value(@form, @media, :recording_group_name, :name)}
         />
         <.input

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -115,7 +115,7 @@
       <div :if={group_name_mode(@form, @media)} class="grid grid-cols-1 gap-6 sm:grid-cols-3 sm:gap-2">
         <.input
           field={@form[:recording_group_name]}
-          label="Group label (admin-only; optional)"
+          label="Group label (optional; admin-only unless shown below)"
           value={group_field_value(@form, @media, :recording_group_name, :name)}
         />
         <.input

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -79,9 +79,18 @@ defmodule AmbryWeb.AudiobookLive do
           </section>
 
           <%= if @part_set do %>
-            <h2 class="mt-6 mb-2 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
-              {part_set_label(@part_set)}
-            </h2>
+            <%= if @part_set.show_label && @part_set.name do %>
+              <h2 class="mt-6 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                {@part_set.name}
+              </h2>
+              <p class="mb-2 text-sm text-zinc-600 dark:text-zinc-400">
+                {part_set_label(@part_set)}
+              </p>
+            <% else %>
+              <h2 class="mt-6 mb-2 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                {part_set_label(@part_set)}
+              </h2>
+            <% end %>
             <div class="grid grid-cols-3 gap-4 sm:gap-6">
               <div :for={part <- @part_set.media} class="text-center">
                 <%= if part.id == @media.id do %>
@@ -153,13 +162,16 @@ defmodule AmbryWeb.AudiobookLive do
         end
 
       # true alternates only: every other edition of the book, minus this
-      # media's own part set (its parts live in the rail above)
+      # media's own part set (its parts live in the rail above). Siblings are
+      # dropped before grouping — book.media already excludes the current
+      # media, and a lone leftover part would otherwise present as a single
+      # edition (one-part groups collapse) and sneak past a post-hoc reject.
       other_editions =
         media.book.media
-        |> Editions.from_media()
         |> Enum.reject(
-          &(&1.kind == :group and &1.group != nil and &1.group.id == media.recording_group_id)
+          &(media.recording_group_id && &1.recording_group_id == media.recording_group_id)
         )
+        |> Editions.from_media()
 
       {:ok,
        assign(socket,
@@ -179,8 +191,8 @@ defmodule AmbryWeb.AudiobookLive do
     Ambry.Media.Media.part_label(part, group) || part.title || "Untitled"
   end
 
-  # "Part 2 of 3" / "Episode 4 of 6" / nil — the group name is admin-only
-  # and deliberately not shown
+  # "Part 2 of 3" / "Episode 4 of 6" / nil — the group name renders in the
+  # parts-rail heading (when the group opts in via show_label), not here
   defp part_set_line(media) do
     Ambry.Media.Media.part_label(media)
   end

--- a/test/ambry/metadata/providers/hardcover_test.exs
+++ b/test/ambry/metadata/providers/hardcover_test.exs
@@ -86,6 +86,24 @@ defmodule Ambry.Metadata.Providers.HardcoverTest do
       assert [%Provider.Series{name: "Some Series", number: "10.5"}] = book.series
     end
 
+    test "a full January 1st date reads as year-only display" do
+      patch(Client, :query, fn _config, _query, %{id: 1} ->
+        {:ok,
+         %{
+           "books_by_pk" => %{
+             "id" => 1,
+             "title" => "Year Only Book",
+             "release_date" => "2021-01-01",
+             "book_series" => [],
+             "contributions" => []
+           }
+         }}
+      end)
+
+      assert {:ok, %Provider.Book{published: published}} = Hardcover.book_details("1", %{})
+      assert %Provider.PublishedDate{date: ~D[2021-01-01], display_format: :year} = published
+    end
+
     test "missing books are not_found" do
       patch(Client, :query, fn _config, _query, _vars -> {:ok, %{"books_by_pk" => nil}} end)
 

--- a/test/ambry/metadata/providers/rreading_glasses_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses_test.exs
@@ -108,6 +108,29 @@ defmodule Ambry.Metadata.Providers.RreadingGlassesTest do
       assert %Provider.PublishedDate{date: ~D[2011-09-27]} = published
     end
 
+    test "a full January 1st date reads as year-only display" do
+      # Goodreads-shaped data encodes year-only knowledge as a literal
+      # YYYY-01-01 (e.g. Project Hail Mary), indistinguishable from a
+      # real date — assume year-only rather than display a made-up Jan 1
+      work = %{
+        "ForeignId" => 1,
+        "Title" => "Project Hail Mary",
+        "ReleaseDateRaw" => "2021-01-01",
+        "BestBookId" => 5,
+        "Books" => [%{"ForeignId" => 5, "ReleaseDateRaw" => "2021-05-04", "ImageUrl" => "x"}]
+      }
+
+      patch(Client, :get_json, fn _base, "/work/1", [] -> {:ok, work} end)
+
+      assert {:ok, %Provider.Book{published: published, editions: [edition]}} =
+               RreadingGlasses.book_details("1", %{})
+
+      assert %Provider.PublishedDate{date: ~D[2021-01-01], display_format: :year} = published
+      # a real non-Jan-1 edition date keeps full display
+      assert %Provider.PublishedDate{date: ~D[2021-05-04], display_format: :full} =
+               edition.published
+    end
+
     test "no date at all yields nil" do
       work = %{
         "ForeignId" => 1,

--- a/test/ambry/metadata/providers/rreading_glasses_test.exs
+++ b/test/ambry/metadata/providers/rreading_glasses_test.exs
@@ -71,6 +71,56 @@ defmodule Ambry.Metadata.Providers.RreadingGlassesTest do
     end
   end
 
+  describe "published dates" do
+    # Book.published means the work's ORIGINAL publication date, never a
+    # specific edition's (ROADMAP hard rule)
+    test "prefers the work-level date over the chosen edition's" do
+      work = %{
+        "ForeignId" => 1,
+        "Title" => "The Martian",
+        "ReleaseDateRaw" => "2011-09-27",
+        "BestBookId" => 5,
+        "Books" => [%{"ForeignId" => 5, "ReleaseDateRaw" => "2014-02-11", "ImageUrl" => "x"}]
+      }
+
+      patch(Client, :get_json, fn _base, "/work/1", [] -> {:ok, work} end)
+
+      assert {:ok, %Provider.Book{published: published}} = RreadingGlasses.book_details("1", %{})
+      assert %Provider.PublishedDate{date: ~D[2011-09-27], display_format: :full} = published
+    end
+
+    test "falls back to the earliest edition date when the work carries none" do
+      work = %{
+        "ForeignId" => 1,
+        "Title" => "Undated Work",
+        "ReleaseDateRaw" => "",
+        "BestBookId" => 5,
+        "Books" => [
+          %{"ForeignId" => 5, "ReleaseDateRaw" => "2014-02-11", "ImageUrl" => "x"},
+          %{"ForeignId" => 6, "ReleaseDateRaw" => "2011-09-27"},
+          %{"ForeignId" => 7}
+        ]
+      }
+
+      patch(Client, :get_json, fn _base, "/work/1", [] -> {:ok, work} end)
+
+      assert {:ok, %Provider.Book{published: published}} = RreadingGlasses.book_details("1", %{})
+      assert %Provider.PublishedDate{date: ~D[2011-09-27]} = published
+    end
+
+    test "no date at all yields nil" do
+      work = %{
+        "ForeignId" => 1,
+        "Title" => "Undated Work",
+        "Books" => [%{"ForeignId" => 5}]
+      }
+
+      patch(Client, :get_json, fn _base, "/work/1", [] -> {:ok, work} end)
+
+      assert {:ok, %Provider.Book{published: nil}} = RreadingGlasses.book_details("1", %{})
+    end
+  end
+
   describe "search_authors/2" do
     test "hydrates distinct author ids from book search" do
       search = fixture("rreading_glasses_search.json")

--- a/test/ambry_web/live/editions_ux_test.exs
+++ b/test/ambry_web/live/editions_ux_test.exs
@@ -147,7 +147,8 @@ defmodule AmbryWeb.EditionsUxTest do
 
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{part_two.id}")
 
-      # rail with heading and links to sibling parts (group name is admin-only)
+      # rail with heading and links to sibling parts (no show_label opt-in,
+      # so the group name stays hidden)
       assert html =~ "3 parts"
       refute html =~ "Season One"
       assert html =~ ~p"/audiobooks/#{part_one.id}"
@@ -158,6 +159,20 @@ defmodule AmbryWeb.EditionsUxTest do
 
       # sibling parts appear exactly once (in the rail)
       assert html |> String.split(~p"/audiobooks/#{part_one.id}") |> length() == 2
+    end
+
+    test "a lone sibling part stays in the rail, not Other Editions", %{conn: conn} do
+      # regression: book.media excludes the current media, so a 2-part set
+      # leaves ONE sibling — which collapses to a single edition (one-part
+      # groups present as singles) and used to leak into Other Editions
+      book = insert(:book)
+      [part_one, part_two] = insert_part_set(book, count: 2)
+
+      {:ok, _view, html} = live(conn, ~p"/audiobooks/#{part_one.id}")
+
+      refute html =~ "Other Editions"
+      # the sibling links exactly once — from the rail
+      assert html |> String.split(~p"/audiobooks/#{part_two.id}") |> length() == 2
     end
 
     test "no rail or Other Editions for a lone single-part recording", %{conn: conn} do
@@ -274,9 +289,9 @@ defmodule AmbryWeb.EditionsUxTest do
       {:ok, _view, html} = live(conn, ~p"/books/#{book.id}")
       assert html =~ "The Audio Immersion Experience — Season One"
 
-      # the audiobook page rail heading stays label-free (tile-only choice)
+      # the audiobook page rail heading shows it under the same opt-in
       {:ok, _view, html} = live(conn, ~p"/audiobooks/#{part_one.id}")
-      refute html =~ "The Audio Immersion Experience — Season One"
+      assert html =~ "The Audio Immersion Experience — Season One"
 
       # sanity: another edition exists so the book page didn't redirect
       assert other.status == :ready


### PR DESCRIPTION
The last three items before tagging v1.9.0.

## 1. Other Editions no longer shows sibling parts (bug fix)

On an audiobook page for a part of a group, `book.media` excludes the current media SQL-side. For a 2-part set (or any set with exactly one *other* ready part), the lone leftover sibling collapsed to a `:single` edition (one-part groups present as singles, by design) and slipped past the group-id-based reject — rendering the sibling under **Other Editions** even though it already lives in the parts rail.

Fix: drop same-group siblings by `recording_group_id` *before* `Editions.from_media/1`, replacing the post-hoc reject. Regression test verified to fail against the old code.

## 2. Group name in the parts-rail heading (show_label completion)

The per-group `show_label` flag (#1164) rendered the name on group tiles (library, book page, Other Editions, search) but not on the set's own audiobook page — the rail heading always said just "3 parts" / "6 episodes". The rail heading now shows the group name (count beneath it) under the **same per-group opt-in**; groups without the flag are unchanged. Stale "admin-only" wording updated in the media-form label and comments.

Note: this updates the #1164 test that asserted the rail stays label-free ("tile-only choice") — showing the set's name everywhere-or-nowhere per the flag seemed like the honest reading of "have the name visible to users"; easy to revert if the tile-only behavior was intentional.

## 3. rreading-glasses first-publication dates (investigated + hardened)

Spot-checked live against `api.bookinfo.pro` (both `/work/{id}` and the `/book/bulk` search-hydration path):

| Book | Work-level date | Known first pub | Hit edition's date |
|---|---|---|---|
| The Hobbit | 1937-09-21 | 1937-09-21 | 2002-08-15 |
| The Martian | 2011-09-27 | 2011 self-pub | 2014-02-11 (Crown) |
| Eragon | 2002-06-01 | 2002 self-pub | 2005-06-01 |
| The Eye of the World | 1990-01-15 | 1990-01-15 | 1990-11-15 |

**The work-level `ReleaseDateRaw` IS the true original-publication date**, and the provider already preferred it (0/40 works missing it in a LitRPG-heavy sweep). Also verified end-to-end through the running server's provider code. Two payload-shape holes fixed anyway, per the `Book.published` hard rule:

- the missing-work-date fallback used the **chosen edition's** date → now min-over-editions
- an empty-string work date short-circuited `||` and suppressed any date → handled

Follow-up commit: Goodreads year-only knowledge arrives as `YYYY-01-01` (Project Hail Mary → "2021-01-01"), indistinguishable from a real date in the payload — both work-level providers now demote a full Jan-1 date to **year-only display** (restoring the operator's old manual habit as a heuristic; the date itself is kept and the display format stays per-book editable). Also shortened the group-label form label, which overflowed into the part-word field.

Still recorded in the ROADMAP annotation: searching "<title> GraphicAudio" can match the adaptation's *own work*, whose original date is legitimately the GA release. Hardcover verified in code: maps work-level `release_date`, never an edition's.

`mix check` clean, 683 tests passing.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9
