### PR TITLE
Composite authors: prose name joining + co-writer credits

### DIFF
--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -36,7 +36,11 @@ defmodule Ambry.People do
   alias Ambry.Thumbnails
   alias Ambry.Thumbnails.GenerateThumbnails
 
-  @person_direct_assoc_preloads [:authors, :narrators, author_people: [author: :people]]
+  @person_direct_assoc_preloads [
+    :narrators,
+    authors: :people,
+    author_people: [author: :people]
+  ]
 
   def person_standard_preloads, do: @person_direct_assoc_preloads
 

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1387,6 +1387,37 @@ defmodule AmbryWeb.CoreComponents do
   end
 
   @doc """
+  Renders links to people's person pages joined as prose: "A", "A and B",
+  "A, B, and C".
+  """
+  attr :people, :list, required: true
+
+  def person_name_links(assigns) do
+    count = length(assigns.people)
+
+    assigns =
+      assign(
+        assigns,
+        :separated_people,
+        Enum.with_index(assigns.people, fn person, index ->
+          {prose_separator(index, count), person}
+        end)
+      )
+
+    ~H"""
+    <span :for={{separator, person} <- @separated_people} phx-no-format><%= separator %><.link
+        navigate={~p"/people/#{person}"}
+        class="hover:underline"
+      ><%= person.name %></.link></span>
+    """
+  end
+
+  defp prose_separator(0, _count), do: ""
+  defp prose_separator(1, 2), do: " and "
+  defp prose_separator(index, count) when index == count - 1, do: ", and "
+  defp prose_separator(_index, _count), do: ", "
+
+  @doc """
   Renders a list of links to people (like authors or narrators) separated by
   commas.
 

--- a/lib/ambry_web/live/author_live.ex
+++ b/lib/ambry_web/live/author_live.ex
@@ -36,12 +36,7 @@ defmodule AmbryWeb.AuthorLive do
             <% end %>
           </h1>
           <p :if={pen_name_people(@author) != []} class="mt-2 text-zinc-500">
-            a pen name of <.link
-              :for={person <- pen_name_people(@author)}
-              navigate={~p"/people/#{person}"}
-              class="hover:underline"
-              phx-no-format
-            ><%= person.name %></.link><span class="last:hidden">,</span>
+            a pen name of <.person_name_links people={pen_name_people(@author)} />
           </p>
         </div>
       </div>

--- a/lib/ambry_web/live/person_live.ex
+++ b/lib/ambry_web/live/person_live.ex
@@ -129,9 +129,21 @@ defmodule AmbryWeb.PersonLive do
     """
   end
 
+  # "Ty Franck as James S.A. Corey" — or, when the pen name is shared,
+  # "Ty Franck with Daniel Abraham as James S.A. Corey"
   defp author_name(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :co_writers,
+        Enum.reject(assigns.author.people, &(&1.id == assigns.person.id))
+      )
+
     ~H"""
-    {@person.name} as <.link navigate={~p"/authors/#{@author}"} class="hover:underline">{@author.name}</.link>
+    {@person.name}<span :if={@co_writers != []} phx-no-format> with <.person_name_links
+        people={@co_writers}
+      /></span> as
+    <.link navigate={~p"/authors/#{@author}"} class="hover:underline">{@author.name}</.link>
     """
   end
 

--- a/test/ambry_web/live/author_live_test.exs
+++ b/test/ambry_web/live/author_live_test.exs
@@ -28,6 +28,17 @@ defmodule AmbryWeb.AuthorLiveTest do
     assert html =~ html_escape(author.name)
   end
 
+  test "a composite author page joins its people's names in prose", %{conn: conn} do
+    abraham = insert(:person, name: "Daniel Abraham")
+    franck = insert(:person, name: "Ty Franck")
+    author = insert(:author, name: "James S.A. Corey", people: [abraham, franck])
+
+    {:ok, _view, html} = live(conn, ~p"/authors/#{author.id}")
+
+    text = html |> Floki.parse_document!() |> Floki.text() |> String.replace(~r/\s+/, " ")
+    assert text =~ "a pen name of Daniel Abraham and Ty Franck"
+  end
+
   test "renders a narrator page with no narrated media", %{conn: conn} do
     narrator = insert(:narrator, person: build(:person))
 

--- a/test/ambry_web/live/person_live_test.exs
+++ b/test/ambry_web/live/person_live_test.exs
@@ -20,6 +20,19 @@ defmodule AmbryWeb.PersonLiveTest do
     assert html =~ html_escape(book.title)
   end
 
+  test "a composite pen name's section credits the co-writers", %{conn: conn} do
+    abraham = insert(:person, name: "Daniel Abraham")
+    franck = insert(:person, name: "Ty Franck")
+    author = insert(:author, name: "James S.A. Corey", people: [abraham, franck])
+    book = insert(:book, book_authors: [build(:book_author, author: author)])
+    insert(:media, book: book, status: :ready)
+
+    {:ok, _view, html} = live(conn, ~p"/people/#{franck.id}")
+
+    text = html |> Floki.parse_document!() |> Floki.text() |> String.replace(~r/\s+/, " ")
+    assert text =~ "Written by Ty Franck with Daniel Abraham as James S.A. Corey"
+  end
+
   test "renders a person show page with narrated books", %{conn: conn} do
     media =
       insert(:media,


### PR DESCRIPTION
Two small fixes on the composite-author surfaces (both shipped with v1.9.0's composite-author work, so worth merging before the tag if it hasn't been cut yet):

**Bug — author page pen-name line ran names together** ("a pen name of Daniel AbrahamTy Franck"): the comma `<span class="last:hidden">,</span>` sat *outside* the `:for` loop, so it rendered once after all the links — and, being the last child, was hidden. Replaced with a new shared `person_name_links` component that joins person-page links as prose: "A", "A and B", "A, B, and C".

**Enhancement — person page credits co-writers of a shared pen name**: Ty Franck's section header now reads "Written by Ty Franck **with Daniel Abraham** as James S.A. Corey" (co-writer names link to their person pages). Symmetric on Daniel Abraham's page. Solo pen names are unchanged. `Person` preloads now carry `authors: :people` to feed this.

Tests assert the rendered prose via Floki text extraction (whitespace-normalized, so heex reflows can't break them). `mix check` clean, 687 tests passing.

https://claude.ai/code/session_013Fe6wyFZ9chpUVnGDqyqY9