### PR TITLE
Phase 2a: the ffprobe scan step

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -36,6 +36,8 @@ defmodule Ambry.Media do
   alias Ambry.Media.PubSub.MediaUpdated
   alias Ambry.Media.RecordingGroup
   alias Ambry.Media.RunProcessor
+  alias Ambry.Media.RunScan
+  alias Ambry.Media.Scanner
   alias Ambry.Paths
   alias Ambry.PubSub
   alias Ambry.Repo
@@ -356,6 +358,23 @@ defmodule Ambry.Media do
   def run_processor_async(%Media{} = media, processor) do
     %{media_id: media.id, processor: processor}
     |> RunProcessor.new()
+    |> Oban.insert()
+  end
+
+  @doc """
+  Scans a media's source files into direct-play tracks.
+
+  Delegates to `Ambry.Media.Scanner`; returns `{:ok, media}` or
+  `{:error, reason}`.
+  """
+  defdelegate scan_media(media), to: Scanner, as: :scan
+
+  @doc """
+  Scans a media's source files asynchronously.
+  """
+  def scan_media_async(%Media{} = media) do
+    %{media_id: media.id}
+    |> RunScan.new()
     |> Oban.insert()
   end
 

--- a/lib/ambry/media/run_scan.ex
+++ b/lib/ambry/media/run_scan.ex
@@ -1,0 +1,28 @@
+defmodule Ambry.Media.RunScan do
+  @moduledoc """
+  Direct-play media scan Oban job.
+  """
+
+  use Oban.Worker,
+    queue: :media,
+    max_attempts: 1
+
+  alias Ambry.Media
+  alias Ambry.Media.Scanner
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"media_id" => id}}) do
+    media = Media.get_media!(id)
+
+    case Scanner.scan(media) do
+      {:ok, _media} = success ->
+        success
+
+      {:error, reason} = error ->
+        Logger.warning(fn -> "Scan failed for media #{id}: #{inspect(reason)}" end)
+        error
+    end
+  end
+end

--- a/lib/ambry/media/scanner.ex
+++ b/lib/ambry/media/scanner.ex
@@ -1,0 +1,98 @@
+defmodule Ambry.Media.Scanner do
+  @moduledoc """
+  Scans a media's source files and records what they are, instead of
+  transcoding them into something else.
+
+  This is the direct-play import step: the files are probed, never copied,
+  rewritten, or repackaged, and what comes back is written as the media's
+  ordered `media_tracks` plus a total duration for the book timeline.
+
+  Scanning does not publish: a scanned media keeps whatever status it had, so
+  this can run over the existing library without changing what clients see.
+  Only the inbox approval flow (Phase 3) makes a direct-play media `ready`.
+
+  Direct-play v1 handles single-file recordings only. A folder of 40 mp3s is
+  reported as `{:error, :multi_file_unsupported}` rather than silently
+  concatenated — the tracks model is ready for it, the player isn't (see the
+  roadmap's 2f).
+  """
+
+  alias Ambry.Media, as: MediaContext
+  alias Ambry.Media.Media
+  alias Ambry.Media.Scanner.Probe
+
+  @extensions ~w(.mp3 .mp4 .m4a .m4b .flac .ogg .opus .wav)
+
+  @doc """
+  Scans a media's source files, replacing its tracks with what's on disk.
+
+  Returns `{:ok, media}` with the updated media, or `{:error, reason}`.
+  """
+  def scan(%Media{} = media) do
+    with {:ok, path} <- single_file(media),
+         {:ok, probe} <- Probe.run(path) do
+      write_tracks(media, probe)
+    end
+  end
+
+  @doc """
+  The audio file extensions direct-play can serve.
+  """
+  def extensions, do: @extensions
+
+  # v1 is single-file; the tracks model is multi-file-shaped for later.
+  defp single_file(media) do
+    case files(media) do
+      [file] -> {:ok, file}
+      [] -> {:error, :no_audio_files}
+      [_ | _] -> {:error, :multi_file_unsupported}
+    end
+  end
+
+  # `Media.files/2` yields names relative to the source folder for media that
+  # recorded `source_files`, and absolute paths for the older ones that
+  # didn't.
+  defp files(media) do
+    media
+    |> Media.files(@extensions)
+    |> Enum.map(fn file ->
+      if Path.type(file) == :absolute, do: file, else: Media.source_path(media, file)
+    end)
+  end
+
+  defp write_tracks(media, %Probe{} = probe) do
+    attrs =
+      %{
+        media_tracks: [track_attrs(probe)],
+        duration: probe.duration
+      }
+      |> maybe_put_chapters(media, probe)
+
+    MediaContext.update_media(media, attrs)
+  end
+
+  defp track_attrs(%Probe{} = probe) do
+    %{
+      index: 0,
+      path: probe.path,
+      size: probe.size,
+      mime: probe.mime,
+      format: probe.format,
+      codec: probe.codec,
+      duration: probe.duration,
+      # single-track v1: the file *is* the whole book timeline
+      start_offset: 0,
+      seek_accuracy: probe.seek_accuracy
+    }
+  end
+
+  # Embedded markers are only offered to a media that has none. Chapters are
+  # curated data, and the merge that pours provider titles onto file-derived
+  # markers is its own piece of work (the roadmap's 1h) — until it exists,
+  # scanning must never overwrite what an operator has already confirmed.
+  defp maybe_put_chapters(attrs, %Media{chapters: []}, %Probe{chapters: [_ | _] = chapters}) do
+    Map.put(attrs, :chapters, chapters)
+  end
+
+  defp maybe_put_chapters(attrs, _media, _probe), do: attrs
+end

--- a/lib/ambry/media/scanner/probe.ex
+++ b/lib/ambry/media/scanner/probe.ex
@@ -1,0 +1,229 @@
+defmodule Ambry.Media.Scanner.Probe do
+  @moduledoc """
+  Reads what an audio file actually *is*: container, codec, size, duration,
+  and any embedded chapter markers.
+
+  This is the direct-play replacement for transcoding: nothing is decoded,
+  repackaged, or written — the file is measured and left alone.
+
+  ## Durations
+
+  `Ambry.Media.Processor.Shared.get_inaccurate_duration/1` trusts whatever the
+  container claims, which is only safe for the MP4s that pipeline produced
+  itself. Source files are not so cooperative: a VBR mp3 with no Xing/VBRI
+  header has no duration to report, so ffprobe extrapolates one from the first
+  frame's bitrate and can be minutes wrong over a long book.
+
+  So the container's word is taken only for formats that genuinely know
+  (MP4/M4B sample tables, FLAC's STREAMINFO, Ogg granule positions, WAV's
+  fixed byte rate, Matroska's header). Everything else is decode-counted once,
+  here at scan time, and the gap between the claimed and the real duration is
+  the tell for seek accuracy: a container that guessed the length wrong has no
+  index to seek by either, which is exactly the VBR-mp3-without-Xing case.
+  """
+
+  alias Ambry.Media.Chapters.Utils
+
+  require Logger
+
+  @enforce_keys [:path, :size, :duration, :seek_accuracy]
+  defstruct [
+    :path,
+    :size,
+    :format,
+    :codec,
+    :mime,
+    :duration,
+    :seek_accuracy,
+    chapters: []
+  ]
+
+  # containers whose reported duration is derived from real indexing data
+  @indexed_formats ~w(mov,mp4,m4a,3gp,3g2,mj2 flac ogg wav matroska,webm)
+
+  @mime_types %{
+    ".aac" => "audio/aac",
+    ".flac" => "audio/flac",
+    ".m4a" => "audio/mp4",
+    ".m4b" => "audio/mp4",
+    ".mp3" => "audio/mpeg",
+    ".mp4" => "audio/mp4",
+    ".oga" => "audio/ogg",
+    ".ogg" => "audio/ogg",
+    ".opus" => "audio/ogg",
+    ".wav" => "audio/wav"
+  }
+
+  # a duration this far off the real one means the container was guessing
+  @tolerance_seconds Decimal.new("1")
+  @tolerance_fraction Decimal.new("0.005")
+
+  @doc """
+  Probes a single audio file.
+
+  Returns `{:ok, %Probe{}}`, or `{:error, reason}` if the file can't be read
+  or carries no audio stream we can measure.
+  """
+  def run(path) do
+    with {:ok, %File.Stat{size: size}} <- File.stat(path),
+         {:ok, json} <- ffprobe(path),
+         {:ok, data} <- decode(json) do
+      build(path, size, data)
+    end
+  end
+
+  defp build(path, size, data) do
+    format = data["format"] || %{}
+
+    case duration(path, format) do
+      nil ->
+        {:error, :no_duration}
+
+      {duration, seek_accuracy} ->
+        {:ok,
+         %__MODULE__{
+           path: path,
+           size: size,
+           format: format["format_name"],
+           codec: audio_codec(data),
+           mime: mime_type(path),
+           duration: duration,
+           seek_accuracy: seek_accuracy,
+           chapters: chapters(data)
+         }}
+    end
+  end
+
+  defp duration(path, format) do
+    claimed = decimal(format["duration"])
+
+    if format["format_name"] in @indexed_formats do
+      claimed && {claimed, :exact}
+    else
+      decode_counted(path, claimed)
+    end
+  end
+
+  defp decode_counted(path, claimed) do
+    case decoded_duration(path) do
+      {:ok, decoded} -> {decoded, seek_accuracy(claimed, decoded)}
+      :error -> claimed && {claimed, :approximate}
+    end
+  end
+
+  # A container that got the length right was reading an index; one that
+  # guessed can't seek accurately either.
+  defp seek_accuracy(nil, _decoded), do: :approximate
+
+  defp seek_accuracy(claimed, decoded) do
+    tolerance = Decimal.max(@tolerance_seconds, Decimal.mult(decoded, @tolerance_fraction))
+
+    if claimed |> Decimal.sub(decoded) |> Decimal.abs() |> Decimal.compare(tolerance) == :gt do
+      :approximate
+    else
+      :exact
+    end
+  end
+
+  defp audio_codec(data) do
+    data
+    |> Map.get("streams", [])
+    |> Enum.find(%{}, &(&1["codec_type"] == "audio"))
+    |> Map.get("codec_name")
+  end
+
+  defp mime_type(path) do
+    Map.get(@mime_types, path |> Path.extname() |> String.downcase())
+  end
+
+  defp chapters(data) do
+    case Utils.adapt_ffmpeg_chapters(data) do
+      {:ok, chapters} -> chapters
+      {:error, _reason} -> []
+    end
+  end
+
+  defp ffprobe(path) do
+    run_command("ffprobe", [
+      "-i",
+      path,
+      "-print_format",
+      "json",
+      "-show_format",
+      "-show_streams",
+      "-show_chapters",
+      "-v",
+      "quiet"
+    ])
+  end
+
+  # Decodes the whole file without writing anything, asking ffmpeg to report
+  # its progress in microseconds; the last report is the real duration.
+  defp decoded_duration(path) do
+    case run_command("ffmpeg", [
+           "-i",
+           path,
+           "-vn",
+           "-v",
+           "quiet",
+           "-f",
+           "null",
+           "-progress",
+           "pipe:1",
+           "-"
+         ]) do
+      {:ok, output} -> parse_progress_duration(output)
+      {:error, _reason} -> :error
+    end
+  end
+
+  defp parse_progress_duration(output) do
+    case Regex.scan(~r/^out_time_us=(\d+)$/m, output) do
+      [] ->
+        Logger.warning(fn -> "No duration reported while decoding" end)
+        :error
+
+      matches ->
+        [_match, microseconds] = List.last(matches)
+
+        {:ok, microseconds |> Decimal.new() |> Decimal.div(1_000_000) |> Decimal.round(6)}
+    end
+  end
+
+  defp run_command(command, args) do
+    Logger.info(fn -> "Running `#{command} #{Enum.join(args, " ")}`" end)
+
+    case System.cmd(command, args, parallelism: true, stderr_to_stdout: false) do
+      {output, 0} ->
+        {:ok, output}
+
+      {output, code} ->
+        Logger.warning(fn -> "#{command} failed. Code: #{code}, Output: #{output}" end)
+        {:error, :probe_failed}
+    end
+  rescue
+    error in ErlangError ->
+      Logger.warning(fn -> "Couldn't run #{command}: #{inspect(error)}" end)
+      {:error, :probe_failed}
+  end
+
+  defp decode(json) do
+    case Jason.decode(json) do
+      {:ok, data} ->
+        {:ok, data}
+
+      {:error, error} ->
+        Logger.warning(fn -> "ffprobe json decode failed: #{inspect(error)}" end)
+        {:error, :invalid_json}
+    end
+  end
+
+  defp decimal(nil), do: nil
+
+  defp decimal(string) do
+    case Decimal.parse(string) do
+      {decimal, ""} -> if Decimal.positive?(decimal), do: decimal
+      _unparseable -> nil
+    end
+  end
+end

--- a/test/ambry/media/scanner/probe_test.exs
+++ b/test/ambry/media/scanner/probe_test.exs
@@ -1,0 +1,131 @@
+defmodule Ambry.Media.Scanner.ProbeTest do
+  use Ambry.DataCase
+
+  alias Ambry.Media.Scanner.Probe
+
+  describe "run/1" do
+    test "reports the container and codec as they are" do
+      assert {:ok, probe} = Probe.run(valid_audio(:m4a))
+
+      assert probe.format == "mov,mp4,m4a,3gp,3g2,mj2"
+      assert probe.codec == "aac"
+      assert probe.mime == "audio/mp4"
+      assert probe.size == File.stat!(valid_audio(:m4a)).size
+    end
+
+    test "identifies each container direct-play serves" do
+      for {type, codec, mime} <- [
+            {:m4a, "aac", "audio/mp4"},
+            {:mp3, "mp3", "audio/mpeg"},
+            {:flac, "flac", "audio/flac"},
+            {:ogg, "vorbis", "audio/ogg"},
+            {:opus, "opus", "audio/ogg"},
+            {:wav, "pcm_s16le", "audio/wav"}
+          ] do
+        assert {:ok, probe} = Probe.run(valid_audio(type))
+        assert probe.codec == codec, "wrong codec for #{type}: #{probe.codec}"
+        assert probe.mime == mime, "wrong mime for #{type}: #{probe.mime}"
+        assert Decimal.compare(probe.duration, 0) == :gt
+      end
+    end
+
+    test "returns an error for a file that isn't there" do
+      assert {:error, :enoent} = Probe.run("/nonexistent/book.m4b")
+    end
+
+    @tag :capture_log
+    test "returns an error for a file with no audio in it" do
+      path = Path.join(tmp_dir(), "not-audio.mp3")
+      File.write!(path, "this is not an mp3")
+
+      assert {:error, _reason} = Probe.run(path)
+    end
+  end
+
+  describe "run/1 seek accuracy" do
+    test "an indexed container seeks exactly" do
+      assert {:ok, probe} = Probe.run(valid_audio(:m4a))
+
+      assert probe.seek_accuracy == :exact
+    end
+
+    test "a VBR mp3 with a Xing index seeks exactly" do
+      assert {:ok, probe} = :xing |> vbr_mp3() |> Probe.run()
+
+      assert probe.seek_accuracy == :exact
+      # the index tells the truth, so the decoded length agrees with it
+      assert_in_seconds(probe.duration, 30, 1)
+    end
+
+    test "a VBR mp3 without one is flagged as approximate" do
+      assert {:ok, probe} = :no_xing |> vbr_mp3() |> Probe.run()
+
+      assert probe.seek_accuracy == :approximate
+      # and the duration is the decoded one, not the container's ~5% guess
+      assert_in_seconds(probe.duration, 30, 1)
+    end
+  end
+
+  defp assert_in_seconds(actual, expected, tolerance) do
+    assert actual |> Decimal.sub(expected) |> Decimal.abs() |> Decimal.compare(tolerance) != :gt,
+           "expected #{actual} to be within #{tolerance}s of #{expected}"
+  end
+
+  # Two very different 15s halves, encoded at the lowest LAME quality, so the
+  # bitrate really does vary and a missing Xing header really does mislead
+  # whoever reads the first frame.
+  defp vbr_mp3(:xing), do: build_vbr_mp3()
+
+  defp vbr_mp3(:no_xing) do
+    source = build_vbr_mp3()
+    stripped = Path.join(tmp_dir(), "vbr-no-xing-#{System.unique_integer([:positive])}.mp3")
+
+    {_output, 0} =
+      System.cmd("ffmpeg", [
+        "-v",
+        "quiet",
+        "-i",
+        source,
+        "-c",
+        "copy",
+        "-write_xing",
+        "0",
+        stripped
+      ])
+
+    stripped
+  end
+
+  defp build_vbr_mp3 do
+    path = Path.join(tmp_dir(), "vbr-#{System.unique_integer([:positive])}.mp3")
+
+    {_output, 0} =
+      System.cmd("ffmpeg", [
+        "-v",
+        "quiet",
+        "-f",
+        "lavfi",
+        "-i",
+        "sine=frequency=200:duration=15",
+        "-f",
+        "lavfi",
+        "-i",
+        "anoisesrc=duration=15:amplitude=0.8",
+        "-filter_complex",
+        "[0][1]concat=n=2:v=0:a=1",
+        "-codec:a",
+        "libmp3lame",
+        "-q:a",
+        "9",
+        path
+      ])
+
+    path
+  end
+
+  defp tmp_dir do
+    dir = Ambry.Paths.source_media_disk_path("probe-test")
+    File.mkdir_p!(dir)
+    dir
+  end
+end

--- a/test/ambry/media/scanner_test.exs
+++ b/test/ambry/media/scanner_test.exs
@@ -1,0 +1,189 @@
+defmodule Ambry.Media.ScannerTest do
+  use Ambry.DataCase
+
+  alias Ambry.Media
+  alias Ambry.Media.MediaTrack
+  alias Ambry.Media.Scanner
+
+  describe "scan/1" do
+    test "records what the file is, without touching it" do
+      media = scannable_media(:m4a)
+      [source_file] = media.source_files
+      before = File.stat!(source_file)
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert [%MediaTrack{} = track] = Media.get_media!(media.id).media_tracks
+      assert track.index == 0
+      assert track.path == source_file
+      assert track.size == before.size
+      assert track.codec == "aac"
+      assert track.mime == "audio/mp4"
+      assert track.format =~ "mp4"
+      assert Decimal.equal?(track.start_offset, 0)
+
+      assert File.stat!(source_file).size == before.size
+    end
+
+    test "gives the media the track's duration" do
+      media = scannable_media(:m4a)
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert Decimal.compare(media.duration, "3.8") == :gt
+      assert Decimal.compare(media.duration, "3.9") == :lt
+    end
+
+    test "trusts an indexed container's duration" do
+      media = scannable_media(:m4a)
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert [%MediaTrack{seek_accuracy: :exact}] = Media.get_media!(media.id).media_tracks
+    end
+
+    test "decode-counts a container that can't be trusted" do
+      media = scannable_media(:mp3)
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert [track] = Media.get_media!(media.id).media_tracks
+      assert track.codec == "mp3"
+      assert track.mime == "audio/mpeg"
+      # the sample is CBR, so the claimed duration holds up and seeking is fine
+      assert track.seek_accuracy == :exact
+      assert Decimal.compare(track.duration, "3.7") == :gt
+      assert Decimal.compare(track.duration, "3.9") == :lt
+    end
+
+    test "scans every container direct-play serves" do
+      for type <- [:m4a, :mp3, :flac, :ogg, :opus, :wav] do
+        media = scannable_media(type)
+
+        assert {:ok, media} = Scanner.scan(media), "couldn't scan a #{type} file"
+        assert [%MediaTrack{}] = Media.get_media!(media.id).media_tracks
+      end
+    end
+
+    test "replaces the tracks of a media scanned before" do
+      media = scannable_media(:m4a)
+
+      assert {:ok, _media} = Scanner.scan(media)
+      media = Media.get_media!(media.id)
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert [%MediaTrack{index: 0}] = Media.get_media!(media.id).media_tracks
+    end
+
+    test "does not publish the media" do
+      media = scannable_media(:m4a)
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert media.status == :pending
+    end
+
+    test "refuses a multi-file recording rather than guessing" do
+      media = scannable_media(:mp3, 3)
+
+      assert {:error, :multi_file_unsupported} = Scanner.scan(media)
+      assert Media.get_media!(media.id).media_tracks == []
+    end
+
+    test "reports a media with nothing to scan" do
+      media = insert(:media, book: build(:book))
+
+      assert {:error, :no_audio_files} = Scanner.scan(media)
+    end
+
+    test "reports a file that has gone missing" do
+      media = scannable_media(:m4a)
+      media.source_files |> hd() |> File.rm!()
+
+      assert {:error, :enoent} = Scanner.scan(media)
+    end
+  end
+
+  describe "scan/1 chapters" do
+    test "takes embedded chapter markers when the media has none" do
+      media = chaptered_media()
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert [first, second] = media.chapters
+      assert first.title == "Opening Credits"
+      assert Decimal.equal?(first.time, 0)
+      assert second.title == "Chapter One"
+      assert Decimal.compare(second.time, 0) == :gt
+    end
+
+    test "never overwrites chapters the operator already has" do
+      media = chaptered_media(chapters: [%{time: Decimal.new(0), title: "Curated"}])
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert [%{title: "Curated"}] = media.chapters
+    end
+
+    test "leaves chapters alone when the file has none" do
+      media = scannable_media(:m4a)
+
+      assert {:ok, media} = Scanner.scan(media)
+
+      assert media.chapters == []
+    end
+  end
+
+  defp scannable_media(type, count \\ 1, attrs \\ []) do
+    :media
+    |> build([book: build(:book)] ++ attrs)
+    |> with_copied_source_files(type, count)
+    |> insert()
+    |> then(&Media.get_media!(&1.id))
+  end
+
+  # ffmpeg is the only thing around that writes chapter atoms, so the fixture
+  # is built the same way a real m4b gets them.
+  defp chaptered_media(attrs \\ []) do
+    media = scannable_media(:m4a, 1, attrs)
+    [source_file] = media.source_files
+
+    metadata_path = Path.join(Path.dirname(source_file), "chapters.txt")
+
+    File.write!(metadata_path, """
+    ;FFMETADATA1
+    [CHAPTER]
+    TIMEBASE=1/1000
+    START=0
+    END=2000
+    title=Opening Credits
+    [CHAPTER]
+    TIMEBASE=1/1000
+    START=2000
+    END=3800
+    title=Chapter One
+    """)
+
+    chaptered_path = Path.join(Path.dirname(source_file), "chaptered.m4a")
+
+    {_output, 0} =
+      System.cmd("ffmpeg", [
+        "-i",
+        source_file,
+        "-i",
+        metadata_path,
+        "-map_metadata",
+        "1",
+        "-c",
+        "copy",
+        "-v",
+        "quiet",
+        chaptered_path
+      ])
+
+    File.rm!(source_file)
+
+    {:ok, media} = Media.update_media(media, %{source_files: [chaptered_path]})
+    Media.get_media!(media.id)
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -236,6 +236,26 @@ defmodule Ambry.Factory do
     %{media | source_files: for(_ <- 1..count, do: audio_file_disk_path)}
   end
 
+  @doc """
+  Copies real audio fixtures into the media's own source folder, the way an
+  upload does — so `source_files` holds absolute paths to files that are
+  actually there and can be probed.
+  """
+  def with_copied_source_files(%Media{} = media, type \\ :m4a, count \\ 1) do
+    fixture = valid_audio(type)
+    folder = Media.source_path(media)
+    File.mkdir_p!(folder)
+
+    files =
+      for index <- 1..count do
+        dest = Path.join(folder, "#{index}-sample#{Path.extname(fixture)}")
+        File.cp!(fixture, dest)
+        dest
+      end
+
+    %{media | source_files: files}
+  end
+
   def with_output_files(media, processor \\ :auto)
 
   def with_output_files(%Media{__meta__: %{state: :loaded}} = media, processor) do


### PR DESCRIPTION
> Stacked on #1168 (which is stacked on #1167) — this PR's diff is the third
> commit.

Replaces transcoding with **measuring**: the scanner probes a media's source
files and records what they are as direct-play tracks, without copying,
rewriting, or repackaging anything.

## Durations are the substance

`get_inaccurate_duration/1` trusts whatever the container claims, which was
only ever safe for the MP4s that pipeline produced itself. Source files are
not so cooperative: a VBR mp3 with no Xing/VBRI header has no duration to
report, so ffprobe extrapolates one from the first frame's bitrate and can be
minutes wrong over a book.

So the container's word is taken only for formats that genuinely know —
MP4/M4B sample tables, FLAC's STREAMINFO, Ogg granule positions, WAV's fixed
byte rate, Matroska headers. Everything else is decode-counted once, here, at
scan time.

## Seek accuracy comes free from the same decode

A container that got the length wrong has no index to seek by either — which
is precisely the VBR-mp3-without-Xing case. So a claimed duration that misses
the decoded truth by more than `max(1s, 0.5%)` is recorded as `approximate`.

Verified against a generated VBR mp3 rather than assumed:

| file | container claims | decoded | recorded |
|---|---|---|---|
| VBR + Xing header | 60.000s | 60.000s | `exact` |
| same file, `-write_xing 0` | 62.896s | 60.029s | `approximate` |

(Real-world VBR-without-Xing errors run 5–30%, so the threshold sits well
clear of both rounding noise and the failure it's looking for.)

## Deliberate non-behaviors

- **Scanning does not publish.** A scanned media keeps its status, so this can
  run over the existing library without changing anything clients see.
  Publishing is the inbox's job (3b), behind the operator switch.
- **Chapters are taken only when the media has none.** The merge that pours
  provider titles onto file-derived markers is its own work (1h); until it
  exists, a scan must never overwrite confirmed curation.
- **Multi-file sources are refused**, returning `:multi_file_unsupported`
  rather than being silently concatenated. The tracks model is ready for
  them; the player isn't (2f).

## Reachability

`Ambry.Media.scan_media/1` + `scan_media_async/1` and a `RunScan` Oban
worker. There's **no UI trigger yet** — that lands with 2b alongside serving
and GraphQL, so there's nothing to exercise on staging from this PR alone.

## Verification

`mix check` clean. `ScannerTest` covers all six containers direct-play
serves, re-scan idempotency, the multi-file and missing-file errors, the
"doesn't publish" and chapter-preservation rules; `ProbeTest` covers
codec/mime identification per container and the seek-accuracy table above
(fixtures generated with ffmpeg at test time).