### PR TITLE
Phase 2b: serve original files

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -29,6 +29,7 @@ defmodule Ambry.Media do
   alias Ambry.Media.Audit
   alias Ambry.Media.Media
   alias Ambry.Media.MediaFlat
+  alias Ambry.Media.MediaTrack
   alias Ambry.Media.Processor
   alias Ambry.Media.PubSub.MediaCreated
   alias Ambry.Media.PubSub.MediaDeleted
@@ -166,6 +167,13 @@ defmodule Ambry.Media do
 
   """
   def fetch_media(id), do: Repo.fetch(Media, id)
+
+  @doc """
+  Fetches a single direct-play track.
+
+  Returns `{:ok, media_track}` on success or `{:error, :not_found}`.
+  """
+  def fetch_media_track(id), do: Repo.fetch(MediaTrack, id)
 
   @doc """
   Creates a media.

--- a/lib/ambry/media/media_track.ex
+++ b/lib/ambry/media/media_track.ex
@@ -18,6 +18,7 @@ defmodule Ambry.Media.MediaTrack do
 
   import Ecto.Changeset
 
+  alias Ambry.Hashids
   alias Ambry.Media.Media
   alias Ambry.Media.MediaTrack
 
@@ -61,6 +62,18 @@ defmodule Ambry.Media.MediaTrack do
     |> validate_number(:duration, greater_than: 0)
     |> validate_number(:start_offset, greater_than_or_equal_to: 0)
     |> unique_constraint([:media_id, :index])
+  end
+
+  @doc """
+  The URL clients fetch this track from.
+
+  The track's own path is a disk path that may be anywhere — the uploads
+  tree, a folder referenced in place, or a library root — so the URL is keyed
+  on the track instead, and ends in the file's real name so downloads keep
+  their real extension.
+  """
+  def web_path(%MediaTrack{id: id, path: path}) do
+    "/files/track/#{Hashids.encode(id)}/#{Path.basename(path)}"
   end
 
   @doc """

--- a/lib/ambry_web/controllers/track_controller.ex
+++ b/lib/ambry_web/controllers/track_controller.ex
@@ -1,0 +1,35 @@
+defmodule AmbryWeb.TrackController do
+  @moduledoc """
+  Serves direct-play audio files to authenticated clients.
+
+  The file is served from wherever it actually lives — the uploads tree, a
+  local-import folder referenced in place, or (Phase 3) a library root — so
+  the lookup goes through the track record rather than through a path the
+  client supplies.
+  """
+
+  use AmbryWeb, :controller
+
+  alias Ambry.Hashids
+  alias Ambry.Media
+  alias AmbryWeb.FileResponse
+
+  def show(conn, params) do
+    with {:ok, [track_id]} <- Hashids.decode(params["id"]),
+         {:ok, track} <- Media.fetch_media_track(track_id),
+         %Plug.Conn{state: state} = conn when state != :unset <-
+           FileResponse.send(conn, track.path, track.mime) do
+      conn
+    else
+      _else -> not_found(conn)
+    end
+  end
+
+  defp not_found(conn) do
+    conn
+    |> put_status(:not_found)
+    |> put_layout(false)
+    |> put_view(AmbryWeb.ErrorHTML)
+    |> render(:"404")
+  end
+end

--- a/lib/ambry_web/file_response.ex
+++ b/lib/ambry_web/file_response.ex
@@ -1,0 +1,140 @@
+defmodule AmbryWeb.FileResponse do
+  @moduledoc """
+  Sends a file from anywhere on disk, with the byte-range support audio
+  players need to seek.
+
+  `Plug.Static` already does this, but only under one fixed root. Direct-play
+  files aren't under a fixed root: today they can sit in the uploads tree or
+  wherever a local import referenced them in place, and Phase 3 adds
+  configurable library roots plus external collections that are read where
+  they lie. So the same behavior is reimplemented here, keyed on a path the
+  caller has already authorized.
+
+  The ETag is derived from mtime and size, exactly as `Plug.Static` derives
+  it. That is deliberate and load-bearing: replacing a recording's files
+  overwrites them in place, and a changed mtime changes the ETag, so
+  streaming clients revalidate and pick up the new bytes without any new URL
+  or cleanup dance.
+  """
+
+  import Plug.Conn
+
+  @doc """
+  Responds with the file at `path`, honoring `Range` and `If-None-Match`.
+
+  Returns the conn untouched (not halted) when the file isn't there, so the
+  caller can render its own 404.
+  """
+  def send(conn, path, content_type) do
+    case File.stat(path) do
+      {:ok, %File.Stat{type: :regular} = stat} ->
+        send_regular_file(conn, path, content_type, stat)
+
+      _not_a_file ->
+        conn
+    end
+  end
+
+  defp send_regular_file(conn, path, content_type, stat) do
+    etag = etag(stat)
+
+    conn =
+      conn
+      |> put_resp_header("accept-ranges", "bytes")
+      |> put_resp_header("etag", etag)
+      |> put_resp_content_type(content_type || "application/octet-stream")
+
+    if fresh?(conn, etag) do
+      send_resp(conn, 304, "")
+    else
+      send_contents(conn, path, stat.size)
+    end
+  end
+
+  defp send_contents(conn, path, size) do
+    case requested_range(conn, size) do
+      {:ok, first, last} ->
+        conn
+        |> put_resp_header("content-range", "bytes #{first}-#{last}/#{size}")
+        |> send_file(206, path, first, last - first + 1)
+
+      :unsatisfiable ->
+        conn
+        |> put_resp_header("content-range", "bytes */#{size}")
+        |> send_resp(416, "")
+
+      :none ->
+        send_file(conn, 200, path)
+    end
+  end
+
+  # A client that already has the current bytes gets told so, whether or not
+  # it asked for a range.
+  defp fresh?(conn, etag) do
+    etag in (conn |> get_req_header("if-none-match") |> Enum.flat_map(&split_etags/1))
+  end
+
+  defp split_etags(header) do
+    header |> String.split(",") |> Enum.map(&String.trim/1)
+  end
+
+  # Only a single range is honored. Serving the whole file in response to a
+  # multi-range request is allowed, and multipart/byteranges buys nothing for
+  # audio playback.
+  defp requested_range(conn, size) do
+    case get_req_header(conn, "range") do
+      ["bytes=" <> spec] -> parse_range(spec, size)
+      _no_range -> :none
+    end
+  end
+
+  defp parse_range(spec, size) do
+    case String.split(spec, "-") do
+      # bytes=<first>-<last>
+      [first, last] when first != "" and last != "" ->
+        bounded(parse_int(first), parse_int(last), size)
+
+      # bytes=<first>- — everything from `first` on
+      [first, ""] when first != "" ->
+        bounded(parse_int(first), size - 1, size)
+
+      # bytes=-<suffix> — the last `suffix` bytes
+      ["", suffix] when suffix != "" ->
+        case parse_int(suffix) do
+          nil -> :none
+          0 -> :unsatisfiable
+          suffix -> bounded(max(size - suffix, 0), size - 1, size)
+        end
+
+      _unparseable ->
+        :none
+    end
+  end
+
+  defp bounded(nil, _last, _size), do: :none
+  defp bounded(_first, nil, _size), do: :none
+
+  defp bounded(first, last, size) do
+    last = min(last, size - 1)
+
+    cond do
+      # an empty file has no satisfiable range, and neither does a start past
+      # the end
+      size == 0 or first >= size -> :unsatisfiable
+      first > last -> :unsatisfiable
+      true -> {:ok, first, last}
+    end
+  end
+
+  defp parse_int(string) do
+    case Integer.parse(string) do
+      {int, ""} when int >= 0 -> int
+      _unparseable -> nil
+    end
+  end
+
+  # byte-for-byte what Plug.Static does, so both serving paths agree
+  defp etag(%File.Stat{mtime: mtime, size: size}) do
+    <<?", {mtime, size} |> :erlang.phash2() |> Integer.to_string(16)::binary, ?">>
+  end
+end

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -55,6 +55,12 @@ defmodule AmbryWeb.Router do
     pipe_through :downloads
 
     get "/download/media/:media_id/:file_id/*rest", AmbryWeb.DownloadController, :download_media
+
+    # Direct-play audio. Unlike /uploads these files have no single root —
+    # they're served from wherever they actually live — so the route resolves
+    # a track record instead of a path under a static root. `*rest` carries
+    # the file's real name so downloads keep their real extension.
+    get "/files/track/:id/*rest", AmbryWeb.TrackController, :show
   end
 
   scope "/gql" do

--- a/test/ambry_web/controllers/track_controller_test.exs
+++ b/test/ambry_web/controllers/track_controller_test.exs
@@ -1,0 +1,174 @@
+defmodule AmbryWeb.TrackControllerTest do
+  use AmbryWeb.ConnCase, async: true
+
+  alias Ambry.Media.MediaTrack
+
+  setup :register_and_log_in_user
+
+  describe "GET a track" do
+    test "serves the file's bytes", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+
+      conn = get(conn, MediaTrack.web_path(track))
+
+      assert response(conn, 200) == contents
+      assert response_content_type(conn, :mp4) =~ "audio/mp4"
+    end
+
+    test "advertises range support and an etag", %{conn: conn} do
+      %{track: track} = served_track()
+
+      conn = get(conn, MediaTrack.web_path(track))
+
+      assert get_resp_header(conn, "accept-ranges") == ["bytes"]
+      assert [etag] = get_resp_header(conn, "etag")
+      assert etag =~ ~r/^".+"$/
+    end
+
+    test "ends the URL in the file's real name, not the media id" do
+      %{track: track} = served_track()
+
+      assert MediaTrack.web_path(track) =~ ~r/\/sample\.m4a$/
+    end
+
+    test "404s for a track that doesn't exist", %{conn: conn} do
+      conn = get(conn, "/files/track/#{Ambry.Hashids.encode(999_999)}/gone.m4b")
+
+      assert response(conn, 404)
+    end
+
+    test "404s for a track whose file has vanished", %{conn: conn} do
+      %{track: track, path: path} = served_track()
+      File.rm!(path)
+
+      conn = get(conn, MediaTrack.web_path(track))
+
+      assert response(conn, 404)
+    end
+
+    test "requires authentication" do
+      %{track: track} = served_track()
+
+      conn = get(build_conn(), MediaTrack.web_path(track))
+
+      assert response(conn, 401)
+    end
+  end
+
+  describe "GET a track with a range" do
+    test "serves the requested bytes as partial content", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+
+      conn = conn |> put_req_header("range", "bytes=10-19") |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 206) == binary_part(contents, 10, 10)
+
+      assert get_resp_header(conn, "content-range") == [
+               "bytes 10-19/#{byte_size(contents)}"
+             ]
+    end
+
+    test "serves an open-ended range to the end of the file", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+      size = byte_size(contents)
+
+      conn = conn |> put_req_header("range", "bytes=10-") |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 206) == binary_part(contents, 10, size - 10)
+      assert get_resp_header(conn, "content-range") == ["bytes 10-#{size - 1}/#{size}"]
+    end
+
+    test "serves a suffix range from the end of the file", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+      size = byte_size(contents)
+
+      conn = conn |> put_req_header("range", "bytes=-100") |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 206) == binary_part(contents, size - 100, 100)
+      assert get_resp_header(conn, "content-range") == ["bytes #{size - 100}-#{size - 1}/#{size}"]
+    end
+
+    test "clamps a range that runs past the end", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+      size = byte_size(contents)
+
+      conn =
+        conn
+        |> put_req_header("range", "bytes=10-999999999")
+        |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 206) == binary_part(contents, 10, size - 10)
+      assert get_resp_header(conn, "content-range") == ["bytes 10-#{size - 1}/#{size}"]
+    end
+
+    test "rejects a range that starts past the end", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+
+      conn =
+        conn
+        |> put_req_header("range", "bytes=999999999-")
+        |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 416)
+      assert get_resp_header(conn, "content-range") == ["bytes */#{byte_size(contents)}"]
+    end
+
+    test "ignores an unparseable range and serves the whole file", %{conn: conn} do
+      %{track: track, contents: contents} = served_track()
+
+      conn =
+        conn |> put_req_header("range", "bytes=abc-def") |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 200) == contents
+    end
+  end
+
+  describe "GET a track a client already has" do
+    test "answers a matching etag with 304", %{conn: conn} do
+      %{track: track} = served_track()
+
+      [etag] = conn |> get(MediaTrack.web_path(track)) |> get_resp_header("etag")
+
+      conn =
+        build_conn()
+        |> log_in_user(insert(:user))
+        |> put_req_header("if-none-match", etag)
+        |> get(MediaTrack.web_path(track))
+
+      assert response(conn, 304) == ""
+    end
+
+    # Replacing a recording overwrites its files in place; a changed mtime has
+    # to invalidate the cached copy, or clients keep playing the old bytes.
+    test "changes the etag when the file is replaced in place", %{conn: conn} do
+      %{track: track, path: path} = served_track()
+
+      [before_etag] = conn |> get(MediaTrack.web_path(track)) |> get_resp_header("etag")
+
+      File.write!(path, "completely different contents")
+      File.touch!(path, System.os_time(:second) + 10)
+
+      [after_etag] =
+        build_conn()
+        |> log_in_user(insert(:user))
+        |> get(MediaTrack.web_path(track))
+        |> get_resp_header("etag")
+
+      refute before_etag == after_etag
+    end
+  end
+
+  defp served_track do
+    media = :media |> build(book: build(:book)) |> with_copied_source_files(:m4a) |> insert()
+    [source_file] = media.source_files
+
+    # the real fixture, under the media's own source folder, named as a
+    # client would see it
+    path = Path.join(Path.dirname(source_file), "sample.m4a")
+    File.rename!(source_file, path)
+
+    track = insert(:media_track, media: media, path: path, mime: "audio/mp4")
+
+    %{track: track, path: path, contents: File.read!(path)}
+  end
+end


### PR DESCRIPTION
> Stacked on #1169. Diff is the one commit.

Clients can now fetch a direct-play track's actual file, behind the same auth
as everything else under `/uploads`.

## Why this isn't another Plug.Static mount

Direct-play files have no single root. Today a track can sit in the uploads
tree or in a folder a local import referenced in place, and Phase 3 adds
configurable library roots plus external collections read where they lie.
`Plug.Static` serves one fixed root, so instead the route resolves a *track
record* — `GET /files/track/:id/*rest` — and the client never supplies a
filesystem path.

## What FileResponse does

Everything `Plug.Static` would, for one arbitrary path:

- `Accept-Ranges: bytes` on every response
- single-range `206` with `Content-Range`, including open-ended (`bytes=10-`),
  suffix (`bytes=-100`), and past-the-end ranges, which are clamped
- `416` for a range starting past the end
- `304` on a matching `If-None-Match`
- multi-range requests get the whole file — allowed, and multipart/byteranges
  buys nothing for audio

## The ETag is load-bearing

It's derived from mtime and size exactly as `Plug.Static` derives it, and
that's deliberate. Replacing a recording's files overwrites them **in place**
(that's why the current implementation reuses the output UUID instead of
minting a new one), so a changed mtime has to change the ETag or streaming
clients keep playing the old bytes. There's a test pinning it.

Note what it does *not* fix: already-downloaded offline copies. Mobile
downloads are keyed on `mediaId` with no version or hash, so stale downloads
stay stale — today's out-of-band policy ("delete and re-download") still
applies, and closing that gap means a file version in the tracks payload.

## Filenames

The URL ends in the file's real name via `*rest`, so downloads keep their real
extension instead of the hard-coded `<mediaId>.mp4` the mobile app assumes —
the client-side half of that is 2c.

## Verification

`mix check` clean; 14 tests covering the range table above, auth (401 without
a token), both 404 paths, and ETag invalidation on in-place replacement.