### PR TITLE
Phase 2b: expose tracks over GraphQL and sync

### DIFF
--- a/lib/ambry/deletions/deletion.ex
+++ b/lib/ambry/deletions/deletion.ex
@@ -8,7 +8,7 @@ defmodule Ambry.Deletions.Deletion do
   schema "deletions" do
     field :type, Ecto.Enum,
       values:
-        ~w(person author author_person narrator book book_author book_universe series series_book media media_narrator recording_group universe)a
+        ~w(person author author_person narrator book book_author book_universe series series_book media media_narrator media_track recording_group universe)a
 
     field :record_id, :integer
     field :deleted_at, :utc_datetime

--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -4,7 +4,7 @@ defmodule AmbrySchema.Media do
   use Absinthe.Schema.Notation
   use Absinthe.Relay.Schema.Notation, :modern
 
-  import Absinthe.Resolution.Helpers, only: [dataloader: 1, dataloader: 2]
+  import Absinthe.Resolution.Helpers, only: [dataloader: 1, dataloader: 2, dataloader: 3]
 
   alias AmbrySchema.Resolvers
 
@@ -29,6 +29,15 @@ defmodule AmbrySchema.Media do
     field :path, non_null(:string)
   end
 
+  @desc "How accurately a player can seek within a track"
+  enum :seek_accuracy do
+    @desc "Seeking lands where it says it does"
+    value :exact
+
+    @desc "The file carries no seek index (e.g. VBR mp3 with no Xing header); positions may drift"
+    value :approximate
+  end
+
   node object(:media) do
     field :status, non_null(:media_processing_status)
 
@@ -45,6 +54,14 @@ defmodule AmbrySchema.Media do
     field :recording_group, :recording_group, resolve: dataloader(Resolvers)
 
     field :duration, :float, resolve: Resolvers.resolve_decimal(:duration)
+
+    @desc "Direct-play audio files, in playback order; empty for media that only has the legacy packaged artifacts below"
+    field :tracks, non_null(list_of(non_null(:media_track))),
+      resolve: dataloader(Resolvers, :media_tracks, args: %{order: {:asc, :index}})
+
+    # kept as-is, not deprecated: until direct-play publishing is switched on
+    # these are still the only way to play anything, and every deployed client
+    # queries them
     field :mpd_path, :string
     field :hls_path, :string
     field :mp4_path, :string
@@ -85,6 +102,39 @@ defmodule AmbrySchema.Media do
 
     field :media, non_null(list_of(non_null(:media))),
       resolve: dataloader(Resolvers, args: %{order: {:asc, :part_number}})
+
+    field :inserted_at, non_null(:datetime)
+    field :updated_at, non_null(:datetime)
+  end
+
+  @desc "One audio file of a recording, played directly by the client"
+  node object(:media_track) do
+    field :media, non_null(:media), resolve: dataloader(Resolvers, args: %{allow_all_media: true})
+
+    @desc "Position in the recording's ordered track list, 0-based"
+    field :index, non_null(:integer)
+
+    @desc "Where to fetch the file; requires the same authentication as any other media URL"
+    field :path, non_null(:string), resolve: &Resolvers.media_track_path/3
+
+    @desc "Size in bytes. A float because audiobook files routinely exceed what GraphQL's 32-bit Int can hold"
+    field :size, non_null(:float), resolve: fn track, _, _ -> {:ok, track.size / 1} end
+
+    @desc "Media type of the file, e.g. \"audio/mp4\""
+    field :mime, :string
+
+    @desc "Container as probed, e.g. \"mov,mp4,m4a,3gp,3g2,mj2\""
+    field :format, :string
+
+    @desc "Audio codec as probed, e.g. \"aac\". Clients decide playability from this and `mime` — nothing here is assumed playable"
+    field :codec, :string
+
+    field :duration, non_null(:float), resolve: Resolvers.resolve_decimal(:duration)
+
+    @desc "Where this track starts on the book's continuous timeline, in seconds. Playback positions are always absolute book-seconds"
+    field :start_offset, non_null(:float), resolve: Resolvers.resolve_decimal(:start_offset)
+
+    field :seek_accuracy, non_null(:seek_accuracy)
 
     field :inserted_at, non_null(:datetime)
     field :updated_at, non_null(:datetime)

--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -16,6 +16,7 @@ defmodule AmbrySchema.Resolvers do
   alias Ambry.Hashids
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.MediaTrack
   alias Ambry.Media.RecordingGroup
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
@@ -107,6 +108,9 @@ defmodule AmbrySchema.Resolvers do
   def media_narrators_changed_since(args, _resolution),
     do: Sync.changes_since(MediaNarrator, args[:since])
 
+  def media_tracks_changed_since(args, _resolution),
+    do: Sync.changes_since(MediaTrack, args[:since])
+
   def recording_groups_changed_since(args, _resolution),
     do: Sync.changes_since(RecordingGroup, args[:since])
 
@@ -142,6 +146,9 @@ defmodule AmbrySchema.Resolvers do
          }
      end)}
   end
+
+  def media_track_path(%MediaTrack{} = track, _args, _resolution),
+    do: {:ok, MediaTrack.web_path(track)}
 
   def resolve_decimal(key) do
     fn
@@ -185,6 +192,7 @@ defmodule AmbrySchema.Resolvers do
   def type(%Deletion{}, _resolution), do: :deletion
   def type(%Media{}, _resolution), do: :media
   def type(%MediaNarrator{}, _resolution), do: :media_narrator
+  def type(%MediaTrack{}, _resolution), do: :media_track
   def type(%Narrator{}, _resolution), do: :narrator
   def type(%Person{}, _resolution), do: :person
   def type(%RecordingGroup{}, _resolution), do: :recording_group

--- a/lib/ambry_schema/sync.ex
+++ b/lib/ambry_schema/sync.ex
@@ -20,6 +20,7 @@ defmodule AmbrySchema.Sync do
     value :series_book
     value :media
     value :media_narrator
+    value :media_track
     value :recording_group
     value :universe
   end
@@ -130,6 +131,14 @@ defmodule AmbrySchema.Sync do
       middleware AmbrySchema.AuthMiddleware
 
       resolve &Resolvers.media_narrators_changed_since/2
+    end
+
+    field :media_tracks_changed_since, non_null(list_of(non_null(:media_track))) do
+      arg :since, :datetime
+
+      middleware AmbrySchema.AuthMiddleware
+
+      resolve &Resolvers.media_tracks_changed_since/2
     end
 
     field :recording_groups_changed_since, non_null(list_of(non_null(:recording_group))) do

--- a/priv/repo/migrations/20260803042227_media_tracks_sync.exs
+++ b/priv/repo/migrations/20260803042227_media_tracks_sync.exs
@@ -1,0 +1,20 @@
+defmodule Ambry.Repo.Migrations.MediaTracksSync do
+  use Ecto.Migration
+
+  # Lets clients learn that a track went away, the same way they learn about
+  # every other deleted record: a BEFORE DELETE trigger writes a row into
+  # `deletions`, which `deletionsSince` hands out.
+  def up do
+    execute """
+    CREATE TRIGGER track_delete_trigger
+    BEFORE DELETE ON media_tracks
+    FOR EACH ROW
+    EXECUTE FUNCTION track_delete('media_track');
+    """
+  end
+
+  def down do
+    execute "DROP TRIGGER track_delete_trigger ON media_tracks;"
+    execute "DELETE FROM deletions WHERE type = 'media_track'"
+  end
+end

--- a/test/ambry_schema/media_tracks_test.exs
+++ b/test/ambry_schema/media_tracks_test.exs
@@ -1,0 +1,220 @@
+defmodule AmbrySchema.MediaTracksTest do
+  use AmbryWeb.ConnCase
+
+  import Absinthe.Relay.Node, only: [to_global_id: 2]
+  import Ambry.GraphQLSigil
+
+  alias Ambry.Media
+  alias Ambry.Media.MediaTrack
+
+  setup :register_and_put_user_api_token
+
+  describe "Media.tracks" do
+    @query ~G"""
+    query Media($id: ID!) {
+      node(id: $id) {
+        ... on Media {
+          duration
+          tracks {
+            id
+            index
+            path
+            size
+            mime
+            format
+            codec
+            duration
+            startOffset
+            seekAccuracy
+          }
+        }
+      }
+    }
+    """
+    test "resolves a recording's tracks", %{conn: conn} do
+      media = insert(:media, book: build(:book))
+
+      track =
+        insert(:media_track,
+          media: media,
+          index: 0,
+          size: 123_456,
+          mime: "audio/mp4",
+          format: "mov,mp4,m4a,3gp,3g2,mj2",
+          codec: "aac",
+          duration: Decimal.new("3600.5"),
+          start_offset: Decimal.new(0),
+          seek_accuracy: :exact
+        )
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{id: gid(media)}})
+
+      assert %{
+               "data" => %{
+                 "node" => %{
+                   "tracks" => [
+                     %{
+                       "index" => 0,
+                       "path" => path,
+                       "size" => size,
+                       "mime" => "audio/mp4",
+                       "format" => "mov,mp4,m4a,3gp,3g2,mj2",
+                       "codec" => "aac",
+                       "duration" => track_duration,
+                       "startOffset" => start_offset,
+                       "seekAccuracy" => "EXACT"
+                     }
+                   ]
+                 }
+               }
+             } = json_response(conn, 200)
+
+      assert path == MediaTrack.web_path(track)
+      assert size == 123_456.0
+      assert track_duration == 3600.5
+      assert start_offset == 0.0
+    end
+
+    test "orders them by their place on the timeline", %{conn: conn} do
+      media = insert(:media, book: build(:book))
+      insert(:media_track, media: media, index: 1, start_offset: Decimal.new("3600"))
+      insert(:media_track, media: media, index: 0, start_offset: Decimal.new(0))
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{id: gid(media)}})
+
+      assert %{"data" => %{"node" => %{"tracks" => [%{"index" => 0}, %{"index" => 1}]}}} =
+               json_response(conn, 200)
+    end
+
+    test "is empty for a legacy recording rather than absent", %{conn: conn} do
+      media = insert(:media, book: build(:book))
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{id: gid(media)}})
+
+      assert %{"data" => %{"node" => %{"tracks" => []}}} = json_response(conn, 200)
+    end
+
+    test "reports a size no 32-bit Int could carry", %{conn: conn} do
+      media = insert(:media, book: build(:book))
+      insert(:media_track, media: media, size: 5_000_000_000)
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{id: gid(media)}})
+
+      assert %{"data" => %{"node" => %{"tracks" => [%{"size" => size}]}}} =
+               json_response(conn, 200)
+
+      assert size == 5_000_000_000.0
+    end
+  end
+
+  describe "mediaTracksChangedSince" do
+    @query ~G"""
+    query Sync($since: DateTime) {
+      mediaTracksChangedSince(since: $since) {
+        id
+        index
+        path
+        media {
+          id
+        }
+      }
+      deletionsSince(since: $since) {
+        type
+        recordId
+      }
+    }
+    """
+    test "returns tracks and records their deletions", %{conn: conn} do
+      media = insert(:media, book: build(:book))
+      track = insert(:media_track, media: media, index: 0)
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{
+               "data" => %{
+                 "mediaTracksChangedSince" => [%{"index" => 0, "media" => %{"id" => media_gid}}],
+                 "deletionsSince" => []
+               }
+             } = json_response(conn, 200)
+
+      assert media_gid == gid(media)
+
+      {:ok, _track} = Ambry.Repo.delete(track)
+
+      # deletions are only reported against a `since` — a client with no
+      # previous sync gets the current world, not its history
+      since = DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.to_iso8601()
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{since: since}})
+
+      assert %{
+               "data" => %{
+                 "mediaTracksChangedSince" => [],
+                 "deletionsSince" => [%{"type" => "MEDIA_TRACK", "recordId" => deleted_gid}]
+               }
+             } = json_response(conn, 200)
+
+      assert deleted_gid == to_global_id("MediaTrack", track.id)
+    end
+
+    test "reports tracks of media a client can't see yet, harmlessly", %{conn: conn} do
+      # a scanned-but-unpublished media syncs its tracks; clients only ever
+      # play `ready` media, so this costs a few rows and no correctness
+      media = insert(:media, book: build(:book), status: :pending)
+      insert(:media_track, media: media)
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{"data" => %{"mediaTracksChangedSince" => [_track]}} = json_response(conn, 200)
+    end
+  end
+
+  describe "a scanned recording end to end" do
+    @query ~G"""
+    query Media($id: ID!) {
+      node(id: $id) {
+        ... on Media {
+          duration
+          tracks {
+            path
+            mime
+            codec
+            seekAccuracy
+          }
+        }
+      }
+    }
+    """
+    test "is playable straight from what the scanner wrote", %{conn: conn} do
+      media =
+        :media
+        |> build(book: build(:book))
+        |> with_copied_source_files(:m4a)
+        |> insert()
+        |> then(&Media.get_media!(&1.id))
+
+      {:ok, media} = Media.scan_media(media)
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{id: gid(media)}})
+
+      assert %{
+               "data" => %{
+                 "node" => %{
+                   "duration" => duration,
+                   "tracks" => [
+                     %{
+                       "path" => "/files/track/" <> _,
+                       "mime" => "audio/mp4",
+                       "codec" => "aac",
+                       "seekAccuracy" => "EXACT"
+                     }
+                   ]
+                 }
+               }
+             } = json_response(conn, 200)
+
+      assert duration > 3.8 and duration < 3.9
+    end
+  end
+
+  defp gid(%{id: id}), do: to_global_id("Media", id)
+end


### PR DESCRIPTION
> Stacked on #1170. Diff is the one commit.

Clients can now see a recording's direct-play tracks: an ordered `tracks` list
on `Media`, and a `mediaTracksChangedSince` sync field with deletions tracked
the usual way.

## Additive, and deliberately not deprecating anything

No deployed client queries any of this, and old clients never see fields they
don't ask for. `mpdPath`/`hlsPath`/`mp4Path` are **not** marked deprecated:
until the publishing switch is on they're still the only way to play
anything, and every deployed client queries them. Contract comes after fleet
verification, per the roadmap's invariants.

`tracks` is an empty list for legacy media rather than null, so clients can
branch on it without special cases.

## What a track carries

Enough to *decide*, not just to fetch: `path` (a URL behind the same auth as
any other media URL), plus `mime`, `format`, and `codec` exactly as probed.
Nothing here claims a file is playable — that's the client's call, which is
what lets the deferred compatibility fallback (2e) slot in later without a
schema change. `startOffset` and `duration` are absolute book-seconds;
`seekAccuracy` warns when the file has no seek index.

`size` is a `Float`, not an `Int`, on purpose: GraphQL's Int is 32-bit and
audiobook files routinely exceed the 2.1 GB it can hold. There's a test
pinning a 5 GB track.

## Sync plumbing

Server-side checklist complete: `BEFORE DELETE` trigger writing `media_track`
deletions, the `deletions.type` Ecto enum, the `deletion_type` GraphQL enum,
and the changed-since field.

The mobile half — Drizzle table plus the `sync.ts` mapping — is a separate
repo on its own release schedule, and none of this is required until the 2c
app release.

One accepted wrinkle: tracks of a scanned-but-unpublished media do sync.
Clients only ever play `ready` media, so this costs a few rows and no
correctness; there's a test naming that explicitly.

## Verification

`mix check` clean; 7 tests including an end-to-end one that scans a real
fixture and queries the result over GraphQL.