### PR TITLE
Phase 2a: the tracks data model

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -14,6 +14,7 @@ defmodule Ambry.Media do
       Media.Chapter,
       MediaFlat,
       MediaNarrator,
+      MediaTrack,
       RecordingGroup,
       PubSub.MediaCreated,
       PubSub.MediaDeleted,
@@ -101,7 +102,10 @@ defmodule Ambry.Media do
 
   """
   def get_media!(id),
-    do: Media |> preload([:book, :media_narrators, :recording_group]) |> Repo.get!(id)
+    do:
+      Media
+      |> preload([:book, :media_narrators, :media_tracks, :recording_group])
+      |> Repo.get!(id)
 
   @doc """
   Gets a media and the book with all its details.

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -11,6 +11,7 @@ defmodule Ambry.Media.Media do
   alias Ambry.Media.Media
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.MediaTrack
   alias Ambry.Media.Processor
   alias Ambry.Media.RecordingGroup
   alias Ambry.Provenance
@@ -28,6 +29,10 @@ defmodule Ambry.Media.Media do
     has_many :media_narrators, MediaNarrator, on_replace: :delete
     has_many :authors, through: [:book, :authors]
     has_many :narrators, through: [:media_narrators, :narrator]
+
+    # direct-play: the ordered audio files clients play as-is. Empty for
+    # legacy media, which stream/download the packaged artifacts below.
+    has_many :media_tracks, MediaTrack, on_replace: :delete, preload_order: [asc: :index]
 
     embeds_many :chapters, Chapter, on_replace: :delete
     embeds_many :supplemental_files, SupplementalFile, on_replace: :delete
@@ -110,6 +115,7 @@ defmodule Ambry.Media.Media do
       sort_param: :media_narrators_sort,
       drop_param: :media_narrators_drop
     )
+    |> maybe_cast_tracks(attrs)
     |> cast_embed(:chapters,
       sort_param: :chapters_sort,
       drop_param: :chapters_drop
@@ -278,13 +284,48 @@ defmodule Ambry.Media.Media do
     |> maybe_validate_paths()
   end
 
+  # A ready media needs *some* playable representation. Direct-play media have
+  # tracks; legacy media have the packaged artifacts, which is why the trio is
+  # nullable rather than gone — already-imported media keep playing untouched
+  # until the back-catalog reclaim retires them.
   defp maybe_validate_paths(changeset) do
-    if get_field(changeset, :status) == :ready do
+    if get_field(changeset, :status) == :ready and not direct_play?(changeset) do
       validate_required(changeset, [
         :mpd_path,
         :hls_path,
         :mp4_path
       ])
+    else
+      changeset
+    end
+  end
+
+  # An unloaded assoc can't vouch for itself, so it reads as "no tracks" and
+  # the legacy paths stay required. `get_media!/1` preloads tracks, so every
+  # caller that edits an existing media sees the truth.
+  defp direct_play?(changeset) do
+    case tracks(changeset) do
+      [_ | _] -> true
+      _no_tracks -> false
+    end
+  end
+
+  defp tracks(changeset) do
+    case changeset.changes do
+      %{media_tracks: tracks} -> tracks
+      _unchanged -> loaded_tracks(changeset.data)
+    end
+  end
+
+  defp loaded_tracks(%Media{media_tracks: %Ecto.Association.NotLoaded{}}), do: []
+  defp loaded_tracks(%Media{media_tracks: tracks}), do: tracks
+  defp loaded_tracks(_data), do: []
+
+  # Tracks are written by the scanner, never by a form: the admin forms don't
+  # submit the param, and casting an assoc they never loaded would raise.
+  defp maybe_cast_tracks(changeset, attrs) do
+    if Map.has_key?(attrs, :media_tracks) or Map.has_key?(attrs, "media_tracks") do
+      cast_assoc(changeset, :media_tracks)
     else
       changeset
     end

--- a/lib/ambry/media/media_track.ex
+++ b/lib/ambry/media/media_track.ex
@@ -1,0 +1,72 @@
+defmodule Ambry.Media.MediaTrack do
+  @moduledoc """
+  One audio file belonging to a media, played directly by clients.
+
+  Tracks are ordered by `index` and laid end-to-end on the book's continuous
+  timeline: `start_offset` is where a track begins in absolute book-seconds.
+  Direct-play v1 only ever writes a single track per media (multi-file books
+  are deferred), but the model stays multi-file-shaped so that adding
+  multi-track playback later is a player-layer feature rather than a
+  data-model migration.
+
+  `format`, `codec` and `mime` are recorded exactly as probed — never assumed
+  playable — so a client can answer "can this device play this?" from synced
+  track metadata alone.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Media.Media
+  alias Ambry.Media.MediaTrack
+
+  @seek_accuracies [:exact, :approximate]
+
+  schema "media_tracks" do
+    belongs_to :media, Media
+
+    field :index, :integer
+    field :path, :string
+    field :size, :integer
+    field :mime, :string
+    field :format, :string
+    field :codec, :string
+    field :duration, :decimal
+    field :start_offset, :decimal, default: Decimal.new(0)
+    field :seek_accuracy, Ecto.Enum, values: @seek_accuracies, default: :exact
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def seek_accuracies, do: @seek_accuracies
+
+  @doc false
+  def changeset(media_track, attrs) do
+    media_track
+    |> cast(attrs, [
+      :index,
+      :path,
+      :size,
+      :mime,
+      :format,
+      :codec,
+      :duration,
+      :start_offset,
+      :seek_accuracy
+    ])
+    |> validate_required([:index, :path, :size, :duration, :start_offset])
+    |> validate_number(:index, greater_than_or_equal_to: 0)
+    |> validate_number(:size, greater_than_or_equal_to: 0)
+    |> validate_number(:duration, greater_than: 0)
+    |> validate_number(:start_offset, greater_than_or_equal_to: 0)
+    |> unique_constraint([:media_id, :index])
+  end
+
+  @doc """
+  The absolute book-seconds range this track covers, as `{start, end}`.
+  """
+  def range(%MediaTrack{start_offset: start_offset, duration: duration}) do
+    {start_offset, Decimal.add(start_offset, duration)}
+  end
+end

--- a/priv/repo/migrations/20260803035538_media_tracks.exs
+++ b/priv/repo/migrations/20260803035538_media_tracks.exs
@@ -1,0 +1,55 @@
+defmodule Ambry.Repo.Migrations.MediaTracks do
+  use Ecto.Migration
+
+  # The direct-play data model (Phase 2a): a media is a list of ordered audio
+  # files that clients play as-is, instead of a transcoded/packaged artifact.
+  #
+  # The table is multi-file-shaped even though direct-play v1 only ever writes
+  # one track per media (multi-file books are deferred, see the roadmap's 2f):
+  # ordered files with per-track duration and `start_offset` against one
+  # continuous book timeline, so adding multi-track playback later is a
+  # player-layer feature, not a data-model migration.
+  #
+  # Positions and progress events stay in absolute book-seconds throughout —
+  # nothing about the sync model changes here.
+  def change do
+    create table(:media_tracks) do
+      timestamps(type: :utc_datetime)
+
+      add :media_id, references(:media, on_delete: :delete_all), null: false
+
+      # position in the media's ordered track list, 0-based
+      add :index, :integer, null: false
+
+      # absolute path on disk; the file is played/served as-is, never rewritten
+      add :path, :text, null: false
+      add :size, :bigint, null: false
+
+      # real container/codec facts as probed, never assumed — clients decide
+      # playability from these (and a future compatibility fallback needs them
+      # to be honest, see the roadmap's 2e)
+      add :mime, :text
+      add :format, :text
+      add :codec, :text
+
+      # seconds; `start_offset` is where this track begins on the book's
+      # continuous timeline (always 0 while v1 writes a single track)
+      add :duration, :numeric, null: false
+      add :start_offset, :numeric, null: false, default: 0
+
+      # whether seeking within this track lands where we say it does —
+      # `approximate` covers e.g. VBR mp3 with no Xing/VBRI index
+      add :seek_accuracy, :text, null: false, default: "exact"
+    end
+
+    create unique_index(:media_tracks, [:media_id, :index])
+
+    create constraint(:media_tracks, :media_tracks_index_non_negative, check: "index >= 0")
+    create constraint(:media_tracks, :media_tracks_size_non_negative, check: "size >= 0")
+    create constraint(:media_tracks, :media_tracks_duration_positive, check: "duration > 0")
+
+    create constraint(:media_tracks, :media_tracks_start_offset_non_negative,
+             check: "start_offset >= 0"
+           )
+  end
+end

--- a/test/ambry/media/media_track_test.exs
+++ b/test/ambry/media/media_track_test.exs
@@ -1,0 +1,119 @@
+defmodule Ambry.Media.MediaTrackTest do
+  use Ambry.DataCase
+
+  alias Ambry.Media
+  alias Ambry.Media.MediaTrack
+
+  describe "changeset/2" do
+    test "requires the facts a client needs to play the file" do
+      changeset = MediaTrack.changeset(%MediaTrack{}, %{})
+
+      assert %{
+               index: ["can't be blank"],
+               path: ["can't be blank"],
+               size: ["can't be blank"],
+               duration: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "rejects a zero-length track" do
+      changeset = MediaTrack.changeset(%MediaTrack{}, params_for(:media_track, duration: "0"))
+
+      assert %{duration: ["must be greater than 0"]} = errors_on(changeset)
+    end
+
+    test "rejects a negative start offset" do
+      changeset =
+        MediaTrack.changeset(%MediaTrack{}, params_for(:media_track, start_offset: "-1"))
+
+      assert %{start_offset: ["must be greater than or equal to 0"]} = errors_on(changeset)
+    end
+
+    test "defaults to exact seeking" do
+      changeset = MediaTrack.changeset(%MediaTrack{}, params_for(:media_track))
+
+      assert %MediaTrack{seek_accuracy: :exact} = apply_changes(changeset)
+    end
+  end
+
+  describe "range/1" do
+    test "returns the absolute book-seconds the track covers" do
+      track = build(:media_track, start_offset: Decimal.new("60.5"), duration: Decimal.new("120"))
+
+      assert {start_time, end_time} = MediaTrack.range(track)
+      assert Decimal.equal?(start_time, "60.5")
+      assert Decimal.equal?(end_time, "180.5")
+    end
+  end
+
+  describe "tracks on a media" do
+    test "are persisted in order" do
+      media = :media |> insert(book: build(:book)) |> then(&Media.get_media!(&1.id))
+
+      {:ok, media} =
+        Media.update_media(media, %{
+          media_tracks: [
+            params_for(:media_track, index: 1, start_offset: "3600"),
+            params_for(:media_track, index: 0, start_offset: "0")
+          ]
+        })
+
+      assert [%MediaTrack{index: 0}, %MediaTrack{index: 1}] =
+               Media.get_media!(media.id).media_tracks
+    end
+
+    test "cannot share an index within one media" do
+      media = insert(:media, book: build(:book))
+
+      assert_raise Ecto.ConstraintError, fn ->
+        insert_list(2, :media_track, media: media, index: 0)
+      end
+    end
+
+    test "are deleted with their media" do
+      media = insert(:media, book: build(:book))
+      insert(:media_track, media: media)
+
+      {:ok, _media} = Media.delete_media(media)
+
+      assert Repo.aggregate(MediaTrack, :count) == 0
+    end
+  end
+
+  describe "readiness validation" do
+    test "a media with tracks is ready without the legacy packaged artifacts" do
+      media = :media |> insert(book: build(:book)) |> then(&Media.get_media!(&1.id))
+
+      assert {:ok, media} =
+               Media.update_media(media, %{
+                 status: :ready,
+                 media_tracks: [params_for(:media_track)]
+               })
+
+      assert media.status == :ready
+      assert is_nil(media.mp4_path)
+    end
+
+    test "a media without tracks still requires them" do
+      media = insert(:media, book: build(:book))
+
+      assert {:error, changeset} = Media.update_media(media, %{status: :ready})
+
+      assert %{
+               mpd_path: ["can't be blank"],
+               hls_path: ["can't be blank"],
+               mp4_path: ["can't be blank"]
+             } = errors_on(changeset)
+    end
+
+    test "an existing direct-play media stays editable without them" do
+      media = insert(:media, book: build(:book), status: :ready)
+      insert(:media_track, media: media)
+
+      media = Media.get_media!(media.id)
+
+      assert {:ok, media} = Media.update_media(media, %{notes: "still direct-play"})
+      assert media.notes == "still direct-play"
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -13,6 +13,7 @@ defmodule Ambry.Factory do
   alias Ambry.Fake
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
+  alias Ambry.Media.MediaTrack
   alias Ambry.Media.RecordingGroup
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
@@ -193,6 +194,40 @@ defmodule Ambry.Factory do
     %RecordingGroup{
       name: nil
     }
+  end
+
+  def media_track_factory do
+    %MediaTrack{
+      index: 0,
+      path: fn -> Ambry.Paths.source_media_disk_path("#{Ecto.UUID.generate()}.m4b") end,
+      size: trunc(Fake.uniform() * 500_000_000),
+      mime: "audio/mp4",
+      format: "mov,mp4,m4a,3gp,3g2,mj2",
+      codec: "aac",
+      duration: (Fake.uniform() * 30_000) |> Decimal.from_float() |> Decimal.round(2),
+      start_offset: Decimal.new(0),
+      seek_accuracy: :exact
+    }
+  end
+
+  @doc """
+  Gives a media a direct-play track per the given durations, laid end-to-end
+  on the book's timeline.
+  """
+  def with_tracks(%Media{} = media, durations \\ ["3600.0"]) do
+    {tracks, _offset} =
+      durations
+      |> Enum.with_index()
+      |> Enum.map_reduce(Decimal.new(0), fn {duration, index}, offset ->
+        duration = Decimal.new(duration)
+
+        track =
+          build(:media_track, index: index, duration: duration, start_offset: offset)
+
+        {track, Decimal.add(offset, duration)}
+      end)
+
+    %{media | media_tracks: tracks}
   end
 
   def with_source_files(%Media{} = media, type \\ :m4a, count \\ 1) do


### PR DESCRIPTION
> Replaces #1168, which GitHub auto-closed when its base branch was deleted on
> merge. Same commit, now rebased onto main — the diff is self-contained.

The core of direct-play: a media becomes an ordered list of audio files that
clients play **as-is**, instead of a transcoded MP4 plus DASH/HLS artifacts.

## The model

New `media_tracks` table, one row per file:

| column | why |
|---|---|
| `index` | position in the media's ordered track list, 0-based |
| `path`, `size` | the file, played and served as-is |
| `mime`, `format`, `codec` | recorded exactly as probed, never assumed |
| `duration` | seconds |
| `start_offset` | where the track begins on the book's continuous timeline |
| `seek_accuracy` | `exact` / `approximate` — the VBR-mp3-without-Xing case |

Container and codec are facts, not guesses, so a client can answer "can this
device play this?" from synced track metadata alone. That's the design safety
the deferred compatibility fallback (roadmap 2e) needs — ogg/opus is
unplayable on AVPlayer, and the scan step has to be honest about it.

## Multi-file-shaped on purpose

Direct-play v1 will only ever write one track per media (multi-file books are
deferred, 2f). The table is built for many anyway: ordered files with
per-track `start_offset` against one continuous timeline mean multi-track
playback lands later as a player-layer feature, not a data-model migration.

Positions and progress events stay in absolute book-seconds — **nothing about
the sync model changes.**

## Legacy media keep playing

`mpd_path`/`hls_path`/`mp4_path` stay (already nullable in the DB). The change
is in the changeset: the trio is now required only for a `ready` media that
has *no* tracks. Already-imported media are untouched until Phase 4 retires
them.

## Two Ecto sharp edges worth knowing

Ecto **raises** on `cast_assoc`/`get_field` for an assoc that wasn't loaded,
so both guards here are load-bearing:

- the changeset casts `media_tracks` only when the param is actually present
  (forms never submit it), and
- the "is this direct-play?" check reads `changeset.changes` first and falls
  back to loaded data, treating an unloaded assoc as "no tracks".

`get_media!/1` now preloads `:media_tracks` so every caller editing an
existing media sees the truth.

## Scope

Server-side only, invisible to clients. Exposing tracks over GraphQL is 2b,
which is also where the sync-table plumbing (delete trigger, `deletions.type`,
`*ChangedSince`) lands.

## Verification

`mix check` clean; new `Ambry.Media.MediaTrackTest` covers the changeset
validations, ordering, the unique `(media_id, index)` constraint, cascade
delete, and all three readiness cases.
