### PR TITLE
Phase 1b: read embedded tags at scan time

### DIFF
--- a/lib/ambry/media/scanner.ex
+++ b/lib/ambry/media/scanner.ex
@@ -36,6 +36,22 @@ defmodule Ambry.Media.Scanner do
   end
 
   @doc """
+  Reads a media's embedded tags without writing anything.
+
+  This is the tags-first half of discovery: what the file claims about
+  itself, for 1g auto-match to turn into a pre-filled inbox item. Nothing
+  here is applied to any record — tags propose, the operator confirms.
+
+  Returns `{:ok, %Tags{}}` or `{:error, reason}`.
+  """
+  def tags(%Media{} = media) do
+    with {:ok, path} <- single_file(media),
+         {:ok, probe} <- Probe.run(path) do
+      {:ok, probe.tags}
+    end
+  end
+
+  @doc """
   The audio file extensions direct-play can serve.
   """
   def extensions, do: @extensions

--- a/lib/ambry/media/scanner/probe.ex
+++ b/lib/ambry/media/scanner/probe.ex
@@ -23,6 +23,7 @@ defmodule Ambry.Media.Scanner.Probe do
   """
 
   alias Ambry.Media.Chapters.Utils
+  alias Ambry.Media.Scanner.Tags
 
   require Logger
 
@@ -35,6 +36,7 @@ defmodule Ambry.Media.Scanner.Probe do
     :mime,
     :duration,
     :seek_accuracy,
+    :tags,
     chapters: []
   ]
 
@@ -89,7 +91,8 @@ defmodule Ambry.Media.Scanner.Probe do
            mime: mime_type(path),
            duration: duration,
            seek_accuracy: seek_accuracy,
-           chapters: chapters(data)
+           chapters: chapters(data),
+           tags: tags(data, format)
          }}
     end
   end
@@ -123,6 +126,17 @@ defmodule Ambry.Media.Scanner.Probe do
     else
       :exact
     end
+  end
+
+  defp tags(data, format) do
+    Tags.parse(format["tags"] || %{}, has_cover_art: cover_art?(data))
+  end
+
+  # Embedded cover art rides along as a video stream flagged `attached_pic`.
+  defp cover_art?(data) do
+    data
+    |> Map.get("streams", [])
+    |> Enum.any?(&(&1["disposition"]["attached_pic"] == 1))
   end
 
   defp audio_codec(data) do

--- a/lib/ambry/media/scanner/tags.ex
+++ b/lib/ambry/media/scanner/tags.ex
@@ -1,0 +1,185 @@
+defmodule Ambry.Media.Scanner.Tags do
+  @moduledoc """
+  Embedded metadata read out of an audiobook file — the tags-first half of
+  discovery.
+
+  Audiobook tagging is a set of conventions rather than a standard, and the
+  two containers spell everything differently, so this normalizes both into
+  one struct:
+
+  | Fact | mp3 (ID3v2) | m4b (MP4 atoms) |
+  |---|---|---|
+  | book title | `TALB` (album) | `©alb` |
+  | author(s) | `TPE1`/`TPE2` | `©ART`/`aART` |
+  | narrator(s) | `TCOM` (composer) | `©wrt` |
+  | series | `TXXX:SERIES`, `MVNM` | freeform `SERIES`, `mvnm` |
+  | series number | `TXXX:SERIES-PART`, `MVIN` | freeform, `mvi` |
+  | ASIN | `TXXX:ASIN` | `----:com.apple.iTunes:ASIN` |
+
+  The narrator-in-composer convention is what Audible and Libation-style rips
+  use, and it's the one genuinely load-bearing mapping here — it's the only
+  place a narrator credit appears in a file at all.
+
+  ffprobe surfaces both `TXXX:` frames and MP4 freeform atoms under their
+  bare names, which is why no tag library beyond it is needed (the open
+  question in the roadmap's 1b). Cover art arrives as an `attached_pic`
+  stream and is detected here; pulling the image out is
+  `ffmpeg -i <file> -an -c:v copy <out>.jpg` when something wants it.
+
+  ## What this deliberately does not do
+
+  Nothing here is applied to anything. Providers and tags *propose*; the
+  operator owns structure (the roadmap's 1c non-goal). The consumer is 1g
+  auto-match, which turns these into pre-filled inbox items for confirmation.
+  """
+
+  alias Ambry.Media.Scanner.Tags
+
+  defstruct [
+    :title,
+    :book_title,
+    :series,
+    :series_number,
+    :published,
+    :published_format,
+    :description,
+    :publisher,
+    :genre,
+    :language,
+    :asin,
+    authors: [],
+    narrators: [],
+    has_cover_art: false,
+    raw: %{}
+  ]
+
+  # Container bookkeeping ffprobe reports as "tags" — never metadata.
+  @noise ~w(major_brand minor_version compatible_brands encoder creation_time handler_name
+            vendor_id compatible_brand media_type)
+
+  @doc """
+  Parses a raw ffprobe tag map into normalized metadata.
+  """
+  def parse(raw_tags, opts \\ []) when is_map(raw_tags) do
+    tags = normalize_keys(raw_tags)
+
+    %Tags{
+      title: get(tags, ~w(title)),
+      book_title: get(tags, ~w(album title)),
+      authors: get_list(tags, ~w(artist album_artist author authors)),
+      narrators: get_list(tags, ~w(composer narrator narrators)),
+      series: get(tags, ~w(series movement_name mvnm grouping)),
+      series_number: get_number(tags, ~w(series-part series_part part movement mvi)),
+      description: get(tags, ~w(description comment synopsis ldes desc)),
+      publisher: get(tags, ~w(publisher label)),
+      genre: get(tags, ~w(genre)),
+      language: get(tags, ~w(language)),
+      asin: get_asin(tags),
+      has_cover_art: Keyword.get(opts, :has_cover_art, false),
+      raw: tags
+    }
+    |> put_published(tags)
+  end
+
+  @doc """
+  Whether anything usable was found — an untagged rip parses to an empty
+  struct rather than an error.
+  """
+  def any?(%Tags{} = tags) do
+    Enum.any?(
+      [tags.title, tags.book_title, tags.series, tags.description, tags.publisher, tags.asin],
+      & &1
+    ) or tags.authors != [] or tags.narrators != []
+  end
+
+  # ffprobe reports keys in whatever case the file used, and prefixes ID3
+  # user-defined frames with "TXXX:" — index both away so lookups are boring.
+  defp normalize_keys(raw_tags) do
+    raw_tags
+    |> Enum.flat_map(fn {key, value} ->
+      key = key |> to_string() |> String.trim() |> String.downcase()
+      key = String.replace_prefix(key, "txxx:", "")
+
+      if key in @noise or blank?(value), do: [], else: [{key, String.trim(value)}]
+    end)
+    |> Map.new()
+  end
+
+  defp get(tags, keys) do
+    Enum.find_value(keys, &Map.get(tags, &1))
+  end
+
+  # Multi-value tags are a single string with no agreed separator. Splitting
+  # can be wrong ("Sanderson, Brandon" is one person), which is fine here:
+  # these are proposals, the operator confirms them, and `raw` keeps the
+  # original string for a consumer that wants to try a whole-string match
+  # first.
+  defp get_list(tags, keys) do
+    case get(tags, keys) do
+      nil ->
+        []
+
+      value ->
+        value
+        |> String.split(~r/\s*[;,&]\s*|\s+(?:and|feat\.?|with)\s+/i)
+        |> Enum.map(&String.trim/1)
+        |> Enum.reject(&(&1 == ""))
+        |> Enum.uniq()
+    end
+  end
+
+  defp get_number(tags, keys) do
+    with value when is_binary(value) <- get(tags, keys),
+         [number] <- Regex.run(~r/\d+(?:\.\d+)?/, value),
+         {decimal, ""} <- Decimal.parse(number) do
+      decimal
+    else
+      _no_number -> nil
+    end
+  end
+
+  # ASINs are 10-character Amazon identifiers; anything else in the field is
+  # somebody else's convention and not worth guessing at.
+  defp get_asin(tags) do
+    with value when is_binary(value) <- get(tags, ~w(asin audible_asin amazon_asin)),
+         value = String.upcase(value),
+         true <- Regex.match?(~r/^[A-Z0-9]{10}$/, value) do
+      value
+    else
+      _not_an_asin -> nil
+    end
+  end
+
+  # Reuses the same granularity the rest of the app already models on
+  # `published_format`: a tag saying "2010" must not become "Jan 1st, 2010".
+  defp put_published(%Tags{} = tags, raw) do
+    case get(raw, ~w(date year originaldate original_year)) do
+      nil ->
+        tags
+
+      value ->
+        case parse_date(value) do
+          {:ok, date, format} -> %{tags | published: date, published_format: format}
+          :error -> tags
+        end
+    end
+  end
+
+  defp parse_date(value) do
+    case Regex.run(~r/^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?/, String.trim(value)) do
+      [_match, year] -> build_date(year, "1", "1", :year)
+      [_match, year, month] -> build_date(year, month, "1", :year_month)
+      [_match, year, month, day] -> build_date(year, month, day, :full)
+      _unparseable -> :error
+    end
+  end
+
+  defp build_date(year, month, day, format) do
+    case Date.new(String.to_integer(year), String.to_integer(month), String.to_integer(day)) do
+      {:ok, date} -> {:ok, date, format}
+      {:error, _reason} -> :error
+    end
+  end
+
+  defp blank?(value), do: !is_binary(value) or String.trim(value) == ""
+end

--- a/test/ambry/media/scanner/tags_test.exs
+++ b/test/ambry/media/scanner/tags_test.exs
@@ -1,0 +1,172 @@
+defmodule Ambry.Media.Scanner.TagsTest do
+  use Ambry.DataCase
+
+  alias Ambry.Media.Scanner.Tags
+
+  describe "parse/2" do
+    test "reads what an audiobook file says about itself" do
+      tags =
+        Tags.parse(%{
+          "album" => "The Way of Kings",
+          "artist" => "Brandon Sanderson",
+          "composer" => "Michael Kramer, Kate Reading",
+          "date" => "2010-08-31",
+          "comment" => "The first book of the Stormlight Archive.",
+          "genre" => "Fantasy",
+          "publisher" => "Macmillan Audio"
+        })
+
+      assert tags.book_title == "The Way of Kings"
+      assert tags.authors == ["Brandon Sanderson"]
+      assert tags.narrators == ["Michael Kramer", "Kate Reading"]
+      assert tags.published == ~D[2010-08-31]
+      assert tags.published_format == :full
+      assert tags.description =~ "Stormlight"
+      assert tags.genre == "Fantasy"
+      assert tags.publisher == "Macmillan Audio"
+    end
+
+    test "takes the narrator from composer, the audiobook convention" do
+      tags = Tags.parse(%{"composer" => "Ray Porter"})
+
+      assert tags.narrators == ["Ray Porter"]
+    end
+
+    test "prefers album over title for the book, since title is per-file" do
+      tags = Tags.parse(%{"album" => "Dungeon Crawler Carl", "title" => "Chapter One"})
+
+      assert tags.book_title == "Dungeon Crawler Carl"
+      assert tags.title == "Chapter One"
+    end
+
+    test "falls back to title when there's no album" do
+      tags = Tags.parse(%{"title" => "Project Hail Mary"})
+
+      assert tags.book_title == "Project Hail Mary"
+    end
+
+    test "ignores container bookkeeping" do
+      tags =
+        Tags.parse(%{
+          "major_brand" => "M4A ",
+          "minor_version" => "512",
+          "compatible_brands" => "M4A isomiso2",
+          "encoder" => "Lavf62.12.102",
+          "handler_name" => "SoundHandler"
+        })
+
+      assert tags.raw == %{}
+      refute Tags.any?(tags)
+    end
+
+    test "an untagged file parses to nothing, not an error" do
+      tags = Tags.parse(%{})
+
+      assert tags.authors == []
+      assert tags.narrators == []
+      refute Tags.any?(tags)
+    end
+  end
+
+  describe "parse/2 series" do
+    test "reads series and a decimal position" do
+      tags = Tags.parse(%{"series" => "The Stormlight Archive", "series-part" => "1"})
+
+      assert tags.series == "The Stormlight Archive"
+      assert Decimal.equal?(tags.series_number, 1)
+    end
+
+    test "keeps a half-book position" do
+      tags = Tags.parse(%{"series" => "The Expanse", "series-part" => "3.5"})
+
+      assert Decimal.equal?(tags.series_number, "3.5")
+    end
+
+    test "digs a number out of a wordy position" do
+      tags = Tags.parse(%{"series" => "Discworld", "series-part" => "Book 5"})
+
+      assert Decimal.equal?(tags.series_number, 5)
+    end
+
+    test "reads the MP4 movement atoms some taggers use instead" do
+      tags = Tags.parse(%{"movement_name" => "Mistborn", "movement" => "2"})
+
+      assert tags.series == "Mistborn"
+      assert Decimal.equal?(tags.series_number, 2)
+    end
+  end
+
+  describe "parse/2 dates" do
+    test "keeps a year-only tag year-only" do
+      tags = Tags.parse(%{"date" => "2010"})
+
+      assert tags.published == ~D[2010-01-01]
+      assert tags.published_format == :year
+    end
+
+    test "keeps a year-month tag year-month" do
+      tags = Tags.parse(%{"date" => "2010-08"})
+
+      assert tags.published == ~D[2010-08-01]
+      assert tags.published_format == :year_month
+    end
+
+    test "handles a full timestamp" do
+      tags = Tags.parse(%{"date" => "2010-08-31T00:00:00Z"})
+
+      assert tags.published == ~D[2010-08-31]
+      assert tags.published_format == :full
+    end
+
+    test "ignores a date it can't make sense of" do
+      tags = Tags.parse(%{"date" => "sometime in the 90s"})
+
+      refute tags.published
+    end
+
+    test "ignores an impossible date" do
+      tags = Tags.parse(%{"date" => "2010-02-30"})
+
+      refute tags.published
+    end
+  end
+
+  describe "parse/2 ASIN" do
+    test "reads an ASIN, however the tagger cased the key" do
+      assert Tags.parse(%{"ASIN" => "b003zwfo7e"}).asin == "B003ZWFO7E"
+      assert Tags.parse(%{"asin" => "B003ZWFO7E"}).asin == "B003ZWFO7E"
+      assert Tags.parse(%{"TXXX:ASIN" => "B003ZWFO7E"}).asin == "B003ZWFO7E"
+      assert Tags.parse(%{"audible_asin" => "B003ZWFO7E"}).asin == "B003ZWFO7E"
+    end
+
+    test "refuses something that isn't one" do
+      refute Tags.parse(%{"asin" => "not-an-asin"}).asin
+      refute Tags.parse(%{"asin" => "B003"}).asin
+      refute Tags.parse(%{"asin" => ""}).asin
+    end
+  end
+
+  describe "parse/2 multi-value fields" do
+    test "splits the separators taggers actually use" do
+      assert Tags.parse(%{"artist" => "A; B"}).authors == ["A", "B"]
+      assert Tags.parse(%{"artist" => "A & B"}).authors == ["A", "B"]
+      assert Tags.parse(%{"artist" => "A and B"}).authors == ["A", "B"]
+      assert Tags.parse(%{"composer" => "A, B, C"}).narrators == ["A", "B", "C"]
+    end
+
+    test "doesn't repeat a name listed twice" do
+      assert Tags.parse(%{"artist" => "A; A"}).authors == ["A"]
+    end
+
+    # Splitting "Sanderson, Brandon" into two people is wrong, and there's no
+    # way to tell it from "Kramer, Reading" in the tag alone. That's tolerable
+    # because these are only ever proposals — and `raw` keeps the original for
+    # a consumer that wants to try matching the whole string first.
+    test "keeps the raw value so a bad split can be second-guessed" do
+      tags = Tags.parse(%{"artist" => "Sanderson, Brandon"})
+
+      assert tags.authors == ["Sanderson", "Brandon"]
+      assert tags.raw["artist"] == "Sanderson, Brandon"
+    end
+  end
+end

--- a/test/ambry/media/scanner_test.exs
+++ b/test/ambry/media/scanner_test.exs
@@ -134,6 +134,108 @@ defmodule Ambry.Media.ScannerTest do
     end
   end
 
+  describe "tags/1" do
+    test "reads embedded metadata off a real file" do
+      media = tagged_media()
+
+      assert {:ok, tags} = Scanner.tags(media)
+
+      assert tags.book_title == "The Way of Kings"
+      assert tags.authors == ["Brandon Sanderson"]
+      assert tags.narrators == ["Michael Kramer", "Kate Reading"]
+      assert tags.series == "The Stormlight Archive"
+      assert Decimal.equal?(tags.series_number, 1)
+      assert tags.asin == "B003ZWFO7E"
+      assert tags.published == ~D[2010-08-31]
+      assert tags.published_format == :full
+    end
+
+    test "notices embedded cover art" do
+      media = media_with_cover_art()
+
+      assert {:ok, tags} = Scanner.tags(media)
+      assert tags.has_cover_art
+      assert tags.book_title == "Illustrated Edition"
+    end
+
+    test "reports no cover art when there is none" do
+      media = tagged_media()
+
+      assert {:ok, tags} = Scanner.tags(media)
+      refute tags.has_cover_art
+    end
+
+    test "an untagged file yields an empty struct, not an error" do
+      media = scannable_media(:m4a)
+
+      assert {:ok, tags} = Scanner.tags(media)
+      refute Ambry.Media.Scanner.Tags.any?(tags)
+    end
+
+    test "reports a media with nothing to read" do
+      media = insert(:media, book: build(:book))
+
+      assert {:error, :no_audio_files} = Scanner.tags(media)
+    end
+  end
+
+  # Tagged the way a real rip is: freeform MP4 atoms for the things the
+  # container has no standard place for (ASIN, series), narrator in composer.
+  defp tagged_media do
+    retag(["-movflags", "use_metadata_tags"], [
+      "album=The Way of Kings",
+      "artist=Brandon Sanderson",
+      "composer=Michael Kramer, Kate Reading",
+      "SERIES=The Stormlight Archive",
+      "SERIES-PART=1",
+      "ASIN=B003ZWFO7E",
+      "date=2010-08-31"
+    ])
+  end
+
+  # Separate fixture because ffmpeg's mov muxer drops the attached-pic stream
+  # when asked to write freeform atoms — a quirk of *writing* these files, not
+  # of reading them, so real rips carry both happily.
+  defp media_with_cover_art do
+    retag(["-cover"], ["album=Illustrated Edition"])
+  end
+
+  defp retag(flags, metadata) do
+    media = scannable_media(:m4a)
+    [source_file] = media.source_files
+    dir = Path.dirname(source_file)
+    tagged_path = Path.join(dir, "tagged.m4b")
+
+    {inputs, flags} = cover_args(flags, dir, source_file)
+
+    args =
+      ["-v", "quiet"] ++
+        inputs ++
+        ["-c", "copy"] ++
+        flags ++
+        Enum.flat_map(metadata, &["-metadata", &1]) ++
+        [tagged_path]
+
+    {_output, 0} = System.cmd("ffmpeg", args)
+
+    File.rm!(source_file)
+
+    {:ok, media} = Media.update_media(media, %{source_files: [tagged_path]})
+    Media.get_media!(media.id)
+  end
+
+  defp cover_args(["-cover"], dir, source_file) do
+    cover = Path.join(dir, "cover.jpg")
+
+    {_output, 0} =
+      System.cmd("ffmpeg", ~w(-v quiet -f lavfi -i color=red:s=64x64:d=1 -frames:v 1) ++ [cover])
+
+    {["-i", source_file, "-i", cover, "-map", "0:a", "-map", "1:v"],
+     ["-disposition:v", "attached_pic"]}
+  end
+
+  defp cover_args(flags, _dir, source_file), do: {["-i", source_file], flags}
+
   defp scannable_media(type, count \\ 1, attrs \\ []) do
     :media
     |> build([book: build(:book)] ++ attrs)


### PR DESCRIPTION
The tags-first half of discovery: what an audiobook file says about itself,
normalized out of both container conventions into one struct.

## The mapping

Audiobook tagging is a set of conventions, not a standard, and mp3 and m4b
spell everything differently:

| Fact | mp3 (ID3v2) | m4b (MP4 atoms) |
|---|---|---|
| book title | `TALB` (album) | `©alb` |
| author(s) | `TPE1`/`TPE2` | `©ART`/`aART` |
| narrator(s) | `TCOM` (composer) | `©wrt` |
| series | `TXXX:SERIES`, `MVNM` | freeform `SERIES`, `mvnm` |
| series number | `TXXX:SERIES-PART`, `MVIN` | freeform, `mvi` |
| ASIN | `TXXX:ASIN` | `----:com.apple.iTunes:ASIN` |

**Narrator-in-composer** is the one genuinely load-bearing mapping — it's what
Audible and Libation-style rips use, and the only place a narrator credit
exists in a file at all.

Dates keep their granularity by reusing the `published_format` the app already
models: a tag saying `2010` becomes year-only, not January 1st 2010 (the same
distinction the v1.9.0 punch list had to restore by hand for the work-level
providers). Series numbers parse to Decimal so half-books survive. ASINs are
shape-checked rather than taken on faith.

## A knowingly imperfect bit

Multi-value splitting: `"Sanderson, Brandon"` is one person, and nothing in
the tag distinguishes it from `"Kramer, Reading"`. That's tolerable here
because tags only ever *propose* — and the raw tag map is kept on the struct,
so 1g can attempt a whole-string match against existing authors before
trusting the split. There's a test naming that trade-off rather than hiding
it.

## The tag-library question, answered

1b left open whether ffprobe suffices or a tag library is needed. **It
suffices.** ffprobe surfaces `TXXX:` frames *and* MP4 freeform atoms under
their bare names, and cover art arrives as an `attached_pic` stream — so
detection is free, and extraction is `ffmpeg -i <file> -an -c:v copy` if
something wants the image. Verified both against generated files. No new
dependency.

(Fixture quirk worth recording: ffmpeg's mov *muxer* drops the attached-pic
stream when asked to write freeform atoms, so the tests build the tagged and
cover-art fixtures separately. It's a writing quirk — real rips carry both
happily, and reading is unaffected.)

## Scope

Extraction only; nothing is applied to any record. Wiring tags into today's
import forms is deliberately **skipped** — those surfaces are being replaced
per the admin-redesign decision, and the consumer that matters is 1g
auto-match feeding the inbox. `Scanner.tags/1` is the entry point waiting for
it, which does mean this has no runtime caller until 1g lands.

## Verification

`mix check` clean; 766 tests pass. 20 unit tests over the mapping, dates,
ASIN shapes and splitting, plus 5 end-to-end tests reading real tagged files
written with ffmpeg.