### PR TITLE
Phase 3a: positional authors, narrators and series

### DIFF
--- a/lib/ambry/books/book.ex
+++ b/lib/ambry/books/book.ex
@@ -5,6 +5,7 @@ defmodule Ambry.Books.Book do
 
   use Ecto.Schema
 
+  import Ambry.Ecto.Positions
   import Ecto.Changeset
 
   alias Ambry.Books.BookUniverse
@@ -18,8 +19,8 @@ defmodule Ambry.Books.Book do
 
   schema "books" do
     has_many :media, Media, preload_order: [desc: :published]
-    has_many :series_books, SeriesBook, on_replace: :delete
-    has_many :book_authors, BookAuthor, on_replace: :delete
+    has_many :series_books, SeriesBook, on_replace: :delete, preload_order: [asc: :position]
+    has_many :book_authors, BookAuthor, on_replace: :delete, preload_order: [asc: :position]
     has_many :book_universes, BookUniverse, on_replace: :delete
     has_many :series, through: [:series_books, :series]
     has_many :authors, through: [:book_authors, :author]
@@ -54,6 +55,8 @@ defmodule Ambry.Books.Book do
       sort_param: :book_universes_sort,
       drop_param: :book_universes_drop
     )
+    |> put_positions(:book_authors)
+    |> put_positions(:series_books)
     |> validate_required([:title, :published])
     |> foreign_key_constraint(:media, name: "media_book_id_fkey")
     |> Provenance.track_changes(@provenance_fields, opts[:provenance] || %{})

--- a/lib/ambry/books/series_book.ex
+++ b/lib/ambry/books/series_book.ex
@@ -18,13 +18,21 @@ defmodule Ambry.Books.SeriesBook do
 
     field :book_number, :decimal
 
+    # Which series comes first when a book belongs to several (a main series
+    # and a sub-series, say). The first is the book's primary series — what
+    # the library naming template uses for the folder.
+    #
+    # Note this orders a *book's* series, not a series' books; those are
+    # ordered by `book_number`.
+    field :position, :integer, default: 0
+
     timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(series_book, attrs) do
     series_book
-    |> cast(attrs, [:book_id, :book_number, :series_id])
+    |> cast(attrs, [:book_id, :book_number, :series_id, :position])
     |> validate_required([:book_number])
     |> validate_number(:book_number, greater_than_or_equal_to: 0)
   end

--- a/lib/ambry/ecto/positions.ex
+++ b/lib/ambry/ecto/positions.ex
@@ -1,0 +1,52 @@
+defmodule Ambry.Ecto.Positions do
+  @moduledoc """
+  Keeps an ordered `has_many` numbered by its position in the list.
+
+  Phoenix's `sort_param` already gives a form control over the *order* of an
+  association's entries — it reorders the changesets before they're cast. What
+  it can't do is make that order survive the round trip, because nothing
+  writes it down. This does: after casting, each entry's `position` is set to
+  where it actually sits.
+
+  Entries on their way out are left exactly as they are and don't consume a
+  number, so removing the first of three authors leaves 0, 1 — not a hole at
+  0. They are deliberately kept in the list rather than filtered out: the
+  list *is* the instruction to Ecto, and dropping an entry from it would make
+  `on_replace: :delete` fire on something the operator never removed.
+  """
+
+  import Ecto.Changeset
+
+  @doc """
+  Numbers the entries of `field` by their position in the list.
+  """
+  def put_positions(changeset, field) do
+    case get_change(changeset, field) do
+      nil ->
+        changeset
+
+      entries ->
+        # Written straight into `changes` rather than via `put_change/3`:
+        # these entries have already been through `cast_assoc`, and Ecto
+        # refuses to run its relation-change tracking over its own output
+        # ("cannot replace related ... only once per assoc"). Nothing here
+        # adds or removes an entry — it only sets a field on each — so the
+        # tracking has nothing left to do anyway.
+        %{changeset | changes: Map.put(changeset.changes, field, number(entries))}
+    end
+  end
+
+  defp number(entries) do
+    {numbered, _next} =
+      Enum.map_reduce(entries, 0, fn entry, next ->
+        if leaving?(entry),
+          do: {entry, next},
+          else: {put_change(entry, :position, next), next + 1}
+      end)
+
+    numbered
+  end
+
+  defp leaving?(%Ecto.Changeset{action: action}), do: action in [:delete, :replace]
+  defp leaving?(_entry), do: false
+end

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -5,6 +5,7 @@ defmodule Ambry.Media.Media do
 
   use Ecto.Schema
 
+  import Ambry.Ecto.Positions
   import Ecto.Changeset
 
   alias Ambry.Books.Book
@@ -27,7 +28,7 @@ defmodule Ambry.Media.Media do
   schema "media" do
     belongs_to :book, Book
     belongs_to :recording_group, RecordingGroup
-    has_many :media_narrators, MediaNarrator, on_replace: :delete
+    has_many :media_narrators, MediaNarrator, on_replace: :delete, preload_order: [asc: :position]
     has_many :authors, through: [:book, :authors]
     has_many :narrators, through: [:media_narrators, :narrator]
 
@@ -124,6 +125,7 @@ defmodule Ambry.Media.Media do
       sort_param: :media_narrators_sort,
       drop_param: :media_narrators_drop
     )
+    |> put_positions(:media_narrators)
     |> maybe_cast_tracks(attrs)
     |> cast_embed(:chapters,
       sort_param: :chapters_sort,

--- a/lib/ambry/media/media_narrator.ex
+++ b/lib/ambry/media/media_narrator.ex
@@ -14,13 +14,17 @@ defmodule Ambry.Media.MediaNarrator do
     belongs_to :media, Media
     belongs_to :narrator, Narrator
 
+    # Billing order. The first narrator is the one a single-narrator display
+    # shows, and the order every list of narrators is rendered in.
+    field :position, :integer, default: 0
+
     timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(media_narrator, attrs) do
     media_narrator
-    |> cast(attrs, [:narrator_id])
+    |> cast(attrs, [:narrator_id, :position])
     |> validate_required(:narrator_id)
   end
 end

--- a/lib/ambry/people/book_author.ex
+++ b/lib/ambry/people/book_author.ex
@@ -14,13 +14,18 @@ defmodule Ambry.People.BookAuthor do
     belongs_to :author, Author
     belongs_to :book, Book
 
+    # Which credit comes first. The first one is the book's primary author —
+    # what the library naming template uses for the folder, and the order
+    # every list of authors is rendered in.
+    field :position, :integer, default: 0
+
     timestamps(type: :utc_datetime)
   end
 
   @doc false
   def changeset(book_author, attrs) do
     book_author
-    |> cast(attrs, [:author_id])
+    |> cast(attrs, [:author_id, :position])
     |> validate_required(:author_id)
     |> unique_constraint([:author_id, :book_id])
   end

--- a/lib/ambry_schema/books.ex
+++ b/lib/ambry_schema/books.ex
@@ -17,6 +17,11 @@ defmodule AmbrySchema.Books do
   node object(:series_book) do
     field :book_number, non_null(:decimal)
 
+    # Which series comes first when a book is in several. Additive: clients
+    # that don't ask for it are unaffected, and one that does can order a
+    # book's series the way the operator did.
+    field :position, non_null(:integer)
+
     field :book, non_null(:book), resolve: dataloader(Resolvers)
     field :series, non_null(:series), resolve: dataloader(Resolvers)
 
@@ -78,6 +83,9 @@ defmodule AmbrySchema.Books do
   end
 
   node object(:book_author) do
+    # Billing order: position 0 is the book's primary author.
+    field :position, non_null(:integer)
+
     field :author, non_null(:author), resolve: dataloader(Resolvers)
     field :book, non_null(:book), resolve: dataloader(Resolvers)
 

--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -141,6 +141,9 @@ defmodule AmbrySchema.Media do
   end
 
   node object(:media_narrator) do
+    # Billing order: position 0 is the recording's lead narrator.
+    field :position, non_null(:integer)
+
     field :media, non_null(:media), resolve: dataloader(Resolvers, args: %{allow_all_media: true})
     field :narrator, non_null(:narrator), resolve: dataloader(Resolvers)
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -454,6 +454,67 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  @doc """
+  Carries a row's place in the list back to the server.
+
+  Not decoration: a reorder that changes no field is invisible to Ecto —
+  `cast_assoc` returns `:ignore` when every child changeset comes back empty,
+  and the new order is silently dropped. This input is what makes a moved row
+  a real change. See `AmbryWeb.Admin.Reordering`.
+  """
+  attr :field, FormField, required: true
+  attr :index, :integer, required: true
+
+  def position_input(assigns) do
+    ~H"""
+    <input type="hidden" name={@field.name} value={@index} />
+    """
+  end
+
+  @doc """
+  Up/down buttons for reordering one entry of an ordered association.
+
+  The button at each end of the list is rendered disabled rather than hidden,
+  so the controls don't shift horizontally as rows move past them.
+  """
+  attr :field, :atom, required: true, doc: "the association field being reordered"
+  attr :index, :integer, required: true
+  attr :count, :integer, required: true
+  attr :class, :string, default: nil
+
+  def move_buttons(assigns) do
+    ~H"""
+    <div class={["flex flex-col", @class]} data-role="move-buttons">
+      <button
+        type="button"
+        phx-click="move"
+        phx-value-field={@field}
+        phx-value-index={@index}
+        phx-value-direction="up"
+        disabled={@index == 0}
+        title="Move up"
+        data-role="move-up"
+        class="disabled:opacity-25"
+      >
+        <.icon name="fa-chevron-up" class="h-3 w-3 text-current transition-colors hover:text-blue-600" />
+      </button>
+      <button
+        type="button"
+        phx-click="move"
+        phx-value-field={@field}
+        phx-value-index={@index}
+        phx-value-direction="down"
+        disabled={@index == @count - 1}
+        title="Move down"
+        data-role="move-down"
+        class="disabled:opacity-25"
+      >
+        <.icon name="fa-chevron-down" class="h-3 w-3 text-current transition-colors hover:text-blue-600" />
+      </button>
+    </div>
+    """
+  end
+
   attr :field, FormField, required: true
   slot :inner_block, required: true
 

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -9,6 +9,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   alias Ambry.Provenance
   alias AmbryWeb.Admin.BookLive.Form.ProviderImportForm
   alias AmbryWeb.Admin.ProvenanceHints
+  alias AmbryWeb.Admin.Reordering
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -109,6 +110,13 @@ defmodule AmbryWeb.Admin.BookLive.Form do
     {:noreply, handle_import_form_params(socket, %{"import" => type})}
   end
 
+  def handle_event("move", params, socket) do
+    changeset = socket.assigns.form.source
+    book_params = Reordering.move(changeset, socket.assigns.form.params, params)
+
+    {:noreply, assign_form(socket, Books.change_book(socket.assigns.book, book_params))}
+  end
+
   @impl Phoenix.LiveView
   def handle_info({:import, %{"book" => book_params}, source}, socket) do
     # authors and/or series could have been created, reload the data-lists
@@ -162,7 +170,12 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do
-    assign(socket, :form, to_form(changeset))
+    assign(socket,
+      form: to_form(changeset),
+      # the move buttons need to know where the ends of each list are
+      book_author_count: length(Changeset.get_assoc(changeset, :book_authors)),
+      series_book_count: length(Changeset.get_assoc(changeset, :series_books))
+    )
   end
 
   defp open_import_form(%Book{id: nil}, type), do: JS.patch(~p"/admin/books/new?import=#{type}")

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -53,14 +53,24 @@
         <.label>Authors</.label>
         <.inputs_for :let={book_author_form} field={@form[:book_authors]}>
           <.sort_input field={@form[:book_authors_sort]} index={book_author_form.index} />
+          <.position_input field={book_author_form[:position]} index={book_author_form.index} />
 
-          <div class="relative">
-            <.input field={book_author_form[:author_id]} type="autocomplete" options={@authors} list="authors" />
-            <.delete_button
-              field={@form[:book_authors_drop]}
+          <div class="relative flex items-start gap-2">
+            <.move_buttons
+              :if={@book_author_count > 1}
+              field={:book_authors}
               index={book_author_form.index}
-              class="absolute top-3 right-2"
+              count={@book_author_count}
+              class="mt-3 flex-none"
             />
+            <div class="relative grow">
+              <.input field={book_author_form[:author_id]} type="autocomplete" options={@authors} list="authors" />
+              <.delete_button
+                field={@form[:book_authors_drop]}
+                index={book_author_form.index}
+                class="absolute top-3 right-2"
+              />
+            </div>
           </div>
         </.inputs_for>
 
@@ -72,8 +82,16 @@
         <.label>Series</.label>
         <.inputs_for :let={series_book_form} field={@form[:series_books]}>
           <.sort_input field={@form[:series_books_sort]} index={series_book_form.index} />
+          <.position_input field={series_book_form[:position]} index={series_book_form.index} />
 
           <div class="relative flex items-start gap-2">
+            <.move_buttons
+              :if={@series_book_count > 1}
+              field={:series_books}
+              index={series_book_form.index}
+              count={@series_book_count}
+              class="mt-3 flex-none"
+            />
             <.input
               field={series_book_form[:book_number]}
               placeholder="no."

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -13,6 +13,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   alias AmbryWeb.Admin.MediaLive.Form.FileBrowser
   alias AmbryWeb.Admin.MediaLive.Form.ProviderImportForm
   alias AmbryWeb.Admin.ProvenanceHints
+  alias AmbryWeb.Admin.Reordering
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
@@ -159,6 +160,13 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   def handle_event("toggle-provenance-lock", %{"field" => field}, socket) do
     {:ok, media} = Provenance.toggle_lock(socket.assigns.media, field)
     {:noreply, assign(socket, media: media)}
+  end
+
+  def handle_event("move", params, socket) do
+    changeset = socket.assigns.form.source
+    media_params = Reordering.move(changeset, socket.assigns.form.params, params)
+
+    {:noreply, assign_form(socket, Media.change_media(socket.assigns.media, media_params))}
   end
 
   def handle_event("cancel-upload", %{"ref" => ref}, socket) do
@@ -329,7 +337,11 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do
-    assign(socket, :form, to_form(changeset))
+    assign(socket,
+      form: to_form(changeset),
+      # the move buttons need to know where the ends of the list are
+      media_narrator_count: length(Changeset.get_assoc(changeset, :media_narrators))
+    )
   end
 
   defp maybe_start_processor!(media, media_params, :new) do

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -80,14 +80,29 @@
         <.label>Narrated by</.label>
         <.inputs_for :let={media_narrator_form} field={@form[:media_narrators]}>
           <.sort_input field={@form[:media_narrators_sort]} index={media_narrator_form.index} />
+          <.position_input field={media_narrator_form[:position]} index={media_narrator_form.index} />
 
-          <div class="relative">
-            <.input field={media_narrator_form[:narrator_id]} type="autocomplete" options={@narrators} list="narrators" />
-            <.delete_button
-              field={@form[:media_narrators_drop]}
+          <div class="relative flex items-start gap-2">
+            <.move_buttons
+              :if={@media_narrator_count > 1}
+              field={:media_narrators}
               index={media_narrator_form.index}
-              class="absolute top-3 right-2"
+              count={@media_narrator_count}
+              class="mt-3 flex-none"
             />
+            <div class="relative grow">
+              <.input
+                field={media_narrator_form[:narrator_id]}
+                type="autocomplete"
+                options={@narrators}
+                list="narrators"
+              />
+              <.delete_button
+                field={@form[:media_narrators_drop]}
+                index={media_narrator_form.index}
+                class="absolute top-3 right-2"
+              />
+            </div>
           </div>
         </.inputs_for>
 

--- a/lib/ambry_web/live/admin/reordering.ex
+++ b/lib/ambry_web/live/admin/reordering.ex
@@ -1,0 +1,118 @@
+defmodule AmbryWeb.Admin.Reordering do
+  @moduledoc """
+  Moving an entry of an ordered `has_many` up or down in an admin form.
+
+  Deliberately not drag-and-drop. Ordering a book's two authors is a
+  once-in-a-while act on a list that is almost always two or three long, and
+  a pair of buttons needs no JavaScript, works on a phone, and can be tested
+  without a browser.
+
+  ## Why this works on params rather than the changeset
+
+  The obvious implementation — reorder the changeset's assoc list — does not
+  work, and the reason is worth writing down.
+
+  `cast_assoc`'s `:sort_param` really does order the incoming params (see
+  `Ecto.Changeset.cast_params/4`), but `cast_relation` then throws the result
+  away unless something actually changed: a pure reorder leaves every child
+  changeset empty, `Relation.cast` returns `:ignore`, and the association ends
+  up with no change at all. Reordering alone is invisible to Ecto.
+
+  So the order has to be carried by a real field. Each row renders a hidden
+  `position` input holding its rendered index; moving a row swaps two entries
+  in the params, which swaps both their render order *and* their positions.
+  Now the children genuinely differ, the cast keeps them in the new order, and
+  `Ambry.Ecto.Positions` renumbers them 0..n on the way to the database.
+  """
+
+  import Ecto.Changeset
+
+  @doc """
+  Applies a `move` event's params to the form's params.
+
+  Returns the updated params map, ready to rebuild a changeset with. Anything
+  unrecognised returns the params untouched rather than raising: these values
+  come off the wire, and the field name is only ever resolved against the
+  schema's own associations, so a crafted event can't reach an arbitrary atom
+  or an unrelated field.
+  """
+  def move(%Ecto.Changeset{} = changeset, params, %{
+        "field" => field,
+        "index" => index,
+        "direction" => direction
+      }) do
+    with {:ok, association} <- association(changeset, field),
+         {index, ""} <- Integer.parse(index),
+         {:ok, offset} <- offset(direction) do
+      swap(changeset, params, association, field, index, index + offset)
+    else
+      _unrecognized -> params
+    end
+  end
+
+  def move(%Ecto.Changeset{}, params, _params), do: params
+
+  defp swap(changeset, params, association, field, from, to) do
+    entries = entries(changeset, params, field, get_assoc(changeset, association))
+    keys = entries |> Map.keys() |> Enum.sort_by(&String.to_integer/1)
+
+    with from_key when not is_nil(from_key) <- Enum.at(keys, from),
+         to_key when not is_nil(to_key) <- Enum.at(keys, to),
+         true <- to >= 0 do
+      entries =
+        entries
+        |> Map.put(from_key, Map.fetch!(entries, to_key))
+        |> Map.put(to_key, Map.fetch!(entries, from_key))
+        |> renumber(keys)
+
+      params
+      |> Map.put(field, entries)
+      |> Map.put(field <> "_sort", keys)
+    else
+      _out_of_range -> params
+    end
+  end
+
+  # The position belongs to the slot, not to the row that's sitting in it.
+  #
+  # Letting it travel with the row is the subtle way to build buttons that do
+  # nothing: every row would submit the position it already had, no child
+  # changeset would differ, and `cast_relation` would discard the whole
+  # association as unchanged — visibly reordered on screen, unchanged in the
+  # database.
+  defp renumber(entries, keys) do
+    keys
+    |> Enum.with_index()
+    |> Enum.reduce(entries, fn {key, index}, entries ->
+      Map.update!(entries, key, &Map.put(&1, "position", to_string(index)))
+    end)
+  end
+
+  # What the form last submitted, or — before it has submitted anything — the
+  # minimum that describes each existing row. Partial params are safe here:
+  # `cast_assoc` only casts the keys it's given, so an untouched field keeps
+  # its stored value.
+  defp entries(_changeset, params, field, _assoc) when is_map_key(params, field) do
+    Map.fetch!(params, field)
+  end
+
+  defp entries(_changeset, _params, _field, assoc) do
+    assoc
+    |> Enum.with_index()
+    |> Map.new(fn {entry, index} ->
+      {key(index), %{"id" => to_string(get_field(entry, :id)), "position" => to_string(index)}}
+    end)
+  end
+
+  defp association(%Ecto.Changeset{data: %schema{}}, field) do
+    Enum.find_value(schema.__schema__(:associations), :error, fn association ->
+      if Atom.to_string(association) == field, do: {:ok, association}
+    end)
+  end
+
+  defp offset("up"), do: {:ok, -1}
+  defp offset("down"), do: {:ok, 1}
+  defp offset(_other), do: :error
+
+  defp key(index), do: to_string(index)
+end

--- a/priv/repo/migrations/20260803152127_credit_positions.exs
+++ b/priv/repo/migrations/20260803152127_credit_positions.exs
@@ -1,0 +1,54 @@
+defmodule Ambry.Repo.Migrations.CreditPositions do
+  use Ecto.Migration
+
+  # Which credit comes first, as data rather than an accident.
+  #
+  # Until now the order of a book's authors, a recording's narrators and a
+  # book's series was whatever order the rows happened to be inserted in —
+  # `ORDER BY author_link.id` sits in the flat views to this day. That's
+  # invisible and unfixable from the admin UI, and for anything the inbox
+  # creates it's simply whatever order a metadata provider returned.
+  #
+  # It also blocks the library naming template (roadmap 3a), which has to
+  # answer "which author owns this folder?" and "which series?" for books
+  # that have several of each. A designated primary is the decided answer,
+  # and a position column is what makes the designation persist.
+  #
+  # Backfilled from the existing id order so nothing visibly reorders on
+  # deploy: today's implicit order becomes today's explicit order.
+  @tables [
+    {"authors_books", "book_id"},
+    {"media_narrators", "media_id"},
+    {"books_series", "book_id"}
+  ]
+
+  def up do
+    for {table, parent} <- @tables do
+      alter table(table) do
+        add :position, :integer, null: false, default: 0
+      end
+
+      execute """
+      UPDATE #{table} AS t
+      SET position = ordered.row_number - 1
+      FROM (
+        SELECT id, ROW_NUMBER() OVER (PARTITION BY #{parent} ORDER BY id) AS row_number
+        FROM #{table}
+      ) AS ordered
+      WHERE t.id = ordered.id
+      """
+
+      create index(table, [parent, :position])
+    end
+  end
+
+  def down do
+    for {table, parent} <- @tables do
+      drop index(table, [parent, :position])
+
+      alter table(table) do
+        remove :position
+      end
+    end
+  end
+end

--- a/priv/repo/migrations/20260803152448_flat_views_by_credit_position.exs
+++ b/priv/repo/migrations/20260803152448_flat_views_by_credit_position.exs
@@ -1,0 +1,26 @@
+defmodule Ambry.Repo.Migrations.FlatViewsByCreditPosition do
+  use Ecto.Migration
+  use Familiar
+
+  # The flat views built their author, narrator and series arrays in
+  # alphabetical order (and a book's series list in book-number order, which
+  # across two different series means nothing at all). Now that credits carry
+  # an explicit position, the views follow the operator's ordering instead —
+  # so the first author really is the primary one everywhere a book or
+  # recording is rendered.
+  #
+  # `series_flat` and `people_flat` are deliberately untouched: a series' list
+  # of authors is a DISTINCT set gathered across every book in it, so no one
+  # book's ordering owns it, and `people_flat` doesn't build an ordered credit
+  # array at all.
+
+  def up do
+    update_view("books_flat", version: 13)
+    update_view("media_flat", version: 12)
+  end
+
+  def down do
+    update_view("books_flat", version: 12)
+    update_view("media_flat", version: 11)
+  end
+end

--- a/priv/repo/views/books_flat_v13.sql
+++ b/priv/repo/views/books_flat_v13.sql
@@ -1,0 +1,92 @@
+SELECT
+  book.id,
+  book.title,
+  book.published,
+  book.published_format,
+  ARRAY(
+    -- tile system v2: one cover per edition — a part set contributes its
+    -- first part — newest edition first. Mirrors Ambry.Media.Editions
+    -- (all_statuses: admin lists deliberately include non-ready media);
+    -- held in lockstep by test/ambry/flat_view_stack_test.exs.
+    SELECT
+      media.thumbnails -> 'small'
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+      AND media.thumbnails IS NOT NULL
+      AND (
+        media.recording_group_id IS NULL
+        OR media.id = (
+          SELECT m2.id
+          FROM media m2
+          WHERE m2.recording_group_id = media.recording_group_id
+          ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
+          LIMIT 1
+        )
+      )
+    ORDER BY
+      media.published DESC NULLS LAST,
+      media.id DESC
+  ) AS thumbnails,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      authored_by.position,
+      authored_by.id
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.position,
+      books_series.id
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  (
+    SELECT
+      COUNT(media.id)
+    FROM
+      media
+    WHERE
+      media.book_id = book.id
+  ) AS media,
+  book.inserted_at,
+  book.updated_at,
+  -- deprecated
+  book.image_path,
+  book.description IS NOT NULL AS has_description
+FROM
+  books AS book
+ORDER BY
+  book.title

--- a/priv/repo/views/media_flat_v12.sql
+++ b/priv/repo/views/media_flat_v12.sql
@@ -1,0 +1,91 @@
+SELECT
+  media.id,
+  media.status,
+  media.title,
+  media.part_number,
+  media.parts_total,
+  (
+    SELECT
+      recording_group.part_word
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS part_word,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.position,
+      books_series.id
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      authored_by.position,
+      authored_by.id
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrated_by.position,
+      narrated_by.id
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/test/ambry/credit_positions_test.exs
+++ b/test/ambry/credit_positions_test.exs
@@ -1,0 +1,175 @@
+defmodule Ambry.CreditPositionsTest do
+  @moduledoc """
+  Ordering of a book's authors, a book's series and a recording's narrators.
+
+  Before positions existed this order was whatever the rows happened to be
+  inserted in — the flat views literally said `ORDER BY author_link.id` —
+  which meant an inbox-created book was ordered by whatever a metadata
+  provider returned, with no way for the operator to change it.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Books
+  alias Ambry.Books.Book
+  alias Ambry.Media
+  alias Ambry.Repo
+
+  describe "book authors" do
+    test "are numbered in the order they're given" do
+      first = insert(:author)
+      second = insert(:author)
+
+      {:ok, book} =
+        Books.create_book(%{
+          title: "Good Omens",
+          published: ~D[1990-05-01],
+          published_format: :full,
+          book_authors: [%{author_id: second.id}, %{author_id: first.id}]
+        })
+
+      book = Repo.preload(book, :book_authors)
+
+      assert Enum.map(book.book_authors, &{&1.position, &1.author_id}) == [
+               {0, second.id},
+               {1, first.id}
+             ]
+    end
+
+    test "renumber from zero when the list is reordered" do
+      book = book_with_authors()
+      [a, b, c] = book.book_authors
+
+      book = reorder_authors(book, [c, a, b])
+
+      assert Enum.map(book.book_authors, &{&1.position, &1.id}) == [
+               {0, c.id},
+               {1, a.id},
+               {2, b.id}
+             ]
+    end
+
+    # Removing an entry must not leave a hole: the survivors are 0 and 1, not
+    # 1 and 2, or "the first author" stops meaning position zero.
+    test "renumber without a gap when one is dropped" do
+      book = book_with_authors()
+      [a, _b, c] = book.book_authors
+
+      book = reorder_authors(book, [a, c])
+
+      assert Enum.map(book.book_authors, & &1.position) == [0, 1]
+    end
+
+    test "preload comes back in position order, not insertion order" do
+      book = book_with_authors()
+      [a, b, c] = book.book_authors
+
+      _reordered = reorder_authors(book, [c, b, a])
+
+      reloaded = Book |> Repo.get!(book.id) |> Repo.preload(:book_authors)
+      assert Enum.map(reloaded.book_authors, & &1.id) == [c.id, b.id, a.id]
+    end
+
+    # `has_many :authors, through: [:book_authors, :author]` inheriting the
+    # join's `preload_order` is what lets every existing `preload(:authors)`
+    # call site stay untouched. If Ecto ever stops doing that, dozens of
+    # display surfaces silently revert to insertion order — so it's pinned
+    # here rather than assumed.
+    test "the through association inherits the join's ordering" do
+      book = book_with_authors()
+      [a, b, c] = book.book_authors
+
+      _reordered = reorder_authors(book, [c, a, b])
+
+      reloaded = Book |> Repo.get!(book.id) |> Repo.preload([:authors, :book_authors])
+
+      assert Enum.map(reloaded.authors, & &1.id) ==
+               Enum.map(reloaded.book_authors, & &1.author_id)
+    end
+  end
+
+  describe "media narrators" do
+    test "are numbered in the order they're given" do
+      book = insert(:book)
+      first = insert(:narrator, person: build(:person))
+      second = insert(:narrator, person: build(:person))
+
+      {:ok, media} =
+        Media.create_media(%{
+          book_id: book.id,
+          source_path: "/tmp/#{Ecto.UUID.generate()}",
+          media_narrators: [%{narrator_id: second.id}, %{narrator_id: first.id}]
+        })
+
+      media = Repo.preload(media, :media_narrators)
+
+      assert Enum.map(media.media_narrators, &{&1.position, &1.narrator_id}) == [
+               {0, second.id},
+               {1, first.id}
+             ]
+    end
+  end
+
+  describe "book series" do
+    # The old flat views ordered a book's series by book_number, which across
+    # two different series compares numbers that have nothing to do with each
+    # other — #2 of a sub-series sorted ahead of #11 of its parent.
+    test "keep the given order even when the lower book number is second" do
+      main = insert(:series)
+      sub = insert(:series)
+
+      {:ok, book} =
+        Books.create_book(%{
+          title: "Reaper Man",
+          published: ~D[1991-05-01],
+          published_format: :full,
+          series_books: [
+            %{series_id: main.id, book_number: 11},
+            %{series_id: sub.id, book_number: 2}
+          ]
+        })
+
+      book = Repo.preload(book, :series_books)
+
+      assert Enum.map(book.series_books, &{&1.position, &1.series_id}) == [
+               {0, main.id},
+               {1, sub.id}
+             ]
+    end
+  end
+
+  defp book_with_authors do
+    book = insert(:book)
+    authors = for _each <- 1..3, do: insert(:author)
+
+    put_authors(book, Enum.map(authors, &%{"author_id" => &1.id}))
+  end
+
+  # Keeps each row's identity while changing its place in the list, which is
+  # exactly what the form submits after a move.
+  defp reorder_authors(book, book_authors) do
+    put_authors(book, Enum.map(book_authors, &%{"id" => &1.id, "author_id" => &1.author_id}))
+  end
+
+  # The association exactly as a form submits it: an index-keyed map in
+  # rendered order, the `_sort` array, and each row's `position`.
+  #
+  # The position is what makes a reorder register at all. `cast_assoc` orders
+  # the params by the sort array, but `cast_relation` discards the result when
+  # no child actually changed — and moving a row changes nothing about it.
+  # Without a position the reorder is silently a no-op.
+  defp put_authors(book, entries) do
+    params =
+      entries
+      |> Enum.with_index()
+      |> Map.new(fn {entry, index} ->
+        {to_string(index), Map.put(entry, "position", to_string(index))}
+      end)
+
+    sort = Enum.map(0..(length(entries) - 1), &to_string/1)
+
+    {:ok, book} =
+      Books.update_book(book, %{"book_authors" => params, "book_authors_sort" => sort})
+
+    Repo.preload(book, [:book_authors], force: true)
+  end
+end

--- a/test/ambry_web/live/admin/book_live/reorder_test.exs
+++ b/test/ambry_web/live/admin/book_live/reorder_test.exs
@@ -1,0 +1,166 @@
+defmodule AmbryWeb.Admin.BookLive.ReorderTest do
+  @moduledoc """
+  Reordering a book's authors and series through the actual form.
+
+  The unit tests cover the changeset; this covers the part that historically
+  went wrong — that clicking a button in the rendered form actually reaches
+  the database. A reorder that changes no field is invisible to `cast_assoc`,
+  so it is entirely possible for the buttons to look like they work, the list
+  to visibly move, and nothing at all to be saved.
+  """
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Books
+  alias Ambry.Repo
+
+  setup :register_and_log_in_admin_user
+
+  describe "authors" do
+    test "moving one down and saving persists the new order", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      view |> element("[data-role='move-down']:not([disabled])") |> render_click()
+      view |> form("#book-form") |> render_submit()
+
+      assert author_order(book) == [second.id, first.id]
+    end
+
+    test "moving one up and saving persists the new order", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      view |> element("[data-role='move-up']:not([disabled])") |> render_click()
+      view |> form("#book-form") |> render_submit()
+
+      assert author_order(book) == [second.id, first.id]
+    end
+
+    test "the moved row visibly changes place before saving", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, html} = live(conn, ~p"/admin/books/#{book}/edit")
+      assert rendered_author_ids(html) == [first.id, second.id]
+
+      html = view |> element("[data-role='move-down']:not([disabled])") |> render_click()
+      assert rendered_author_ids(html) == [second.id, first.id]
+    end
+
+    # The ends of the list can't move past themselves, and a stale page that
+    # tries anyway must not crash the LiveView.
+    test "the buttons are disabled at the ends of the list", %{conn: conn} do
+      %{book: book} = book_with_two_authors()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      document = Floki.parse_document!(html)
+      assert [_up_disabled] = Floki.find(document, "[data-role='move-up'][disabled]")
+      assert [_down_disabled] = Floki.find(document, "[data-role='move-down'][disabled]")
+    end
+
+    test "an out-of-range move is ignored rather than crashing", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      render_click(view, "move", %{
+        "field" => "book_authors",
+        "index" => "9",
+        "direction" => "down"
+      })
+
+      view |> form("#book-form") |> render_submit()
+      assert author_order(book) == [first.id, second.id]
+    end
+
+    # Moving up from the top computes index -1, and `Enum.at(list, -1)` is the
+    # *last* element — so a careless implementation swaps the first row with
+    # the last instead of doing nothing.
+    test "moving up from the top does not wrap around to the bottom", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      render_click(view, "move", %{
+        "field" => "book_authors",
+        "index" => "0",
+        "direction" => "up"
+      })
+
+      view |> form("#book-form") |> render_submit()
+      assert author_order(book) == [first.id, second.id]
+    end
+
+    # The field name comes off the wire, so it's resolved against the schema's
+    # own associations and nothing else.
+    test "a move naming an unknown field is ignored", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      render_click(view, "move", %{
+        "field" => "not_an_association",
+        "index" => "0",
+        "direction" => "down"
+      })
+
+      view |> form("#book-form") |> render_submit()
+      assert author_order(book) == [first.id, second.id]
+    end
+
+    # One author means no ambiguity and nothing to order.
+    test "no buttons appear for a single author", %{conn: conn} do
+      book = insert(:book)
+      author = insert(:author)
+      {:ok, book} = put_authors(book, [author.id])
+
+      {:ok, _view, html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      assert html |> Floki.parse_document!() |> Floki.find("[data-role='move-buttons']") == []
+    end
+  end
+
+  defp book_with_two_authors do
+    book = insert(:book)
+    first = insert(:author)
+    second = insert(:author)
+    {:ok, book} = put_authors(book, [first.id, second.id])
+
+    %{book: book, authors: [first, second]}
+  end
+
+  defp put_authors(book, author_ids) do
+    params =
+      author_ids
+      |> Enum.with_index()
+      |> Map.new(fn {author_id, index} ->
+        {to_string(index), %{"author_id" => author_id, "position" => to_string(index)}}
+      end)
+
+    Books.update_book(book, %{
+      "book_authors" => params,
+      "book_authors_sort" => Enum.map(0..(length(author_ids) - 1), &to_string/1)
+    })
+  end
+
+  defp author_order(book) do
+    book.id
+    |> Books.get_book!()
+    |> Repo.preload(:book_authors)
+    |> Map.fetch!(:book_authors)
+    |> Enum.map(& &1.author_id)
+  end
+
+  # The autocomplete input carries the author id, so the rendered order of
+  # those values is the rendered order of the rows.
+  defp rendered_author_ids(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("input[name^='book[book_authors]'][name$='[author_id]']")
+    |> Enum.map(&(&1 |> Floki.attribute("value") |> hd() |> String.to_integer()))
+  end
+end


### PR DESCRIPTION
Which credit comes first was never data. The flat views said `ORDER BY author_link.id` outright, and sorted a book's series by `book_number` — which across two different series compares numbers that have nothing to do with each other. Nothing in the admin UI could change any of it, and for anything the inbox creates the order is whatever a metadata provider happened to return.

It also blocks the library naming template, which has to answer "which author owns this folder?" and "which series?" for books that have several of each.

**Narrators are included** — they weren't in the original framing but had exactly the same defect.

## What changed

- `position` on `authors_books`, `media_narrators` and `books_series`, backfilled from the existing id order so **nothing visibly reorders on deploy**.
- `books_flat` v13 / `media_flat` v12 order by it. They previously ordered authors and narrators *alphabetically*.
- `series_flat` and `people_flat` deliberately untouched: a series' author list is a `DISTINCT` set gathered across every book in it, so no one book's ordering owns it.
- **Up/down reordering buttons in the book and media forms.** There was no reordering UI at all before this — not drag-and-drop, per the ask.
- `position` exposed on all three GraphQL join types. Additive; existing clients are unaffected.

## The subtle part

A pure reorder is invisible to Ecto, and this cost real time to find. `cast_assoc`'s `:sort_param` genuinely does order the incoming params (`Ecto.Changeset.cast_params/4`), but `cast_relation` then discards the result unless a child actually changed — moving a row changes nothing about it, so `Relation.cast` returns `:ignore` and the new order is dropped on the floor.

So the order has to be carried by a real field. Each row submits its rendered index as `position` — and **that position belongs to the slot, not to the row sitting in it**. Letting it travel with the row is the way to build buttons that visibly reorder the screen and save nothing; I built exactly that bug first, and there's a test for it now.

`Enum.at(list, -1)` returning the last element is the other trap: moving up from the top computes index `-1` and a careless implementation swaps the first row with the last. Also tested.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: 896 passed, 1 skipped. 15 new tests.
- Migration rolls back and re-applies; backfill preserves current ordering.
- `has_many :through` **does** inherit the join's `preload_order`, so every existing `preload(:authors)` / `preload(:narrators)` call site is correct untouched. Pinned by a test rather than assumed — if it regresses, dozens of display surfaces quietly revert to insertion order.

## Known gap, deliberately out of scope

`authors_people` — the order of the people making up a composite author ("Daniel Abraham and Ty Franck") — is still `ORDER BY author_link.id`. Same defect class, but it needs the person form too. Recorded in the roadmap.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek