### PR TITLE
Phase 3a: the naming template and file placement

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -60,6 +60,66 @@ defmodule Ambry.Books do
   def book_standard_preloads, do: @book_direct_assoc_preloads
 
   @doc """
+  The values a library naming template renders from.
+
+  A folder can only sit under one author, so `author` and `series` resolve to
+  the **primary** credit — position 0, which the operator controls from the
+  book form. That designation is the entire reason credits carry a position.
+
+  Needs `book_authors: [:author]` and `series_books: [:series]` loaded, and
+  `media_narrators: [:narrator]` on the media; anything not loaded simply
+  resolves to nothing rather than raising, since a missing series is a normal
+  state and the template collapses empty segments anyway.
+  """
+  def naming_values(%Book{} = book, %Media{} = media) do
+    primary_series = primary(book.series_books)
+
+    %{
+      author: book.book_authors |> primary() |> credit_name(:author),
+      narrator: media.media_narrators |> primary() |> credit_name(:narrator),
+      series: primary_series && primary_series.series && primary_series.series.name,
+      series_book_number: primary_series && book_number(primary_series.book_number),
+      # the media's own title wins when set — that's what the title override
+      # is for — and the book's title is the fallback
+      title: presence(media.title) || book.title,
+      year: year(media.published || book.published)
+    }
+  end
+
+  # Position 0 is the operator's designated primary. The list arrives in
+  # position order via `preload_order`, but this is explicit rather than
+  # trusting whatever order a caller happened to load it in.
+  defp primary(entries) when is_list(entries),
+    do: Enum.min_by(entries, & &1.position, fn -> nil end)
+
+  defp primary(_not_loaded), do: nil
+
+  defp credit_name(nil, _key), do: nil
+
+  defp credit_name(entry, key) do
+    case Map.get(entry, key) do
+      %{name: name} -> name
+      _not_loaded -> nil
+    end
+  end
+
+  defp presence(nil), do: nil
+  defp presence(value) when is_binary(value), do: if(String.trim(value) != "", do: value)
+
+  defp year(nil), do: nil
+  defp year(%Date{year: year}), do: year
+
+  # Book numbers are decimals so half-books (1.5) work, but "1.0" in a folder
+  # name is noise.
+  defp book_number(nil), do: nil
+
+  defp book_number(decimal) do
+    if Decimal.equal?(decimal, Decimal.round(decimal, 0)),
+      do: decimal |> Decimal.round(0) |> Decimal.to_string(),
+      else: Decimal.to_string(decimal, :normal)
+  end
+
+  @doc """
   Returns a limited list of books and whether or not there are more.
 
   By default, it will limit to the first 10 results. Supply `offset` and `limit`

--- a/lib/ambry/inbox/approval.ex
+++ b/lib/ambry/inbox/approval.ex
@@ -10,12 +10,23 @@ defmodule Ambry.Inbox.Approval do
 
   ## Custody
 
-  Recordings created here are **external**: the files are referenced exactly
-  where they lie and Ambry never moves, copies, renames or deletes them.
-  Removing such a recording later deletes records only. Hardlinking messy
-  sources into a managed library tree is the rest of 3a; external custody is
-  both the honest default for a watched folder and the only thing that can
-  work against a read-only mount.
+  Where an item came from decides what happens to its bytes:
+
+    * from a **downloads** location, the file is brought into that location's
+      library root under the naming template — hardlinked, copied or moved
+      per the location's policy — and the recording becomes **managed**.
+      Ambry owns those bytes and may reorganize or delete them.
+    * from an **external collection**, or from an item with no location at
+      all, the file is referenced exactly where it lies and the recording is
+      **external**. Ambry never moves, copies, renames or deletes it, and
+      removing the recording later deletes records only. This is also the
+      only thing that can work against a read-only mount.
+
+  A hardlink cannot cross a filesystem, and here the downloads folder and the
+  library can easily be on different NAS boxes. Approval **refuses** in that
+  case rather than falling back to a copy: a silent copy is the storage
+  doubling this whole phase exists to eliminate, and the operator would have
+  no way to know it happened.
 
   ## Publishing
 
@@ -39,12 +50,19 @@ defmodule Ambry.Inbox.Approval do
   alias Ambry.Books.Series
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library
+  alias Ambry.Library.Location
+  alias Ambry.Library.NamingTemplate
+  alias Ambry.Library.Placement
   alias Ambry.Media
   alias Ambry.Media.Scanner
   alias Ambry.People
   alias Ambry.People.Author
   alias Ambry.People.Narrator
   alias Ambry.Repo
+  alias Ambry.Settings
+
+  require Logger
 
   @doc """
   Approves an item, creating everything it implies.
@@ -55,16 +73,97 @@ defmodule Ambry.Inbox.Approval do
   def approve(%InboxItem{status: :approved}), do: {:error, :already_approved}
 
   def approve(%InboxItem{} = item) do
+    item = Repo.preload(item, :location)
+
     with {:ok, file} <- single_file(item),
-         {:ok, probe} <- probe(file) do
-      Repo.transact(fn ->
-        with {:ok, book} <- resolve_book(item),
-             {:ok, media} <- create_media(item, book, probe),
-             {:ok, _item} <- link(item, media) do
-          {:ok, media}
-        end
-      end)
+         {:ok, probe} <- probe(file),
+         {:ok, destination} <- destination(item),
+         {:ok, {media, placement}} <- create(item, file, probe, destination) do
+      # Only now, with the records committed, is it safe to remove a moved
+      # file's source.
+      log_finalize(Placement.finalize(placement), item)
+      {:ok, media}
     end
+  end
+
+  # Placement is deliberately the LAST thing inside the transaction, with
+  # nothing but the commit after it. Fail earlier and no bytes have moved;
+  # fail at the commit and the worst case is a stray file in the library,
+  # which the audit tooling surfaces — never a file whose source was already
+  # deleted and whose record didn't survive.
+  defp create(item, file, probe, destination) do
+    Repo.transact(fn ->
+      with {:ok, book} <- resolve_book(item),
+           {:ok, media} <- create_media(item, book, probe),
+           {:ok, _item} <- link(item, media),
+           {:ok, media, placement} <- place(destination, book, media, file) do
+        {:ok, {media, placement}}
+      end
+    end)
+  end
+
+  # What approval should do with the bytes, decided by where the item came
+  # from. Only a downloads folder imports; an external collection is adopted
+  # exactly where it lies (that is the entire promise of external custody),
+  # and a file already sitting in a library root is already home.
+  defp destination(%InboxItem{location: %Location{kind: :downloads} = location}) do
+    with {:ok, root} <- Library.target_root(location) do
+      {:ok, {root, location.import_policy}}
+    end
+  end
+
+  defp destination(%InboxItem{}), do: {:ok, :adopt}
+
+  defp place(:adopt, _book, media, _file), do: {:ok, media, nil}
+
+  defp place({root, policy}, book, media, file) do
+    # Forced: a freshly-created book carries its `book_authors` as insert
+    # results with the nested `author` unloaded, and a reused one carries
+    # nothing at all. Without this every folder silently loses its author
+    # segment — the template collapses empty tokens, so it fails quietly
+    # rather than raising.
+    book = Repo.preload(book, [{:book_authors, :author}, {:series_books, :series}], force: true)
+    media = Repo.preload(media, [{:media_narrators, :narrator}], force: true)
+
+    values = Books.naming_values(book, media)
+
+    with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
+         {:ok, filename} <- NamingTemplate.filename(values, file),
+         path = Path.join([root.path, folder, filename]),
+         {:ok, placement} <- Placement.place(file, path, policy),
+         {:ok, media} <- adopt_managed(media, path) do
+      {:ok, media, placement}
+    end
+  end
+
+  # The recording now points at the library copy and Ambry owns those bytes.
+  defp adopt_managed(media, path) do
+    with {:ok, _track} <- repoint_track(media, path) do
+      media
+      |> Ecto.Changeset.change(%{
+        custody: :managed,
+        source_path: Path.dirname(path),
+        source_files: [path]
+      })
+      |> Repo.update()
+    end
+  end
+
+  defp repoint_track(%{media_tracks: [track | _rest]}, path) do
+    track |> Ecto.Changeset.change(%{path: path}) |> Repo.update()
+  end
+
+  defp repoint_track(_no_tracks, _path), do: {:error, :no_tracks}
+
+  # A source that couldn't be removed is untidy, not broken: the library copy
+  # exists and is recorded. Failing the import here would be worse than
+  # saying so.
+  defp log_finalize(:ok, _item), do: :ok
+
+  defp log_finalize({:error, reason}, item) do
+    Logger.warning(fn ->
+      "Approved #{item.path} but couldn't remove the source: #{inspect(reason)}"
+    end)
   end
 
   # Direct-play v1 is single-file, and a recording whose tracks can't be

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -28,7 +28,7 @@ defmodule Ambry.Library do
 
   use Boundary,
     deps: [Ambry.Repo],
-    exports: [Location]
+    exports: [Location, NamingTemplate, Placement]
 
   import Ecto.Query
 
@@ -77,11 +77,59 @@ defmodule Ambry.Library do
   def get_location!(id), do: Repo.get!(Location, id)
 
   def create_location(attrs) do
-    %Location{} |> Location.changeset(attrs) |> Repo.insert()
+    %Location{} |> Location.changeset(attrs) |> validate_target_root() |> Repo.insert()
   end
 
   def update_location(%Location{} = location, attrs) do
-    location |> Location.changeset(attrs) |> Repo.update()
+    location |> Location.changeset(attrs) |> validate_target_root() |> Repo.update()
+  end
+
+  @doc """
+  The library root a downloads location imports into.
+
+  With a single root the answer is obvious and the location needn't say, so a
+  null `target_root_id` resolves to the only root there is. With several it
+  has to be explicit — guessing would be guessing about which NAS, and
+  therefore about whether hardlinking is possible at all.
+
+  Only `:downloads` locations import anywhere; everything else is adopted in
+  place, so asking is a caller error rather than a missing configuration.
+  """
+  def target_root(%Location{kind: kind}) when kind != :downloads, do: {:error, :not_importing}
+
+  def target_root(%Location{target_root_id: id}) when is_integer(id) do
+    case Repo.get(Location, id) do
+      %Location{kind: :library_root} = root -> {:ok, root}
+      %Location{} -> {:error, :target_not_a_root}
+      nil -> {:error, :target_root_missing}
+    end
+  end
+
+  def target_root(%Location{}) do
+    case library_roots() do
+      [root] -> {:ok, root}
+      [] -> {:error, :no_library_root}
+      _several -> {:error, :ambiguous_library_root}
+    end
+  end
+
+  # Pairing a downloads folder with something that isn't a root would produce
+  # imports landing in someone else's collection, which external custody
+  # exists to promise never happens.
+  defp validate_target_root(changeset) do
+    case Ecto.Changeset.get_field(changeset, :target_root_id) do
+      nil ->
+        changeset
+
+      id ->
+        case Repo.get(Location, id) do
+          %Location{kind: :library_root} ->
+            changeset
+
+          _missing_or_wrong_kind ->
+            Ecto.Changeset.add_error(changeset, :target_root_id, "must be a library root")
+        end
+    end
   end
 
   @doc """

--- a/lib/ambry/library/location.ex
+++ b/lib/ambry/library/location.ex
@@ -29,6 +29,10 @@ defmodule Ambry.Library.Location do
   @import_policies [:hardlink, :copy, :move]
 
   schema "library_locations" do
+    # Which root a `:downloads` location imports into. Null means "the only
+    # root there is" — see `Ambry.Library.target_root/1`.
+    belongs_to :target_root, __MODULE__
+
     field :name, :string
     field :path, :string
     field :kind, Ecto.Enum, values: @kinds
@@ -61,11 +65,21 @@ defmodule Ambry.Library.Location do
   @doc false
   def changeset(location, attrs) do
     location
-    |> cast(attrs, [:name, :path, :kind, :import_policy, :enabled, :last_scanned_at])
+    |> cast(attrs, [
+      :name,
+      :path,
+      :kind,
+      :import_policy,
+      :enabled,
+      :last_scanned_at,
+      :target_root_id
+    ])
     |> update_change(:path, &normalize_path/1)
     |> validate_required([:name, :path, :kind])
     |> validate_absolute_path()
     |> put_import_policy()
+    |> put_target_root()
+    |> foreign_key_constraint(:target_root_id)
     |> unique_constraint(:path)
     |> unique_constraint(:name)
   end
@@ -101,6 +115,15 @@ defmodule Ambry.Library.Location do
     case get_field(changeset, :kind) do
       :downloads -> update_change_default(changeset, :import_policy, :hardlink)
       _other -> put_change(changeset, :import_policy, nil)
+    end
+  end
+
+  # Only a downloads folder imports anywhere, so only a downloads folder can
+  # name a destination.
+  defp put_target_root(changeset) do
+    case get_field(changeset, :kind) do
+      :downloads -> changeset
+      _other -> put_change(changeset, :target_root_id, nil)
     end
   end
 

--- a/lib/ambry/library/naming_template.ex
+++ b/lib/ambry/library/naming_template.ex
@@ -1,0 +1,174 @@
+defmodule Ambry.Library.NamingTemplate do
+  @moduledoc """
+  Where a managed recording's files live inside a library root.
+
+  The template describes the *folder*; the file inside it is named after the
+  work. So the default
+
+      {author}/{series}/{series_book_number} - {title} ({year})
+
+  produces
+
+      Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings (2010)/
+        The Way of Kings.m4b
+
+  This is a pure renderer over a map of already-resolved values — deciding
+  *which* author is "the" author is domain knowledge that belongs with books,
+  not with the filesystem. See `Ambry.Books.naming_values/2`.
+
+  ## Empty segments collapse
+
+  A standalone book has no series, and a book can be in a series without a
+  number. Rather than producing `Author//Title` or a stray leading `- `, a
+  segment whose tokens all resolve to nothing is dropped entirely, and a
+  partially-empty segment loses the punctuation that was only there to join
+  the missing part. Otherwise every standalone book in the library would sit
+  in a folder whose name starts with a dash.
+  """
+
+  @default "{author}/{series}/{series_book_number} - {title} ({year})"
+
+  @tokens ~w(author series series_book_number title year narrator)
+
+  # Separators and brackets are stripped rather than substituted: a title
+  # containing a slash must not silently become two directories, and a NUL or
+  # a control character has no business in a filename at all. Everything else
+  # — apostrophes, commas, ampersands, unicode — is left alone, because
+  # mangling "Gwendy's Button Box" helps nobody.
+  @unsafe ~r/[\/\\:\*\?"<>\|\x00-\x1f]/
+
+  # Most filesystems cap a single name at 255 bytes. Truncating on a byte
+  # boundary can split a multi-byte character, so it's done on graphemes.
+  @max_segment_bytes 255
+
+  def default_template, do: @default
+  def tokens, do: @tokens
+
+  @doc """
+  The folder path for a recording, relative to its library root.
+
+  Returns `{:error, :no_title}` rather than inventing a name — a folder called
+  "Unknown" is worse than a refusal that says what's missing.
+  """
+  def render(template \\ @default, values) do
+    values = stringify(values)
+
+    if blank?(values["title"]) do
+      {:error, :no_title}
+    else
+      {:ok,
+       template
+       |> String.split("/")
+       |> Enum.map(&segment(&1, values))
+       |> Enum.reject(&(&1 == ""))
+       |> Path.join()}
+    end
+  end
+
+  @doc """
+  The filename for a recording's file, keeping the source's extension.
+  """
+  def filename(values, source_path) do
+    values = stringify(values)
+
+    case sanitize(to_string(values["title"] || "")) do
+      "" -> {:error, :no_title}
+      name -> {:ok, name <> String.downcase(Path.extname(source_path))}
+    end
+  end
+
+  @doc """
+  Checks a template without needing anything to render it against.
+  """
+  def validate(template) do
+    cond do
+      blank?(template) -> {:error, :blank}
+      String.starts_with?(template, "/") -> {:error, :absolute}
+      String.contains?(template, "..") -> {:error, :traversal}
+      unknown = unknown_token(template) -> {:error, {:unknown_token, unknown}}
+      not String.contains?(template, "{title}") -> {:error, :no_title_token}
+      true -> :ok
+    end
+  end
+
+  defp stringify(values) do
+    Map.new(values, fn {key, value} -> {to_string(key), value} end)
+  end
+
+  defp unknown_token(template) do
+    ~r/\{([^}]*)\}/
+    |> Regex.scan(template, capture: :all_but_first)
+    |> List.flatten()
+    |> Enum.find(&(&1 not in @tokens))
+  end
+
+  # One path segment. If every token in it is empty the segment disappears;
+  # if only some are, the literal text that joined them goes too, so a
+  # missing series number doesn't leave "- The Way of Kings".
+  defp segment(segment, values) do
+    tokens = ~r/\{([^}]*)\}/ |> Regex.scan(segment, capture: :all_but_first) |> List.flatten()
+
+    cond do
+      tokens == [] -> sanitize(segment)
+      Enum.all?(tokens, &blank?(values[&1])) -> ""
+      true -> segment |> drop_empty_token_phrases(values) |> replace_tokens(values) |> sanitize()
+    end
+  end
+
+  # Removes an empty token together with the punctuation and spacing that
+  # only existed to attach it: " - {series_book_number}" or "({year})".
+  defp drop_empty_token_phrases(segment, values) do
+    Enum.reduce(@tokens, segment, fn token, segment ->
+      if blank?(values[token]) do
+        segment
+        |> String.replace(~r/\s*[-–—:]\s*\{#{token}\}/, "")
+        |> String.replace(~r/\s*[\(\[]\s*\{#{token}\}\s*[\)\]]/, "")
+        |> String.replace(~r/\{#{token}\}\s*[-–—:]\s*/, "")
+        |> String.replace("{#{token}}", "")
+      else
+        segment
+      end
+    end)
+  end
+
+  defp replace_tokens(segment, values) do
+    Enum.reduce(@tokens, segment, fn token, segment ->
+      String.replace(segment, "{#{token}}", to_string(values[token] || ""))
+    end)
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(""), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_value), do: false
+
+  defp sanitize(segment) do
+    segment
+    |> String.replace(@unsafe, "")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+    # A trailing dot or space is legal on Linux and silently dropped by
+    # Windows and SMB, which is where these files are usually read from.
+    |> String.trim_trailing(".")
+    |> String.trim()
+    |> truncate()
+  end
+
+  defp truncate(segment) when byte_size(segment) <= @max_segment_bytes, do: segment
+
+  defp truncate(segment) do
+    segment
+    |> String.graphemes()
+    |> Enum.reduce_while({[], 0}, fn grapheme, {acc, size} ->
+      size = size + byte_size(grapheme)
+
+      if size > @max_segment_bytes,
+        do: {:halt, {acc, size}},
+        else: {:cont, {[grapheme | acc], size}}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+    |> Enum.join()
+    |> String.trim()
+  end
+end

--- a/lib/ambry/library/placement.ex
+++ b/lib/ambry/library/placement.ex
@@ -1,0 +1,158 @@
+defmodule Ambry.Library.Placement do
+  @moduledoc """
+  Bringing a file into a library root.
+
+  Three policies, set per downloads location:
+
+    * `:hardlink` — **same filesystem required**. One inode, two names, no
+      extra bytes. This is the point of the whole exercise: the torrent keeps
+      seeding from the downloads folder while the library serves the same
+      bytes.
+    * `:copy` — duplicates. Honest and always possible.
+    * `:move` — the library gets the file and the source folder is left clean.
+
+  ## Why hardlink refuses instead of falling back
+
+  A hardlink cannot cross a filesystem, and in this deployment the downloads
+  folder and the library live on two different NAS boxes. The tempting
+  behaviour — quietly copy when a link isn't possible — is precisely the
+  storage doubling this whole phase exists to eliminate, and it fails
+  *silently*: the operator asked for 1x storage and gets 2x with no
+  indication. So `:hardlink` across filesystems is an error, and the operator
+  either moves the root or picks `:copy` deliberately.
+
+  ## Why move deletes late
+
+  `:move` is implemented as place-then-delete, with the delete deferred until
+  the caller confirms the database work committed (`finalize/1`). A file moved
+  before a failed commit is a file with no record pointing at it — the source
+  gone, the library row absent. Linking (or copying) first means the worst
+  case is a stray file in the library, which `undo/1` removes and the audit
+  tooling would spot anyway.
+  """
+
+  alias Ambry.Library
+  alias Ambry.Library.Location
+
+  @enforce_keys [:source, :destination, :policy]
+  defstruct [:source, :destination, :policy]
+
+  @doc """
+  Places `source` at `destination` according to the location's policy.
+
+  Returns a struct describing what happened, which must be passed to
+  `finalize/1` once the surrounding transaction commits, or to `undo/1` if it
+  doesn't.
+  """
+  def place(source, destination, %Location{kind: :downloads, import_policy: policy}) do
+    place(source, destination, policy)
+  end
+
+  def place(source, destination, policy) when policy in [:hardlink, :copy, :move] do
+    with :ok <- readable(source),
+         :ok <- vacant(destination),
+         :ok <- File.mkdir_p(Path.dirname(destination)),
+         :ok <- transfer(source, destination, policy) do
+      {:ok, %__MODULE__{source: source, destination: destination, policy: policy}}
+    end
+  end
+
+  @doc """
+  Completes a placement once the database work has committed.
+
+  Only `:move` has anything left to do.
+  """
+  def finalize(%__MODULE__{policy: :move} = placement) do
+    case File.rm(placement.source) do
+      :ok -> :ok
+      # The library copy exists and is recorded; a source we couldn't remove
+      # is untidy, not broken, and must not fail an import that has already
+      # committed.
+      {:error, reason} -> {:error, {:source_not_removed, reason}}
+    end
+  end
+
+  def finalize(%__MODULE__{}), do: :ok
+
+  # An adopted item was never placed, so there's nothing to finish.
+  def finalize(nil), do: :ok
+
+  @doc """
+  Removes a placement, for when the surrounding transaction failed.
+
+  Never touches the source — for every policy the source is still the only
+  copy at this point.
+  """
+  def undo(%__MODULE__{destination: destination}) do
+    File.rm(destination)
+    prune_empty_parents(Path.dirname(destination))
+    :ok
+  end
+
+  def undo(_not_placed), do: :ok
+
+  @doc """
+  Whether a hardlink is possible between a source and a library root.
+
+  Returns `{:error, reason}` rather than `false` when it can't be determined:
+  "I couldn't tell" must never be actioned as "different filesystem, copy
+  instead".
+  """
+  def hardlinkable?(source, root_path) do
+    Library.same_filesystem?(source, root_path)
+  end
+
+  defp transfer(source, destination, :copy) do
+    case File.cp(source, destination) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:copy_failed, reason}}
+    end
+  end
+
+  # A move is a link-or-copy now and a delete later, so `:move` gets the
+  # cheap same-filesystem path without ever being able to strand a file.
+  defp transfer(source, destination, policy) when policy in [:hardlink, :move] do
+    case File.ln(source, destination) do
+      :ok ->
+        :ok
+
+      {:error, :exdev} when policy == :move ->
+        transfer(source, destination, :copy)
+
+      # The whole reason this module exists: say so, don't silently double
+      # the operator's storage.
+      {:error, :exdev} ->
+        {:error, {:cross_filesystem, source, destination}}
+
+      {:error, reason} ->
+        {:error, {:link_failed, reason}}
+    end
+  end
+
+  defp readable(source) do
+    if File.regular?(source), do: :ok, else: {:error, {:source_missing, source}}
+  end
+
+  # Never clobber. A collision means two recordings rendered to the same
+  # path, which is a curation problem the operator has to see, not something
+  # to paper over with " (2)".
+  defp vacant(destination) do
+    if File.exists?(destination), do: {:error, {:destination_exists, destination}}, else: :ok
+  end
+
+  # An undone placement shouldn't leave "Brandon Sanderson/The Stormlight
+  # Archive/" standing empty. Stops at the first non-empty directory, so it
+  # can never walk up out of the library root.
+  defp prune_empty_parents(directory) do
+    case File.ls(directory) do
+      {:ok, []} ->
+        case File.rmdir(directory) do
+          :ok -> prune_empty_parents(Path.dirname(directory))
+          {:error, _reason} -> :ok
+        end
+
+      _not_empty_or_unreadable ->
+        :ok
+    end
+  end
+end

--- a/lib/ambry/settings.ex
+++ b/lib/ambry/settings.ex
@@ -17,10 +17,36 @@ defmodule Ambry.Settings do
   step — making a recording that has *only* tracks visible to clients.
   """
 
+  alias Ambry.Library.NamingTemplate
   alias Ambry.Repo
   alias Ambry.Settings.Setting
 
   @direct_play_publishing "direct_play_publishing"
+  @library_naming_template "library_naming_template"
+
+  @doc """
+  The folder template managed recordings are organized into.
+
+  See `Ambry.Library.NamingTemplate` for the tokens and how empty ones
+  collapse.
+  """
+  def library_naming_template do
+    case Repo.get(Setting, @library_naming_template) do
+      %Setting{value: %{"template" => template}} when is_binary(template) -> template
+      _missing_or_malformed -> NamingTemplate.default_template()
+    end
+  end
+
+  @doc """
+  Sets the folder template, refusing one that can't produce a usable path.
+  """
+  def set_library_naming_template(template) when is_binary(template) do
+    with :ok <- NamingTemplate.validate(template) do
+      %Setting{}
+      |> Setting.changeset(%{key: @library_naming_template, value: %{"template" => template}})
+      |> Repo.insert(on_conflict: {:replace, [:value, :updated_at]}, conflict_target: :key)
+    end
+  end
 
   @doc """
   Whether the server may publish direct-play recordings to clients.

--- a/lib/ambry_web/live/admin/location_live/form.ex
+++ b/lib/ambry_web/live/admin/location_live/form.ex
@@ -75,7 +75,17 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
     |> assign(:form, to_form(changeset))
     |> assign(:kind, Changeset.get_field(changeset, :kind))
     |> assign(:status, path_status(Changeset.get_field(changeset, :path)))
+    |> assign(:root_options, root_options())
   end
+
+  # Only roots can receive imports, so only roots are offered.
+  defp root_options do
+    Enum.map(Library.library_roots(), &{&1.name, &1.id})
+  end
+
+  defp root_prompt([]), do: "No library roots yet"
+  defp root_prompt([{name, _id}]), do: "#{name} (the only root)"
+  defp root_prompt(_several), do: "Choose a library root"
 
   # Checking the path as it's typed is worth the stat call: "that folder isn't
   # there" is the single most common way one of these rows is wrong, and

--- a/lib/ambry_web/live/admin/location_live/form.html.heex
+++ b/lib/ambry_web/live/admin/location_live/form.html.heex
@@ -42,18 +42,34 @@
 
       <.input field={@form[:kind]} type="select" label="Kind" options={kind_options()} />
 
-      <div :if={@kind == :downloads}>
-        <.input
-          field={@form[:import_policy]}
-          type="select"
-          label="On approval"
-          options={policy_options()}
-        />
-        <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-          Hardlinking only works within a single filesystem. If this folder and the library root
-          it imports into are on different disks, approval will say so rather than quietly
-          copying and doubling your storage.
-        </p>
+      <div :if={@kind == :downloads} class="space-y-6">
+        <div>
+          <.input
+            field={@form[:import_policy]}
+            type="select"
+            label="On approval"
+            options={policy_options()}
+          />
+          <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            Hardlinking only works within a single filesystem. If this folder and the library root
+            it imports into are on different disks, approval will say so rather than quietly
+            copying and doubling your storage.
+          </p>
+        </div>
+
+        <div>
+          <.input
+            field={@form[:target_root_id]}
+            type="select"
+            label="Imports into"
+            options={@root_options}
+            prompt={root_prompt(@root_options)}
+          />
+          <p :if={@root_options == []} class="mt-2 text-sm text-amber-600 dark:text-amber-400">
+            There are no library roots yet, so nothing can be imported. Add a location of kind
+            "Library root" first — until then, approving an item from this folder will refuse.
+          </p>
+        </div>
       </div>
 
       <.input field={@form[:enabled]} type="checkbox" label="Watched" />

--- a/lib/ambry_web/live/admin/settings_live/index.ex
+++ b/lib/ambry_web/live/admin/settings_live/index.ex
@@ -5,6 +5,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
 
   use AmbryWeb, :admin_live_view
 
+  alias Ambry.Library.NamingTemplate
   alias Ambry.Settings
 
   @impl Phoenix.LiveView
@@ -48,6 +49,40 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
             </div>
           </div>
         </section>
+
+        <section>
+          <h2 class="mb-1 text-lg font-bold">Library naming</h2>
+          <p class="mb-4 text-sm text-zinc-500 dark:text-zinc-400">
+            How managed recordings are organized inside a library root. Files imported from a
+            downloads folder are placed here; external collections are never reorganized.
+          </p>
+
+          <.simple_form
+            id="naming-template-form"
+            for={@template_form}
+            phx-change="validate-template"
+            phx-submit="save-template"
+            autocomplete="off"
+          >
+            <.input field={@template_form[:template]} label="Folder template" />
+
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">
+              Available: {Enum.map_join(NamingTemplate.tokens(), ", ", &"{#{&1}}")}. A book with
+              several authors or series uses the first one — reorder them on the book to change
+              which. Empty parts collapse, so a standalone book doesn't get an empty folder or a
+              leading dash.
+            </p>
+
+            <div class="rounded-sm border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900">
+              <p class="mb-1 text-xs font-semibold text-zinc-500 dark:text-zinc-400">Preview</p>
+              <p class="font-mono break-all text-sm" data-role="template-preview">{@preview}</p>
+            </div>
+
+            <:actions>
+              <.button disabled={@template_error != nil}>Save</.button>
+            </:actions>
+          </.simple_form>
+        </section>
       </div>
     </.layout>
     """
@@ -60,9 +95,67 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
     {:noreply, assign_settings(socket)}
   end
 
-  defp assign_settings(socket) do
-    assign(socket, :direct_play_publishing, Settings.direct_play_publishing?())
+  def handle_event("validate-template", %{"settings" => %{"template" => template}}, socket) do
+    {:noreply, assign_template(socket, template)}
   end
+
+  def handle_event("save-template", %{"settings" => %{"template" => template}}, socket) do
+    case Settings.set_library_naming_template(template) do
+      {:ok, _setting} ->
+        {:noreply,
+         socket |> put_flash(:info, "Saved the naming template.") |> assign_template(template)}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Can't use that template: #{template_error(reason)}")
+         |> assign_template(template)}
+    end
+  end
+
+  defp assign_settings(socket) do
+    socket
+    |> assign(:direct_play_publishing, Settings.direct_play_publishing?())
+    |> assign_template(Settings.library_naming_template())
+  end
+
+  # A live preview against a worked example, because a template's failure mode
+  # is a folder tree you don't notice is wrong until it's full of files.
+  @example %{
+    author: "Brandon Sanderson",
+    series: "The Stormlight Archive",
+    series_book_number: "1",
+    narrator: "Michael Kramer",
+    title: "The Way of Kings",
+    year: 2010
+  }
+
+  defp assign_template(socket, template) do
+    error = with :ok <- NamingTemplate.validate(template), do: nil
+
+    preview =
+      case error do
+        nil ->
+          {:ok, folder} = NamingTemplate.render(template, @example)
+          {:ok, filename} = NamingTemplate.filename(@example, "book.m4b")
+          Path.join([folder, filename])
+
+        {:error, reason} ->
+          template_error(reason)
+      end
+
+    assign(socket,
+      template_form: to_form(%{"template" => template}, as: :settings),
+      template_error: error,
+      preview: preview
+    )
+  end
+
+  defp template_error(:blank), do: "it can't be empty"
+  defp template_error(:absolute), do: "it can't start with / — it's relative to a library root"
+  defp template_error(:traversal), do: "it can't contain .. — that would climb out of the root"
+  defp template_error(:no_title_token), do: "it needs {title}, or every book shares one folder"
+  defp template_error({:unknown_token, token}), do: "there's no {#{token}} token"
 
   defp publishing_blurb(true), do: "Scanned recordings can be made visible to clients."
 

--- a/priv/repo/migrations/20260803155958_location_target_root.exs
+++ b/priv/repo/migrations/20260803155958_location_target_root.exs
@@ -1,0 +1,21 @@
+defmodule Ambry.Repo.Migrations.LocationTargetRoot do
+  use Ecto.Migration
+
+  # Which library root a downloads folder imports into.
+  #
+  # With one root this is obvious and stays null; the resolution falls back to
+  # "the only root there is". With several it has to be said explicitly,
+  # because the choice is not cosmetic: a hardlink can only be made within one
+  # filesystem, so pairing a downloads folder with a root on the wrong NAS is
+  # the difference between an import costing nothing and an import being
+  # refused outright.
+  #
+  # Self-referential — a library root is just another location.
+  def change do
+    alter table(:library_locations) do
+      add :target_root_id, references(:library_locations, on_delete: :nilify_all)
+    end
+
+    create index(:library_locations, [:target_root_id])
+  end
+end

--- a/test/ambry/inbox/managed_approval_test.exs
+++ b/test/ambry/inbox/managed_approval_test.exs
@@ -1,0 +1,231 @@
+defmodule Ambry.Inbox.ManagedApprovalTest do
+  @moduledoc """
+  Approving an item that came from a downloads folder, which is the first
+  point where Ambry writes to the library rather than just reading it.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Inbox
+  alias Ambry.Library
+  alias Ambry.Media
+  alias Ambry.Settings
+
+  # A genuinely different filesystem, found at compile time, so the
+  # cross-filesystem refusal is exercised against the kernel rather than a
+  # mock. `/dev/shm` is tmpfs and therefore never the same device as the
+  # project checkout.
+  @other_filesystem Enum.find(["/dev/shm", "/tmp"], fn candidate ->
+                      with true <- File.dir?(candidate),
+                           {:ok, %{major_device: theirs}} <- File.stat(candidate),
+                           {:ok, %{major_device: ours}} <- File.stat(File.cwd!()) do
+                        theirs != ours
+                      else
+                        _unusable -> false
+                      end
+                    end)
+
+  describe "approving from a downloads location" do
+    test "hardlinks into the library under the naming template" do
+      %{item: item, root: root, source: source} = downloads_item()
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      media = Media.get_media!(media.id)
+      assert media.custody == :managed
+
+      assert [placed] = media.source_files
+
+      assert placed ==
+               Path.join([
+                 root,
+                 "Brandon Sanderson",
+                 "The Way of Kings (2010)",
+                 "The Way of Kings.m4b"
+               ])
+
+      assert File.exists?(placed)
+
+      # the whole point: one inode, two names, no extra bytes
+      assert {:ok, %{links: 2}} = File.stat(placed)
+      assert File.exists?(source)
+
+      assert [%{path: ^placed}] = media.media_tracks
+      assert media.source_path == Path.dirname(placed)
+    end
+
+    test "renders the folder from the operator's template" do
+      {:ok, _setting} = Settings.set_library_naming_template("{author}/{year} - {title}")
+      %{item: item, root: root} = downloads_item()
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      assert [placed] = Media.get_media!(media.id).source_files
+
+      assert placed ==
+               Path.join([
+                 root,
+                 "Brandon Sanderson",
+                 "2010 - The Way of Kings",
+                 "The Way of Kings.m4b"
+               ])
+    end
+
+    test "moves instead, leaving the downloads folder clean" do
+      %{item: item, source: source} = downloads_item(policy: :move)
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      assert [placed] = Media.get_media!(media.id).source_files
+      assert File.exists?(placed)
+      # the source is removed only after the records committed
+      refute File.exists?(source)
+    end
+
+    test "copies when asked to, duplicating deliberately" do
+      %{item: item, source: source} = downloads_item(policy: :copy)
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      assert [placed] = Media.get_media!(media.id).source_files
+      assert File.exists?(source)
+      assert {:ok, %{links: 1}} = File.stat(placed)
+    end
+
+    test "marks the item approved and links it to what it became" do
+      %{item: item} = downloads_item()
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      {[item], false} = Inbox.list_items()
+      assert item.status == :approved
+      assert item.media_id == media.id
+    end
+  end
+
+  describe "refusals" do
+    # Silently copying instead is the storage doubling this entire phase
+    # exists to eliminate, and the operator would never know it happened.
+    #
+    # Defined only when a real second filesystem exists, so that on a machine
+    # without one the test is visibly absent rather than passing vacuously.
+    if @other_filesystem do
+      test "refuses to hardlink across filesystems rather than copying" do
+        root = Path.join(@other_filesystem, "ambry-managed-#{Ecto.UUID.generate()}")
+        File.mkdir_p!(root)
+        on_exit(fn -> File.rm_rf(root) end)
+
+        %{item: item, source: source} = downloads_item(root: root)
+
+        assert {:error, {:cross_filesystem, ^source, _destination}} = Inbox.approve_item(item)
+
+        # library untouched, item still queued
+        assert {[item], false} = Inbox.list_items()
+        assert item.status == :pending
+        assert {[], false} = Media.list_media()
+      end
+    end
+
+    test "refuses when there is no library root to import into" do
+      %{item: item} = downloads_item(root: :none)
+
+      assert {:error, :no_library_root} = Inbox.approve_item(item)
+
+      {[item], false} = Inbox.list_items()
+      assert item.status == :pending
+    end
+
+    # With several roots the choice is about which NAS, and therefore about
+    # whether hardlinking is possible at all. Guessing is not acceptable.
+    test "refuses when several roots exist and none was chosen" do
+      %{item: item} = downloads_item()
+      insert(:location, kind: :library_root, import_policy: nil, path: new_dir("second-root"))
+
+      assert {:error, :ambiguous_library_root} = Inbox.approve_item(item)
+    end
+
+    test "uses the explicitly chosen root when there are several" do
+      %{item: item, location: location} = downloads_item()
+
+      chosen =
+        insert(:location, kind: :library_root, import_policy: nil, path: new_dir("chosen-root"))
+
+      {:ok, _location} = Library.update_location(location, %{target_root_id: chosen.id})
+
+      assert {:ok, media} = Inbox.approve_item(Repo.reload(item))
+
+      assert [placed] = Media.get_media!(media.id).source_files
+      assert String.starts_with?(placed, chosen.path)
+    end
+
+    # A collision means two recordings rendered to one path, which is a
+    # curation problem the operator has to see.
+    test "refuses to overwrite something already at the destination" do
+      %{item: item, root: root} = downloads_item()
+
+      occupied =
+        Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)", "The Way of Kings.m4b"])
+
+      File.mkdir_p!(Path.dirname(occupied))
+      File.write!(occupied, "already here")
+
+      assert {:error, {:destination_exists, ^occupied}} = Inbox.approve_item(item)
+      assert File.read!(occupied) == "already here"
+    end
+  end
+
+  describe "other locations" do
+    test "an external collection is still adopted exactly where it lies" do
+      %{item: item, source: source} =
+        downloads_item(kind: :external_collection, policy: nil)
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      media = Media.get_media!(media.id)
+      assert media.custody == :external
+      assert media.source_files == [source]
+      assert File.exists?(source)
+    end
+  end
+
+  defp downloads_item(opts \\ []) do
+    kind = Keyword.get(opts, :kind, :downloads)
+    policy = Keyword.get(opts, :policy, :hardlink)
+
+    root =
+      case Keyword.get(opts, :root, :default) do
+        :none -> nil
+        :default -> new_dir("root")
+        path -> path
+      end
+
+    if root do
+      insert(:location, kind: :library_root, import_policy: nil, path: root, name: "Library")
+    end
+
+    downloads = new_dir("downloads")
+    release = Path.join(downloads, "The Way of Kings [M4B]")
+    File.mkdir_p!(release)
+    source = Path.join(release, "book.m4b")
+    File.cp!(tagged_audio(), source)
+
+    location =
+      insert(:location,
+        kind: kind,
+        import_policy: policy,
+        path: downloads,
+        name: "Downloads #{Ecto.UUID.generate()}"
+      )
+
+    {:ok, _counts} = Inbox.discover(location)
+    {[item], false} = Inbox.list_items()
+    {:ok, item} = Inbox.probe_item(item)
+
+    %{item: item, root: root, source: source, location: location, downloads: downloads}
+  end
+
+  defp new_dir(prefix) do
+    dir = Ambry.Paths.source_media_disk_path("#{prefix}-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    dir
+  end
+end

--- a/test/ambry/library/naming_template_test.exs
+++ b/test/ambry/library/naming_template_test.exs
@@ -1,0 +1,168 @@
+defmodule Ambry.Library.NamingTemplateTest do
+  use ExUnit.Case, async: true
+
+  alias Ambry.Library.NamingTemplate
+
+  @book %{
+    author: "Brandon Sanderson",
+    series: "The Stormlight Archive",
+    series_book_number: "1",
+    title: "The Way of Kings",
+    year: 2010
+  }
+
+  describe "render/2" do
+    test "the default template" do
+      assert {:ok, path} = NamingTemplate.render(@book)
+
+      assert path ==
+               "Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings (2010)"
+    end
+
+    # A standalone book must not land in a folder called "" or leave an empty
+    # path segment behind.
+    test "drops the series segment entirely for a standalone book" do
+      values = %{@book | series: nil, series_book_number: nil}
+
+      assert {:ok, "Andy Weir/Project Hail Mary (2021)"} =
+               NamingTemplate.render(%{
+                 values
+                 | author: "Andy Weir",
+                   title: "Project Hail Mary",
+                   year: 2021
+               })
+    end
+
+    # The dash only existed to join the number. Without this every standalone
+    # book would sit in a folder whose name starts with "- ".
+    test "drops the punctuation that only joined a missing token" do
+      assert {:ok, path} = NamingTemplate.render(%{@book | series_book_number: nil})
+      assert path == "Brandon Sanderson/The Stormlight Archive/The Way of Kings (2010)"
+    end
+
+    test "drops the brackets around a missing year" do
+      assert {:ok, path} = NamingTemplate.render(%{@book | year: nil})
+      assert path == "Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings"
+    end
+
+    test "drops an unknown author rather than writing an empty folder" do
+      assert {:ok, path} = NamingTemplate.render(%{@book | author: nil})
+      assert path == "The Stormlight Archive/1 - The Way of Kings (2010)"
+    end
+
+    test "refuses without a title rather than inventing one" do
+      assert {:error, :no_title} = NamingTemplate.render(%{@book | title: nil})
+      assert {:error, :no_title} = NamingTemplate.render(%{@book | title: "   "})
+    end
+
+    test "accepts a custom template" do
+      assert {:ok, "Brandon Sanderson/The Way of Kings"} =
+               NamingTemplate.render("{author}/{title}", @book)
+    end
+
+    test "accepts string keys as well as atoms" do
+      assert {:ok, "A/T"} =
+               NamingTemplate.render("{author}/{title}", %{"author" => "A", "title" => "T"})
+    end
+
+    # A title containing a slash must never become two directories — that's
+    # how a recording escapes its library root.
+    test "strips path separators out of values" do
+      assert {:ok, path} =
+               NamingTemplate.render("{author}/{title}", %{
+                 author: "AC/DC",
+                 title: "../../etc/passwd"
+               })
+
+      assert path == "ACDC/....etcpasswd"
+      refute String.contains?(path, "/etc")
+    end
+
+    test "strips characters that break Windows and SMB shares" do
+      assert {:ok, path} =
+               NamingTemplate.render("{title}", %{
+                 title: ~s(What Is It? "Quoted" <tag>: *star*|pipe)
+               })
+
+      assert path == "What Is It Quoted tag starpipe"
+    end
+
+    # A trailing dot or space is legal on Linux but silently dropped by
+    # Windows and SMB, which is where these files usually get read from — so
+    # the name on disk would stop matching the name in the database.
+    test "collapses whitespace and trims a trailing dot" do
+      assert {:ok, "A B"} = NamingTemplate.render("{title}", %{title: "  A  B.  "})
+    end
+
+    test "leaves ordinary punctuation alone" do
+      assert {:ok, "Gwendy's Button Box & Other Stories, Vol. 1"} =
+               NamingTemplate.render("{title}", %{
+                 title: "Gwendy's Button Box & Other Stories, Vol. 1"
+               })
+    end
+
+    # Filesystems cap a name at 255 bytes, and cutting on a byte boundary can
+    # split a multi-byte character into invalid UTF-8.
+    test "truncates a very long name on a character boundary" do
+      title = String.duplicate("é", 300)
+
+      assert {:ok, path} = NamingTemplate.render("{title}", %{title: title})
+      assert byte_size(path) <= 255
+      assert String.valid?(path)
+    end
+
+    test "renders a half-numbered book without a trailing zero" do
+      assert {:ok, path} = NamingTemplate.render("{series_book_number} - {title}", @book)
+      assert path == "1 - The Way of Kings"
+    end
+  end
+
+  describe "filename/2" do
+    test "names the file after the work, keeping the extension" do
+      assert {:ok, "The Way of Kings.m4b"} =
+               NamingTemplate.filename(@book, "/downloads/x/book.m4b")
+    end
+
+    test "normalizes the extension's case" do
+      assert {:ok, "The Way of Kings.mp3"} =
+               NamingTemplate.filename(@book, "/downloads/x/BOOK.MP3")
+    end
+
+    test "sanitizes the title" do
+      assert {:ok, "ACDC Live.m4b"} =
+               NamingTemplate.filename(%{@book | title: "AC/DC Live"}, "a.m4b")
+    end
+
+    test "refuses without a title" do
+      assert {:error, :no_title} = NamingTemplate.filename(%{@book | title: nil}, "a.m4b")
+    end
+  end
+
+  describe "validate/1" do
+    test "accepts the default" do
+      assert :ok = NamingTemplate.validate(NamingTemplate.default_template())
+    end
+
+    test "rejects a blank template" do
+      assert {:error, :blank} = NamingTemplate.validate("")
+      assert {:error, :blank} = NamingTemplate.validate("   ")
+    end
+
+    # An absolute template would ignore the library root entirely, and `..`
+    # would climb out of it.
+    test "rejects escaping the library root" do
+      assert {:error, :absolute} = NamingTemplate.validate("/{author}/{title}")
+      assert {:error, :traversal} = NamingTemplate.validate("../{author}/{title}")
+    end
+
+    test "rejects an unknown token" do
+      assert {:error, {:unknown_token, "publisher"}} =
+               NamingTemplate.validate("{author}/{publisher}/{title}")
+    end
+
+    # Without a title every book by one author collapses into one folder.
+    test "requires the title token" do
+      assert {:error, :no_title_token} = NamingTemplate.validate("{author}/{year}")
+    end
+  end
+end

--- a/test/ambry/library/placement_test.exs
+++ b/test/ambry/library/placement_test.exs
@@ -1,0 +1,196 @@
+defmodule Ambry.Library.PlacementTest do
+  use ExUnit.Case, async: true
+
+  alias Ambry.Library.Placement
+
+  # A real second filesystem, found at compile time, so the cross-filesystem
+  # behaviour is exercised against the actual kernel rather than a mock.
+  # `/dev/shm` is tmpfs and therefore always a different device from the
+  # project checkout; if a machine somehow has neither candidate, the
+  # cross-filesystem tests are omitted rather than silently passing.
+  @other_filesystem Enum.find(["/dev/shm", "/tmp"], fn candidate ->
+                      with true <- File.dir?(candidate),
+                           {:ok, %{major_device: theirs}} <- File.stat(candidate),
+                           {:ok, %{major_device: ours}} <- File.stat(File.cwd!()) do
+                        theirs != ours
+                      else
+                        _unusable -> false
+                      end
+                    end)
+
+  setup do
+    root = tmp_dir("placement")
+    source_dir = tmp_dir("source")
+    source = Path.join(source_dir, "book.m4b")
+    File.write!(source, "audio bytes")
+
+    on_exit(fn ->
+      File.rm_rf(root)
+      File.rm_rf(source_dir)
+    end)
+
+    %{root: root, source: source}
+  end
+
+  describe "hardlink" do
+    test "links into the library without using more space", %{root: root, source: source} do
+      destination = Path.join([root, "Author", "Title", "Title.m4b"])
+
+      assert {:ok, placement} = Placement.place(source, destination, :hardlink)
+      assert placement.policy == :hardlink
+
+      assert File.read!(destination) == "audio bytes"
+      # the source keeps seeding
+      assert File.exists?(source)
+      # one inode, two names
+      assert {:ok, %{links: 2}} = File.stat(destination)
+      assert inode(destination) == inode(source)
+    end
+
+    test "creates the intermediate folders", %{root: root, source: source} do
+      destination = Path.join([root, "A", "B", "C", "Title.m4b"])
+
+      assert {:ok, _placement} = Placement.place(source, destination, :hardlink)
+      assert File.dir?(Path.join([root, "A", "B"]))
+    end
+
+    if @other_filesystem do
+      # The silent fallback — copy when a link isn't possible — is exactly the
+      # storage doubling this phase exists to eliminate, and the operator
+      # would have no way to know it happened.
+      test "refuses across filesystems instead of quietly copying", %{source: source} do
+        root = tmp_dir(Path.join(@other_filesystem, "ambry-placement"))
+        on_exit(fn -> File.rm_rf(root) end)
+
+        destination = Path.join([root, "Author", "Title.m4b"])
+
+        assert {:error, {:cross_filesystem, ^source, ^destination}} =
+                 Placement.place(source, destination, :hardlink)
+
+        refute File.exists?(destination)
+      end
+
+      test "a move across filesystems falls back to copying, which is what a move is",
+           %{source: source} do
+        root = tmp_dir(Path.join(@other_filesystem, "ambry-placement"))
+        on_exit(fn -> File.rm_rf(root) end)
+
+        destination = Path.join([root, "Title.m4b"])
+
+        assert {:ok, placement} = Placement.place(source, destination, :move)
+        assert File.read!(destination) == "audio bytes"
+
+        # still there until the database work commits
+        assert File.exists?(source)
+        assert :ok = Placement.finalize(placement)
+        refute File.exists?(source)
+      end
+    end
+  end
+
+  describe "copy" do
+    test "duplicates the file", %{root: root, source: source} do
+      destination = Path.join(root, "Title.m4b")
+
+      assert {:ok, _placement} = Placement.place(source, destination, :copy)
+      assert File.read!(destination) == "audio bytes"
+      assert File.exists?(source)
+      assert inode(destination) != inode(source)
+    end
+  end
+
+  describe "move" do
+    # The source survives until the caller says the database committed. A
+    # file moved before a failed commit is a file with no record pointing at
+    # it and no source left to retry from.
+    test "leaves the source alone until finalized", %{root: root, source: source} do
+      destination = Path.join(root, "Title.m4b")
+
+      assert {:ok, placement} = Placement.place(source, destination, :move)
+      assert File.exists?(source)
+      assert File.exists?(destination)
+
+      assert :ok = Placement.finalize(placement)
+      refute File.exists?(source)
+      assert File.read!(destination) == "audio bytes"
+    end
+
+    test "undoing before finalize leaves the source untouched", %{root: root, source: source} do
+      destination = Path.join([root, "Author", "Title.m4b"])
+
+      assert {:ok, placement} = Placement.place(source, destination, :move)
+      assert :ok = Placement.undo(placement)
+
+      refute File.exists?(destination)
+      assert File.read!(source) == "audio bytes"
+    end
+  end
+
+  describe "refusals" do
+    # Two recordings rendering to one path is a curation problem the operator
+    # needs to see, not something to paper over with " (2)".
+    test "never clobbers an existing file", %{root: root, source: source} do
+      destination = Path.join(root, "Title.m4b")
+      File.mkdir_p!(root)
+      File.write!(destination, "something already here")
+
+      assert {:error, {:destination_exists, ^destination}} =
+               Placement.place(source, destination, :hardlink)
+
+      assert File.read!(destination) == "something already here"
+    end
+
+    test "reports a source that vanished between discovery and approval", %{root: root} do
+      missing = "/nope/not/here.m4b"
+
+      assert {:error, {:source_missing, ^missing}} =
+               Placement.place(missing, Path.join(root, "Title.m4b"), :copy)
+    end
+
+    test "reports a directory given where a file was expected", %{root: root, source: source} do
+      assert {:error, {:source_missing, _path}} =
+               Placement.place(Path.dirname(source), Path.join(root, "T.m4b"), :copy)
+    end
+  end
+
+  describe "undo/1" do
+    test "removes the file and the folders it created", %{root: root, source: source} do
+      destination = Path.join([root, "Author", "Series", "Title.m4b"])
+
+      assert {:ok, placement} = Placement.place(source, destination, :hardlink)
+      assert :ok = Placement.undo(placement)
+
+      refute File.exists?(destination)
+      refute File.dir?(Path.join([root, "Author", "Series"]))
+      refute File.dir?(Path.join([root, "Author"]))
+    end
+
+    # Pruning must stop at the first non-empty directory, or an undo could
+    # walk up and remove the library root itself.
+    test "stops pruning at a folder that still holds something", %{root: root, source: source} do
+      keep = Path.join([root, "Author", "Other Book.m4b"])
+      File.mkdir_p!(Path.dirname(keep))
+      File.write!(keep, "another book")
+
+      destination = Path.join([root, "Author", "Series", "Title.m4b"])
+      assert {:ok, placement} = Placement.place(source, destination, :hardlink)
+      assert :ok = Placement.undo(placement)
+
+      refute File.dir?(Path.join([root, "Author", "Series"]))
+      assert File.exists?(keep)
+      assert File.dir?(root)
+    end
+  end
+
+  defp tmp_dir(prefix) do
+    dir = "#{prefix}-#{Ecto.UUID.generate()}"
+    dir = if String.starts_with?(prefix, "/"), do: dir, else: Path.join(System.tmp_dir!(), dir)
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  defp inode(path) do
+    {:ok, %{inode: inode}} = File.stat(path)
+    inode
+  end
+end

--- a/test/ambry_web/live/admin/settings_live/index_test.exs
+++ b/test/ambry_web/live/admin/settings_live/index_test.exs
@@ -3,6 +3,7 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
 
   import Phoenix.LiveViewTest
 
+  alias Ambry.Library.NamingTemplate
   alias Ambry.Settings
 
   setup :register_and_log_in_admin_user
@@ -28,5 +29,70 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
 
     refute Settings.direct_play_publishing?()
     assert html =~ "Turn on"
+  end
+
+  describe "library naming template" do
+    test "previews the default against a worked example", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/settings")
+
+      assert preview(html) ==
+               "Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings (2010)/" <>
+                 "The Way of Kings.m4b"
+    end
+
+    test "previews an edited template as it's typed", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/settings")
+
+      html =
+        view
+        |> form("#naming-template-form", settings: %{template: "{author}/{title}"})
+        |> render_change()
+
+      assert preview(html) == "Brandon Sanderson/The Way of Kings/The Way of Kings.m4b"
+    end
+
+    test "saves a valid template", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/settings")
+
+      view
+      |> form("#naming-template-form", settings: %{template: "{author}/{title} ({year})"})
+      |> render_submit()
+
+      assert Settings.library_naming_template() == "{author}/{title} ({year})"
+    end
+
+    # A template's failure mode is a folder tree you don't notice is wrong
+    # until it's already full of files, so the preview has to say why rather
+    # than going blank.
+    test "explains an invalid template instead of previewing it", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/settings")
+
+      html =
+        view
+        |> form("#naming-template-form", settings: %{template: "{author}/{publisher}"})
+        |> render_change()
+
+      assert preview(html) =~ "there's no {publisher} token"
+    end
+
+    test "refuses a template that would escape the library root", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/settings")
+
+      html =
+        view
+        |> form("#naming-template-form", settings: %{template: "../{title}"})
+        |> render_submit()
+
+      assert html =~ "climb out of the root"
+      assert Settings.library_naming_template() == NamingTemplate.default_template()
+    end
+  end
+
+  defp preview(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("[data-role='template-preview']")
+    |> Floki.text()
+    |> String.trim()
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -431,6 +431,41 @@ defmodule Ambry.Factory do
     }
   end
 
+  @doc """
+  A real m4b carrying real embedded tags, since the inbox reads them.
+
+  Written into its own folder under `source_media` because the file-audit
+  tests list that directory and expect only folders.
+  """
+  def tagged_audio(opts \\ []) do
+    dir = Ambry.Paths.source_media_disk_path("fixture-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    path = Path.join(dir, "tagged.m4b")
+
+    {_output, 0} =
+      System.cmd(
+        "ffmpeg",
+        [
+          "-v",
+          "quiet",
+          "-i",
+          valid_audio(:m4a),
+          "-c",
+          "copy",
+          "-metadata",
+          "album=#{Keyword.get(opts, :album, "The Way of Kings")}",
+          "-metadata",
+          "artist=#{Keyword.get(opts, :artist, "Brandon Sanderson")}",
+          "-metadata",
+          "composer=#{Keyword.get(opts, :composer, "Michael Kramer, Kate Reading")}"
+        ] ++
+          if(Keyword.get(opts, :dated, true), do: ["-metadata", "date=2010-08-31"], else: []) ++
+          [path]
+      )
+
+    path
+  end
+
   def valid_audio(:flac), do: "test/support/files/sample.flac"
   def valid_audio(:m4a), do: "test/support/files/sample.m4a"
   def valid_audio(:mp3), do: "test/support/files/sample.mp3"


### PR DESCRIPTION
The first point where Ambry **writes** to the library rather than only reading it. An item discovered in a downloads folder is now brought into a library root under a naming template and the recording becomes `managed`; external collections are still adopted exactly where they lie, which is the entire promise of external custody.

## What's in it

- **`NamingTemplate`** — a pure renderer over already-resolved values. Deciding *which* author is "the" author is domain knowledge that belongs with books (`Books.naming_values/2`), not with the filesystem. Tokens: `{author} {series} {series_book_number} {title} {year} {narrator}`. Operator-editable under Settings with a live preview.
- **`Placement`** — `hardlink` / `copy` / `move`, per downloads location.
- **`library_locations.target_root_id`** — which root a downloads folder feeds. Null resolves to "the only root there is"; with several it must be explicit, because the choice is about *which NAS* and therefore about whether hardlinking is possible at all.
- Approval wires it together and flips custody to `managed`.

## The three decisions worth reviewing

**Cross-filesystem hardlinking is refused, not quietly downgraded to a copy.** The downloads folder and the library can easily be on different NAS boxes here, and the tempting fallback is exactly the storage doubling this phase exists to eliminate — silently, with no way for the operator to know. Tested against a **real second filesystem** (`/dev/shm`), not a mock; on a machine without one the test is *absent* rather than passing vacuously.

**`move` places first and deletes the source only after the transaction commits.** A file moved before a failed commit is a file with no record pointing at it and no source left to retry from. Linking first means the worst case is a stray file in the library, which the audit tooling surfaces. For the same reason placement is the *last* operation inside the transaction, with nothing but the commit after it.

**Collisions are refused rather than suffixed.** Two recordings rendering to one path is a curation problem the operator has to see, not something to paper over with " (2)".

## Smaller things

- Empty template segments collapse — a standalone book gets `Author/Title (Year)`, not an empty folder or a name starting with a dash.
- Values are sanitized: a title containing `/` must never become two directories, which is how a recording would escape its root. `..` and absolute templates are rejected outright.
- Segment names truncate at 255 bytes on a *grapheme* boundary, so a long unicode title can't produce invalid UTF-8.
- A trailing dot is trimmed — legal on Linux, silently dropped by Windows and SMB, which is where these files usually get read from.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: **947 passed**, 1 skipped. 46 new tests.
- All pre-existing approval tests pass **unchanged** — external adoption behaves exactly as before.

## Still to do in 3a

Deletion semantics by custody, renames on metadata change, reconciliation, and making approved media `ready`.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek