### PR TITLE
Phase 3a: deletion semantics by custody

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -4,7 +4,7 @@ defmodule Ambry.Media do
   """
 
   use Boundary,
-    deps: [Ambry],
+    deps: [Ambry, Ambry.Library],
     exports: [
       Audit,
       Chapters,
@@ -28,6 +28,7 @@ defmodule Ambry.Media do
   import Ecto.Query
 
   alias Ambry.Books
+  alias Ambry.Library
   alias Ambry.Media.Audit
   alias Ambry.Media.Media
   alias Ambry.Media.MediaFlat
@@ -310,11 +311,40 @@ defmodule Ambry.Media do
   end
 
   defp delete_all_files_async(%Media{} = media) do
-    files_to_delete = all_file_paths(media)
-    folders_to_delete = [media.source_path]
+    folders = source_folders(media)
 
-    try_delete_files_async(files_to_delete, folders_to_delete)
+    try_delete_files_async(all_file_paths(media), folders,
+      prune_until: if(folders != [], do: library_root_paths())
+    )
   end
+
+  # The registered locations are where pruning stops: a root's existence is
+  # configuration, not a consequence of currently holding a book.
+  defp library_root_paths do
+    Enum.map(Library.list_locations(), & &1.path)
+  end
+
+  # Deletion semantics by custody (roadmap 3a).
+  #
+  # `managed` means Ambry owns the bytes — the legacy transcoded library, or
+  # a file placed into a library root — and removing the recording removes
+  # them. If that file is a hardlink, only this name goes; the seeding copy
+  # in the downloads folder is a separate name for the same inode and is
+  # untouched, which is exactly why hardlinking is safe to delete from.
+  #
+  # `external` means the files belong to someone else's workflow and are
+  # merely referenced. Removal deletes records only.
+  #
+  # This is not a nicety. `source_path` for an inbox-approved external
+  # recording is the operator's own downloads folder, and the deletion worker
+  # runs `File.rm_rf` on every folder it's given.
+  #
+  # Transcoded outputs, images and thumbnails are always Ambry's own, under
+  # the uploads path, so they're removed regardless of custody.
+  defp source_folders(%Media{custody: :managed, source_path: path}) when is_binary(path),
+    do: [path]
+
+  defp source_folders(%Media{}), do: []
 
   defp all_file_paths(%Media{} = media) do
     %Media{
@@ -430,6 +460,7 @@ defmodule Ambry.Media do
         processor: processor
       }) do
     old_source_path = media.source_path
+    old_custody = media.custody
 
     with {:ok, updated_media} <-
            update_media(media, %{
@@ -438,16 +469,22 @@ defmodule Ambry.Media do
              status: :pending
            }),
          {:ok, _job} <- run_processor_async(updated_media, processor) do
-      delete_old_source_folder_async(old_source_path, source_path)
+      delete_old_source_folder_async(old_custody, old_source_path, source_path)
       {:ok, updated_media}
     end
   end
 
-  defp delete_old_source_folder_async(old_source_path, new_source_path)
+  # Same custody rule as deletion: the old folder is only Ambry's to remove
+  # if it was managed. Replacing the files of an external recording must not
+  # take the original source folder with it.
+  defp delete_old_source_folder_async(_custody, old_source_path, new_source_path)
        when old_source_path in [nil, new_source_path], do: {:ok, :noop}
 
-  defp delete_old_source_folder_async(old_source_path, _new_source_path),
+  defp delete_old_source_folder_async(:managed, old_source_path, _new_source_path),
     do: try_delete_files_async([], [old_source_path])
+
+  defp delete_old_source_folder_async(_external, _old_source_path, _new_source_path),
+    do: {:ok, :noop}
 
   defdelegate available_processors(media_or_filenames), to: Processor, as: :matched_processors
 

--- a/lib/ambry/utils.ex
+++ b/lib/ambry/utils.ex
@@ -102,10 +102,51 @@ defmodule Ambry.Utils do
   """
   def try_delete_files_async([]), do: {:ok, :noop}
 
-  def try_delete_files_async(disk_paths, folder_paths \\ []) do
+  def try_delete_files_async(disk_paths, folder_paths \\ [], opts \\ []) do
     %{"disk_paths" => disk_paths, "folder_paths" => folder_paths}
+    |> maybe_put("prune_until", opts[:prune_until])
     |> DeleteFiles.new()
     |> Oban.insert()
+  end
+
+  defp maybe_put(args, _key, nil), do: args
+  defp maybe_put(args, key, value), do: Map.put(args, key, value)
+
+  @doc """
+  Removes now-empty parent folders, walking up from each given folder.
+
+  Deleting the last book by an author leaves `Brandon Sanderson/The
+  Stormlight Archive/` standing empty, and a library tree that only ever
+  accumulates empty folders isn't organized for long.
+
+  Stops at the first folder that still holds something, and never removes one
+  of `stop_paths` — those are the registered library roots, whose existence
+  is configuration rather than a side effect of holding a book.
+  """
+  def try_prune_empty_parents(folder_paths, stop_paths) do
+    stop = MapSet.new(stop_paths)
+
+    for folder_path <- folder_paths, is_binary(folder_path) do
+      prune_empty_parents(Path.dirname(folder_path), stop)
+    end
+
+    :ok
+  end
+
+  defp prune_empty_parents(path, stop) do
+    parent = Path.dirname(path)
+
+    cond do
+      MapSet.member?(stop, path) -> :ok
+      parent == path -> :ok
+      not empty_dir?(path) -> :ok
+      File.rmdir(path) != :ok -> :ok
+      true -> prune_empty_parents(parent, stop)
+    end
+  end
+
+  defp empty_dir?(path) do
+    match?({:ok, []}, File.ls(path))
   end
 
   @doc """

--- a/lib/ambry/utils/delete_files.ex
+++ b/lib/ambry/utils/delete_files.ex
@@ -7,14 +7,23 @@ defmodule Ambry.Utils.DeleteFiles do
     queue: :default,
     max_attempts: 1
 
-  import Ambry.Utils, only: [try_delete_files: 1, try_delete_folders: 1]
+  import Ambry.Utils,
+    only: [try_delete_files: 1, try_delete_folders: 1, try_prune_empty_parents: 2]
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"disk_paths" => disk_paths} = args}) do
     try_delete_files(disk_paths)
 
     if Map.has_key?(args, "folder_paths") do
-      try_delete_folders(args["folder_paths"])
+      folder_paths = args["folder_paths"]
+      try_delete_folders(folder_paths)
+
+      # Only when the caller says where to stop. Without a boundary this
+      # would happily walk up and remove a library root, whose existence is
+      # configuration rather than a consequence of holding a book.
+      if stop_paths = args["prune_until"] do
+        try_prune_empty_parents(folder_paths, stop_paths)
+      end
     end
 
     :ok

--- a/test/ambry/media/deletion_custody_test.exs
+++ b/test/ambry/media/deletion_custody_test.exs
@@ -1,0 +1,208 @@
+defmodule Ambry.Media.DeletionCustodyTest do
+  @moduledoc """
+  What deleting a recording is allowed to do to the bytes.
+
+  Custody is the whole answer: `managed` means Ambry owns the files and may
+  remove them; `external` means the files belong to someone else's workflow
+  and removal deletes records only. Getting this wrong doesn't produce a
+  wrong page — it produces `rm -rf` on a folder the operator never gave
+  Ambry permission to touch.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Media
+
+  describe "external custody" do
+    # The promise external custody makes is the entire reason it exists: the
+    # files are referenced where they lie and Ambry never writes to them.
+    # `delete_media` used to hand `source_path` to a worker that runs
+    # `File.rm_rf` on it — which for an inbox-approved recording is the
+    # operator's own downloads folder.
+    test "deleting a recording never touches the source folder" do
+      %{media: media, folder: folder, file: file} = external_media()
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      assert File.exists?(file), "external source file was deleted"
+      assert File.dir?(folder), "external source folder was deleted"
+    end
+
+    test "the records are gone even though the files remain" do
+      %{media: media} = external_media()
+
+      assert {:ok, _media} = Media.delete_media(media)
+
+      assert_raise Ecto.NoResultsError, fn -> Media.get_media!(media.id) end
+    end
+  end
+
+  describe "replacing an external recording's files" do
+    # Replace deletes the *old* source folder once the new files are in
+    # place, which for an external recording is again the operator's own
+    # folder rather than Ambry's.
+    test "leaves the original source folder alone" do
+      %{media: media, folder: folder, file: file} = external_media()
+      new_folder = new_dir("replacement")
+      new_file = Path.join(new_folder, "better.m4b")
+      File.write!(new_file, "better audio")
+
+      assert {:ok, _media} =
+               Media.replace_media(media, %{
+                 source_path: new_folder,
+                 source_files: [new_file],
+                 processor: :mp4_concat
+               })
+
+      run_deletion_jobs()
+
+      assert File.exists?(file)
+      assert File.dir?(folder)
+    end
+  end
+
+  describe "managed custody" do
+    test "deleting a recording removes the library files it owns" do
+      %{media: media, folder: folder, file: file} = managed_media()
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.exists?(file)
+      refute File.dir?(folder)
+    end
+
+    # A library tree that only ever accumulates empty author and series
+    # folders isn't organized for long.
+    test "prunes the folders left empty behind it" do
+      root = new_dir("root")
+      insert(:location, kind: :library_root, import_policy: nil, path: root)
+
+      folder =
+        Path.join([root, "Brandon Sanderson", "The Stormlight Archive", "The Way of Kings"])
+
+      File.mkdir_p!(folder)
+      file = Path.join(folder, "book.m4b")
+      File.write!(file, "audio")
+
+      media =
+        insert(:media,
+          book: build(:book),
+          custody: :managed,
+          source_path: folder,
+          source_files: [file],
+          mpd_path: nil,
+          hls_path: nil,
+          mp4_path: nil
+        )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.dir?(Path.join([root, "Brandon Sanderson", "The Stormlight Archive"]))
+      refute File.dir?(Path.join(root, "Brandon Sanderson"))
+      # the root itself is configuration, not a consequence of holding a book
+      assert File.dir?(root)
+    end
+
+    test "stops pruning at a folder that still holds another book" do
+      root = new_dir("root")
+      insert(:location, kind: :library_root, import_policy: nil, path: root)
+
+      author = Path.join(root, "Brandon Sanderson")
+      keeper = Path.join([author, "Warbreaker", "Warbreaker.m4b"])
+      File.mkdir_p!(Path.dirname(keeper))
+      File.write!(keeper, "another book")
+
+      folder = Path.join(author, "The Way of Kings")
+      File.mkdir_p!(folder)
+      file = Path.join(folder, "book.m4b")
+      File.write!(file, "audio")
+
+      media =
+        insert(:media,
+          book: build(:book),
+          custody: :managed,
+          source_path: folder,
+          source_files: [file],
+          mpd_path: nil,
+          hls_path: nil,
+          mp4_path: nil
+        )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.dir?(folder)
+      assert File.exists?(keeper)
+      assert File.dir?(author)
+    end
+
+    # A hardlink is one inode with two names. Removing the library's name
+    # leaves the seeding copy untouched — that's inherent to hardlinks, and
+    # it's precisely why hardlinking is safe to delete from.
+    test "removing a hardlinked file leaves the other link alone" do
+      %{media: media, file: file} = managed_media()
+
+      seeding = Path.join(System.tmp_dir!(), "seeding-#{Ecto.UUID.generate()}.m4b")
+      File.ln!(file, seeding)
+      on_exit(fn -> File.rm(seeding) end)
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.exists?(file)
+      assert File.read!(seeding) == "audio"
+    end
+  end
+
+  defp external_media do
+    folder = new_dir("external")
+    file = Path.join(folder, "book.m4b")
+    File.write!(file, "audio")
+
+    media =
+      insert(:media,
+        book: build(:book),
+        custody: :external,
+        source_path: folder,
+        source_files: [file],
+        mpd_path: nil,
+        hls_path: nil,
+        mp4_path: nil
+      )
+
+    %{media: media, folder: folder, file: file}
+  end
+
+  defp managed_media do
+    folder = new_dir("managed")
+    file = Path.join(folder, "book.m4b")
+    File.write!(file, "audio")
+
+    media =
+      insert(:media,
+        book: build(:book),
+        custody: :managed,
+        source_path: folder,
+        source_files: [file],
+        mpd_path: nil,
+        hls_path: nil,
+        mp4_path: nil
+      )
+
+    %{media: media, folder: folder, file: file}
+  end
+
+  defp new_dir(prefix) do
+    dir = Ambry.Paths.source_media_disk_path("#{prefix}-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    dir
+  end
+
+  # Deletion is scheduled rather than immediate, so the assertions have to
+  # wait for the worker rather than for the function to return.
+  defp run_deletion_jobs do
+    Oban.drain_queue(queue: :default)
+  end
+end

--- a/test/ambry/people_test.exs
+++ b/test/ambry/people_test.exs
@@ -42,10 +42,14 @@ defmodule Ambry.PeopleTest do
   end
 
   describe "list_people/3" do
+    # Named explicitly rather than via the faker: the search is trigram-based,
+    # so two randomly generated names that happen to look alike both match and
+    # the test fails for reasons that have nothing to do with the search.
     test "accepts a 'search' filter that searches by person name" do
-      [_, _, %{id: id, name: name}, _, _] = insert_list(5, :person)
+      for name <- ["Wodehouse", "Zamyatin", "Kobayashi"], do: insert(:person, name: name)
+      %{id: id} = insert(:person, name: "Quetzalcoatl")
 
-      {[matched], has_more?} = People.list_people(0, 10, %{search: name})
+      {[matched], has_more?} = People.list_people(0, 10, %{search: "Quetzalcoatl"})
 
       refute has_more?
       assert matched.id == id


### PR DESCRIPTION
**This fixes a live data-loss bug**, not just an unbuilt feature.

`delete_media` handed `media.source_path` to a worker that runs `File.rm_rf` on it. That was harmless when every recording's source folder was Ambry's own upload directory — but since the inbox landed (#1176), an approved **external** recording's `source_path` *is* the operator's own downloads folder. Deleting such a recording from the admin UI deleted their source files.

`replace_media` had the same bug via `delete_old_source_folder_async`.

External custody makes exactly one promise — the files are referenced where they lie and Ambry never writes to them — and both paths broke it. The failing test came first:

```
1) test external custody deleting a recording never touches the source folder
   external source file was deleted
```

## What changed

- Both deletion paths gated on `custody == :managed`.
- Transcoded outputs, images and thumbnails are still removed regardless of custody — those are always Ambry's own, under the uploads path.
- Deleting a **managed** recording now prunes the folders left empty behind it, stopping at any registered location path. A library root's existence is configuration, not a consequence of currently holding a book, so pruning must never remove one.
- Hardlinks need no special handling: removing the library's name for an inode leaves the seeding copy untouched. That's inherent to hardlinks and precisely why hardlinking is safe to delete from — there's a test asserting it.

## Drive-by

Fixed a pre-existing flake in `Ambry.PeopleTest`. It inserted five faker-named people and searched for one expecting a single match, but the search is trigram-based, so two similar random names both matched. It failed once during this work and passed on three re-runs — same class as the `Ambry.MediaTest` flake fixed in #1176, and the same fix: name them explicitly.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: **954 passed**, 1 skipped. 7 new tests.

## Still to do in 3a

Renames on metadata change, reconciliation (vanished files → `missing`, scheduled scans, audit tooling over the library tree), and making approved media `ready`.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek