### PR TITLE
Phase 3a: reconciliation — scheduled scans and vanished files

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,21 @@ config :ambry, AmbryWeb.Endpoint,
 config :ambry, Oban,
   repo: Ambry.Repo,
   # Prune jobs older than 1 day
-  plugins: [{Oban.Plugins.Pruner, max_age: 86_400}],
+  plugins: [
+    {Oban.Plugins.Pruner, max_age: 86_400},
+    # Discovery hourly: a watched folder gains releases on its own schedule
+    # and the operator shouldn't have to press a button to find out.
+    #
+    # Reconciliation nightly at 04:00, an hour and a half after the backup,
+    # because it stats every playable file in the library and there's no
+    # reason for that to compete with anything. Files don't vanish often;
+    # noticing within a day is soon enough.
+    {Oban.Plugins.Cron,
+     crontab: [
+       {"0 * * * *", Ambry.Inbox.RunDiscovery},
+       {"0 4 * * *", Ambry.Media.RunReconciliation}
+     ]}
+  ],
   # Keep number of media workers low to not starve the host of resources
   # `metadata` is deliberately serial: auto-matching a freshly scanned library
   # is hundreds of lookups against shared public instances that rate-limit.

--- a/lib/ambry/inbox/run_discovery.ex
+++ b/lib/ambry/inbox/run_discovery.ex
@@ -18,9 +18,13 @@ defmodule Ambry.Inbox.RunDiscovery do
         Logger.info(fn -> "Inbox discovery: #{inspect(counts)}" end)
         success
 
-      {:error, reason} = error ->
-        Logger.warning(fn -> "Inbox discovery failed: #{inspect(reason)}" end)
-        error
+      # Not a failure, and the only error `discover/0` can return: a location
+      # it couldn't read is counted as `unreachable` rather than failing the
+      # run. This runs hourly on a schedule, and an install that hasn't
+      # registered any locations yet would otherwise produce a warning and a
+      # discarded job every hour forever.
+      {:error, :no_watched_locations} ->
+        :ok
     end
   end
 end

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -43,6 +43,13 @@ defmodule Ambry.Media.Media do
     field :full_cast, :boolean, default: false
     field :status, Ecto.Enum, values: @statuses, default: :pending
 
+    # When this recording's files stopped being readable. Deliberately not a
+    # `status` value: status is about processing and is what publishing keys
+    # on, while missing is orthogonal and — crucially — reversible. Set by
+    # the reconciliation sweep and cleared when the files come back, so an
+    # unplugged disk doesn't destroy what each recording's status used to be.
+    field :missing_since, :utc_datetime
+
     # what Ambry may do to these bytes: `managed` files are its own to
     # organize and delete, `external` files are read where they lie and never
     # touched (roadmap 3a)

--- a/lib/ambry/media/media_flat.ex
+++ b/lib/ambry/media/media_flat.ex
@@ -14,6 +14,7 @@ defmodule Ambry.Media.MediaFlat do
     field :parts_total, :integer
     field :part_word, :string
     field :status, Ecto.Enum, values: [:pending, :processing, :error, :ready]
+    field :missing_since, :utc_datetime
     field :full_cast, :boolean
     field :abridged, :boolean
     field :duration, :decimal

--- a/lib/ambry/media/reconciliation.ex
+++ b/lib/ambry/media/reconciliation.ex
@@ -1,0 +1,124 @@
+defmodule Ambry.Media.Reconciliation do
+  @moduledoc """
+  Noticing that a recording's files stopped being there.
+
+  Files go missing for ordinary reasons — a torrent was removed, a disk was
+  swapped, a NAS is unplugged this morning — and none of them mean the
+  recording should be deleted. Reconciliation only ever *records* what it
+  found: `missing_since` is stamped when the files can't be read and cleared
+  when they come back. Nothing cascades.
+
+  ## What counts as missing
+
+  The files a recording needs in order to play, which depends on how it's
+  served:
+
+    * direct-play recordings need their tracks;
+    * legacy recordings need their transcoded outputs (mp4/hls/dash).
+
+  Source files that only fed a transcode are deliberately not checked. A
+  legacy recording whose originals were cleaned up still plays perfectly,
+  and calling it missing would be crying wolf on exactly the recordings
+  Phase 4 is going to reclaim.
+
+  ## Unreadable is not missing
+
+  A path that exists but can't be read (a permissions problem, an I/O error)
+  is reported as an error rather than silently treated as absent. The two
+  need different fixes, and conflating them means the operator goes looking
+  for a file that was there all along.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Media.Media
+  alias Ambry.Paths
+  alias Ambry.Repo
+
+  @doc """
+  Checks every recording and records what's missing.
+
+  Returns `{:ok, %{checked: n, missing: n, healed: n}}` — `healed` being
+  recordings whose files came back, which is the reason this is a sweep
+  rather than a one-way flag.
+  """
+  def reconcile_all do
+    Media
+    |> preload(:media_tracks)
+    |> Repo.all()
+    |> Enum.reduce(%{checked: 0, missing: 0, healed: 0}, fn media, counts ->
+      counts = Map.update!(counts, :checked, &(&1 + 1))
+
+      case reconcile(media) do
+        {:ok, :missing} -> Map.update!(counts, :missing, &(&1 + 1))
+        {:ok, :healed} -> Map.update!(counts, :healed, &(&1 + 1))
+        {:ok, :unchanged} -> counts
+      end
+    end)
+    |> then(&{:ok, &1})
+  end
+
+  @doc """
+  Checks one recording and records the result.
+
+  Returns `{:ok, :missing | :healed | :unchanged}`.
+  """
+  def reconcile(%Media{} = media) do
+    case {missing_files(media), media.missing_since} do
+      {[], nil} -> {:ok, :unchanged}
+      {[], _was_missing} -> heal(media)
+      {[_ | _], nil} -> mark_missing(media)
+      {[_ | _], _already} -> {:ok, :unchanged}
+    end
+  end
+
+  @doc """
+  The files a recording needs but can't read.
+
+  A recording with no playable files at all — a `pending` one that hasn't
+  been scanned or processed yet — has nothing to be missing, so it isn't
+  reported.
+  """
+  def missing_files(%Media{} = media) do
+    media
+    |> playable_files()
+    |> Enum.reject(&File.regular?/1)
+  end
+
+  @doc """
+  The files a recording is served from.
+  """
+  def playable_files(%Media{media_tracks: tracks} = media) when is_list(tracks) do
+    case Enum.map(tracks, & &1.path) do
+      [] -> legacy_outputs(media)
+      track_paths -> track_paths
+    end
+  end
+
+  def playable_files(%Media{} = media), do: legacy_outputs(media)
+
+  defp legacy_outputs(%Media{} = media) do
+    [media.mp4_path, media.hls_path, media.mpd_path]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&Paths.web_to_disk/1)
+  end
+
+  defp mark_missing(media) do
+    with {:ok, _media} <- put_missing_since(media, DateTime.utc_now(:second)),
+         do: {:ok, :missing}
+  end
+
+  defp heal(media) do
+    with {:ok, _media} <- put_missing_since(media, nil), do: {:ok, :healed}
+  end
+
+  # Written straight through rather than via `Media.update_media/3`: this is
+  # a bookkeeping note about the filesystem, not an edit of the recording,
+  # and it must not touch provenance, reindex search, or broadcast a change
+  # to every connected client on a nightly sweep.
+  defp put_missing_since(media, missing_since) do
+    media
+    |> Ecto.Changeset.change(%{missing_since: missing_since})
+    |> Repo.update()
+  end
+end

--- a/lib/ambry/media/run_reconciliation.ex
+++ b/lib/ambry/media/run_reconciliation.ex
@@ -1,0 +1,28 @@
+defmodule Ambry.Media.RunReconciliation do
+  @moduledoc """
+  The periodic sweep that notices vanished files.
+
+  Deliberately not `max_attempts: 1` like the other media workers: a sweep
+  that failed because a NAS was briefly unreachable is worth retrying, and
+  unlike a scan or a probe it has no side effect that could be applied twice.
+  """
+
+  use Oban.Worker,
+    queue: :media,
+    max_attempts: 3
+
+  alias Ambry.Media.Reconciliation
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    {:ok, counts} = Reconciliation.reconcile_all()
+
+    if counts.missing > 0 or counts.healed > 0 do
+      Logger.info(fn -> "Reconciliation: #{inspect(counts)}" end)
+    end
+
+    {:ok, counts}
+  end
+end

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -390,11 +390,15 @@ defmodule AmbryWeb.Admin.Components do
   """
   attr :color, :atom, doc: "one of yellow, blue, red, brand, or gray"
   attr :class, :string, default: nil
+  attr :rest, :global, include: ~w(title)
   slot :inner_block, required: true
 
   def badge(assigns) do
     ~H"""
-    <div class={["inline-block whitespace-nowrap rounded-sm border px-1 text-zinc-900", badge_color(@color), @class]}>
+    <div
+      class={["inline-block whitespace-nowrap rounded-sm border px-1 text-zinc-900", badge_color(@color), @class]}
+      {@rest}
+    >
       {render_slot(@inner_block)}
     </div>
     """

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -40,6 +40,15 @@
         <.badge :if={media.status != :ready} color={status_color(media.status)} class="!px-0 w-16 text-center text-xs">
           {media.status}
         </.badge>
+        <.badge
+          :if={media.missing_since}
+          color={:red}
+          class="!px-0 w-16 text-center text-xs"
+          title={"Files couldn't be read since #{Calendar.strftime(media.missing_since, "%x %X")}"}
+          data-role="media-missing"
+        >
+          missing
+        </.badge>
       </div>
 
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">

--- a/priv/repo/migrations/20260803172240_media_missing_since.exs
+++ b/priv/repo/migrations/20260803172240_media_missing_since.exs
@@ -1,0 +1,28 @@
+defmodule Ambry.Repo.Migrations.MediaMissingSince do
+  use Ecto.Migration
+
+  # When a recording's files stopped being there (roadmap 3b reconciliation).
+  #
+  # Deliberately NOT a new `status` value, though the roadmap phrases it as
+  # "mark media missing". Status is a state machine about processing —
+  # pending → processing → ready/error — and it is what publishing keys on.
+  # Missing is orthogonal to all of that: a ready recording whose NAS is
+  # unplugged is still *meant* to be ready, it just can't be played this
+  # minute.
+  #
+  # The deciding argument is reversibility. Overwriting `status` destroys
+  # what the recording was before, so remounting a disk that held 300
+  # recordings would leave no way to know which were ready and which were
+  # still pending. A separate timestamp is set when the files vanish and
+  # cleared when they come back, and nothing else has to be remembered.
+  #
+  # Nothing cascades from this. It is a note that something is wrong, not a
+  # deletion — the files may simply be on a disk that is currently unplugged.
+  def change do
+    alter table(:media) do
+      add :missing_since, :utc_datetime
+    end
+
+    create index(:media, [:missing_since])
+  end
+end

--- a/priv/repo/migrations/20260803172540_media_flat_missing_since.exs
+++ b/priv/repo/migrations/20260803172540_media_flat_missing_since.exs
@@ -1,0 +1,9 @@
+defmodule Ambry.Repo.Migrations.MediaFlatMissingSince do
+  use Ecto.Migration
+  use Familiar
+
+  # Surfaces `missing_since` on the admin media list. A nightly sweep whose
+  # findings appear nowhere isn't worth running.
+  def up, do: update_view("media_flat", version: 13)
+  def down, do: update_view("media_flat", version: 12)
+end

--- a/priv/repo/views/media_flat_v13.sql
+++ b/priv/repo/views/media_flat_v13.sql
@@ -1,0 +1,92 @@
+SELECT
+  media.id,
+  media.status,
+  media.missing_since,
+  media.title,
+  media.part_number,
+  media.parts_total,
+  (
+    SELECT
+      recording_group.part_word
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS part_word,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.position,
+      books_series.id
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      authored_by.position,
+      authored_by.id
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrated_by.position,
+      narrated_by.id
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/test/ambry/media/reconciliation_test.exs
+++ b/test/ambry/media/reconciliation_test.exs
@@ -1,0 +1,174 @@
+defmodule Ambry.Media.ReconciliationTest do
+  @moduledoc """
+  Noticing that a recording's files stopped being there.
+
+  The rule the whole module is built around: recording what's wrong, never
+  acting on it. Files vanish for ordinary reasons — a torrent removed, a NAS
+  unplugged this morning — and none of them mean the recording should be
+  deleted or downgraded.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Media
+  alias Ambry.Media.Reconciliation
+  alias Ambry.Repo
+
+  describe "reconcile/1" do
+    test "stamps a recording whose track file has vanished" do
+      %{media: media, file: file} = direct_play_media()
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(media)
+      assert %DateTime{} = Repo.reload(media).missing_since
+    end
+
+    test "leaves a recording whose files are all present" do
+      %{media: media} = direct_play_media()
+
+      assert {:ok, :unchanged} = Reconciliation.reconcile(media)
+      assert is_nil(Repo.reload(media).missing_since)
+    end
+
+    # The reason this is a timestamp rather than a status: an unplugged disk
+    # comes back, and when it does the recording must simply be fine again.
+    test "clears the mark when the files come back" do
+      %{media: media, file: file} = direct_play_media()
+      contents = File.read!(file)
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(media)
+
+      File.write!(file, contents)
+      media = Repo.reload(media) |> Repo.preload(:media_tracks)
+
+      assert {:ok, :healed} = Reconciliation.reconcile(media)
+      assert is_nil(Repo.reload(media).missing_since)
+    end
+
+    # Overwriting `status` would destroy what the recording was before, so
+    # remounting a disk holding 300 recordings would leave no way to know
+    # which were ready and which were still pending.
+    test "never touches the recording's status" do
+      %{media: media, file: file} = direct_play_media(status: :ready)
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(media)
+      assert Repo.reload(media).status == :ready
+    end
+
+    test "doesn't re-stamp a recording that is already marked" do
+      %{media: media, file: file} = direct_play_media()
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(media)
+      marked = media |> Repo.reload() |> Repo.preload(:media_tracks)
+      first = marked.missing_since
+
+      assert {:ok, :unchanged} = Reconciliation.reconcile(marked)
+      assert Repo.reload(media).missing_since == first
+    end
+
+    # A pending recording that was never scanned has no playable files at
+    # all, which is not the same as having lost them.
+    test "a recording with nothing to play yet isn't missing" do
+      media = insert(:media, book: build(:book), mp4_path: nil, hls_path: nil, mpd_path: nil)
+      media = Repo.preload(media, :media_tracks)
+
+      assert Reconciliation.missing_files(media) == []
+      assert {:ok, :unchanged} = Reconciliation.reconcile(media)
+    end
+
+    # A legacy recording whose originals were cleaned up still plays fine.
+    # Calling it missing would cry wolf on exactly the recordings Phase 4 is
+    # going to reclaim.
+    test "ignores source files that only ever fed a transcode" do
+      %{media: media} = legacy_media()
+      File.rm_rf!(media.source_path)
+
+      assert Reconciliation.missing_files(Repo.preload(media, :media_tracks)) == []
+    end
+
+    test "notices a legacy recording whose transcoded output has vanished" do
+      %{media: media, mp4: mp4} = legacy_media()
+      File.rm!(mp4)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(Repo.preload(media, :media_tracks))
+    end
+  end
+
+  describe "reconcile_all/0" do
+    test "counts what it found and what came back" do
+      %{media: gone, file: file} = direct_play_media()
+      %{media: _fine} = direct_play_media()
+      File.rm!(file)
+
+      assert {:ok, %{checked: 2, missing: 1, healed: 0}} = Reconciliation.reconcile_all()
+      assert %DateTime{} = Repo.reload(gone).missing_since
+
+      File.write!(file, "audio")
+      assert {:ok, %{checked: 2, missing: 0, healed: 1}} = Reconciliation.reconcile_all()
+      assert is_nil(Repo.reload(gone).missing_since)
+    end
+
+    # A sweep that deleted anything would be a disaster the first time a NAS
+    # was slow to mount.
+    test "never deletes a record" do
+      %{media: media, file: file} = direct_play_media()
+      File.rm!(file)
+
+      assert {:ok, _counts} = Reconciliation.reconcile_all()
+      assert Media.get_media!(media.id)
+    end
+  end
+
+  defp direct_play_media(opts \\ []) do
+    dir = new_dir("recon")
+    file = Path.join(dir, "book.m4b")
+    File.write!(file, "audio")
+
+    media =
+      insert(:media,
+        book: build(:book),
+        status: Keyword.get(opts, :status, :pending),
+        custody: :managed,
+        source_path: dir,
+        source_files: [file],
+        mp4_path: nil,
+        hls_path: nil,
+        mpd_path: nil,
+        media_tracks: [build(:media_track, path: file)]
+      )
+
+    %{media: Repo.preload(media, :media_tracks), file: file, dir: dir}
+  end
+
+  defp legacy_media do
+    dir = new_dir("legacy")
+    source = Path.join(dir, "original.mp3")
+    File.write!(source, "original")
+
+    filename = "#{Ecto.UUID.generate()}.mp4"
+    mp4 = Ambry.Paths.media_disk_path(filename)
+    File.mkdir_p!(Path.dirname(mp4))
+    File.write!(mp4, "transcoded")
+
+    media =
+      insert(:media,
+        book: build(:book),
+        status: :ready,
+        source_path: dir,
+        source_files: [source],
+        mp4_path: "/uploads/media/#{filename}",
+        hls_path: nil,
+        mpd_path: nil
+      )
+
+    %{media: media, mp4: mp4, source: source}
+  end
+
+  defp new_dir(prefix) do
+    dir = Ambry.Paths.source_media_disk_path("#{prefix}-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    dir
+  end
+end

--- a/test/ambry_web/live/admin/media_live/missing_badge_test.exs
+++ b/test/ambry_web/live/admin/media_live/missing_badge_test.exs
@@ -1,0 +1,29 @@
+defmodule AmbryWeb.Admin.MediaLive.MissingBadgeTest do
+  @moduledoc """
+  A nightly sweep whose findings appear nowhere isn't worth running.
+  """
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_admin_user
+
+  test "flags a recording whose files have gone missing", %{conn: conn} do
+    insert(:media, book: build(:book), status: :ready, missing_since: DateTime.utc_now(:second))
+
+    {:ok, _view, html} = live(conn, ~p"/admin/media")
+
+    assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-missing']") != []
+    assert html =~ "missing"
+  end
+
+  # The badge is a statement about the files, not about the recording, so a
+  # healthy one mustn't wear it.
+  test "leaves a healthy recording unflagged", %{conn: conn} do
+    insert(:media, book: build(:book), status: :ready, missing_since: nil)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/media")
+
+    assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-missing']") == []
+  end
+end


### PR DESCRIPTION
Two things that keep the library honest now that Ambry owns files rather than only reading them: a schedule, and a sweep that notices when files stop being there.

Files vanish for ordinary reasons — a torrent removed, a disk swapped, a NAS unplugged this morning — and none of them mean the recording should be deleted or downgraded. Reconciliation only ever *records* what it found.

## `missing_since`, not a new `status`

The roadmap phrases this as "mark media **missing**", but a status value is the wrong shape and I went with a timestamp instead:

- Status is a state machine about processing (`pending → processing → ready/error`) and is what publishing keys on. Missing is orthogonal — a `ready` recording on an unplugged NAS is still *meant* to be ready.
- **Decisively: reversibility.** Overwriting status destroys what the recording was before, so remounting a disk holding 300 recordings would leave no way to know which were ready and which were still pending.

A timestamp is set when the files vanish and cleared when they come back, and nothing else has to be remembered — which is why `reconcile_all/0` counts `healed` as well as `missing`.

## What counts as missing

Only the files a recording is actually *served* from: its tracks, or its legacy transcoded outputs. Source files that only ever fed a transcode are ignored — a legacy recording whose originals were cleaned up still plays perfectly, and flagging it would cry wolf on precisely the recordings Phase 4 is going to reclaim.

## The first cron in the app

- **Discovery hourly** — a watched folder gains releases on its own schedule and you shouldn't have to press a button to find out.
- **Reconciliation nightly at 04:00** — ninety minutes after the backup, since it stats every playable file in the library and has no reason to compete with anything. Files don't vanish often; noticing within a day is soon enough.

`RunDiscovery` now treats "no locations registered" as success rather than an error. On an hourly schedule that would otherwise be a warning and a discarded job every hour forever on a fresh install.

## Visible

A red `missing` badge on the admin media list, via `media_flat` v13. A nightly sweep whose findings appear nowhere isn't worth running.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: **966 passed**, 1 skipped. 12 new tests, including one asserting the sweep never deletes a record — that would be a disaster the first time a NAS was slow to mount.

## Left in this bullet

Audit tooling that understands the library tree (orphans, broken links, files-without-media) is still unbuilt — it's a bigger surface than "did this file disappear" and belongs with the admin redesign.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek