### PR TITLE
Phase 3a: keep managed files in line with the naming template

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -43,7 +43,11 @@ config :ambry, Oban,
     {Oban.Plugins.Cron,
      crontab: [
        {"0 * * * *", Ambry.Inbox.RunDiscovery},
-       {"0 4 * * *", Ambry.Media.RunReconciliation}
+       {"0 4 * * *", Ambry.Media.RunReconciliation},
+       # Organizing is triggered by the edits that invalidate a path, so this
+       # is the backstop for the one thing no edit can announce: a change to
+       # the naming template itself, which invalidates every path at once.
+       {"30 4 * * *", Ambry.Media.RunOrganize}
      ]}
   ],
   # Keep number of media workers low to not starve the host of resources

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -39,6 +39,7 @@ defmodule Ambry.Media do
   alias Ambry.Media.PubSub.MediaProgress
   alias Ambry.Media.PubSub.MediaUpdated
   alias Ambry.Media.RecordingGroup
+  alias Ambry.Media.RunOrganize
   alias Ambry.Media.RunProcessor
   alias Ambry.Media.RunScan
   alias Ambry.Media.Scanner
@@ -52,6 +53,26 @@ defmodule Ambry.Media do
 
   defdelegate get_media_file_details(media), to: Audit
   defdelegate orphaned_files_audit(), to: Audit
+
+  @doc """
+  Brings a recording's managed files back in line with the naming template.
+
+  Asynchronous because it touches the filesystem, and safe to call after any
+  edit: a recording that is already where it belongs, external, or outside a
+  library root is a no-op.
+  """
+  def organize_async(%Media{id: id}), do: enqueue_organize(%{"media_id" => id})
+
+  @doc """
+  The same, for every managed recording of a book.
+
+  A book's title, primary author and primary series all appear in the path of
+  every recording of it, so editing the book moves its files, not just its
+  own page.
+  """
+  def organize_book_async(book_id), do: enqueue_organize(%{"book_id" => book_id})
+
+  defp enqueue_organize(args), do: args |> RunOrganize.new() |> Oban.insert()
 
   @doc """
   Returns a limited list of media and whether or not there are more.

--- a/lib/ambry/media/organization.ex
+++ b/lib/ambry/media/organization.ex
@@ -1,0 +1,188 @@
+defmodule Ambry.Media.Organization do
+  @moduledoc """
+  Keeping a managed recording's files where the naming template says.
+
+  A library tree organized once at import drifts the moment anything is
+  corrected: fix a misspelled title, reorder a book's authors, add the series
+  you forgot, and the folder still says what it said when the file landed.
+  Organizing brings the files back in line.
+
+  ## What it will and won't touch
+
+  Only `managed` recordings whose files sit inside a **registered library
+  root**. That's two separate guards doing two separate jobs:
+
+    * custody keeps it away from external files, which Ambry has promised
+      never to write to;
+    * the root check keeps it away from the legacy uploads library, which is
+      `managed` but isn't template-organized and belongs to Phase 4.
+
+  A rename stays inside the root the file already lives in, so it's always a
+  move within one filesystem — never a copy, never a cross-device problem.
+
+  ## Collisions refuse
+
+  If the new path is already occupied, nothing moves. Two recordings
+  rendering to one path is a curation problem the operator has to see, and
+  quietly appending " (2)" would hide it forever.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Books
+  alias Ambry.Library
+  alias Ambry.Library.NamingTemplate
+  alias Ambry.Media.Media
+  alias Ambry.Repo
+  alias Ambry.Settings
+  alias Ambry.Utils
+
+  require Logger
+
+  @doc """
+  Moves one recording's files to where the template says they belong.
+
+  Returns `{:ok, :moved | :noop}` or `{:error, reason}`. Already being in
+  the right place is a `:noop`, which is the common case every time this
+  runs on a schedule.
+  """
+  def organize(%Media{} = media) do
+    media =
+      Repo.preload(media, [:media_tracks, book: [book_authors: :author, series_books: :series]])
+
+    with {:ok, root} <- root_for(media),
+         {:ok, file} <- single_file(media),
+         {:ok, destination} <- destination(media, root, file) do
+      if destination == file, do: {:ok, :noop}, else: move(media, file, destination)
+    else
+      :noop -> {:ok, :noop}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Organizes every managed recording.
+
+  The backstop for everything an edit-time trigger can't see — most obviously
+  a change to the template itself, which invalidates every path at once.
+  """
+  def organize_all do
+    Media
+    |> where([m], m.custody == :managed)
+    |> Repo.all()
+    |> Enum.reduce(%{moved: 0, noop: 0, failed: 0}, fn media, counts ->
+      case organize(media) do
+        {:ok, :moved} ->
+          Map.update!(counts, :moved, &(&1 + 1))
+
+        {:ok, :noop} ->
+          Map.update!(counts, :noop, &(&1 + 1))
+
+        {:error, reason} ->
+          Logger.warning(fn -> "Couldn't organize media #{media.id}: #{inspect(reason)}" end)
+          Map.update!(counts, :failed, &(&1 + 1))
+      end
+    end)
+    |> then(&{:ok, &1})
+  end
+
+  @doc """
+  The managed recordings of one book, for after its metadata changed.
+  """
+  def book_media(book_id) do
+    Media
+    |> where([m], m.book_id == ^book_id and m.custody == :managed)
+    |> Repo.all()
+  end
+
+  # The root the file already lives in. Not the location's *target* root —
+  # this is about where the bytes are now, and a rename never moves a
+  # recording between roots.
+  defp root_for(%Media{custody: :managed, source_path: path}) when is_binary(path) do
+    case Enum.find(Library.library_roots(), &inside?(path, &1.path)) do
+      nil -> :noop
+      root -> {:ok, root}
+    end
+  end
+
+  defp root_for(%Media{}), do: :noop
+
+  # Prefix-matching on a separator boundary, so `/data/library-old` is not
+  # treated as living inside `/data/library`.
+  defp inside?(path, root_path) do
+    String.starts_with?(path, root_path <> "/")
+  end
+
+  # Direct-play v1 is single-file. A recording with several tracks would need
+  # every one moved and re-pointed, which isn't reachable yet and shouldn't
+  # be guessed at.
+  defp single_file(%Media{media_tracks: [%{path: path}]}), do: {:ok, path}
+  defp single_file(%Media{}), do: :noop
+
+  defp destination(media, root, current_file) do
+    values = Books.naming_values(media.book, media)
+
+    with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
+         {:ok, filename} <- NamingTemplate.filename(values, current_file) do
+      {:ok, Path.join([root.path, folder, filename])}
+    end
+  end
+
+  defp move(media, from, to) do
+    cond do
+      not File.regular?(from) ->
+        # Reconciliation's job to notice and record, not this one's to guess
+        # at. Moving a file that isn't there would only turn one problem into
+        # two.
+        {:error, {:source_missing, from}}
+
+      File.exists?(to) ->
+        {:error, {:destination_exists, to}}
+
+      true ->
+        do_move(media, from, to)
+    end
+  end
+
+  defp do_move(media, from, to) do
+    with :ok <- File.mkdir_p(Path.dirname(to)),
+         :ok <- File.rename(from, to),
+         {:ok, _media} <- repoint(media, from, to) do
+      prune(from)
+      {:ok, :moved}
+    else
+      {:error, reason} -> {:error, {:move_failed, reason}}
+    end
+  end
+
+  defp repoint(media, from, to) do
+    Repo.transact(fn ->
+      with {:ok, _track} <- repoint_track(media, to) do
+        media
+        |> Ecto.Changeset.change(%{
+          source_path: Path.dirname(to),
+          source_files: replace_path(media.source_files, from, to)
+        })
+        |> Repo.update()
+      end
+    end)
+  end
+
+  defp repoint_track(%Media{media_tracks: [track]}, to) do
+    track |> Ecto.Changeset.change(%{path: to}) |> Repo.update()
+  end
+
+  defp replace_path(source_files, from, to) when is_list(source_files) do
+    Enum.map(source_files, fn path -> if path == from, do: to, else: path end)
+  end
+
+  defp replace_path(_source_files, _from, to), do: [to]
+
+  # The folder the file just left, and any parent left empty by it. Passing
+  # the old *file* path is what makes the pruning start at its folder rather
+  # than at the folder's parent. Stops at any registered location — a root's
+  # existence is configuration, not a consequence of holding a book.
+  defp prune(from) do
+    Utils.try_prune_empty_parents([from], Enum.map(Library.list_locations(), & &1.path))
+  end
+end

--- a/lib/ambry/media/run_organize.ex
+++ b/lib/ambry/media/run_organize.ex
@@ -1,0 +1,55 @@
+defmodule Ambry.Media.RunOrganize do
+  @moduledoc """
+  Brings managed files back in line with the naming template.
+
+  Three shapes of job, all idempotent — a recording already in the right
+  place is a no-op, which is what almost every run finds:
+
+    * `%{"media_id" => id}` — after that recording was edited;
+    * `%{"book_id" => id}` — after a book was edited, since its title,
+      authors and series appear in the path of every recording of it;
+    * `%{}` — the whole library, for the nightly sweep and for the one thing
+      no edit-time trigger can see: a change to the template itself.
+  """
+
+  use Oban.Worker,
+    queue: :media,
+    max_attempts: 3
+
+  alias Ambry.Media.Organization
+  alias Ambry.Repo
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"media_id" => media_id}}) do
+    case Repo.get(Ambry.Media.Media, media_id) do
+      nil -> :ok
+      media -> log(Organization.organize(media), media_id)
+    end
+  end
+
+  def perform(%Oban.Job{args: %{"book_id" => book_id}}) do
+    for media <- Organization.book_media(book_id), do: log(Organization.organize(media), media.id)
+    :ok
+  end
+
+  def perform(%Oban.Job{}) do
+    {:ok, counts} = Organization.organize_all()
+
+    if counts.moved > 0 or counts.failed > 0,
+      do: Logger.info(fn -> "Organize: #{inspect(counts)}" end)
+
+    :ok
+  end
+
+  # A recording that can't be moved — most likely because something is
+  # already at its new path — must not fail the job and retry forever. The
+  # operator has to resolve the collision; the queue can't.
+  defp log({:ok, _moved_or_noop}, _media_id), do: :ok
+
+  defp log({:error, reason}, media_id) do
+    Logger.warning(fn -> "Couldn't organize media #{media_id}: #{inspect(reason)}" end)
+    :ok
+  end
+end

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -4,6 +4,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
 
   alias Ambry.Books
   alias Ambry.Books.Book
+  alias Ambry.Media
   alias Ambry.Metadata.Registry
   alias Ambry.People
   alias Ambry.Provenance
@@ -144,6 +145,10 @@ defmodule AmbryWeb.Admin.BookLive.Form do
 
     case Books.update_book(socket.assigns.book, book_params, opts) do
       {:ok, book} ->
+        # the title, primary author and primary series all appear in the path
+        # of every managed recording of this book
+        {:ok, _job} = Media.organize_book_async(book.id)
+
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{book.title}")

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -307,6 +307,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     case Media.update_media(socket.assigns.media, media_params, opts) do
       {:ok, media} ->
         maybe_start_processor!(media, media_params, :edit)
+        # a title override or a changed date moves the folder
+        {:ok, _job} = Media.organize_async(media)
 
         {:noreply,
          socket

--- a/test/ambry/media/organization_test.exs
+++ b/test/ambry/media/organization_test.exs
@@ -1,0 +1,184 @@
+defmodule Ambry.Media.OrganizationTest do
+  @moduledoc """
+  Keeping a managed recording's files where the naming template says.
+
+  A tree organized once at import drifts the moment anything is corrected —
+  fix a title, reorder the authors, add the series you forgot — and the
+  folder still says what it said the day the file landed.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Books
+  alias Ambry.Media.Organization
+  alias Ambry.Repo
+  alias Ambry.Settings
+
+  describe "organize/1" do
+    test "moves the file when the book's title changed" do
+      %{media: media, root: root, file: file} = organized_media()
+
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+      media = reload(media)
+
+      assert {:ok, :moved} = Organization.organize(media)
+
+      moved = Path.join([root, "Brandon Sanderson", "Oathbringer (2010)", "Oathbringer.m4b"])
+      assert File.read!(moved) == "audio"
+      refute File.exists?(file)
+
+      media = reload(media)
+      assert media.source_files == [moved]
+      assert media.source_path == Path.dirname(moved)
+      assert [%{path: ^moved}] = media.media_tracks
+    end
+
+    test "does nothing when the file is already where it belongs" do
+      %{media: media, file: file} = organized_media()
+
+      assert {:ok, :noop} = Organization.organize(media)
+      assert File.exists?(file)
+    end
+
+    # The folder the file left shouldn't stand around empty, but the root
+    # itself is configuration and must survive.
+    test "prunes the folders it emptied, but never the root" do
+      %{media: media, root: root} = organized_media()
+
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+
+      assert {:ok, :moved} = Organization.organize(reload(media))
+
+      refute File.dir?(Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"]))
+      assert File.dir?(Path.join(root, "Brandon Sanderson"))
+      assert File.dir?(root)
+    end
+
+    # External custody promises Ambry never writes to those files, and a
+    # rename is a write.
+    test "never moves an external recording" do
+      %{media: media, file: file} = organized_media(custody: :external)
+
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+
+      assert {:ok, :noop} = Organization.organize(reload(media))
+      assert File.exists?(file)
+    end
+
+    # The legacy uploads library is `managed` but isn't template-organized —
+    # it's Phase 4's to migrate, not this function's to rearrange.
+    test "never moves a managed recording that lives outside a library root" do
+      %{media: media, file: file} = organized_media(register_root: false)
+
+      assert {:ok, :noop} = Organization.organize(reload(media))
+      assert File.exists?(file)
+    end
+
+    # `/data/library-old` is not inside `/data/library`, however much the
+    # string says otherwise.
+    test "matches the root on a path boundary, not a bare prefix" do
+      %{media: media, file: file, root: root} = organized_media(register_root: false)
+      insert(:location, kind: :library_root, import_policy: nil, path: root <> "-elsewhere")
+
+      assert {:ok, :noop} = Organization.organize(reload(media))
+      assert File.exists?(file)
+    end
+
+    test "follows a changed template" do
+      %{media: media, root: root} = organized_media()
+      {:ok, _setting} = Settings.set_library_naming_template("{title}")
+
+      assert {:ok, :moved} = Organization.organize(reload(media))
+
+      assert File.read!(Path.join([root, "The Way of Kings", "The Way of Kings.m4b"])) == "audio"
+    end
+
+    # Two recordings rendering to one path is a curation problem the operator
+    # has to see; quietly appending " (2)" would hide it forever.
+    test "refuses when something already occupies the new path" do
+      %{media: media, root: root, file: file} = organized_media()
+
+      occupied = Path.join([root, "Brandon Sanderson", "Oathbringer (2010)", "Oathbringer.m4b"])
+      File.mkdir_p!(Path.dirname(occupied))
+      File.write!(occupied, "someone else")
+
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+
+      assert {:error, {:destination_exists, ^occupied}} = Organization.organize(reload(media))
+      assert File.read!(occupied) == "someone else"
+      assert File.exists?(file)
+    end
+
+    # Reconciliation's job to notice and record. Moving a file that isn't
+    # there would only turn one problem into two.
+    test "refuses when the file it was going to move has vanished" do
+      %{media: media, file: file} = organized_media()
+      File.rm!(file)
+
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+
+      assert {:error, {:source_missing, ^file}} = Organization.organize(reload(media))
+    end
+  end
+
+  describe "organize_all/0" do
+    test "counts what moved and what was already right" do
+      %{media: media} = organized_media()
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+
+      assert {:ok, %{moved: 1, noop: 0, failed: 0}} = Organization.organize_all()
+      assert {:ok, %{moved: 0, noop: 1, failed: 0}} = Organization.organize_all()
+    end
+  end
+
+  defp organized_media(opts \\ []) do
+    root = new_dir("root")
+
+    if Keyword.get(opts, :register_root, true) do
+      insert(:location, kind: :library_root, import_policy: nil, path: root)
+    end
+
+    author = insert(:author, name: "Brandon Sanderson")
+
+    book =
+      insert(:book,
+        title: "The Way of Kings",
+        published: ~D[2010-08-31],
+        published_format: :full,
+        book_authors: [build(:book_author, author: author, position: 0)]
+      )
+
+    folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
+    File.mkdir_p!(folder)
+    file = Path.join(folder, "The Way of Kings.m4b")
+    File.write!(file, "audio")
+
+    media =
+      insert(:media,
+        book: book,
+        # the recording's own date wins over the book's in the template, and
+        # the factory would otherwise pick a random one
+        published: ~D[2010-08-31],
+        custody: Keyword.get(opts, :custody, :managed),
+        source_path: folder,
+        source_files: [file],
+        mp4_path: nil,
+        hls_path: nil,
+        mpd_path: nil,
+        media_tracks: [build(:media_track, path: file)]
+      )
+
+    %{media: reload(media), root: root, file: file, folder: folder, book: book}
+  end
+
+  defp reload(media) do
+    media.id
+    |> then(&Repo.get!(Ambry.Media.Media, &1))
+    |> Repo.preload([:media_tracks, book: [book_authors: :author, series_books: :series]])
+  end
+
+  defp new_dir(prefix) do
+    dir = Ambry.Paths.source_media_disk_path("#{prefix}-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    dir
+  end
+end


### PR DESCRIPTION
A library tree organized once at import drifts the moment anything is corrected. Fix a misspelled title, reorder a book's authors, add the series you forgot — and the folder still says what it said the day the file landed.

## Two guards, doing two different jobs

- **Custody** keeps this off external files, which Ambry has promised never to write to. A rename is a write.
- **Requiring the file to be inside a registered library root** keeps it off the legacy uploads library, which is `managed` but was never template-organized and is Phase 4's to migrate rather than this function's to rearrange.

Root matching is on a path boundary (`root <> "/"`), so `/data/library-old` isn't treated as living inside `/data/library`. There's a test for that.

A rename stays within the root the file already occupies, which makes it always a move within one filesystem — never a copy, never a cross-device problem.

## Where the trigger lives, and why

The admin book and media form saves. Those are the only write paths for this metadata; the GraphQL API is read-only apart from progress and auth.

Worth recording why it isn't in the contexts: **`Ambry.Media` already depends on `Ambry.Books`, so `Books` enqueueing a `Media` job would be a boundary cycle.** The web layer depends on both, so that's where it goes.

A nightly 04:30 sweep backs it up — for the one thing no edit-time trigger can announce: a change to the naming template itself, which invalidates every path at once.

## Refusals

- **Collision** → refuse. Two recordings rendering to one path is a curation problem the operator has to see; quietly appending " (2)" would hide it forever.
- **Source vanished** → refuse. Noticing and recording that is reconciliation's job, and moving a file that isn't there would only turn one problem into two.

Neither fails the job into a retry loop — the operator has to resolve them, the queue can't.

## A gap this surfaced (recorded, not fixed)

`{year}` resolves to `media.published || book.published` and the file is named `{title}.ext`, so **two recordings of the same work published the same year render to the identical path** and the second is refused. Workable today by putting `{narrator}` in the template, but properly it wants a recording-distinguishing token in the filename rather than relying on the operator to notice. Written into the roadmap as an open item rather than patched blind.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: **976 passed**, 1 skipped. 10 new tests.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek