### PR TITLE
Phase 3a: publish approved recordings

### DIFF
--- a/lib/ambry/inbox/approval.ex
+++ b/lib/ambry/inbox/approval.ex
@@ -96,10 +96,30 @@ defmodule Ambry.Inbox.Approval do
       with {:ok, book} <- resolve_book(item),
            {:ok, media} <- create_media(item, book, probe),
            {:ok, _item} <- link(item, media),
-           {:ok, media, placement} <- place(destination, book, media, file) do
+           {:ok, media, placement} <- place(destination, book, media, file),
+           {:ok, media} <- publish(media) do
         {:ok, {media, placement}}
       end
     end)
+  end
+
+  # An approved recording is finished, so it's published — unless the switch
+  # says the fleet can't play direct-play media yet, in which case it waits
+  # in `pending` and is released when the switch is turned on.
+  #
+  # The reload is load-bearing: `Media.changeset` reads tracks off the struct
+  # to decide whether the legacy paths are required, and an unloaded assoc
+  # reads as "no tracks" — which would demand an mp4 path this recording will
+  # never have.
+  defp publish(media) do
+    if Settings.direct_play_publishing?() do
+      media
+      |> Repo.reload()
+      |> Repo.preload(:media_tracks)
+      |> Media.update_media(%{status: :ready})
+    else
+      {:ok, media}
+    end
   end
 
   # What approval should do with the bytes, decided by where the item came

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -41,6 +41,7 @@ defmodule Ambry.Media do
   alias Ambry.Media.RecordingGroup
   alias Ambry.Media.RunOrganize
   alias Ambry.Media.RunProcessor
+  alias Ambry.Media.RunPublishPending
   alias Ambry.Media.RunScan
   alias Ambry.Media.Scanner
   alias Ambry.Paths
@@ -73,6 +74,44 @@ defmodule Ambry.Media do
   def organize_book_async(book_id), do: enqueue_organize(%{"book_id" => book_id})
 
   defp enqueue_organize(args), do: args |> RunOrganize.new() |> Oban.insert()
+
+  @doc """
+  Publishes every direct-play recording that's only waiting on the switch.
+
+  The switch holds recordings back until the fleet can play them, so turning
+  it on has to release the ones that piled up behind it — otherwise the
+  operator would have to open and re-save every recording the inbox ever
+  approved.
+
+  Deliberately narrow. A recording qualifies only if it is `pending`, has
+  tracks, has **no** legacy transcoded paths, and isn't currently missing.
+  That last pair matters: a legacy recording sitting in `pending` is waiting
+  on transcoding, not on this switch, and publishing a recording whose files
+  have vanished would hand clients something unplayable.
+  """
+  def publish_pending_direct_play do
+    Media
+    |> where([m], m.status == :pending and is_nil(m.missing_since))
+    |> where([m], is_nil(m.mp4_path) and is_nil(m.hls_path) and is_nil(m.mpd_path))
+    |> join(:inner, [m], t in MediaTrack, on: t.media_id == m.id)
+    |> distinct(true)
+    |> preload(:media_tracks)
+    |> Repo.all()
+    |> Enum.reduce(%{published: 0, failed: 0}, fn media, counts ->
+      case update_media(media, %{status: :ready}) do
+        {:ok, _media} -> Map.update!(counts, :published, &(&1 + 1))
+        {:error, _changeset} -> Map.update!(counts, :failed, &(&1 + 1))
+      end
+    end)
+    |> then(&{:ok, &1})
+  end
+
+  @doc """
+  The same, in the background — the switch shouldn't block on a large library.
+  """
+  def publish_pending_direct_play_async do
+    %{} |> RunPublishPending.new() |> Oban.insert()
+  end
 
   @doc """
   Returns a limited list of media and whether or not there are more.

--- a/lib/ambry/media/run_publish_pending.ex
+++ b/lib/ambry/media/run_publish_pending.ex
@@ -1,0 +1,23 @@
+defmodule Ambry.Media.RunPublishPending do
+  @moduledoc """
+  Releases the direct-play recordings the publishing switch was holding back.
+
+  Runs when the operator turns the switch on. A large library shouldn't make
+  that click take a minute, and nothing about it needs to be synchronous.
+  """
+
+  use Oban.Worker,
+    queue: :media,
+    max_attempts: 3
+
+  alias Ambry.Media
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    {:ok, counts} = Media.publish_pending_direct_play()
+    Logger.info(fn -> "Published pending direct-play recordings: #{inspect(counts)}" end)
+    :ok
+  end
+end

--- a/lib/ambry_web/live/admin/settings_live/index.ex
+++ b/lib/ambry_web/live/admin/settings_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
   use AmbryWeb, :admin_live_view
 
   alias Ambry.Library.NamingTemplate
+  alias Ambry.Media
   alias Ambry.Settings
 
   @impl Phoenix.LiveView
@@ -90,7 +91,13 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
 
   @impl Phoenix.LiveView
   def handle_event("toggle-direct-play-publishing", _params, socket) do
-    {:ok, _setting} = Settings.set_direct_play_publishing(!socket.assigns.direct_play_publishing)
+    enabled? = !socket.assigns.direct_play_publishing
+    {:ok, _setting} = Settings.set_direct_play_publishing(enabled?)
+
+    # Turning it on releases everything that piled up behind it. Turning it
+    # off deliberately does nothing to what's already published — the switch
+    # governs the act of publishing, not the recordings that got through.
+    if enabled?, do: {:ok, _job} = Media.publish_pending_direct_play_async()
 
     {:noreply, assign_settings(socket)}
   end

--- a/test/ambry/inbox/managed_approval_test.exs
+++ b/test/ambry/inbox/managed_approval_test.exs
@@ -173,6 +173,39 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     end
   end
 
+  describe "publishing on approval" do
+    # An approved recording is finished. Leaving it pending forever was the
+    # gap that made the inbox produce records nothing could ever see.
+    test "publishes when the switch is on" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+      %{item: item} = downloads_item()
+
+      assert {:ok, media} = Inbox.approve_item(item)
+      assert Media.get_media!(media.id).status == :ready
+    end
+
+    # The whole point of the switch: the server must never hand a client a
+    # direct-play recording before the fleet can play one.
+    test "waits in pending when the switch is off" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(false)
+      %{item: item} = downloads_item()
+
+      assert {:ok, media} = Inbox.approve_item(item)
+      assert Media.get_media!(media.id).status == :pending
+    end
+
+    test "turning the switch on later releases what was waiting" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(false)
+      %{item: item} = downloads_item()
+      {:ok, media} = Inbox.approve_item(item)
+
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+      assert {:ok, %{published: 1}} = Media.publish_pending_direct_play()
+
+      assert Media.get_media!(media.id).status == :ready
+    end
+  end
+
   describe "other locations" do
     test "an external collection is still adopted exactly where it lies" do
       %{item: item, source: source} =

--- a/test/ambry/media/publishing_test.exs
+++ b/test/ambry/media/publishing_test.exs
@@ -1,0 +1,108 @@
+defmodule Ambry.Media.PublishingTest do
+  @moduledoc """
+  Getting an approved recording all the way to visible.
+
+  The publishing switch exists so the server never hands a client a
+  direct-play recording it can't play. That means approval can't simply
+  publish — and it also means turning the switch on has to release everything
+  that piled up behind it, or the operator would have to open and re-save
+  every recording the inbox ever approved.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Media
+  alias Ambry.Repo
+  alias Ambry.Settings
+
+  describe "publish_pending_direct_play/0" do
+    test "publishes a pending direct-play recording" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+      media = direct_play_media()
+
+      assert {:ok, %{published: 1, failed: 0}} = Media.publish_pending_direct_play()
+      assert Repo.reload(media).status == :ready
+    end
+
+    # The switch governs the act of publishing. With it off, the changeset
+    # itself refuses, and the sweep must report that rather than pretending.
+    test "publishes nothing while the switch is off" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(false)
+      media = direct_play_media()
+
+      assert {:ok, %{published: 0, failed: 1}} = Media.publish_pending_direct_play()
+      assert Repo.reload(media).status == :pending
+    end
+
+    # A legacy recording sitting in `pending` is waiting on transcoding, not
+    # on this switch.
+    test "leaves a legacy recording alone" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+
+      media =
+        insert(:media,
+          book: build(:book),
+          status: :pending,
+          mp4_path: "/uploads/media/x.mp4",
+          hls_path: nil,
+          mpd_path: nil
+        )
+
+      assert {:ok, %{published: 0}} = Media.publish_pending_direct_play()
+      assert Repo.reload(media).status == :pending
+    end
+
+    # Publishing a recording whose files have vanished would hand clients
+    # something unplayable.
+    test "skips a recording whose files are missing" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+      media = direct_play_media(missing_since: DateTime.utc_now(:second))
+
+      assert {:ok, %{published: 0}} = Media.publish_pending_direct_play()
+      assert Repo.reload(media).status == :pending
+    end
+
+    test "leaves an already-published recording alone" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+      media = direct_play_media(status: :ready)
+
+      assert {:ok, %{published: 0}} = Media.publish_pending_direct_play()
+      assert Repo.reload(media).status == :ready
+    end
+
+    # A recording with several tracks would otherwise be counted once per
+    # track by the join.
+    test "counts a multi-track recording once" do
+      {:ok, _setting} = Settings.set_direct_play_publishing(true)
+
+      media =
+        insert(:media,
+          book: build(:book),
+          status: :pending,
+          mp4_path: nil,
+          hls_path: nil,
+          mpd_path: nil,
+          media_tracks: [build(:media_track, index: 0), build(:media_track, index: 1)]
+        )
+
+      assert {:ok, %{published: 1}} = Media.publish_pending_direct_play()
+      assert Repo.reload(media).status == :ready
+    end
+  end
+
+  defp direct_play_media(opts \\ []) do
+    insert(
+      :media,
+      Keyword.merge(
+        [
+          book: build(:book),
+          status: :pending,
+          mp4_path: nil,
+          hls_path: nil,
+          mpd_path: nil,
+          media_tracks: [build(:media_track)]
+        ],
+        opts
+      )
+    )
+  end
+end


### PR DESCRIPTION
The last thing standing between the inbox and a finished recording. Everything approved landed in `pending` and stayed there with no way to promote it — so the inbox produced records nothing could ever see.

## What changed

- **Approval publishes** when the direct-play switch is on, and leaves the recording `pending` when it's off. That switch is the whole reason approval couldn't simply set `ready`: the server must never hand a client a recording it can't play.
- **Turning the switch on releases what piled up behind it.** Without that, the operator would have to open and re-save every recording the inbox had ever approved — the kind of chore that makes a feature not worth using.
- **Turning it off does nothing to what's already published.** The switch governs the act of publishing, not the recordings that got through. (That distinction already existed in `Media.changeset`, which keys on `get_change(:status)` rather than the current status; this keeps faith with it.)

## The release sweep is narrow on purpose

`pending` **and** has tracks **and** no legacy transcoded paths **and** not currently missing.

- A legacy recording sitting in `pending` is waiting on *transcoding*, not on this switch.
- Publishing a recording whose files have vanished would hand clients something unplayable — which is what `missing_since` from #1181 is there to tell us.

## One trap worth knowing

The reload before publishing is load-bearing. `Media.changeset` reads tracks off the struct to decide whether the legacy paths are required, and **an unloaded assoc reads as "no tracks"** — which would demand an `mp4_path` that a direct-play recording is never going to have. Approval reloads with `media_tracks` preloaded before publishing.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: **985 passed**, 1 skipped. 9 new tests, including the switch-off → approve → switch-on → released round trip.

## Note on visibility

This changes nothing for clients until you turn the switch on, and you shouldn't until the app understands tracks. What it does mean is that the moment you do, the whole approved backlog goes live at once.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek