### PR TITLE
Phase 3f: per-record background-job status in the inbox

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -35,6 +35,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.Approval
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.Progress
   alias Ambry.Inbox.RunDiscovery
   alias Ambry.Inbox.RunMatch
   alias Ambry.Inbox.RunProbe
@@ -216,7 +217,65 @@ defmodule Ambry.Inbox do
   the recording and its tracks — with the files referenced where they lie.
   Nothing is published: the recording is created `pending`.
   """
-  defdelegate approve_item(item), to: Approval, as: :approve
+  def approve_item(%InboxItem{} = item) do
+    case Approval.approve(item) do
+      {:ok, media} ->
+        {:ok, media}
+
+      {:error, reason} = error ->
+        # A flash lasts one page load; these workers run `max_attempts: 1`,
+        # so a discarded job lasts a day. Neither tells the operator anything
+        # tomorrow, so the reason goes on the item itself.
+        update_item(item, %{issue: describe_error(reason)})
+        error
+    end
+  end
+
+  @doc """
+  Says what went wrong in a sentence the operator can act on.
+
+  Shared between the flash shown at the time and the `issue` recorded on the
+  item, so the row tomorrow says exactly what the toast said today.
+  """
+  def describe_error(:multi_file_unsupported),
+    do:
+      "Direct play handles single-file recordings for now — merge this one externally, or skip it."
+
+  def describe_error(:no_published_date),
+    do:
+      "No publication date, and one can't be invented. Match a work, or tag the file with a date."
+
+  def describe_error(:no_title),
+    do: "Nothing here says what this is. Match a work, or tag the file with a title."
+
+  def describe_error({:unreadable, _reason}),
+    do: "Couldn't read the file — it may have moved or gone away since it was found."
+
+  def describe_error({:source_missing, _path}), do: "The file has gone away since it was found."
+
+  # The refusal this whole phase is built around, so it says what to do
+  # rather than just what failed.
+  def describe_error({:cross_filesystem, _source, _destination}),
+    do:
+      "This folder and its library root are on different filesystems, so the file can't be " <>
+        "hardlinked. Point it at a root on the same disk, or set the location to copy or move."
+
+  def describe_error({:destination_exists, path}),
+    do: "Something is already at #{path}. Two recordings can't share one path."
+
+  def describe_error(:no_library_root),
+    do: "There's no library root to import into. Add one under Locations."
+
+  def describe_error(:ambiguous_library_root),
+    do: "There's more than one library root — say which one this folder imports into."
+
+  def describe_error(:already_approved), do: "Already in the library."
+  def describe_error(_reason), do: "Couldn't add this to the library."
+
+  @doc """
+  What is happening to each of these items in the background.
+  """
+  defdelegate progress(items), to: Progress, as: :statuses
 
   @doc """
   Takes an item out of the queue without touching its files.

--- a/lib/ambry/inbox/progress.ex
+++ b/lib/ambry/inbox/progress.ex
@@ -1,0 +1,94 @@
+defmodule Ambry.Inbox.Progress do
+  @moduledoc """
+  What is happening to an inbox item right now.
+
+  Everything the inbox does to an item happens in a background job, and until
+  now a row gave no sign of whether its jobs were queued, running, finished
+  or failed. "Why is this row blank?" and "did my scan actually run?" had no
+  answer short of opening the Oban dashboard.
+
+  ## Absence of a job does not mean done
+
+  The Oban pruner deletes jobs older than a day, so the job table can only
+  ever answer for recent work. A row from last week has no jobs at all and is
+  perfectly fine. So the status is derived in two steps: if a job exists, its
+  state wins; if none does, the item's own contents say whether the work ever
+  happened.
+
+  That fallback is the whole reason this isn't a two-line query.
+
+  ## Failures outlive their jobs
+
+  These workers run `max_attempts: 1`, so a failure goes straight to
+  `discarded` — visible for a day and then gone forever. Anything worth
+  telling the operator about tomorrow is written onto the item's `issue`
+  instead, and that's what the `:issue` status reflects.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.RunMatch
+  alias Ambry.Inbox.RunProbe
+  alias Ambry.Repo
+
+  @workers [RunProbe, RunMatch]
+
+  @doc """
+  The status of each given item, as a map of item id to status.
+
+  One query for the whole page rather than one per row.
+
+  Statuses:
+
+    * `:working` — a job is executing right now
+    * `:queued` — a job is waiting to run
+    * `:failed` — a job gave up, and recently enough to still be in the table
+    * `:issue` — the item itself records a problem, which outlives the job
+    * `:done` — probed and matched; ready for the operator to decide on
+    * `:incomplete` — probed, but never matched, and nothing is queued
+    * `:never_ran` — no probe, no job; something went wrong long ago
+  """
+  def statuses(items) when is_list(items) do
+    jobs = job_states(Enum.map(items, & &1.id))
+    Map.new(items, &{&1.id, status(&1, Map.get(jobs, &1.id, []))})
+  end
+
+  @doc """
+  The status of a single item.
+  """
+  def status(%InboxItem{} = item) do
+    status(item, Map.get(job_states([item.id]), item.id, []))
+  end
+
+  defp status(%InboxItem{} = item, states) do
+    cond do
+      "executing" in states -> :working
+      Enum.any?(states, &(&1 in ~w(available scheduled retryable))) -> :queued
+      Enum.any?(states, &(&1 in ~w(discarded cancelled))) -> :failed
+      item.issue -> :issue
+      is_nil(item.probe) -> :never_ran
+      is_nil(item.matches) -> :incomplete
+      true -> :done
+    end
+  end
+
+  # Oban stores args as jsonb, so the item id is queryable without any new
+  # writes and without a job↔record association that would have to be kept
+  # in step.
+  defp job_states([]), do: %{}
+
+  defp job_states(item_ids) do
+    ids = Enum.map(item_ids, &to_string/1)
+
+    from(j in "oban_jobs",
+      where: j.worker in ^Enum.map(@workers, &worker_name/1),
+      where: fragment("?->>'inbox_item_id'", j.args) in ^ids,
+      select: {fragment("?->>'inbox_item_id'", j.args), j.state}
+    )
+    |> Repo.all()
+    |> Enum.group_by(fn {id, _state} -> String.to_integer(id) end, fn {_id, state} -> state end)
+  end
+
+  defp worker_name(module), do: module |> to_string() |> String.replace_prefix("Elixir.", "")
+end

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -73,7 +73,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
          |> reload()}
 
       {:error, reason} ->
-        {:noreply, put_flash(socket, :error, approval_error(reason))}
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(reason))}
     end
   end
 
@@ -114,6 +114,8 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     socket
     |> assign(
       items: items,
+      # one query for the page, not one per row
+      progress: Inbox.progress(items),
       counts: Inbox.count_by_status(),
       status: status,
       list_opts: list_opts,
@@ -127,23 +129,17 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   defp reload(socket), do: load_items(socket, patch(socket, []))
 
-  # Say what to do about it, not just what went wrong.
-  defp approval_error(:multi_file_unsupported),
-    do:
-      "Direct play handles single-file recordings for now — merge this one externally, or skip it."
+  # What the row's background work is doing. `:done` and `:issue` say nothing
+  # here — the row already shows its matches or its issue, and repeating
+  # "done" on every settled row is noise that hides the rows that aren't.
+  defp progress_label(:working), do: "Working on it…"
+  defp progress_label(:queued), do: "Queued"
+  defp progress_label(:failed), do: "A background job failed — try re-probing or re-matching."
 
-  defp approval_error(:no_published_date),
-    do:
-      "No publication date, and one can't be invented. Match a work, or tag the file with a date."
+  defp progress_label(:incomplete), do: "Never finished matching. Try re-matching."
 
-  defp approval_error(:no_title),
-    do: "Nothing here says what this is. Match a work, or tag the file with a title."
-
-  defp approval_error({:unreadable, _reason}),
-    do: "Couldn't read the file — it may have moved or gone away since it was found."
-
-  defp approval_error(:already_approved), do: "Already in the library."
-  defp approval_error(_reason), do: "Couldn't add this to the library."
+  defp progress_label(:never_ran), do: "Never read. Try re-probing."
+  defp progress_label(_settled), do: nil
 
   # Blank values are dropped rather than passed as nil: the shared pagination
   # helpers read params with `Map.get(params, "filter", "")`, which only
@@ -231,10 +227,15 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   """
   def match_summary(%InboxItem{matches: matches}) when is_map(matches) do
     Enum.map(["work", "recording"], fn level ->
+      # `|| []` on both lines: a level present without candidates used to
+      # crash `List.first/1` here, taking the whole page down over one
+      # malformed row, while the line below already guarded for it.
+      candidates = get_in(matches, [level, "candidates"]) || []
+
       %{
         level: level,
-        best: get_in(matches, [level, "candidates"]) |> List.first(),
-        alternatives: max(length(get_in(matches, [level, "candidates"]) || []) - 1, 0),
+        best: List.first(candidates),
+        alternatives: max(length(candidates) - 1, 0),
         confidence: get_in(matches, [level, "confidence"]) || 0.0,
         query: get_in(matches, [level, "query"])
       }

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -75,6 +75,14 @@
           {item.issue}
         </p>
 
+        <p
+          :if={progress_label(@progress[item.id])}
+          class="text-xs text-zinc-500 dark:text-zinc-400"
+          data-role="item-progress"
+        >
+          {progress_label(@progress[item.id])}
+        </p>
+
         <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs dark:text-zinc-600">
           {item.path}
         </p>

--- a/test/ambry/inbox/progress_test.exs
+++ b/test/ambry/inbox/progress_test.exs
@@ -1,0 +1,158 @@
+defmodule Ambry.Inbox.ProgressTest do
+  @moduledoc """
+  What is happening to an inbox item right now.
+
+  The whole difficulty is that the job table is not the answer. Oban prunes
+  jobs after a day, so an item from last week has no jobs and is perfectly
+  fine — "no job" has to mean "look at the item itself", not "nothing
+  happened".
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Progress
+
+  describe "status/1 from the job table" do
+    test "a queued job reads as queued" do
+      item = item()
+      job(item, :available)
+
+      assert Progress.status(item) == :queued
+    end
+
+    test "a running job reads as working" do
+      item = item()
+      job(item, :executing)
+
+      assert Progress.status(item) == :working
+    end
+
+    # These workers run max_attempts: 1, so a failure goes straight to
+    # discarded rather than retrying.
+    test "a discarded job reads as failed" do
+      item = item()
+      job(item, :discarded)
+
+      assert Progress.status(item) == :failed
+    end
+
+    # Running beats waiting: an item with a finished probe and a queued match
+    # is still being worked on.
+    test "the most active job wins" do
+      item = item()
+      job(item, :completed)
+      job(item, :executing)
+
+      assert Progress.status(item) == :working
+    end
+  end
+
+  describe "status/1 with no jobs left" do
+    # The pruner deletes jobs after a day. An item probed and matched last
+    # week is done, not broken.
+    test "a fully processed item reads as done" do
+      item = item(probe: %{"duration" => 1}, matches: %{"work" => %{}})
+
+      assert Progress.status(item) == :done
+    end
+
+    test "an item that was never probed reads as never ran" do
+      assert Progress.status(item()) == :never_ran
+    end
+
+    test "an item probed but never matched reads as incomplete" do
+      item = item(probe: %{"duration" => 1})
+
+      assert Progress.status(item) == :incomplete
+    end
+
+    # An issue outlives every job, which is the entire reason failures get
+    # written onto the item.
+    test "a recorded issue wins over the item's contents" do
+      item = item(probe: %{"duration" => 1}, matches: %{}, issue: "no publication date")
+
+      assert Progress.status(item) == :issue
+    end
+  end
+
+  describe "statuses/1" do
+    test "answers for a whole page in one go" do
+      queued = item()
+      job(queued, :available)
+      done = item(probe: %{"d" => 1}, matches: %{"work" => %{}})
+      fresh = item()
+
+      statuses = Progress.statuses([queued, done, fresh])
+
+      assert statuses[queued.id] == :queued
+      assert statuses[done.id] == :done
+      assert statuses[fresh.id] == :never_ran
+    end
+
+    test "handles an empty page" do
+      assert Progress.statuses([]) == %{}
+    end
+
+    # Jobs are matched on the item id inside the args, so one item's jobs must
+    # never be read as another's.
+    test "doesn't attribute one item's jobs to another" do
+      mine = item()
+      theirs = item()
+      job(theirs, :executing)
+
+      statuses = Progress.statuses([mine, theirs])
+
+      assert statuses[mine.id] == :never_ran
+      assert statuses[theirs.id] == :working
+    end
+  end
+
+  describe "approval failures" do
+    # A flash lasts one page load and a discarded job lasts a day; the
+    # operator needs to know tomorrow.
+    test "are written onto the item" do
+      item = item(files: [], probe: %{"d" => 1})
+
+      assert {:error, :no_audio_files} = Inbox.approve_item(item)
+
+      assert Repo.reload(item).issue == "Couldn't add this to the library."
+    end
+
+    test "say what to do about a cross-filesystem refusal" do
+      message = Inbox.describe_error({:cross_filesystem, "/a/x.m4b", "/b/x.m4b"})
+
+      assert message =~ "different filesystems"
+      assert message =~ "copy or move"
+    end
+  end
+
+  defp item(attrs \\ []) do
+    {:ok, item} =
+      %Ambry.Inbox.InboxItem{}
+      |> Ambry.Inbox.InboxItem.changeset(
+        Enum.into(attrs, %{
+          path: "/downloads/release-#{Ecto.UUID.generate()}",
+          files: ["/downloads/x/book.m4b"],
+          status: :pending
+        })
+      )
+      |> Repo.insert()
+
+    item
+  end
+
+  defp job(item, state) do
+    Repo.insert_all("oban_jobs", [
+      %{
+        state: to_string(state),
+        queue: "media",
+        worker: "Ambry.Inbox.RunProbe",
+        args: %{"inbox_item_id" => item.id},
+        inserted_at: DateTime.utc_now(:second),
+        scheduled_at: DateTime.utc_now(:second)
+      }
+    ])
+
+    :ok
+  end
+end

--- a/test/ambry_web/live/admin/inbox_live/progress_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/progress_test.exs
@@ -1,0 +1,100 @@
+defmodule AmbryWeb.Admin.InboxLive.ProgressTest do
+  @moduledoc """
+  The gap this closes: a row gave no sign of whether its background jobs were
+  queued, running, finished or failed. "Why is this row blank?" had no answer
+  short of opening the Oban dashboard.
+  """
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Repo
+
+  setup :register_and_log_in_admin_user
+
+  test "says when a row's work is still queued", %{conn: conn} do
+    item = item()
+    job(item, :available)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+    assert progress(html) == ["Queued"]
+  end
+
+  test "says when a row is being worked on", %{conn: conn} do
+    item = item()
+    job(item, :executing)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+    assert progress(html) == ["Working on it…"]
+  end
+
+  test "says when a row's background job failed", %{conn: conn} do
+    item = item()
+    job(item, :discarded)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+    assert [message] = progress(html)
+    assert message =~ "background job failed"
+  end
+
+  # Repeating "done" on every settled row is noise that hides the rows that
+  # aren't settled — which is the entire point of the feature.
+  test "says nothing about a row that's finished", %{conn: conn} do
+    item(probe: %{"duration" => 1}, matches: %{"work" => %{}})
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+    assert progress(html) == []
+  end
+
+  # The pruner deletes jobs after a day, so "no job" can't mean "nothing
+  # happened" — but an item with nothing to show for itself and no job really
+  # did fall through.
+  test "flags a row that was never read and has no job to explain it", %{conn: conn} do
+    item()
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+    assert [message] = progress(html)
+    assert message =~ "Never read"
+  end
+
+  defp item(attrs \\ []) do
+    {:ok, item} =
+      %InboxItem{}
+      |> InboxItem.changeset(
+        Enum.into(attrs, %{
+          path: "/downloads/release-#{Ecto.UUID.generate()}",
+          files: ["/downloads/x/book.m4b"],
+          status: :pending
+        })
+      )
+      |> Repo.insert()
+
+    item
+  end
+
+  defp job(item, state) do
+    Repo.insert_all("oban_jobs", [
+      %{
+        state: to_string(state),
+        queue: "media",
+        worker: "Ambry.Inbox.RunProbe",
+        args: %{"inbox_item_id" => item.id},
+        inserted_at: DateTime.utc_now(:second),
+        scheduled_at: DateTime.utc_now(:second)
+      }
+    ])
+  end
+
+  defp progress(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("[data-role='item-progress']")
+    |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+  end
+end


### PR DESCRIPTION
Everything the inbox does to an item happens in a background job, and a row gave no sign of whether its jobs were queued, running, finished or failed. "Why is this row blank?" and "did my scan actually run?" had no answer short of opening the Oban dashboard.

## The job table can't be the whole answer

This is the part the roadmap's design note warns about, and it's the only real difficulty here. **The pruner deletes jobs after a day**, so an item from last week has no jobs at all and is perfectly fine. "No job" has to mean "look at the item itself", not "nothing happened".

So: a job's state wins when there is one; the item's own contents decide when there isn't.

| | |
|---|---|
| `:working` / `:queued` / `:failed` | a job says so |
| `:issue` | the item records a problem — outlives every job |
| `:done` | probed and matched |
| `:incomplete` | probed, never matched, nothing queued |
| `:never_ran` | nothing to show for itself and no job to explain it |

Job state comes from `oban_jobs.args->>'inbox_item_id'` — no new writes, no job↔record association to keep in step. One query per page, not one per row.

**Settled rows say nothing.** Repeating "done" on every finished row is noise that hides the handful that are stuck, which is the entire point of the feature.

## Failures now outlive their jobs

A flash lasts one page load; these workers run `max_attempts: 1`, so a discarded job lasts a day. Neither tells the operator anything tomorrow.

Approval failures are written onto the item's `issue`, and the flash and the recorded issue share one `Inbox.describe_error/1` — so the row tomorrow says exactly what the toast said today. While moving it, the placement refusals added with hardlinking (cross-filesystem, no/ambiguous library root, destination occupied) got proper operator-facing wording instead of falling through to a generic "couldn't add this to the library". The cross-filesystem one now says what to *do*: point at a root on the same disk, or switch the location to copy or move.

## A latent crash, found by a test

`match_summary/1` called `List.first/1` on a possibly-nil candidates list — while the very next line guarded the same value with `|| []`. One malformed row would have taken down the whole inbox page. Both lines now share a guarded binding.

## Verified

- `mix check` clean (format, warnings-as-errors, credo, dialyzer).
- Full suite: **1003 passed**, 1 skipped. 18 new tests.

## Left in 3f

The **ambient status widget** — "is the server busy?", "did something break?" without leaving the page. The roadmap calls it a natural piece of the 3e redesign; this PR is the half worth having before then.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek