### PR TITLE
Phase 3e: the staged import form (walking skeleton)

### DIFF
--- a/lib/ambry.ex
+++ b/lib/ambry.ex
@@ -16,6 +16,7 @@ defmodule Ambry do
       {FileBrowser, []},
       {Inbox, []},
       {Hashids, []},
+      {Images, []},
       {Library, []},
       {Media, []},
       {Metadata, []},

--- a/lib/ambry/images.ex
+++ b/lib/ambry/images.ex
@@ -1,0 +1,131 @@
+defmodule Ambry.Images do
+  @moduledoc """
+  Bringing images into the uploads tree, from a URL or from inside an audio
+  file.
+
+  This lives in the core rather than the web layer because the inbox needs it:
+  approval lands a recording's cover, and `Ambry.Inbox` cannot call into
+  `AmbryWeb`. `AmbryWeb.Admin.UploadHelpers` delegates here, so there is one
+  implementation of "download this and give me a web path" rather than two
+  that drift.
+
+  Everything written here is Ambry's own, under the uploads path — never a
+  file the library references in place. That distinction is what makes these
+  safe to delete with a record regardless of its custody.
+  """
+
+  import Ambry.Paths
+
+  require Logger
+
+  @accepted_mime ~w(image/jpeg image/png image/webp)
+
+  @doc """
+  Downloads an image and returns its web path.
+  """
+  def import_url(nil), do: {:ok, :no_image_url}
+  def import_url(""), do: {:ok, :no_image_url}
+
+  def import_url(url) do
+    if valid_url?(url), do: download(url), else: {:error, :invalid_image_url}
+  end
+
+  defp download(url) do
+    with {:ok, response} <- Req.get(url: url, headers: [{"user-agent", user_agent()}]),
+         [mime | _rest] when mime in @accepted_mime <-
+           Req.Response.get_header(response, "content-type") do
+      filename = generate_filename(mime)
+      File.write!(images_disk_path(filename), response.body)
+
+      {:ok, web_path(filename)}
+    else
+      _term -> {:error, :failed_to_download_image}
+    end
+  end
+
+  @doc """
+  Extracts an audio file's embedded cover art and returns its web path.
+
+  Cover art rides along as an `attached_pic` video stream, so pulling it out
+  is a stream copy rather than a re-encode — `-c:v copy` keeps the publisher's
+  original bytes instead of generationally re-compressing them.
+  """
+  def extract_embedded(audio_path) do
+    filename = generate_filename("image/jpeg")
+    destination = images_disk_path(filename)
+
+    case ffmpeg(audio_path, destination) do
+      {_output, 0} ->
+        if File.exists?(destination) and File.stat!(destination).size > 0 do
+          {:ok, web_path(filename)}
+        else
+          {:error, :no_embedded_image}
+        end
+
+      {output, status} ->
+        Logger.warning(fn ->
+          "Couldn't extract cover art from #{audio_path} (#{status}): #{output}"
+        end)
+
+        File.rm(destination)
+        {:error, :no_embedded_image}
+    end
+  end
+
+  defp ffmpeg(source, destination) do
+    System.cmd(
+      "ffmpeg",
+      ["-nostdin", "-y", "-i", source, "-an", "-c:v", "copy", "-frames:v", "1", destination],
+      stderr_to_stdout: true
+    )
+  rescue
+    error in ErlangError ->
+      Logger.warning(fn -> "ffmpeg unavailable: #{inspect(error)}" end)
+      {"ffmpeg unavailable", 1}
+  end
+
+  @doc """
+  Whether a string is plausibly an image URL, cheaply where possible.
+  """
+  def valid_url?(string) when is_binary(string) do
+    case URI.new(string) do
+      {:ok, %{scheme: scheme} = uri} when is_binary(scheme) ->
+        image_mime?(MIME.from_path(string)) or head_says_image?(uri)
+
+      _term ->
+        false
+    end
+  end
+
+  def valid_url?(_term), do: false
+
+  @doc false
+  def head_says_image?(uri) do
+    case Req.head(url: uri, headers: [{"user-agent", user_agent()}]) do
+      {:ok, response} ->
+        case Req.Response.get_header(response, "content-type") do
+          [mime | _rest] -> image_mime?(mime)
+          [] -> false
+        end
+
+      _else ->
+        false
+    end
+  end
+
+  def image_mime?("image/" <> _rest), do: true
+  def image_mime?(_mime), do: false
+
+  @doc """
+  A fresh uploads filename for a mime type.
+  """
+  def generate_filename(mime) do
+    [ext | _rest] = MIME.extensions(mime)
+    "#{Ecto.UUID.generate()}.#{ext}"
+  end
+
+  @doc "The web path an uploaded image is served from."
+  def web_path(filename), do: "/uploads/images/#{filename}"
+
+  defp user_agent, do: Ambry.Utils.http_user_agent()
+end

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -28,12 +28,16 @@ defmodule Ambry.Inbox do
 
   use Boundary,
     deps: [Ambry, Ambry.Library, Ambry.Media],
-    exports: [InboxItem]
+    # The draft tree is exported because it IS the import form's data model —
+    # the form renders and edits it directly. Approval stays internal.
+    exports: [InboxItem, {Draft, []}]
 
   import Ecto.Query
 
   alias Ambry.Inbox.Approval
   alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.Progress
   alias Ambry.Inbox.RunDiscovery
@@ -60,6 +64,7 @@ defmodule Ambry.Inbox do
     items =
       InboxItem
       |> filter_by_status(opts[:status])
+      |> filter_by_ready(opts[:ready])
       |> filter_by_path(opts[:filter])
       |> order_by([i], desc: i.inserted_at, desc: i.id)
       |> offset(^Keyword.get(opts, :offset, 0))
@@ -80,6 +85,18 @@ defmodule Ambry.Inbox do
     |> select([i], {i.status, count(i.id)})
     |> Repo.all()
     |> Map.new()
+  end
+
+  @doc """
+  How many pending items are fully settled and waiting on a click.
+
+  Reads the denormalized flag rather than loading every draft — the whole
+  reason it's stored.
+  """
+  def count_ready do
+    InboxItem
+    |> where([i], i.status == :pending and i.ready == true)
+    |> Repo.aggregate(:count)
   end
 
   def get_item!(id), do: Repo.get!(InboxItem, id)
@@ -200,7 +217,11 @@ defmodule Ambry.Inbox do
   not a broken queue entry.
   """
   def match_item(%InboxItem{} = item) do
-    update_item(item, AutoMatch.match(item))
+    with {:ok, item} <- update_item(item, AutoMatch.match(item)) do
+      # Staging the import is the point of matching — proposals nothing turns
+      # into decisions are just data sitting in a column.
+      prepare_draft(item)
+    end
   end
 
   @doc """
@@ -209,6 +230,141 @@ defmodule Ambry.Inbox do
   def match_item_async(%InboxItem{} = item) do
     %{inbox_item_id: item.id} |> RunMatch.new() |> Oban.insert()
   end
+
+  @doc """
+  Stages the import: turns what we found into a tree of decisions.
+
+  Runs after matching, and is what the queue's Ready badge and the import
+  form both read. Rebuilding is destructive to curation by definition, so it
+  only ever happens when there is no draft yet — an operator's choices are
+  not something a background job may overwrite.
+  """
+  def prepare_draft(%InboxItem{draft: nil} = item), do: rebuild_draft(item)
+  def prepare_draft(%InboxItem{} = item), do: {:ok, item}
+
+  @doc """
+  Throws away the staged import and seeds a fresh one from current evidence.
+
+  The operator's escape hatch when a draft was built against the wrong match
+  and editing it would be more work than starting over. Never automatic.
+  """
+  def rebuild_draft(%InboxItem{} = item) do
+    item
+    |> InboxItem.put_draft(item |> Seed.build() |> dump())
+    |> Repo.update()
+  end
+
+  @doc """
+  Saves operator edits to the staged import.
+
+  Every save recomputes readiness, so the queue can never claim an item is
+  importable when its draft says otherwise.
+  """
+  def update_draft(%InboxItem{} = item, attrs) do
+    item
+    |> InboxItem.put_draft(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  A changeset for the staged import, for the form to render.
+  """
+  def change_draft(%InboxItem{} = item, attrs \\ %{}) do
+    InboxItem.put_draft(item, attrs)
+  end
+
+  @doc """
+  What approval will do with this item's bytes, decided before it's asked.
+
+  Placement can fail for reasons no amount of curation fixes — a downloads
+  folder on a different NAS from its library root, a destination already
+  occupied, no root registered at all. Those used to surface as an error at
+  the moment the operator clicked approve. Working them out up front is what
+  lets the form refuse to offer a button that fails, and it tells the
+  operator *where the file is going* before they commit to it.
+
+  Returns a map with `:custody`, a human `:summary`, and `:blocker` — nil when
+  placement will work.
+  """
+  def destination_preflight(%InboxItem{} = item) do
+    item = Repo.preload(item, :location)
+
+    case item.location do
+      %Location{kind: :downloads} = location -> downloads_preflight(item, location)
+      %Location{kind: :library_root} -> adopt_preflight("It's already inside a library root.")
+      %Location{kind: :external_collection} -> adopt_preflight("It's an external collection.")
+      nil -> adopt_preflight("It came from an ad-hoc scan with no location.")
+    end
+  end
+
+  defp adopt_preflight(why) do
+    %{
+      custody: :external,
+      summary: "Referenced where it lies — #{why} Ambry will never move, rename or delete it.",
+      blocker: nil
+    }
+  end
+
+  defp downloads_preflight(item, location) do
+    base = %{custody: :managed, blocker: nil, summary: nil}
+
+    case Library.target_root(location) do
+      {:error, reason} ->
+        %{base | blocker: describe_error(reason)}
+
+      {:ok, root} ->
+        %{
+          base
+          | summary: policy_summary(location.import_policy, root),
+            blocker: hardlink_blocker(item, location, root)
+        }
+    end
+  end
+
+  defp policy_summary(:hardlink, root),
+    do: "Hardlinked into #{root.path} — one copy of the bytes, the download keeps seeding."
+
+  defp policy_summary(:copy, root),
+    do: "Copied into #{root.path} — deliberately duplicating the bytes."
+
+  defp policy_summary(:move, root),
+    do: "Moved into #{root.path} — the downloads folder is left clean."
+
+  defp policy_summary(_unset, root), do: "Placed into #{root.path}."
+
+  # The refusal this whole phase exists for: a hardlink cannot cross a
+  # filesystem, and silently copying instead is the storage doubling the
+  # roadmap set out to eliminate. Worth knowing before the click, not after.
+  defp hardlink_blocker(
+         %InboxItem{files: [file | _rest]},
+         %Location{import_policy: :hardlink},
+         root
+       ) do
+    case Library.same_filesystem?(Path.dirname(file), root.path) do
+      {:ok, true} -> nil
+      {:ok, false} -> describe_error({:cross_filesystem, file, root.path})
+      {:error, _reason} -> "Couldn't tell whether these are on the same filesystem."
+    end
+  end
+
+  defp hardlink_blocker(_item, _location, _root), do: nil
+
+  @doc """
+  A draft as params, for staging it back onto an item.
+  """
+  def dump_draft(%Draft{} = draft), do: dump(draft)
+
+  # Embedded schema structs go back through `cast_embed`, which wants params.
+  defp dump(%Draft{} = draft) do
+    draft |> Ecto.embedded_dump(:json) |> stringify()
+  end
+
+  defp stringify(%{} = map) when not is_struct(map) do
+    Map.new(map, fn {key, value} -> {to_string(key), stringify(value)} end)
+  end
+
+  defp stringify(list) when is_list(list), do: Enum.map(list, &stringify/1)
+  defp stringify(other), do: other
 
   @doc """
   Approves an item into the library.
@@ -270,6 +426,17 @@ defmodule Ambry.Inbox do
     do: "There's more than one library root — say which one this folder imports into."
 
   def describe_error(:already_approved), do: "Already in the library."
+
+  # The invariant, phrased for a human. It names the count rather than the
+  # decisions because the form lists them properly — this is the flash you get
+  # if you somehow reached approval from the queue.
+  def describe_error({:unresolved, outstanding}) do
+    count = length(outstanding)
+
+    "#{count} thing#{if count > 1, do: "s"} still to settle before this can be imported. " <>
+      "Open it to see what."
+  end
+
   def describe_error(_reason), do: "Couldn't add this to the library."
 
   @doc """
@@ -304,6 +471,9 @@ defmodule Ambry.Inbox do
 
   defp filter_by_status(query, nil), do: query
   defp filter_by_status(query, status), do: where(query, [i], i.status == ^status)
+
+  defp filter_by_ready(query, nil), do: query
+  defp filter_by_ready(query, ready?), do: where(query, [i], i.ready == ^ready?)
 
   defp filter_by_path(query, blank) when blank in [nil, ""], do: query
 
@@ -426,9 +596,23 @@ defmodule Ambry.Inbox do
       :skipped
     else
       {:ok, item} = update_item(item, changes)
-      if item.status == :pending and Map.has_key?(changes, :files), do: probe_item_async(item)
+
+      if item.status == :pending and Map.has_key?(changes, :files) do
+        # The draft describes files that just moved under it. Say so; don't
+        # re-seed over whatever the operator already decided.
+        mark_draft_stale(item)
+        probe_item_async(item)
+      end
+
       :updated
     end
+  end
+
+  defp mark_draft_stale(%InboxItem{draft: nil}), do: :ok
+
+  defp mark_draft_stale(%InboxItem{} = item) do
+    item |> InboxItem.put_draft(item.draft |> Seed.restale(item) |> dump()) |> Repo.update()
+    :ok
   end
 
   defp put_if(map, _key, _value, false), do: map

--- a/lib/ambry/inbox/approval.ex
+++ b/lib/ambry/inbox/approval.ex
@@ -1,12 +1,26 @@
 defmodule Ambry.Inbox.Approval do
   @moduledoc """
-  Turns a curated inbox item into real library records.
+  Turns a fully-resolved staged import into real library records.
 
-  Approval is the only thing that creates records — discovery and matching
-  only ever propose. It covers the whole entity graph in one transaction:
-  book, authors, narrators, series, the recording and its direct-play tracks.
-  Either all of it lands or none of it does, so a half-approved item can't
-  exist.
+  Approval is the only thing that creates records — discovery, matching and
+  the form only ever propose. It covers the whole entity graph in one
+  transaction: book, authors, narrators, series, the recording and its
+  direct-play tracks. Either all of it lands or none of it does, so a
+  half-approved item can't exist.
+
+  ## It executes a draft; it does not decide anything
+
+  Every choice was made in `Ambry.Inbox.Draft` and settled by the operator (or
+  by a seeding rule confident enough to settle it). This module refuses
+  outright unless `Draft.resolved?/1`, then does exactly what the draft says.
+  That is the point of the whole design: the form cannot offer a button that
+  fails here, because everything that could fail was a visible decision
+  before the button was pressed.
+
+  Consequently there are no fallbacks here. If the draft doesn't say what the
+  title is, that is a bug in the form's gating, not something to paper over
+  with a guess — and inventing a series number or a publication date is
+  exactly the confidently-wrong data the inbox exists to prevent.
 
   ## Custody
 
@@ -15,40 +29,33 @@ defmodule Ambry.Inbox.Approval do
     * from a **downloads** location, the file is brought into that location's
       library root under the naming template — hardlinked, copied or moved
       per the location's policy — and the recording becomes **managed**.
-      Ambry owns those bytes and may reorganize or delete them.
     * from an **external collection**, or from an item with no location at
       all, the file is referenced exactly where it lies and the recording is
-      **external**. Ambry never moves, copies, renames or deletes it, and
-      removing the recording later deletes records only. This is also the
-      only thing that can work against a read-only mount.
+      **external**. Ambry never moves, copies, renames or deletes it.
 
   A hardlink cannot cross a filesystem, and here the downloads folder and the
   library can easily be on different NAS boxes. Approval **refuses** in that
   case rather than falling back to a copy: a silent copy is the storage
-  doubling this whole phase exists to eliminate, and the operator would have
-  no way to know it happened.
+  doubling this whole phase exists to eliminate.
 
-  ## Publishing
+  ## Provenance
 
-  Approval does not publish. The recording is created `pending`, so clients
-  don't see it until the direct-play switch is on and it's marked ready —
-  the client-first rollout order the whole of Phase 2 is built around.
-
-  ## Re-probing
-
-  The files are probed again here rather than trusting what discovery
-  recorded. It costs one ffprobe and buys two things: the track data is
-  current at the moment it's written, and a file that vanished between
-  discovery and approval fails the approval instead of creating a recording
-  that points at nothing.
+  Every scalar the draft settled knows which source settled it, so
+  `field_provenance` is written by construction — a provider-accepted value
+  records that provider and stays unlocked so refresh can update it later, an
+  operator's typed value records `manual` and locks. This is what closes 1d's
+  loop for the inbox without a separate hint-collection layer.
   """
-
-  import Ecto.Query
 
   alias Ambry.Books
   alias Ambry.Books.Book
   alias Ambry.Books.Series
-  alias Ambry.Inbox.AutoMatch
+  alias Ambry.Images
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.PersonRef
+  alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.InboxItem
   alias Ambry.Library
   alias Ambry.Library.Location
@@ -58,6 +65,7 @@ defmodule Ambry.Inbox.Approval do
   alias Ambry.Media.Scanner
   alias Ambry.People
   alias Ambry.People.Author
+  alias Ambry.People.AuthorPerson
   alias Ambry.People.Narrator
   alias Ambry.Repo
   alias Ambry.Settings
@@ -65,7 +73,7 @@ defmodule Ambry.Inbox.Approval do
   require Logger
 
   @doc """
-  Approves an item, creating everything it implies.
+  Approves an item, creating everything its draft implies.
 
   Returns `{:ok, media}`, or `{:error, reason}` — leaving the item untouched
   and the library unchanged.
@@ -75,14 +83,29 @@ defmodule Ambry.Inbox.Approval do
   def approve(%InboxItem{} = item) do
     item = Repo.preload(item, :location)
 
+    # Facts about the files come first, then the draft, then placement. The
+    # order is the order the operator can act on them: a multi-file release or
+    # a vanished file is not something any amount of curation fixes, so
+    # reporting an unresolved decision on one would send them to the form to
+    # fix something the form can't fix.
     with {:ok, file} <- single_file(item),
          {:ok, probe} <- probe(file),
+         :ok <- resolved(item),
          {:ok, destination} <- destination(item),
          {:ok, {media, placement}} <- create(item, file, probe, destination) do
       # Only now, with the records committed, is it safe to remove a moved
       # file's source.
       log_finalize(Placement.finalize(placement), item)
       {:ok, media}
+    end
+  end
+
+  # The invariant, enforced at the one place it has teeth. Anything the
+  # operator hasn't settled is a refusal, not a default.
+  defp resolved(%InboxItem{draft: draft}) do
+    case Draft.unresolved(draft) do
+      [] -> :ok
+      outstanding -> {:error, {:unresolved, outstanding}}
     end
   end
 
@@ -93,7 +116,7 @@ defmodule Ambry.Inbox.Approval do
   # deleted and whose record didn't survive.
   defp create(item, file, probe, destination) do
     Repo.transact(fn ->
-      with {:ok, book} <- resolve_book(item),
+      with {:ok, book} <- resolve_book(item.draft.work),
            {:ok, media} <- create_media(item, book, probe),
            {:ok, _item} <- link(item, media),
            {:ok, media, placement} <- place(destination, book, media, file),
@@ -102,6 +125,226 @@ defmodule Ambry.Inbox.Approval do
       end
     end)
   end
+
+  ## the work
+
+  defp resolve_book(%{mode: :link, book_id: book_id} = work) do
+    case Repo.get(Book, book_id) do
+      nil -> {:error, :book_not_found}
+      book -> add_series(book, work.series)
+    end
+  end
+
+  defp resolve_book(%{mode: :create} = work) do
+    Books.create_book(
+      %{
+        title: Field.value(work.title),
+        published: Field.date(work.published),
+        published_format: Field.atom(work.published_format, :full),
+        book_authors: author_params(work.authors),
+        series_books: series_params(work.series)
+      },
+      provenance:
+        provenance(%{
+          "title" => work.title,
+          "published" => work.published,
+          "published_format" => work.published_format
+        })
+    )
+  end
+
+  # Fill-gaps on a linked book: an import may add a series membership the book
+  # doesn't have, never touch one it does. The seeder has already dropped
+  # memberships the book already carries, so anything left here is additive.
+  defp add_series(book, []), do: {:ok, book}
+
+  defp add_series(book, links) do
+    book = Repo.preload(book, series_books: :series)
+
+    existing =
+      Enum.map(book.series_books, &%{series_id: &1.series_id, book_number: &1.book_number})
+
+    case Books.update_book(book, %{series_books: existing ++ series_params(links)}) do
+      {:ok, book} -> {:ok, book}
+      {:error, _changeset} = error -> error
+    end
+  end
+
+  defp author_params(credits) do
+    Enum.map(credits, fn credit ->
+      {:ok, author} = resolve_identity(credit)
+      %{author_id: author.id}
+    end)
+  end
+
+  defp series_params(links) do
+    Enum.map(links, fn link ->
+      {:ok, series} = resolve_series(link)
+      %{series_id: series.id, book_number: SeriesLink.decimal(link)}
+    end)
+  end
+
+  defp resolve_series(%SeriesLink{mode: :link, series_id: id}), do: {:ok, Repo.get!(Series, id)}
+
+  defp resolve_series(%SeriesLink{mode: :create, name: name}),
+    do: Books.create_series(%{name: name})
+
+  ## credits
+
+  # The identity is what a credit resolves to — never a Person. Person appears
+  # only when creating, and how many of them there are is just the length of
+  # the list the operator left behind.
+  defp resolve_identity(%Credit{mode: :link, kind: :author, identity_id: id}),
+    do: {:ok, Repo.get!(Author, id)}
+
+  defp resolve_identity(%Credit{mode: :link, kind: :narrator, identity_id: id}),
+    do: {:ok, Repo.get!(Narrator, id)}
+
+  # An identity's own changeset only casts its name — identities are normally
+  # created *through* a Person, which can't express "this pen name is two
+  # people". So the link rows go in explicitly. Each `AuthorPerson` in the
+  # list is one human behind the credit; the list being longer than one is the
+  # entire composite-author case.
+  defp resolve_identity(%Credit{mode: :create, kind: :author} = credit) do
+    with {:ok, people} <- resolve_people(credit.people),
+         {:ok, author} <- %Author{} |> Author.changeset(%{name: credit.name}) |> Repo.insert() do
+      Enum.each(people, fn person ->
+        Repo.insert!(%AuthorPerson{author_id: author.id, person_id: person.id})
+      end)
+
+      {:ok, author}
+    end
+  end
+
+  # Narrators stay one-to-one with a Person by design — composite narrator
+  # identities aren't a real-world thing — so only the first reference is used
+  # and the form caps the control at one.
+  defp resolve_identity(%Credit{mode: :create, kind: :narrator} = credit) do
+    with {:ok, [person | _rest]} <- resolve_people(credit.people) do
+      %Narrator{}
+      |> Narrator.changeset(%{name: credit.name})
+      |> Ecto.Changeset.put_change(:person_id, person.id)
+      |> Repo.insert()
+    end
+  end
+
+  # A person reference is either somebody already here, or somebody to create
+  # alongside the credit. Creating one is the 1:1 default the form falls back
+  # to; two or more is a shared pen name, and needs no special handling beyond
+  # being a longer list.
+  defp resolve_people(refs) do
+    Enum.reduce_while(refs, {:ok, []}, fn ref, {:ok, acc} ->
+      case resolve_person(ref) do
+        {:ok, person} -> {:cont, {:ok, acc ++ [person]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp resolve_person(%PersonRef{person_id: id}) when not is_nil(id),
+    do: {:ok, Repo.get!(People.Person, id)}
+
+  defp resolve_person(%PersonRef{name: name}), do: People.create_person(%{name: name})
+
+  ## the recording
+
+  defp create_media(item, book, probe) do
+    recording = item.draft.recording
+
+    Media.create_media(
+      %{
+        book_id: book.id,
+        # external until placement says otherwise; a downloads item is
+        # repointed to its library copy below
+        custody: :external,
+        source_path: item.path,
+        source_files: item.files,
+        status: :pending,
+        duration: probe.duration,
+        chapters: probe.chapters,
+        media_narrators: narrator_params(recording.narrators),
+        media_tracks: [track_params(probe)],
+        title: Field.value(recording.title),
+        published: Field.date(recording.published),
+        publisher: Field.value(recording.publisher),
+        description: Field.value(recording.description),
+        image_path: cover(recording.cover)
+      },
+      provenance:
+        provenance(%{
+          "title" => recording.title,
+          "published" => recording.published,
+          "publisher" => recording.publisher,
+          "description" => recording.description,
+          "image_path" => recording.cover
+        })
+    )
+  end
+
+  defp narrator_params(credits) do
+    Enum.map(credits, fn credit ->
+      {:ok, narrator} = resolve_identity(credit)
+      %{narrator_id: narrator.id}
+    end)
+  end
+
+  # A cover that can't be fetched is not worth failing an import over — the
+  # recording is still correct without one, and the admin form can set it
+  # afterwards. It is worth saying so in the log.
+  defp cover(%Field{value: nil}), do: nil
+
+  defp cover(%Field{source: "embedded", value: audio_path}) do
+    case Images.extract_embedded(audio_path) do
+      {:ok, web_path} -> web_path
+      {:error, reason} -> log_cover(audio_path, reason)
+    end
+  end
+
+  defp cover(%Field{value: url}) do
+    case Images.import_url(url) do
+      {:ok, web_path} when is_binary(web_path) -> web_path
+      other -> log_cover(url, other)
+    end
+  end
+
+  defp log_cover(source, reason) do
+    Logger.warning(fn -> "Couldn't bring in the cover from #{source}: #{inspect(reason)}" end)
+    nil
+  end
+
+  defp track_params(probe) do
+    %{
+      index: 0,
+      path: probe.path,
+      size: probe.size,
+      mime: probe.mime,
+      format: probe.format,
+      codec: probe.codec,
+      duration: probe.duration,
+      start_offset: 0,
+      seek_accuracy: probe.seek_accuracy
+    }
+  end
+
+  ## provenance
+
+  # Each decision already knows where its value came from, so the provenance
+  # map is a projection of the draft rather than anything to collect
+  # separately. A field the operator typed records `manual` and locks; an
+  # accepted provider value records that provider and stays unlocked, so a
+  # future refresh may still update it.
+  defp provenance(fields) do
+    fields
+    |> Enum.flat_map(fn
+      {_name, nil} -> []
+      {_name, %Field{source: nil}} -> []
+      {_name, %Field{source: "manual"}} -> []
+      {name, %Field{source: source}} -> [{name, source}]
+    end)
+    |> Map.new()
+  end
+
+  ## publishing
 
   # An approved recording is finished, so it's published — unless the switch
   # says the fleet can't play direct-play media yet, in which case it waits
@@ -122,10 +365,11 @@ defmodule Ambry.Inbox.Approval do
     end
   end
 
+  ## placement
+
   # What approval should do with the bytes, decided by where the item came
   # from. Only a downloads folder imports; an external collection is adopted
-  # exactly where it lies (that is the entire promise of external custody),
-  # and a file already sitting in a library root is already home.
+  # exactly where it lies (that is the entire promise of external custody).
   defp destination(%InboxItem{location: %Location{kind: :downloads} = location}) do
     with {:ok, root} <- Library.target_root(location) do
       {:ok, {root, location.import_policy}}
@@ -186,179 +430,22 @@ defmodule Ambry.Inbox.Approval do
     end)
   end
 
+  ## files
+
   # Direct-play v1 is single-file, and a recording whose tracks can't be
   # described has no business in the library.
   defp single_file(%InboxItem{files: [file]}), do: {:ok, file}
   defp single_file(%InboxItem{files: []}), do: {:error, :no_audio_files}
   defp single_file(%InboxItem{}), do: {:error, :multi_file_unsupported}
 
+  # Re-probed rather than trusting what discovery recorded: it costs one
+  # ffprobe and buys current track data, plus a file that vanished between
+  # discovery and approval failing the approval instead of creating a
+  # recording that points at nothing.
   defp probe(file) do
     case Scanner.probe_file(file, single_file: true) do
       {:ok, probe} -> {:ok, probe}
       {:error, reason} -> {:error, {:unreadable, reason}}
-    end
-  end
-
-  # An existing Book is always preferred over a new one: reusing the work is
-  # what keeps a second recording of it from splitting the library in two.
-  defp resolve_book(%InboxItem{} = item) do
-    case selected(item, "work") do
-      %{"source" => "local", "id" => id} -> fetch_book(id)
-      candidate -> create_book(item, candidate)
-    end
-  end
-
-  defp fetch_book(id) do
-    case Repo.get(Book, id) do
-      nil -> {:error, :book_not_found}
-      book -> {:ok, book}
-    end
-  end
-
-  defp create_book(item, candidate) do
-    hints = hints(item)
-    title = presence(candidate["title"]) || hints["title"]
-    {published, format} = published(candidate, hints)
-
-    cond do
-      is_nil(title) ->
-        {:error, :no_title}
-
-      # A work has to have a publication date, and the inbox has no business
-      # inventing one — today's date would be worse than no import. Matching
-      # a work supplies it; so does tagging the file.
-      is_nil(published) ->
-        {:error, :no_published_date}
-
-      true ->
-        Books.create_book(%{
-          title: title,
-          published: published,
-          published_format: format,
-          book_authors: author_params(candidate, hints),
-          series_books: series_params(candidate, hints)
-        })
-    end
-  end
-
-  defp published(candidate, hints) do
-    case date(candidate["published"]) do
-      nil -> {date(hints["published"]), format(hints["published_format"]) || :year}
-      date -> {date, format(candidate["published_format"]) || :full}
-    end
-  end
-
-  defp format(format) when format in ["full", "year_month", "year"],
-    do: String.to_existing_atom(format)
-
-  defp format(format) when format in [:full, :year_month, :year], do: format
-  defp format(_other), do: nil
-
-  defp author_params(candidate, hints) do
-    names = names(candidate["authors"]) || names(hints["authors"]) || []
-
-    Enum.map(names, fn name ->
-      {:ok, author} = find_or_create_author(name)
-      %{author_id: author.id}
-    end)
-  end
-
-  defp series_params(candidate, hints) do
-    case candidate["series"] |> List.wrap() |> List.first() |> presence() ||
-           presence(hints["series"]) do
-      nil ->
-        []
-
-      name ->
-        {:ok, series} = find_or_create_series(name)
-        [%{series_id: series.id, book_number: decimal(hints["series_number"]) || Decimal.new(1)}]
-    end
-  end
-
-  defp create_media(item, book, probe) do
-    candidate = selected(item, "recording") || %{}
-    hints = hints(item)
-
-    Media.create_media(%{
-      book_id: book.id,
-      # external custody: referenced where they lie, never touched
-      custody: :external,
-      source_path: item.path,
-      source_files: item.files,
-      status: :pending,
-      duration: probe.duration,
-      chapters: chapter_params(probe),
-      media_narrators: narrator_params(candidate, hints),
-      media_tracks: [track_params(probe)],
-      published: date(candidate["published"]),
-      publisher: presence(candidate["publisher"]) || presence(hints["publisher"]),
-      description: presence(candidate["description"]) || presence(hints["description"])
-    })
-  end
-
-  defp track_params(probe) do
-    %{
-      index: 0,
-      path: probe.path,
-      size: probe.size,
-      mime: probe.mime,
-      format: probe.format,
-      codec: probe.codec,
-      duration: probe.duration,
-      start_offset: 0,
-      seek_accuracy: probe.seek_accuracy
-    }
-  end
-
-  defp chapter_params(%{chapters: chapters}), do: chapters
-
-  defp narrator_params(candidate, hints) do
-    names = names(candidate["narrators"]) || names(hints["narrators"]) || []
-
-    Enum.map(names, fn name ->
-      {:ok, narrator} = find_or_create_narrator(name)
-      %{narrator_id: narrator.id}
-    end)
-  end
-
-  # Attach-or-create, by exact name, case-insensitively. A brand-new credit
-  # brings a Person into being with it, because an Author or Narrator is an
-  # identity *of* somebody — there's no such thing as a free-floating one.
-  defp find_or_create_author(name) do
-    case Repo.one(from a in Author, where: fragment("lower(?)", a.name) == ^String.downcase(name)) do
-      %Author{} = author ->
-        {:ok, author}
-
-      nil ->
-        with {:ok, person} <-
-               People.create_person(%{name: name, author_people: [%{author: %{name: name}}]}) do
-          person = Repo.preload(person, :authors)
-          {:ok, hd(person.authors)}
-        end
-    end
-  end
-
-  defp find_or_create_narrator(name) do
-    query = from n in Narrator, where: fragment("lower(?)", n.name) == ^String.downcase(name)
-
-    case Repo.one(query) do
-      %Narrator{} = narrator ->
-        {:ok, narrator}
-
-      nil ->
-        with {:ok, person} <- People.create_person(%{name: name, narrators: [%{name: name}]}) do
-          person = Repo.preload(person, :narrators)
-          {:ok, hd(person.narrators)}
-        end
-    end
-  end
-
-  defp find_or_create_series(name) do
-    query = from s in Series, where: fragment("lower(?)", s.name) == ^String.downcase(name)
-
-    case Repo.one(query) do
-      %Series{} = series -> {:ok, series}
-      nil -> Books.create_series(%{name: name})
     end
   end
 
@@ -367,68 +454,4 @@ defmodule Ambry.Inbox.Approval do
     |> InboxItem.changeset(%{status: :approved, media_id: media.id})
     |> Repo.update()
   end
-
-  defp selected(%InboxItem{matches: matches}, level) when is_map(matches) do
-    candidates = get_in(matches, [level, "candidates"]) || []
-    selection = get_in(matches, [level, "selected"])
-
-    Enum.find(candidates, List.first(candidates), fn candidate ->
-      (selection && candidate["source"] == selection["source"]) and
-        candidate["id"] == selection["id"]
-    end)
-  end
-
-  defp selected(_item, _level), do: nil
-
-  # One hint builder, shared with matching, so approving an item that was
-  # never matched still knows what its files say it is.
-  defp hints(%InboxItem{} = item) do
-    parsed = AutoMatch.hints(item)
-    tags = item.tags || %{}
-
-    %{
-      "title" => parsed.title,
-      "authors" => names(tags["authors"]) || names(parsed.author) || [],
-      "narrators" => names(tags["narrators"]) || names(parsed.narrator) || [],
-      "series" => parsed.series,
-      "series_number" => tags["series_number"],
-      "published" => tags["published"],
-      "published_format" => tags["published_format"],
-      "publisher" => tags["publisher"],
-      "description" => tags["description"]
-    }
-  end
-
-  defp names(nil), do: nil
-  defp names([]), do: nil
-  defp names(names) when is_list(names), do: Enum.filter(names, &presence/1)
-  defp names(name) when is_binary(name), do: [name]
-
-  defp date(nil), do: nil
-
-  defp date(string) when is_binary(string) do
-    case Date.from_iso8601(string) do
-      {:ok, date} -> date
-      {:error, _reason} -> nil
-    end
-  end
-
-  defp date(%Date{} = date), do: date
-  defp date(_other), do: nil
-
-  defp decimal(nil), do: nil
-  defp decimal(%Decimal{} = decimal), do: decimal
-
-  defp decimal(string) when is_binary(string) do
-    case Decimal.parse(string) do
-      {decimal, ""} -> decimal
-      _unparseable -> nil
-    end
-  end
-
-  defp decimal(_other), do: nil
-
-  defp presence(nil), do: nil
-  defp presence(string) when is_binary(string), do: with("" <- String.trim(string), do: nil)
-  defp presence(other), do: other
 end

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -1,0 +1,124 @@
+defmodule Ambry.Inbox.Draft do
+  @moduledoc """
+  The staged import: everything this release will become, before any of it is
+  real.
+
+  ## The invariant
+
+  **An import is a tree of decisions, and import is possible iff every
+  decision is resolved.** `unresolved/1` is the single expression of that —
+  the import button, the queue's Ready badge and the tests all read it, so
+  they cannot disagree about whether an item is finished.
+
+  Nothing about an import may be implicit. A field nobody proposed is a
+  `:missing` decision the operator can see, not a surprise at approval time;
+  a field two sources disagree about is `:ambiguous` rather than silently
+  first-wins. The corollary is that the form must never render an import
+  button that fails.
+
+  ## Why an embed, not staging tables
+
+  Held as an embed in a jsonb column on `inbox_items`, so half-curated
+  discoveries never touch the library tables (3b's reason for a separate
+  inbox table in the first place). Embedded schemas buy changesets,
+  validation and `inputs_for`, which is what makes the form ordinary nested
+  LiveView rather than hand-rolled jsonb poking. Real staging tables would
+  add referential integrity to data whose entire point is that it isn't real
+  yet.
+
+  ## Rescans never touch a draft
+
+  Discovery updates an item's `files`, `probe` and `tags` and stops there. A
+  curated choice is not something a background scan may overwrite; where the
+  evidence genuinely moved, the affected decisions are marked stale rather
+  than rewritten (see `Ambry.Inbox.Draft.Seed.restale/2`).
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.Work
+
+  @primary_key false
+
+  embedded_schema do
+    embeds_one :work, Work, on_replace: :update
+    embeds_one :recording, Recording, on_replace: :update
+
+    # Bumped when discovery sees the underlying files change, so a draft built
+    # against evidence that has since moved can say so instead of quietly
+    # describing a file that isn't there any more.
+    field :evidence, :string
+    field :stale, :boolean, default: false
+  end
+
+  @doc false
+  def changeset(draft, attrs) do
+    draft
+    |> cast(attrs, [:evidence, :stale])
+    |> cast_embed(:work)
+    |> cast_embed(:recording)
+  end
+
+  @doc """
+  Every decision still needing a human, in the order the form presents them.
+
+  Returns a list of `%{section:, label:, state:}`. Empty means importable —
+  that is the whole invariant, and it is the only thing anything else should
+  ask.
+  """
+  def unresolved(nil), do: [%{section: :draft, label: "Not yet prepared", state: :missing}]
+
+  def unresolved(%__MODULE__{} = draft) do
+    stale(draft) ++ work(draft) ++ recording(draft)
+  end
+
+  defp stale(%__MODULE__{stale: true}),
+    do: [%{section: :draft, label: "The files changed since this was prepared", state: :stale}]
+
+  defp stale(%__MODULE__{}), do: []
+
+  defp work(%__MODULE__{work: nil}), do: [%{section: :work, label: "Which book", state: :missing}]
+
+  defp work(%__MODULE__{work: work}), do: Work.unresolved(work)
+
+  defp recording(%__MODULE__{recording: nil}),
+    do: [%{section: :recording, label: "Which recording", state: :missing}]
+
+  defp recording(%__MODULE__{recording: recording}), do: Recording.unresolved(recording)
+
+  @doc """
+  Whether this draft can be imported.
+  """
+  def resolved?(draft), do: unresolved(draft) == []
+
+  @doc """
+  How far along the operator is, for the queue and the form header.
+  """
+  def progress(nil), do: %{resolved: 0, total: 0}
+
+  def progress(%__MODULE__{} = draft) do
+    outstanding = length(unresolved(draft))
+    %{resolved: total(draft) - outstanding, total: total(draft)}
+  end
+
+  # Every decision the tree contains, resolved or not. Counted rather than
+  # stored: a stored total is a second source of truth waiting to drift from
+  # the first.
+  defp total(%__MODULE__{} = draft) do
+    work_total(draft.work) + recording_total(draft.recording)
+  end
+
+  defp work_total(nil), do: 1
+
+  defp work_total(%Work{mode: :link} = work), do: 1 + length(work.series)
+
+  defp work_total(%Work{} = work) do
+    1 + 3 + length(work.authors) + length(work.series)
+  end
+
+  defp recording_total(nil), do: 1
+  defp recording_total(%Recording{} = recording), do: 1 + 5 + length(recording.narrators)
+end

--- a/lib/ambry/inbox/draft/candidate.ex
+++ b/lib/ambry/inbox/draft/candidate.ex
@@ -1,0 +1,32 @@
+defmodule Ambry.Inbox.Draft.Candidate do
+  @moduledoc """
+  One source's proposal for a scalar field.
+
+  `source` doubles as the provenance source string written at approval
+  (`"provider:hardcover"`, `"tags"`, `"manual"`), which is what lets the
+  import form close 1d's loop without a separate hint-collection layer: the
+  decision already knows where its value came from.
+
+  `label` is what the operator reads — a provider's display name, or "the
+  file's tags" — because `provider:rreading_glasses` is an id, not a sentence.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+
+  embedded_schema do
+    field :value, :string
+    field :source, :string
+    field :label, :string
+  end
+
+  @doc false
+  def changeset(candidate, attrs) do
+    candidate
+    |> cast(attrs, [:value, :source, :label])
+    |> validate_required([:source])
+  end
+end

--- a/lib/ambry/inbox/draft/credit.ex
+++ b/lib/ambry/inbox/draft/credit.ex
@@ -1,0 +1,159 @@
+defmodule Ambry.Inbox.Draft.Credit do
+  @moduledoc """
+  One credited name, resolved to an `Author` or `Narrator` **identity**.
+
+  A link decision never targets a `Person` — that was the v1.9.0 pen-name bug
+  (matching found a Person and linked its first identity, so a James S.A.
+  Corey book credited Ty Franck). Person appears here only when creating.
+
+  ## The import resolves credits, not personhood
+
+  A credited name *is* an identity. How many humans stand behind it is a fact
+  about the person, not about this book, and no provider reports it —
+  Hardcover just says "James S.A. Corey". So this never gates on personhood:
+  it defaults to one new person of the same name and makes the interesting
+  case reachable.
+
+  Four cases, one control (`people`):
+
+    * the identity already exists — link it, personhood already settled
+    * a brand-new name — new identity, one new person, 1:1
+    * a Person exists but this identity doesn't — back the new identity with
+      that person (a narrator who has now written something, or a known
+      author under a new pen name)
+    * a shared pen name — back it with two or more people, new or existing
+
+  The last two are the same widget with a different number of entries, which
+  is what stops the case space exploding. Importing The Expanse into an empty
+  library is the fourth case with two brand-new people: one Author, two
+  People, no special composite pathway anywhere.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Inbox.Draft.PersonRef
+
+  @primary_key false
+
+  embedded_schema do
+    # what the source credited, which is the identity's name
+    field :name, :string
+    field :kind, Ecto.Enum, values: [:author, :narrator]
+
+    field :mode, Ecto.Enum, values: [:link, :create], default: :create
+    # when linking: the Author or Narrator id, never a Person id
+    field :identity_id, :id
+
+    field :source, :string
+    field :approved, :boolean, default: false
+
+    # candidate identities that matched the name, so the operator can choose
+    # rather than retype
+    embeds_many :candidates, __MODULE__.Match, on_replace: :delete
+
+    # who is behind this credit — only meaningful when creating the identity
+    embeds_many :people, PersonRef, on_replace: :delete
+  end
+
+  defmodule Match do
+    @moduledoc """
+    An existing identity that could be what this credit means, with the people
+    already behind it so the operator can tell two same-named authors apart.
+    """
+
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    @primary_key false
+
+    embedded_schema do
+      field :identity_id, :id
+      field :name, :string
+      # "Daniel Abraham and Ty Franck" — the disambiguator when two identities
+      # share a name
+      field :people, :string
+      field :exact, :boolean, default: false
+    end
+
+    @doc false
+    def changeset(match, attrs) do
+      cast(match, attrs, [:identity_id, :name, :people, :exact])
+    end
+  end
+
+  @doc false
+  def changeset(credit, attrs) do
+    credit
+    |> cast(attrs, [:name, :kind, :mode, :identity_id, :source, :approved])
+    |> validate_required([:name, :kind])
+    |> cast_embed(:candidates)
+    |> cast_embed(:people)
+    |> validate_resolution()
+  end
+
+  # Only what can never be legitimate is rejected: an *approved* credit with
+  # nothing behind it. An unapproved one is allowed to be half-made, because
+  # that's what the operator is doing while they make it — `resolved?/1`
+  # reports it instead, and the import button reads that.
+  defp validate_resolution(changeset) do
+    approved? = get_field(changeset, :approved)
+
+    cond do
+      not approved? ->
+        changeset
+
+      get_field(changeset, :mode) == :link ->
+        validate_required(changeset, [:identity_id])
+
+      get_field(changeset, :people) == [] ->
+        add_error(changeset, :people, "needs at least one person behind it")
+
+      true ->
+        changeset
+    end
+  end
+
+  @doc """
+  Whether this credit still needs a human.
+  """
+  def resolved?(%__MODULE__{approved: true, mode: :link, identity_id: id}), do: not is_nil(id)
+  def resolved?(%__MODULE__{approved: true, mode: :create, people: []}), do: false
+
+  # Every person behind the credit has to actually say who they are. A blank
+  # row the operator added and hasn't filled in yet is stored happily and
+  # reported here — which is what lets them add two people and name them one
+  # at a time.
+  def resolved?(%__MODULE__{approved: true, mode: :create, people: people}),
+    do: Enum.all?(people, &PersonRef.complete?/1)
+
+  def resolved?(%__MODULE__{}), do: false
+
+  @doc """
+  Why it isn't resolved.
+
+  A name that matched more than one existing identity is `:ambiguous` — two
+  people really can share a name, and picking the first is how a library ends
+  up crediting the wrong human.
+  """
+  def state(%__MODULE__{} = credit) do
+    cond do
+      resolved?(credit) -> :approved
+      length(credit.candidates) > 1 -> :ambiguous
+      credit.candidates != [] -> :ambiguous
+      true -> :unconfirmed
+    end
+  end
+
+  @doc """
+  The default resolution for a name nothing in the library matches: create the
+  identity, backed by one new person of the same name.
+
+  Never wrong expensively — a placeholder person is fixed in the person form
+  by creating the real people and linking this identity to each — which is
+  what earns the right to default here rather than stopping to ask.
+  """
+  def new_person_default(name), do: [%PersonRef{name: name}]
+end

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -1,0 +1,238 @@
+defmodule Ambry.Inbox.Draft.Edit do
+  @moduledoc """
+  The operations the import form performs on a staged import.
+
+  Scalar *values* are ordinary form inputs — the form autosaves, so typing is
+  handled by casting params. Everything here is the other half: the choices
+  that aren't text, where the operator is picking between things rather than
+  writing one (which candidate, which identity, who's behind a credit).
+
+  Doing those as explicit operations rather than as more form params keeps
+  each one a single named transition with the invariant intact afterwards,
+  instead of a hidden-input trick whose meaning has to be reconstructed from
+  the params on the way back in.
+  """
+
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.PersonRef
+  alias Ambry.Inbox.Draft.SeriesLink
+
+  @doc """
+  Accepts one of a scalar's proposed candidates.
+  """
+  def choose_field(draft, section, name, source) do
+    update_field(draft, section, name, &Field.choose(&1, source))
+  end
+
+  @doc """
+  Settles a scalar as deliberately empty.
+  """
+  def waive_field(draft, section, name) do
+    update_field(draft, section, name, &Field.waive/1)
+  end
+
+  @doc """
+  Settles which Book this is — an existing one, or a new one.
+  """
+  def choose_work(draft, "local", id) do
+    update_in(draft.work, &%{&1 | mode: :link, book_id: id, approved: true})
+  end
+
+  def choose_work(draft, _provider_source, _id) do
+    update_in(draft.work, &%{&1 | mode: :create, book_id: nil, approved: true})
+  end
+
+  @doc """
+  Points a credit at an identity that already exists.
+  """
+  def link_credit(draft, section, index, identity_id) do
+    update_credit(draft, section, index, fn credit ->
+      %{credit | mode: :link, identity_id: identity_id, approved: true}
+    end)
+  end
+
+  @doc """
+  Switches a credit to creating a new identity, backed by whoever is listed.
+
+  Falls back to the 1:1 default when the list is empty, so the control is
+  never in a state with nobody behind it.
+  """
+  def create_credit(draft, section, index) do
+    update_credit(draft, section, index, fn credit ->
+      people =
+        if credit.people == [], do: Credit.new_person_default(credit.name), else: credit.people
+
+      %{credit | mode: :create, identity_id: nil, people: people}
+    end)
+  end
+
+  @doc """
+  Adds another human behind a credit.
+
+  Two or more is a shared pen name — the whole of the composite-author case,
+  expressed as a longer list rather than a different mode.
+  """
+  def add_person(draft, section, index) do
+    update_credit(draft, section, index, fn credit ->
+      %{credit | mode: :create, people: credit.people ++ [%PersonRef{name: ""}]}
+    end)
+  end
+
+  def remove_person(draft, section, index, person_index) do
+    update_credit(draft, section, index, fn credit ->
+      %{credit | people: List.delete_at(credit.people, person_index)}
+    end)
+  end
+
+  @doc """
+  Names one of the people behind a credit, or points at an existing person.
+  """
+  def set_person(draft, section, index, person_index, attrs) do
+    update_credit(draft, section, index, fn credit ->
+      people =
+        List.update_at(credit.people, person_index, fn person ->
+          %{
+            person
+            | name: Map.get(attrs, :name, person.name),
+              person_id: Map.get(attrs, :person_id, person.person_id)
+          }
+        end)
+
+      %{credit | people: people}
+    end)
+  end
+
+  @doc """
+  Marks a credit settled, or unsettles it for another look.
+  """
+  def approve_credit(draft, section, index, approved?) do
+    update_credit(draft, section, index, &%{&1 | approved: approved?})
+  end
+
+  @doc """
+  Drops a proposed credit entirely — the source suggested somebody this
+  recording isn't actually by.
+  """
+  def remove_credit(draft, section, index) do
+    update_credits(draft, section, &List.delete_at(&1, index))
+  end
+
+  ## series
+
+  def set_series_number(draft, index, number) do
+    update_series(draft, index, &%{&1 | number: presence(number)})
+  end
+
+  def approve_series(draft, index, approved?) do
+    update_series(draft, index, &%{&1 | approved: approved?})
+  end
+
+  def link_series(draft, index, series_id) do
+    update_series(draft, index, &%{&1 | mode: :link, series_id: series_id})
+  end
+
+  def create_series(draft, index) do
+    update_series(draft, index, &%{&1 | mode: :create, series_id: nil})
+  end
+
+  def remove_series(draft, index) do
+    update_in(draft.work.series, &List.delete_at(&1, index))
+  end
+
+  ## the identity decisions
+
+  def approve_work(draft, approved?), do: update_in(draft.work.approved, fn _ -> approved? end)
+
+  def approve_recording(draft, approved?),
+    do: update_in(draft.recording.approved, fn _ -> approved? end)
+
+  @doc """
+  Approves every decision that is only waiting on a nod.
+
+  The "looks right, take it" button. Deliberately does NOT invent values —
+  anything genuinely missing or contradictory stays outstanding, so this can
+  never turn a `:missing` title into an imported book with no title.
+  """
+  def approve_all(%Draft{} = draft) do
+    draft
+    |> update_in([Access.key(:work)], &approve_all_work/1)
+    |> update_in([Access.key(:recording)], &approve_all_recording/1)
+  end
+
+  defp approve_all_work(work) do
+    %{
+      work
+      | # With no candidates there is exactly one thing this can be — a new
+        # book — so confirming it is precisely the nod this button is for.
+        approved: true,
+        title: settle_if_possible(work.title),
+        published: settle_if_possible(work.published),
+        published_format: settle_if_possible(work.published_format),
+        authors: Enum.map(work.authors, &settle_credit/1),
+        series: Enum.map(work.series, &settle_series/1)
+    }
+  end
+
+  defp approve_all_recording(recording) do
+    %{
+      recording
+      | approved: true,
+        title: settle_if_possible(recording.title),
+        published: settle_if_possible(recording.published),
+        publisher: settle_if_possible(recording.publisher),
+        description: settle_if_possible(recording.description),
+        cover: settle_if_possible(recording.cover),
+        narrators: Enum.map(recording.narrators, &settle_credit/1)
+    }
+  end
+
+  # Takes the first proposal where there is one; leaves a required field with
+  # nothing behind it exactly as it was.
+  defp settle_if_possible(%Field{approved: true} = field), do: field
+
+  defp settle_if_possible(%Field{value: value} = field) when not is_nil(value),
+    do: %{field | approved: true}
+
+  defp settle_if_possible(%Field{candidates: [first | _rest]} = field),
+    do: %{field | value: first.value, source: first.source, approved: true}
+
+  defp settle_if_possible(%Field{required: false} = field), do: %{field | approved: true}
+  defp settle_if_possible(field), do: field
+
+  defp settle_credit(%Credit{} = credit) do
+    cond do
+      Credit.resolved?(credit) -> credit
+      credit.mode == :link and credit.identity_id -> %{credit | approved: true}
+      credit.people != [] -> %{credit | approved: true}
+      true -> %{credit | people: Credit.new_person_default(credit.name), approved: true}
+    end
+  end
+
+  # A number nobody supplied stays a question — this is the one thing the
+  # approve-everything button must not paper over.
+  defp settle_series(%SeriesLink{number: nil} = link), do: link
+  defp settle_series(%SeriesLink{} = link), do: %{link | approved: true}
+
+  ## plumbing
+
+  defp update_field(draft, :work, name, fun),
+    do: update_in(draft.work, &Map.update!(&1, name, fun))
+
+  defp update_field(draft, :recording, name, fun),
+    do: update_in(draft.recording, &Map.update!(&1, name, fun))
+
+  defp update_credit(draft, section, index, fun),
+    do: update_credits(draft, section, &List.update_at(&1, index, fun))
+
+  defp update_credits(draft, :work, fun), do: update_in(draft.work.authors, fun)
+  defp update_credits(draft, :recording, fun), do: update_in(draft.recording.narrators, fun)
+
+  defp update_series(draft, index, fun),
+    do: update_in(draft.work.series, &List.update_at(&1, index, fun))
+
+  defp presence(nil), do: nil
+  defp presence(string) when is_binary(string), do: with("" <- String.trim(string), do: nil)
+  defp presence(other), do: other
+end

--- a/lib/ambry/inbox/draft/field.ex
+++ b/lib/ambry/inbox/draft/field.ex
@@ -1,0 +1,173 @@
+defmodule Ambry.Inbox.Draft.Field do
+  @moduledoc """
+  One scalar decision: a value, where it came from, and whether it's settled.
+
+  Values are held as strings regardless of their eventual type. A draft is a
+  staging area whose other half is an HTML form, and strings are what a form
+  produces; approval casts them once, at the point where they become real
+  columns. Keeping `%Date{}` and `%Decimal{}` in the jsonb would mean casting
+  on the way in, on the way out, and again on every re-render.
+
+  `candidates` is what the sources proposed — kept whole rather than reduced
+  to a winner, so "show me the alternatives" costs nothing and re-querying is
+  only needed when the right answer isn't in the list at all.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Inbox.Draft.Candidate
+
+  @manual "manual"
+
+  @primary_key false
+
+  embedded_schema do
+    field :value, :string
+    field :source, :string
+    field :approved, :boolean, default: false
+    field :required, :boolean, default: false
+
+    embeds_many :candidates, Candidate, on_replace: :delete
+  end
+
+  @doc false
+  def changeset(field, attrs) do
+    field
+    |> cast(attrs, [:value, :source, :approved, :required])
+    |> cast_embed(:candidates)
+    |> track_manual_edit(attrs)
+    |> validate_settled()
+  end
+
+  # Typing a value *is* the decision — 1d's lock semantics exactly: editing a
+  # value records it as the operator's and locks it, while accepting a
+  # provider's suggestion records that provider and stays unlocked so a future
+  # refresh may still update it. Without this a field the operator retyped
+  # would keep claiming it came from whichever provider proposed the old
+  # value, and refresh would later overwrite their correction.
+  defp track_manual_edit(changeset, attrs) do
+    explicit_source? = Map.has_key?(attrs, "source") or Map.has_key?(attrs, :source)
+
+    case fetch_change(changeset, :value) do
+      {:ok, _value} when not explicit_source? ->
+        changeset |> put_change(:source, @manual) |> put_change(:approved, true)
+
+      _unchanged_or_sourced ->
+        changeset
+    end
+  end
+
+  # A required field cannot be waived. Without this the form could approve its
+  # way past a missing title or publication date and hand approval a decision
+  # it has no way to execute — the failure would surface as a changeset error
+  # deep inside the transaction, which is exactly the late surprise the whole
+  # decision model exists to eliminate.
+  defp validate_settled(changeset) do
+    required? = get_field(changeset, :required)
+    approved? = get_field(changeset, :approved)
+    blank? = get_field(changeset, :value) in [nil, ""]
+
+    if required? and approved? and blank? do
+      add_error(changeset, :value, "is needed before this can be imported")
+    else
+      changeset
+    end
+  end
+
+  @doc """
+  The operator's edit: a typed value with no provider behind it.
+
+  Editing is what `1d` calls curation, so the source becomes `manual` and the
+  field settles — there is nothing left to decide about a value someone chose
+  deliberately.
+  """
+  def edit(%__MODULE__{} = field, value) do
+    %{field | value: presence(value), source: "manual", approved: true}
+  end
+
+  @doc """
+  Accepts one of the proposed candidates, recording which one.
+  """
+  def choose(%__MODULE__{} = field, source) do
+    case Enum.find(field.candidates, &(&1.source == source)) do
+      nil -> field
+      candidate -> %{field | value: candidate.value, source: candidate.source, approved: true}
+    end
+  end
+
+  @doc """
+  Settles the field as deliberately empty.
+
+  Waiving is an approval, not an omission — it's what makes "every piece is
+  resolved" reachable on a record with optional fields nobody filled in.
+  """
+  def waive(%__MODULE__{} = field), do: %{field | value: nil, source: nil, approved: true}
+
+  @doc """
+  Whether this field still needs a human.
+  """
+  def resolved?(%__MODULE__{approved: true}), do: true
+  def resolved?(%__MODULE__{}), do: false
+
+  @doc """
+  Why it isn't resolved, for the operator-facing unresolved list.
+
+  `:missing` and `:ambiguous` are genuinely different problems — one needs a
+  value from somewhere, the other needs a choice between values already in
+  hand — and the form should not describe them the same way.
+  """
+  def state(%__MODULE__{approved: true}), do: :approved
+  def state(%__MODULE__{candidates: [], required: true}), do: :missing
+  def state(%__MODULE__{candidates: [_one]}), do: :ambiguous
+  def state(%__MODULE__{}), do: :ambiguous
+
+  @doc """
+  The settled value, as the string it's staged as.
+  """
+  def value(nil), do: nil
+  def value(%__MODULE__{value: value}), do: presence(value)
+
+  @doc """
+  The settled value as a `Date`.
+
+  Returns nil for anything unparseable rather than raising: a value that got
+  this far was approved, and a malformed one is a data problem for the
+  changeset to report against the real column, not a crash mid-transaction.
+  """
+  def date(nil), do: nil
+
+  def date(%__MODULE__{value: value}) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> date
+      {:error, _reason} -> nil
+    end
+  end
+
+  def date(%__MODULE__{}), do: nil
+
+  @doc """
+  The settled value as an existing atom, for `Ecto.Enum` columns.
+
+  Only ever converts to atoms that already exist — a draft is operator input,
+  and `String.to_atom/1` on operator input leaks the atom table.
+  """
+  def atom(field, default) do
+    case value(field) do
+      nil ->
+        default
+
+      value ->
+        try do
+          String.to_existing_atom(value)
+        rescue
+          ArgumentError -> default
+        end
+    end
+  end
+
+  defp presence(nil), do: nil
+  defp presence(string) when is_binary(string), do: with("" <- String.trim(string), do: nil)
+  defp presence(other), do: other
+end

--- a/lib/ambry/inbox/draft/person_ref.ex
+++ b/lib/ambry/inbox/draft/person_ref.ex
@@ -1,0 +1,39 @@
+defmodule Ambry.Inbox.Draft.PersonRef do
+  @moduledoc """
+  One human behind a credit: either somebody already in the library, or
+  somebody to create with it.
+
+  Two or more of these on one credit is a shared pen name — that is the whole
+  of the composite-author case as far as an import is concerned. There is no
+  separate composite mode, because "how many people" is a number, not a kind.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+
+  embedded_schema do
+    # set = an existing Person; nil = create one with this name
+    field :person_id, :id
+    field :name, :string
+  end
+
+  # Deliberately permissive: a draft has to be *storable* while it's still
+  # being made up, or the operator couldn't add a second person and then name
+  # them. Whether it's finished is `complete?/1`'s job, reported through
+  # `Draft.unresolved/1` — validation gates saving, the invariant gates
+  # importing, and conflating the two makes the form unusable.
+  @doc false
+  def changeset(person_ref, attrs), do: cast(person_ref, attrs, [:person_id, :name])
+
+  @doc "Whether this reference actually says who it means."
+  def complete?(%__MODULE__{person_id: id}) when not is_nil(id), do: true
+  def complete?(%__MODULE__{name: name}) when is_binary(name), do: String.trim(name) != ""
+  def complete?(%__MODULE__{}), do: false
+
+  @doc "Whether this reference means 'create somebody new'."
+  def new?(%__MODULE__{person_id: nil}), do: true
+  def new?(%__MODULE__{}), do: false
+end

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -1,0 +1,78 @@
+defmodule Ambry.Inbox.Draft.Recording do
+  @moduledoc """
+  What the Media created by this import should say.
+
+  In the walking skeleton a recording is always new. "This release is a better
+  rip of an existing recording" — 3a's replace/upgrade workflow — is the third
+  identity option this schema is shaped to grow, and is deliberately out of
+  the first cut.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+
+  @primary_key false
+
+  embedded_schema do
+    field :candidates, {:array, :map}, default: []
+    field :confidence, :float
+    field :query, :string
+    field :approved, :boolean, default: false
+
+    embeds_one :title, Field, on_replace: :update
+    embeds_one :published, Field, on_replace: :update
+    embeds_one :publisher, Field, on_replace: :update
+    embeds_one :description, Field, on_replace: :update
+    embeds_one :cover, Field, on_replace: :update
+
+    embeds_many :narrators, Credit, on_replace: :delete
+  end
+
+  @doc false
+  def changeset(recording, attrs) do
+    recording
+    |> cast(attrs, [:candidates, :confidence, :query, :approved])
+    |> cast_embed(:title)
+    |> cast_embed(:published)
+    |> cast_embed(:publisher)
+    |> cast_embed(:description)
+    |> cast_embed(:cover)
+    |> cast_embed(:narrators)
+  end
+
+  @doc """
+  Everything about this recording that still needs a human.
+  """
+  def unresolved(%__MODULE__{} = recording) do
+    identity(recording) ++
+      field(recording.title, "Recording title") ++
+      field(recording.published, "Release date") ++
+      field(recording.publisher, "Publisher") ++
+      field(recording.description, "Description") ++
+      field(recording.cover, "Cover image") ++
+      credits(recording.narrators)
+  end
+
+  defp identity(%__MODULE__{approved: true}), do: []
+
+  defp identity(%__MODULE__{}),
+    do: [%{section: :recording, label: "Which recording", state: :unconfirmed}]
+
+  defp field(nil, _label), do: []
+
+  defp field(field, label) do
+    if Field.resolved?(field),
+      do: [],
+      else: [%{section: :recording, label: label, state: Field.state(field)}]
+  end
+
+  defp credits(narrators) do
+    narrators
+    |> Enum.reject(&Credit.resolved?/1)
+    |> Enum.map(&%{section: :recording, label: "Narrator: #{&1.name}", state: Credit.state(&1)})
+  end
+end

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -1,0 +1,447 @@
+defmodule Ambry.Inbox.Draft.Seed do
+  @moduledoc """
+  Builds a draft from what an item's files and providers had to say.
+
+  Seeding is where the auto-approval rules live. Their shared logic: a rule
+  may only settle a decision when getting it wrong would be *cheap* — either
+  because the answer is identity rather than similarity (an ASIN, an exact
+  name match), or because there was only ever one answer on offer. Everything
+  else is left for a human, because the inbox exists precisely for the cases
+  automation gets wrong.
+
+  ## The rules
+
+    * **work identity** — auto on ASIN identity, an exact local title+author
+      match, or a top score ≥ 0.90 whose runner-up is ≤ 0.70. Local books
+      already outrank equal provider hits in `AutoMatch`, so "reuse the work"
+      wins by default.
+    * **scalar** — nothing proposed and optional: waived. One proposal: taken.
+      Several that agree once normalized: taken. Several that disagree:
+      the operator's.
+    * **credit** — one exact identity match: linked. No match at all, name
+      from a provider-matched work: created 1:1. A *Person* matches but the
+      identity doesn't: always the operator's, because "is this the same
+      human?" is exactly the judgment not to automate.
+    * **new credit from tags, never automatically** — tag names come from the
+      multi-value splitting 1b calls knowingly imperfect ("Sanderson,
+      Brandon"). This is the rule that stops the inbox quietly filling the
+      library with malformed people.
+    * **series number** — never invented. Only a number an actual source
+      supplied can settle it.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Books.Book
+  alias Ambry.Books.Series
+  alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Candidate
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.Work
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.People.Author
+  alias Ambry.People.Narrator
+  alias Ambry.People.Person
+  alias Ambry.Repo
+
+  @strong_match 0.90
+  @weak_runner_up 0.70
+
+  @doc """
+  Builds a fresh draft for an item from its matches, tags and release name.
+  """
+  def build(%InboxItem{} = item) do
+    hints = AutoMatch.hints(item)
+    tags = item.tags || %{}
+    matches = item.matches || %{}
+
+    work_level = Map.get(matches, "work", %{})
+    recording_level = Map.get(matches, "recording", %{})
+
+    %Draft{
+      evidence: evidence(item),
+      stale: false,
+      work: work(work_level, hints, tags),
+      recording: recording(recording_level, hints, tags, item)
+    }
+  end
+
+  @doc """
+  Marks a draft as built against evidence that has since changed.
+
+  Discovery must never rewrite a curated choice, so a file that moved or was
+  replaced makes the draft *say so* rather than silently re-seeding over the
+  operator's work.
+  """
+  def restale(nil, _item), do: nil
+
+  def restale(%Draft{} = draft, %InboxItem{} = item) do
+    %{draft | stale: draft.evidence != evidence(item)}
+  end
+
+  # Cheap and sufficient: what a draft was built against is the set of files
+  # and their probe. Neither a rename nor a replacement can slip past it.
+  defp evidence(%InboxItem{} = item) do
+    :erlang.phash2({item.files, item.probe}) |> Integer.to_string()
+  end
+
+  ## work
+
+  defp work(level, hints, tags) do
+    candidates = Map.get(level, "candidates", []) || []
+    best = List.first(candidates)
+    confidence = Map.get(level, "confidence")
+
+    {mode, book_id, approved} = work_identity(candidates, confidence)
+
+    %Work{
+      mode: mode,
+      book_id: book_id,
+      approved: approved,
+      candidates: candidates,
+      confidence: confidence,
+      query: Map.get(level, "query"),
+      title: title_field(best, hints, tags),
+      published: published_field(best, tags),
+      published_format: published_format_field(best, tags),
+      authors: author_credits(best, tags),
+      series: series_links(best, tags, book_id)
+    }
+  end
+
+  # An existing Book is the best outcome there is — it's what stops a second
+  # recording of a work splitting the library — so a confident local hit links
+  # rather than creating a near-duplicate.
+  defp work_identity([], _confidence), do: {:create, nil, false}
+
+  defp work_identity([best | rest], confidence) do
+    strong? = strong?(best, rest, confidence)
+
+    case best do
+      %{"source" => "local", "id" => id} when is_integer(id) -> {:link, id, strong?}
+      _provider -> {:create, nil, strong?}
+    end
+  end
+
+  defp strong?(best, rest, confidence) do
+    runner_up = rest |> List.first() |> then(&(&1 && &1["score"])) || 0.0
+
+    cond do
+      best["score"] == 1.0 -> true
+      (confidence || 0.0) >= @strong_match and runner_up <= @weak_runner_up -> true
+      true -> false
+    end
+  end
+
+  # The release name is a fallback, not a peer. Measured across the real
+  # library, 96% of releases carry a title in tags and the parser is what the
+  # other ~2% rely on — so letting the folder name argue with a provider would
+  # make nearly every import ambiguous on its title for no gain.
+  defp title_field(best, hints, tags) do
+    [candidate(best, "title"), tag_candidate(tags, "book_title")]
+    |> scalar(required: true, fallback: release_candidate(hints.title))
+  end
+
+  defp published_field(best, tags) do
+    [candidate(best, "published"), tag_candidate(tags, "published")]
+    |> scalar(required: true)
+  end
+
+  # Not derivable from the date: year-only knowledge arrives as a literal
+  # Jan 1st, and rendering that as a real release day is the exact bug the
+  # v1.9.0 punch list fixed for the import forms.
+  defp published_format_field(best, tags) do
+    [candidate(best, "published_format"), tag_candidate(tags, "published_format")]
+    |> scalar(required: false)
+    |> default_to("full")
+  end
+
+  defp default_to(%Field{value: nil, candidates: []} = field, value) do
+    %{field | value: value, source: "default", approved: true}
+  end
+
+  defp default_to(field, _value), do: field
+
+  ## recording
+
+  defp recording(level, _hints, tags, item) do
+    candidates = Map.get(level, "candidates", []) || []
+    best = List.first(candidates)
+
+    %Recording{
+      candidates: candidates,
+      confidence: Map.get(level, "confidence"),
+      query: Map.get(level, "query"),
+      # A new recording is what an inbox item almost always is, and the
+      # skeleton has no other option to offer — so the identity is settled by
+      # construction. Replace-an-existing-recording is the option this grows.
+      approved: true,
+      title: [] |> scalar(required: false),
+      published: [candidate(best, "published")] |> scalar(required: false),
+      publisher: [candidate(best, "publisher"), tag_candidate(tags, "publisher")] |> scalar(),
+      description:
+        [candidate(best, "description"), tag_candidate(tags, "description")] |> scalar(),
+      cover: cover_field(best, tags, item),
+      narrators: narrator_credits(best, tags)
+    }
+  end
+
+  # Embedded art and a provider cover are both real answers, so two of them is
+  # a choice rather than a winner. The embedded candidate carries the audio
+  # file to extract from; approval does the extracting.
+  defp cover_field(best, tags, item) do
+    embedded =
+      if tags["has_cover_art"] && item.files != [] do
+        %Candidate{
+          value: List.first(item.files),
+          source: "embedded",
+          label: "Embedded in the file"
+        }
+      end
+
+    [candidate(best, "cover_url"), embedded] |> scalar(required: false)
+  end
+
+  ## credits
+
+  defp author_credits(best, tags) do
+    names = names(best && best["authors"]) || names(tags["authors"]) || []
+    source = if names == names(best && best["authors"]), do: source_of(best), else: "tags"
+
+    Enum.map(names, &credit(&1, :author, source))
+  end
+
+  defp narrator_credits(best, tags) do
+    names = names(best && best["narrators"]) || names(tags["narrators"]) || []
+    source = if names == names(best && best["narrators"]), do: source_of(best), else: "tags"
+
+    Enum.map(names, &credit(&1, :narrator, source))
+  end
+
+  defp credit(name, kind, source) do
+    matches = identity_matches(name, kind)
+    people = person_matches(name)
+
+    base = %Credit{name: name, kind: kind, source: source, candidates: matches}
+
+    case {matches, people} do
+      # exactly one existing identity by that name — link it and move on
+      {[%{exact: true} = match], _people} ->
+        %{base | mode: :link, identity_id: match.identity_id, approved: true}
+
+      # nobody by that name at all: create it, backed by one new person.
+      # Auto only when a provider-matched work supplied the name — tag names
+      # are split by a knowingly imperfect rule.
+      {[], []} ->
+        %{
+          base
+          | mode: :create,
+            people: Credit.new_person_default(name),
+            approved: provider?(source)
+        }
+
+      # a Person exists but this identity doesn't — "is this the same human?"
+      # is never automated
+      {[], _people} ->
+        %{base | mode: :create, people: Credit.new_person_default(name), approved: false}
+
+      # more than one identity shares this name; two people really can
+      {_several, _people} ->
+        %{base | mode: :create, people: Credit.new_person_default(name), approved: false}
+    end
+  end
+
+  defp identity_matches(name, :author) do
+    Author
+    |> where([a], fragment("lower(?)", a.name) == ^String.downcase(name))
+    |> preload(:people)
+    |> Repo.all()
+    |> Enum.map(fn author ->
+      %Credit.Match{
+        identity_id: author.id,
+        name: author.name,
+        people: author.people |> Enum.map_join(" and ", & &1.name) |> presence(),
+        exact: true
+      }
+    end)
+  end
+
+  defp identity_matches(name, :narrator) do
+    Narrator
+    |> where([n], fragment("lower(?)", n.name) == ^String.downcase(name))
+    |> preload(:person)
+    |> Repo.all()
+    |> Enum.map(fn narrator ->
+      %Credit.Match{
+        identity_id: narrator.id,
+        name: narrator.name,
+        people: narrator.person && narrator.person.name,
+        exact: true
+      }
+    end)
+  end
+
+  defp person_matches(name) do
+    Person
+    |> where([p], fragment("lower(?)", p.name) == ^String.downcase(name))
+    |> Repo.all()
+  end
+
+  ## series
+
+  # When linking to an existing book, a proposed series is only offered if the
+  # book doesn't already have it: an import may fill a blank, never overwrite
+  # curation.
+  defp series_links(best, tags, book_id) do
+    names = names(best && best["series"]) || names(tags["series"]) || []
+    number = tags["series_number"]
+    source = if names == names(best && best["series"]), do: source_of(best), else: "tags"
+
+    names
+    |> Enum.reject(&already_on_book?(&1, book_id))
+    |> Enum.map(&series_link(&1, number, source))
+  end
+
+  defp already_on_book?(_name, nil), do: false
+
+  defp already_on_book?(name, book_id) do
+    Book
+    |> where([b], b.id == ^book_id)
+    |> join(:inner, [b], sb in assoc(b, :series_books))
+    |> join(:inner, [_b, sb], s in assoc(sb, :series))
+    |> where([_b, _sb, s], fragment("lower(?)", s.name) == ^String.downcase(name))
+    |> Repo.exists?()
+  end
+
+  defp series_link(name, number, source) do
+    matches =
+      Series
+      |> where([s], fragment("lower(?)", s.name) == ^String.downcase(name))
+      |> Repo.all()
+      |> Enum.map(&%SeriesLink.Match{series_id: &1.id, name: &1.name, exact: true})
+
+    base = %SeriesLink{name: name, number: presence(number), source: source, candidates: matches}
+
+    case matches do
+      # A number nobody supplied is a question, not a default. Getting this
+      # wrong writes confident nonsense into a curated field.
+      _any when number in [nil, ""] ->
+        %{base | mode: mode_for(matches), series_id: series_id(matches), approved: false}
+
+      [one] ->
+        %{base | mode: :link, series_id: one.series_id, approved: true}
+
+      [] ->
+        %{base | mode: :create, approved: provider?(source)}
+
+      _several ->
+        %{base | mode: :create, approved: false}
+    end
+  end
+
+  defp mode_for([_one]), do: :link
+  defp mode_for(_other), do: :create
+
+  defp series_id([one]), do: one.series_id
+  defp series_id(_other), do: nil
+
+  ## scalars
+
+  # `fallback` is a weaker source that only gets a say when the primary ones
+  # said nothing — it never argues with them, and never turns a settled field
+  # into a choice.
+  defp scalar(candidates, opts \\ []) do
+    required = Keyword.get(opts, :required, false)
+    candidates = Enum.reject(candidates, &is_nil/1)
+
+    candidates =
+      case {distinct(candidates), Keyword.get(opts, :fallback)} do
+        {[], fallback} when not is_nil(fallback) -> [fallback]
+        _primary_had_something -> candidates
+      end
+
+    field = %Field{required: required, candidates: candidates}
+
+    case distinct(candidates) do
+      # nothing proposed it. Optional means waived — an explicit "none", which
+      # is what makes "every piece resolved" reachable at all.
+      [] ->
+        %{field | approved: not required}
+
+      # one answer, whether from one source or several that agree
+      [value] ->
+        %{field | value: value, source: source_for(candidates, value), approved: true}
+
+      _several ->
+        %{field | approved: false}
+    end
+  end
+
+  defp distinct(candidates) do
+    candidates
+    |> Enum.map(& &1.value)
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.uniq_by(&normalize/1)
+  end
+
+  defp source_for(candidates, value) do
+    Enum.find_value(candidates, fn candidate ->
+      candidate.value == value && candidate.source
+    end)
+  end
+
+  defp normalize(string) when is_binary(string) do
+    string |> String.downcase() |> String.replace(~r/\s+/, " ") |> String.trim()
+  end
+
+  defp normalize(other), do: other
+
+  ## candidate helpers
+
+  defp candidate(nil, _key), do: nil
+
+  defp candidate(best, key) do
+    case presence(best[key]) do
+      nil -> nil
+      value -> %Candidate{value: to_string(value), source: source_of(best), label: label_of(best)}
+    end
+  end
+
+  defp tag_candidate(tags, key) do
+    case presence(tags[key]) do
+      nil -> nil
+      value -> %Candidate{value: to_string(value), source: "tags", label: "The file's tags"}
+    end
+  end
+
+  defp release_candidate(nil), do: nil
+
+  defp release_candidate(value),
+    do: %Candidate{value: value, source: "release_name", label: "The release name"}
+
+  defp source_of(nil), do: nil
+  defp source_of(%{"source" => source}), do: source
+  defp source_of(_other), do: nil
+
+  defp label_of(%{"provider_name" => name}) when is_binary(name), do: name
+  defp label_of(%{"source" => "local"}), do: "Already in the library"
+  defp label_of(%{"source" => source}), do: source
+  defp label_of(_other), do: nil
+
+  defp provider?("provider:" <> _rest), do: true
+  defp provider?(_other), do: false
+
+  defp names(nil), do: nil
+  defp names([]), do: nil
+  defp names(list) when is_list(list), do: list |> Enum.map(&presence/1) |> Enum.reject(&is_nil/1)
+  defp names(value) when is_binary(value), do: [value]
+  defp names(_other), do: nil
+
+  defp presence(nil), do: nil
+  defp presence(string) when is_binary(string), do: with("" <- String.trim(string), do: nil)
+  defp presence(other), do: other
+end

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -1,0 +1,113 @@
+defmodule Ambry.Inbox.Draft.SeriesLink do
+  @moduledoc """
+  One proposed series membership, with its number.
+
+  Each series is its own decision, which is what fixes the standing complaint
+  that the import forms take all series or none — Goodreads-shaped sources
+  list both "The Expanse" and "The Expanse (Chronological)", and only one of
+  those belongs on the book.
+
+  ## The number never auto-resolves without a source
+
+  `Approval` used to default `book_number` to `1` whenever tags carried no
+  number, and only 36% of releases carry a series tag at all — so most
+  series-bearing imports silently became "book 1". A missing number is a
+  question for the operator, not a value to invent.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+
+  embedded_schema do
+    field :name, :string
+    field :mode, Ecto.Enum, values: [:link, :create], default: :create
+    field :series_id, :id
+
+    field :number, :string
+    field :source, :string
+    field :approved, :boolean, default: false
+
+    embeds_many :candidates, __MODULE__.Match, on_replace: :delete
+  end
+
+  defmodule Match do
+    @moduledoc "An existing series this proposal could mean."
+
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    @primary_key false
+
+    embedded_schema do
+      field :series_id, :id
+      field :name, :string
+      field :exact, :boolean, default: false
+    end
+
+    @doc false
+    def changeset(match, attrs), do: cast(match, attrs, [:series_id, :name, :exact])
+  end
+
+  @doc false
+  def changeset(series_link, attrs) do
+    series_link
+    |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved])
+    |> validate_required([:name])
+    |> cast_embed(:candidates)
+    |> validate_number()
+    |> validate_link()
+  end
+
+  defp validate_number(changeset) do
+    case get_field(changeset, :number) do
+      nil ->
+        changeset
+
+      number ->
+        case Decimal.parse(number) do
+          {_decimal, ""} -> changeset
+          _unparseable -> add_error(changeset, :number, "isn't a number")
+        end
+    end
+  end
+
+  defp validate_link(changeset) do
+    if get_field(changeset, :mode) == :link do
+      validate_required(changeset, [:series_id])
+    else
+      changeset
+    end
+  end
+
+  @doc """
+  Whether this membership still needs a human.
+
+  A number is required to be *settled*, not to be present: "this book has no
+  number in this series" is a real answer, and waiving it is an approval.
+  """
+  def resolved?(%__MODULE__{approved: true, mode: :link, series_id: id}), do: not is_nil(id)
+  def resolved?(%__MODULE__{approved: true, mode: :create, name: name}), do: not is_nil(name)
+  def resolved?(%__MODULE__{}), do: false
+
+  def state(%__MODULE__{} = link) do
+    cond do
+      resolved?(link) -> :approved
+      is_nil(link.number) -> :missing
+      true -> :unconfirmed
+    end
+  end
+
+  @doc "The number as the database wants it, or nil for an unnumbered membership."
+  def decimal(%__MODULE__{number: nil}), do: nil
+
+  def decimal(%__MODULE__{number: number}) do
+    case Decimal.parse(number) do
+      {decimal, ""} -> decimal
+      _unparseable -> nil
+    end
+  end
+end

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -1,0 +1,101 @@
+defmodule Ambry.Inbox.Draft.Work do
+  @moduledoc """
+  Which Book this release is a recording of, and — when it's a new one — what
+  that Book should say.
+
+  This is the pivot of the whole form: linking to a Book already in the
+  library makes every work-level field inherited rather than decided, and
+  reusing the work is what stops a second recording of it splitting the
+  library in two.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.SeriesLink
+
+  @primary_key false
+
+  embedded_schema do
+    field :mode, Ecto.Enum, values: [:link, :create], default: :create
+    field :book_id, :id
+    field :approved, :boolean, default: false
+
+    # the ranked work-level candidate list from auto-match, kept whole
+    field :candidates, {:array, :map}, default: []
+    field :confidence, :float
+    field :query, :string
+
+    embeds_one :title, Field, on_replace: :update
+    embeds_one :published, Field, on_replace: :update
+    embeds_one :published_format, Field, on_replace: :update
+
+    embeds_many :authors, Credit, on_replace: :delete
+    embeds_many :series, SeriesLink, on_replace: :delete
+  end
+
+  @doc false
+  def changeset(work, attrs) do
+    work
+    |> cast(attrs, [:mode, :book_id, :approved, :candidates, :confidence, :query])
+    |> cast_embed(:title)
+    |> cast_embed(:published)
+    |> cast_embed(:published_format)
+    |> cast_embed(:authors)
+    |> cast_embed(:series)
+    |> validate_link()
+  end
+
+  defp validate_link(changeset) do
+    if get_field(changeset, :mode) == :link do
+      validate_required(changeset, [:book_id])
+    else
+      changeset
+    end
+  end
+
+  @doc """
+  Everything about this work that still needs a human.
+
+  When linking, the Book's own fields and credits belong to the existing
+  record and are not decided here — only the identity is, plus any *additive*
+  series membership the import proposes that the book doesn't already have.
+  That is the fill-gaps rule: an import may fill a blank, never overwrite
+  curation.
+  """
+  def unresolved(%__MODULE__{mode: :link} = work) do
+    identity(work) ++ unresolved_in(work.series, &SeriesLink.resolved?/1, "Series")
+  end
+
+  def unresolved(%__MODULE__{mode: :create} = work) do
+    identity(work) ++
+      unresolved_field(work.title, "Title") ++
+      unresolved_field(work.published, "First published") ++
+      unresolved_field(work.published_format, "Date display format") ++
+      unresolved_in(work.authors, &Credit.resolved?/1, "Author") ++
+      unresolved_in(work.series, &SeriesLink.resolved?/1, "Series")
+  end
+
+  defp identity(%__MODULE__{approved: true}), do: []
+  defp identity(%__MODULE__{}), do: [%{section: :work, label: "Which book", state: :unconfirmed}]
+
+  defp unresolved_field(nil, _label), do: []
+
+  defp unresolved_field(field, label) do
+    if Field.resolved?(field),
+      do: [],
+      else: [%{section: :work, label: label, state: Field.state(field)}]
+  end
+
+  defp unresolved_in(items, resolved?, label) do
+    items
+    |> Enum.reject(resolved?)
+    |> Enum.map(&%{section: :work, label: "#{label}: #{&1.name}", state: state_of(&1)})
+  end
+
+  defp state_of(%Credit{} = credit), do: Credit.state(credit)
+  defp state_of(%SeriesLink{} = link), do: SeriesLink.state(link)
+end

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -12,6 +12,7 @@ defmodule Ambry.Inbox.InboxItem do
 
   import Ecto.Changeset
 
+  alias Ambry.Inbox.Draft
   alias Ambry.Library.Location
   alias Ambry.Media.Media
 
@@ -32,6 +33,12 @@ defmodule Ambry.Inbox.InboxItem do
     field :tags, :map
     field :matches, :map
     field :issue, :string
+
+    # Derived from the draft, denormalized so the queue filters and counts in
+    # SQL. `put_draft/2` is its only writer.
+    field :ready, :boolean, default: false
+
+    embeds_one :draft, Draft, on_replace: :update
 
     timestamps(type: :utc_datetime)
   end
@@ -54,6 +61,22 @@ defmodule Ambry.Inbox.InboxItem do
     ])
     |> validate_required([:path, :status])
     |> unique_constraint(:path)
+  end
+
+  @doc """
+  Stages a draft, keeping the denormalized `ready` flag in step.
+
+  Readiness is *defined* by `Draft.resolved?/1` and merely *stored* here.
+  Routing every draft write through one function is what stops the column
+  drifting away from the function — there is no second place that may set it.
+  """
+  def put_draft(inbox_item, attrs) do
+    changeset =
+      inbox_item
+      |> cast(%{draft: attrs}, [])
+      |> cast_embed(:draft)
+
+    put_change(changeset, :ready, Draft.resolved?(fetch_field!(changeset, :draft)))
   end
 
   @doc """

--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -433,4 +433,17 @@ defmodule Ambry.People do
 
     Repo.all(query)
   end
+
+  @doc """
+  Returns all people for use in `Select` components.
+
+  People rather than identities: this is what the import form's "who is behind
+  this credit" control picks from, where the answer is a human, not a name
+  they publish under.
+  """
+  def people_for_select do
+    query = from p in Person, select: {p.name, p.id}, order_by: p.name
+
+    Repo.all(query)
+  end
 end

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -1,0 +1,387 @@
+defmodule AmbryWeb.Admin.Decisions do
+  @moduledoc """
+  The building blocks of a staged import: one decision, and one entity
+  resolution.
+
+  These are deliberately general rather than inbox-specific. Today's
+  book/media/person forms already do a cruder version of both — the
+  provider-import forms' checkbox-merge rows are `decision_row/1` in embryo,
+  and their all-or-nothing "use all authors" grouping is exactly the per-item
+  selection defect this fixes. The intent is that those surfaces converge here
+  whenever they're next touched, and that "a draft over an existing record,
+  with no file placement" ends up being the same form.
+  """
+
+  use Phoenix.Component
+  use AmbryWeb, :verified_routes
+
+  import AmbryWeb.Admin.Components, only: [badge: 1]
+  import AmbryWeb.CoreComponents
+
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.SeriesLink
+
+  attr :label, :string, required: true
+  attr :section, :string, required: true
+  attr :name, :atom, required: true
+  attr :form, :any, required: true, doc: "the enclosing work/recording form"
+  attr :field, Field, required: true, doc: "the staged decision itself"
+  attr :type, :string, default: "text"
+  attr :options, :list, default: nil
+  attr :placeholder, :string, default: nil
+
+  @doc """
+  One scalar decision: what the sources proposed, what it will be, and where
+  that came from.
+
+  The candidates stay visible after one is chosen. Hiding them would make the
+  choice feel final when the whole point is that it's reviewable — and
+  re-querying to see an alternative you already had is the cost the ranked
+  candidate list exists to avoid.
+  """
+  def decision_row(assigns) do
+    ~H"""
+    <div class="space-y-1">
+      <div class="flex items-center gap-2">
+        <.label>{@label}</.label>
+
+        <.badge
+          :if={!@field.approved}
+          color={elem(state_words(Field.state(@field)), 1)}
+          class="text-xs"
+        >
+          {elem(state_words(Field.state(@field)), 0)}
+        </.badge>
+
+        <span :if={@field.approved && @field.source} class="text-xs dark:text-zinc-500">
+          from {source_words(@field.source)}
+        </span>
+      </div>
+
+      <.inputs_for :let={decision} field={@form[@name]}>
+        <.input
+          :if={@type == "select"}
+          field={decision[:value]}
+          type="select"
+          options={@options}
+        />
+        <.input
+          :if={@type != "select"}
+          field={decision[:value]}
+          type={@type}
+          placeholder={@placeholder}
+        />
+      </.inputs_for>
+
+      <div :if={@field.candidates != []} class="flex flex-wrap items-center gap-2 pt-1">
+        <span class="text-xs dark:text-zinc-500">Proposed:</span>
+
+        <button
+          :for={candidate <- @field.candidates}
+          type="button"
+          phx-click="choose-field"
+          phx-value-section={@section}
+          phx-value-field={@name}
+          phx-value-source={candidate.source}
+          class={[
+            "rounded-sm border px-2 py-1 text-left text-xs",
+            @field.source == candidate.source && "border-brand dark:border-brand-dark",
+            @field.source != candidate.source && "border-zinc-300 dark:border-zinc-700"
+          ]}
+        >
+          <span class="dark:text-zinc-500">{candidate.label || source_words(candidate.source)}:</span>
+          <span>{truncate(candidate.value)}</span>
+        </button>
+
+        <%!-- Choosing "none" is an approval, not an omission. It's what makes
+              "every piece is settled" reachable on a record with optional
+              fields nobody filled in. --%>
+        <button
+          :if={!@field.required}
+          type="button"
+          phx-click="waive-field"
+          phx-value-section={@section}
+          phx-value-field={@name}
+          class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+        >
+          None
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :credit, Credit, required: true
+  attr :index, :integer, required: true
+  attr :section, :string, required: true
+  attr :identities, :list, required: true
+  attr :people, :list, required: true
+  attr :verb, :string, required: true
+
+  @doc """
+  One credit, resolved to an identity.
+
+  The vocabulary is doing the teaching: **Credited as** is the name on the
+  book, **Written by** / **Performed by** are the humans behind it. Two or more
+  people is a shared pen name — the whole of the composite-author case,
+  expressed as a longer list rather than a separate mode, which is what stops
+  the case space exploding.
+
+  A link decision always targets an identity, never a Person. That is the
+  generalized fix for the pen-name bug where matching found a Person and
+  linked its first identity.
+  """
+  def credit_row(assigns) do
+    ~H"""
+    <div class="space-y-2 rounded-sm border border-zinc-300 p-3 dark:border-zinc-700">
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex min-w-0 items-center gap-2">
+          <.icon
+            :if={Credit.resolved?(@credit)}
+            name="fa-circle-check"
+            class="text-brand h-4 w-4 flex-none dark:text-brand-dark"
+          />
+          <span class="truncate font-semibold">{@credit.name}</span>
+
+          <.badge
+            :if={!Credit.resolved?(@credit)}
+            color={elem(state_words(Credit.state(@credit)), 1)}
+            class="text-xs"
+          >
+            {elem(state_words(Credit.state(@credit)), 0)}
+          </.badge>
+
+          <span :if={@credit.source} class="text-xs dark:text-zinc-500">
+            from {source_words(@credit.source)}
+          </span>
+        </div>
+
+        <div class="flex flex-none items-center gap-2">
+          <button
+            :if={!@credit.approved}
+            type="button"
+            phx-click="approve-credit"
+            phx-value-section={@section}
+            phx-value-index={@index}
+            phx-value-approved="true"
+            class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+          >
+            Looks right
+          </button>
+
+          <button
+            type="button"
+            phx-click="remove-credit"
+            phx-value-section={@section}
+            phx-value-index={@index}
+            title="This recording isn't by them"
+          >
+            <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-600" />
+          </button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <div>
+          <.label class="text-xs">Credited as</.label>
+          <form id={"credit-#{@section}-#{@index}-identity"} phx-change="link-credit">
+            <input type="hidden" name="section" value={@section} />
+            <input type="hidden" name="index" value={@index} />
+            <select
+              name="identity_id"
+              class="mt-1 w-full rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+            >
+              <option value="">Create "{@credit.name}"</option>
+              <option
+                :for={{name, id} <- @identities}
+                value={id}
+                selected={@credit.mode == :link and @credit.identity_id == id}
+              >
+                {name}
+              </option>
+            </select>
+          </form>
+        </div>
+
+        <div :if={@credit.mode == :create}>
+          <.label class="text-xs">{@verb}</.label>
+
+          <div class="mt-1 space-y-1">
+            <form
+              :for={{person, person_index} <- Enum.with_index(@credit.people)}
+              id={"credit-#{@section}-#{@index}-person-#{person_index}"}
+              phx-change="set-person"
+              class="flex items-center gap-1"
+            >
+              <input type="hidden" name="section" value={@section} />
+              <input type="hidden" name="index" value={@index} />
+              <input type="hidden" name="person" value={person_index} />
+
+              <select
+                name="person_id"
+                class="w-full rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+              >
+                <option value="">New person: {person.name || @credit.name}</option>
+                <option :for={{name, id} <- @people} value={id} selected={person.person_id == id}>
+                  {name}
+                </option>
+              </select>
+
+              <button
+                :if={length(@credit.people) > 1}
+                type="button"
+                phx-click="remove-person"
+                phx-value-section={@section}
+                phx-value-index={@index}
+                phx-value-person={person_index}
+              >
+                <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
+              </button>
+            </form>
+
+            <%!-- Narrators stay one-to-one with a Person by design; only the
+                  author control grows a second entry. --%>
+            <button
+              :if={@section == "work"}
+              type="button"
+              phx-click="add-person"
+              phx-value-section={@section}
+              phx-value-index={@index}
+              class="text-xs underline dark:text-zinc-400"
+            >
+              Add another person
+            </button>
+
+            <p :if={length(@credit.people) > 1} class="text-xs italic dark:text-zinc-500">
+              A shared pen name — {@credit.name} will be one author credited to {Enum.count(@credit.people)} people.
+            </p>
+          </div>
+        </div>
+
+        <p :if={@credit.mode == :link} class="self-end text-xs italic dark:text-zinc-500">
+          {linked_people(@credit) || "Already in the library."}
+        </p>
+      </div>
+    </div>
+    """
+  end
+
+  attr :link, SeriesLink, required: true
+  attr :index, :integer, required: true
+  attr :options, :list, required: true
+
+  @doc """
+  One series membership, with its number.
+
+  Each series is its own decision, which is what fixes the standing complaint
+  that the import forms take all series or none. The number is never
+  defaulted — a series proposal with no number stays outstanding, because
+  inventing "book 1" writes confident nonsense into a curated field.
+  """
+  def series_row(assigns) do
+    ~H"""
+    <div class="flex flex-wrap items-center gap-2 rounded-sm border border-zinc-300 p-3 dark:border-zinc-700">
+      <.icon
+        :if={SeriesLink.resolved?(@link)}
+        name="fa-circle-check"
+        class="text-brand h-4 w-4 flex-none dark:text-brand-dark"
+      />
+
+      <span class="font-semibold">{@link.name}</span>
+
+      <.badge
+        :if={!SeriesLink.resolved?(@link)}
+        color={elem(state_words(SeriesLink.state(@link)), 1)}
+        class="text-xs"
+      >
+        {elem(state_words(SeriesLink.state(@link)), 0)}
+      </.badge>
+
+      <form id={"series-#{@index}-number"} phx-change="set-series-number" class="flex items-center gap-1">
+        <input type="hidden" name="index" value={@index} />
+        <label class="text-xs dark:text-zinc-500">Book no.</label>
+        <input
+          type="text"
+          name="number"
+          value={@link.number}
+          placeholder="?"
+          class="w-16 rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        />
+      </form>
+
+      <form id={"series-#{@index}-link"} phx-change="link-series">
+        <input type="hidden" name="index" value={@index} />
+        <select
+          name="series_id"
+          class="rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        >
+          <option value="">Create "{@link.name}"</option>
+          <option
+            :for={{name, id} <- @options}
+            value={id}
+            selected={@link.mode == :link and @link.series_id == id}
+          >
+            {name}
+          </option>
+        </select>
+      </form>
+
+      <button
+        :if={!@link.approved and @link.number}
+        type="button"
+        phx-click="approve-series"
+        phx-value-index={@index}
+        phx-value-approved="true"
+        class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+      >
+        Looks right
+      </button>
+
+      <button type="button" phx-click="remove-series" phx-value-index={@index} title="Not in this series">
+        <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-600" />
+      </button>
+    </div>
+    """
+  end
+
+  @doc """
+  A decision's state as words and a colour.
+
+  `:missing` and `:ambiguous` read differently on purpose — one needs a value
+  from somewhere, the other needs a choice between values already in hand.
+  Calling both "unresolved" throws that distinction away.
+  """
+  def state_words(:approved), do: {"settled", :brand}
+  def state_words(:missing), do: {"needs a value", :red}
+  def state_words(:ambiguous), do: {"sources disagree", :yellow}
+  def state_words(:unconfirmed), do: {"needs a look", :yellow}
+  def state_words(:stale), do: {"files changed", :red}
+  def state_words(_other), do: {"needs a look", :yellow}
+
+  @doc "Whose proposal this is, in words rather than an id."
+  def source_words(nil), do: "nothing"
+  def source_words("manual"), do: "you"
+  def source_words("tags"), do: "the file's tags"
+  def source_words("release_name"), do: "the release name"
+  def source_words("embedded"), do: "the file's embedded art"
+  def source_words("default"), do: "the default"
+  def source_words("local"), do: "the library"
+  def source_words("provider:" <> id), do: id
+  def source_words(other), do: other
+
+  defp linked_people(%Credit{candidates: candidates, identity_id: id}) do
+    case Enum.find(candidates, &(&1.identity_id == id)) do
+      %{people: people} when is_binary(people) -> "Already in the library — #{people}."
+      _none -> nil
+    end
+  end
+
+  defp truncate(nil), do: "—"
+
+  defp truncate(value) when is_binary(value) do
+    if String.length(value) > 60, do: String.slice(value, 0, 60) <> "…", else: value
+  end
+
+  defp truncate(other), do: to_string(other)
+end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -1,0 +1,285 @@
+defmodule AmbryWeb.Admin.InboxLive.Form do
+  @moduledoc """
+  The staged import form: everything this release will become, before any of
+  it is real.
+
+  Built on one invariant — **an import is a tree of decisions, and import is
+  possible iff every decision is resolved**. The button at the bottom reads
+  `Draft.unresolved/1` and nothing else, which is what guarantees the form
+  never offers an action that fails: everything that could go wrong at
+  approval was a visible decision before the button was pressed.
+
+  ## Two kinds of interaction, deliberately
+
+  Typing is ordinary form input, autosaved on change — so there is never an
+  unsaved edit to lose when something else is clicked. Choosing (which
+  candidate, which identity, who's behind a credit) is a named event that
+  transforms the stored draft through `Draft.Edit`, because those aren't text
+  and pretending they are is where hidden-input tricks come from.
+
+  ## Vocabulary
+
+  Credits read "Credited as" / "Written by" (or "Performed by"), which is what
+  makes the two-level identity model legible without explaining it: the
+  identity is what the book credits, the people are the humans behind it, and
+  two or more of them is a shared pen name. That is the entire composite-author
+  case — a longer list, not a different mode.
+  """
+
+  use AmbryWeb, :admin_live_view
+
+  import AmbryWeb.Admin.Decisions
+  import AmbryWeb.TimeUtils
+
+  alias Ambry.Books
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Work
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.People
+
+  @impl Phoenix.LiveView
+  def mount(%{"id" => id}, _session, socket) do
+    item = Inbox.get_item!(id)
+    {:ok, item} = Inbox.prepare_draft(item)
+
+    {:ok,
+     socket
+     |> assign(page_title: InboxItem.name(item))
+     |> assign(series: Books.series_for_select())
+     |> assign(authors: People.authors_for_select(), narrators: People.narrators_for_select())
+     |> assign(people: People.people_for_select())
+     |> load(item)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", %{"inbox_item" => params}, socket) do
+    # Autosave: the form and the stored draft are never allowed to disagree,
+    # so a click on any of the choice controls below can't discard typing.
+    case Inbox.update_draft(socket.assigns.item, params["draft"] || %{}) do
+      {:ok, item} -> {:noreply, load(socket, item)}
+      {:error, changeset} -> {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  def handle_event("choose-field", %{"section" => section, "field" => field} = params, socket) do
+    {:noreply,
+     edit(socket, &Draft.Edit.choose_field(&1, atom(section), atom(field), params["source"]))}
+  end
+
+  def handle_event("waive-field", %{"section" => section, "field" => field}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.waive_field(&1, atom(section), atom(field)))}
+  end
+
+  def handle_event("choose-work", %{"source" => source} = params, socket) do
+    {:noreply, edit(socket, &Draft.Edit.choose_work(&1, source, to_int(params["id"])))}
+  end
+
+  def handle_event("link-credit", %{"section" => section, "index" => i} = params, socket) do
+    id = to_int(params["identity_id"])
+
+    {:noreply,
+     edit(socket, fn draft ->
+       if id,
+         do: Draft.Edit.link_credit(draft, atom(section), to_int(i), id),
+         else: Draft.Edit.create_credit(draft, atom(section), to_int(i))
+     end)}
+  end
+
+  def handle_event("add-person", %{"section" => section, "index" => i}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.add_person(&1, atom(section), to_int(i)))}
+  end
+
+  def handle_event("remove-person", %{"section" => s, "index" => i, "person" => p}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.remove_person(&1, atom(s), to_int(i), to_int(p)))}
+  end
+
+  def handle_event("set-person", %{"section" => s, "index" => i, "person" => p} = params, socket) do
+    # An existing person is chosen by id; anything else is a name to create.
+    attrs =
+      case to_int(params["person_id"]) do
+        nil -> %{name: params["name"], person_id: nil}
+        id -> %{person_id: id, name: nil}
+      end
+
+    {:noreply, edit(socket, &Draft.Edit.set_person(&1, atom(s), to_int(i), to_int(p), attrs))}
+  end
+
+  def handle_event("approve-credit", %{"section" => s, "index" => i} = params, socket) do
+    {:noreply,
+     edit(
+       socket,
+       &Draft.Edit.approve_credit(&1, atom(s), to_int(i), params["approved"] == "true")
+     )}
+  end
+
+  def handle_event("remove-credit", %{"section" => s, "index" => i}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.remove_credit(&1, atom(s), to_int(i)))}
+  end
+
+  def handle_event("set-series-number", %{"index" => i, "number" => number}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.set_series_number(&1, to_int(i), number))}
+  end
+
+  def handle_event("approve-series", %{"index" => i} = params, socket) do
+    {:noreply,
+     edit(socket, &Draft.Edit.approve_series(&1, to_int(i), params["approved"] == "true"))}
+  end
+
+  def handle_event("link-series", %{"index" => i} = params, socket) do
+    id = to_int(params["series_id"])
+
+    {:noreply,
+     edit(socket, fn draft ->
+       if id,
+         do: Draft.Edit.link_series(draft, to_int(i), id),
+         else: Draft.Edit.create_series(draft, to_int(i))
+     end)}
+  end
+
+  def handle_event("remove-series", %{"index" => i}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.remove_series(&1, to_int(i)))}
+  end
+
+  def handle_event("approve-work", params, socket) do
+    {:noreply, edit(socket, &Draft.Edit.approve_work(&1, params["approved"] == "true"))}
+  end
+
+  def handle_event("approve-all", _params, socket) do
+    {:noreply, edit(socket, &Draft.Edit.approve_all/1)}
+  end
+
+  def handle_event("rebuild", _params, socket) do
+    {:ok, item} = Inbox.rebuild_draft(socket.assigns.item)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Started over from what the files and providers say.")
+     |> load(item)}
+  end
+
+  def handle_event("import", _params, socket) do
+    case Inbox.approve_item(socket.assigns.item) do
+      {:ok, _media} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Added to the library.")
+         |> push_navigate(to: ~p"/admin/inbox")}
+
+      {:error, reason} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, Inbox.describe_error(reason))
+         |> load(Inbox.get_item!(socket.assigns.item.id))}
+    end
+  end
+
+  def handle_event("dismiss", _params, socket) do
+    {:ok, _item} = Inbox.dismiss_item(socket.assigns.item)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Dismissed. Files untouched.")
+     |> push_navigate(to: ~p"/admin/inbox")}
+  end
+
+  defp edit(socket, fun) do
+    draft = fun.(socket.assigns.item.draft)
+
+    case Inbox.update_draft(socket.assigns.item, Inbox.dump_draft(draft)) do
+      {:ok, item} -> load(socket, item)
+      {:error, changeset} -> assign(socket, form: to_form(changeset))
+    end
+  end
+
+  defp load(socket, item) do
+    assign(socket,
+      item: item,
+      form: to_form(Inbox.change_draft(item)),
+      unresolved: Draft.unresolved(item.draft),
+      progress: Draft.progress(item.draft),
+      destination: Inbox.destination_preflight(item)
+    )
+  end
+
+  defp atom("work"), do: :work
+  defp atom("recording"), do: :recording
+  defp atom("title"), do: :title
+  defp atom("published"), do: :published
+  defp atom("published_format"), do: :published_format
+  defp atom("publisher"), do: :publisher
+  defp atom("description"), do: :description
+  defp atom("cover"), do: :cover
+
+  defp to_int(nil), do: nil
+  defp to_int(""), do: nil
+  defp to_int(value) when is_integer(value), do: value
+
+  defp to_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> int
+      _other -> nil
+    end
+  end
+
+  ## rendering helpers
+
+  @doc "What the item's files say they are, for the evidence header."
+  def evidence(%InboxItem{probe: probe}) when is_map(probe) do
+    [
+      probe["duration"] && format_timecode(Decimal.new(probe["duration"])),
+      probe["codec"],
+      probe["chapters"] && probe["chapters"] > 0 && "#{probe["chapters"]} chapters",
+      probe["seek_accuracy"] == "approximate" && "inexact seeking"
+    ]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.join(" · ")
+  end
+
+  def evidence(_item), do: "not read yet"
+
+  @doc """
+  How many chapters the file carries, and where they came from.
+
+  Markers are file-derived by principle — provider chapter times describe
+  their own retail edition, and applying them to somebody's rip drifts by
+  minutes across a book. Provider data is a *title* source only, which is 1h's
+  work and not part of this form yet.
+  """
+  def chapter_summary(%InboxItem{probe: %{"chapters" => count}}) when count > 0,
+    do: "#{count} chapters, read from the file."
+
+  def chapter_summary(%InboxItem{probe: probe}) when is_map(probe),
+    do: "No chapters in the file. The recording will have none until they're added."
+
+  def chapter_summary(_item), do: "Not read yet."
+
+  @doc """
+  Whether this candidate is the one the work decision currently points at.
+  """
+  def chosen_work?(%Work{mode: :link, book_id: id}, %{"source" => "local", "id" => id}), do: true
+  def chosen_work?(%Work{mode: :link}, _candidate), do: false
+  def chosen_work?(%Work{mode: :create}, %{"source" => "local"}), do: false
+
+  # Any non-local candidate means "create a new book"; which provider it came
+  # from is recorded per-field as provenance, not as one winning row.
+  def chosen_work?(%Work{mode: :create, approved: approved?}, _candidate), do: approved?
+
+  @doc "A work candidate as one readable line."
+  def candidate_line(candidate) do
+    [candidate["title"], candidate["authors"] && Enum.join(candidate["authors"], ", ")]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" — ")
+  end
+
+  def candidate_origin(%{"source" => "local"}), do: "already in the library"
+  def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
+  def candidate_origin(%{"source" => "provider:" <> id}), do: id
+  def candidate_origin(_candidate), do: nil
+
+  def confidence_label(nil), do: {"no match", :gray}
+  def confidence_label(confidence) when confidence >= 0.85, do: {"near-certain", :brand}
+  def confidence_label(confidence) when confidence >= 0.6, do: {"likely", :blue}
+  def confidence_label(confidence) when confidence > 0.0, do: {"unsure", :yellow}
+  def confidence_label(_confidence), do: {"no match", :gray}
+end

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -1,0 +1,334 @@
+<.layout title={@page_title} user={@current_user}>
+  <div class="max-w-4xl space-y-8 pb-16">
+    <%!-- the evidence: what was found, before anybody interpreted it --%>
+    <section class="space-y-1 rounded-sm border border-zinc-300 p-4 dark:border-zinc-700">
+      <div class="flex items-start justify-between gap-4">
+        <div class="min-w-0">
+          <p class="truncate font-bold">{@page_title}</p>
+          <p class="truncate text-sm dark:text-zinc-500">{@item.path}</p>
+          <p class="text-sm italic dark:text-zinc-500">{evidence(@item)}</p>
+        </div>
+
+        <div class="flex-none text-right">
+          <p class="text-sm">
+            <span class="font-bold">{@progress.resolved}</span> of {@progress.total} settled
+          </p>
+          <.button type="button" color={:zinc} class="mt-2" phx-click="rebuild">
+            Start over
+          </.button>
+        </div>
+      </div>
+
+      <p :if={@item.issue} class="pt-2 text-sm text-red-600">{@item.issue}</p>
+    </section>
+
+    <%!-- The invariant, rendered. Nothing here is a surprise at import time. --%>
+    <section
+      :if={@unresolved != []}
+      class="rounded-sm border border-amber-500 p-4"
+      data-role="unresolved"
+    >
+      <p class="font-bold">Still to settle</p>
+      <ul class="mt-2 space-y-1">
+        <li :for={decision <- @unresolved} class="flex items-center gap-2 text-sm">
+          <.badge color={elem(state_words(decision.state), 1)} class="text-xs">
+            {elem(state_words(decision.state), 0)}
+          </.badge>
+          <span>{decision.label}</span>
+        </li>
+      </ul>
+      <.button type="button" color={:zinc} class="mt-3" phx-click="approve-all">
+        Accept everything that's only waiting on a nod
+      </.button>
+    </section>
+
+    <%!-- ==================== THE WORK ==================== --%>
+    <section class="space-y-4">
+      <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
+        The work
+      </h2>
+
+      <div class="space-y-2">
+        <div class="flex items-center gap-2">
+          <.label>Which book</.label>
+          <.badge
+            :if={!@item.draft.work.approved}
+            color={elem(state_words(:unconfirmed), 1)}
+            class="text-xs"
+          >
+            {elem(state_words(:unconfirmed), 0)}
+          </.badge>
+          <.badge
+            :if={@item.draft.work.confidence}
+            color={elem(confidence_label(@item.draft.work.confidence), 1)}
+            class="text-xs"
+          >
+            {elem(confidence_label(@item.draft.work.confidence), 0)}
+          </.badge>
+        </div>
+
+        <p :if={@item.draft.work.candidates == []} class="text-sm italic dark:text-zinc-500">
+          Nothing matched. A new book will be created from the fields below.
+        </p>
+
+        <div
+          :for={candidate <- @item.draft.work.candidates}
+          class={[
+            "flex cursor-pointer items-center gap-3 rounded-sm border p-2",
+            chosen_work?(@item.draft.work, candidate) && "border-brand dark:border-brand-dark",
+            !chosen_work?(@item.draft.work, candidate) && "border-zinc-300 dark:border-zinc-700"
+          ]}
+          phx-click="choose-work"
+          phx-value-source={candidate["source"]}
+          phx-value-id={candidate["id"]}
+        >
+          <.icon
+            :if={chosen_work?(@item.draft.work, candidate)}
+            name="fa-circle-check"
+            class="text-brand h-4 w-4 flex-none dark:text-brand-dark"
+          />
+          <div class="min-w-0">
+            <p class="truncate text-sm">{candidate_line(candidate)}</p>
+            <p class="text-xs dark:text-zinc-500">{candidate_origin(candidate)}</p>
+          </div>
+        </div>
+
+        <button
+          :if={!@item.draft.work.approved}
+          type="button"
+          phx-click="approve-work"
+          phx-value-approved="true"
+          class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+        >
+          {if @item.draft.work.candidates == [], do: "Create a new book", else: "That's the one"}
+        </button>
+      </div>
+
+      <%!-- Linking inherits the book's own fields; only additive series
+            memberships remain to decide. --%>
+      <p
+        :if={@item.draft.work.mode == :link}
+        class="rounded-sm bg-zinc-100 p-3 text-sm dark:bg-zinc-800"
+      >
+        Using the book already in the library. Its title, date and authors are left exactly as they
+        are — an import fills blanks, it never overwrites curation.
+      </p>
+
+      <%!-- Typing lives in a form; choosing does not. They are kept apart
+            because a <form> inside a <form> is invalid HTML and the parser
+            silently drops the inner one — which is exactly how the credit
+            controls went missing the first time. --%>
+      <.simple_form
+        :if={@item.draft.work.mode == :create}
+        id="work-form"
+        for={@form}
+        phx-change="validate"
+        autocomplete="off"
+      >
+        <.inputs_for :let={draft} field={@form[:draft]}>
+          <.inputs_for :let={work} field={draft[:work]}>
+            <.decision_row
+              label="Title"
+              section="work"
+              name={:title}
+              form={work}
+              field={@item.draft.work.title}
+            />
+
+            <.decision_row
+              label="First published"
+              section="work"
+              name={:published}
+              form={work}
+              type="date"
+              field={@item.draft.work.published}
+            />
+
+            <.decision_row
+              label="Date display format"
+              section="work"
+              name={:published_format}
+              form={work}
+              type="select"
+              options={[{"Full Date", "full"}, {"Year & Month", "year_month"}, {"Year Only", "year"}]}
+              field={@item.draft.work.published_format}
+            />
+          </.inputs_for>
+        </.inputs_for>
+      </.simple_form>
+
+      <%!-- credits: "Credited as" / "Written by" --%>
+      <div :if={@item.draft.work.mode == :create} class="space-y-2">
+        <.label>Authors</.label>
+        <p :if={@item.draft.work.authors == []} class="text-sm italic dark:text-zinc-500">
+          No author was proposed.
+        </p>
+
+        <.credit_row
+          :for={{credit, index} <- Enum.with_index(@item.draft.work.authors)}
+          credit={credit}
+          index={index}
+          section="work"
+          identities={@authors}
+          people={@people}
+          verb="Written by"
+        />
+      </div>
+
+      <%!-- each series is its own decision, number included --%>
+      <div class="space-y-2">
+        <.label>
+          {if @item.draft.work.mode == :link, do: "Series to add", else: "Series"}
+        </.label>
+
+        <p
+          :if={@item.draft.work.mode == :link and @item.draft.work.series != []}
+          class="text-sm italic dark:text-zinc-500"
+        >
+          This book isn't in these yet. Adding is a blank being filled, not a change to what's
+          already there.
+        </p>
+
+        <p :if={@item.draft.work.series == []} class="text-sm italic dark:text-zinc-500">
+          No series was proposed.
+        </p>
+
+        <.series_row
+          :for={{link, index} <- Enum.with_index(@item.draft.work.series)}
+          link={link}
+          index={index}
+          options={@series}
+        />
+      </div>
+    </section>
+
+    <%!-- ==================== THE RECORDING ==================== --%>
+    <section class="space-y-4">
+      <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
+        The recording
+      </h2>
+
+      <p class="text-sm italic dark:text-zinc-500">
+        A new recording of that work. (Replacing an existing recording's files is a later addition —
+        for now every import creates one.)
+      </p>
+
+      <.simple_form id="recording-form" for={@form} phx-change="validate" autocomplete="off">
+        <.inputs_for :let={draft} field={@form[:draft]}>
+          <.inputs_for :let={recording} field={draft[:recording]}>
+            <.decision_row
+              label="Recording title"
+              section="recording"
+              name={:title}
+              form={recording}
+              placeholder="only if it differs from the book's title"
+              field={@item.draft.recording.title}
+            />
+
+            <.decision_row
+              label="Release date"
+              section="recording"
+              name={:published}
+              form={recording}
+              type="date"
+              field={@item.draft.recording.published}
+            />
+
+            <.decision_row
+              label="Publisher"
+              section="recording"
+              name={:publisher}
+              form={recording}
+              field={@item.draft.recording.publisher}
+            />
+
+            <.decision_row
+              label="Cover image"
+              section="recording"
+              name={:cover}
+              form={recording}
+              placeholder="image URL"
+              field={@item.draft.recording.cover}
+            />
+
+            <.decision_row
+              label="Description"
+              section="recording"
+              name={:description}
+              form={recording}
+              type="textarea"
+              field={@item.draft.recording.description}
+            />
+          </.inputs_for>
+        </.inputs_for>
+      </.simple_form>
+
+      <div class="space-y-2">
+        <.label>Narrators</.label>
+        <p :if={@item.draft.recording.narrators == []} class="text-sm italic dark:text-zinc-500">
+          No narrator was proposed.
+        </p>
+
+        <.credit_row
+          :for={{credit, index} <- Enum.with_index(@item.draft.recording.narrators)}
+          credit={credit}
+          index={index}
+          section="recording"
+          identities={@narrators}
+          people={@people}
+          verb="Performed by"
+        />
+      </div>
+    </section>
+
+    <%!-- ==================== CHAPTERS ==================== --%>
+    <section class="space-y-2">
+      <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">Chapters</h2>
+      <p class="text-sm dark:text-zinc-400">{chapter_summary(@item)}</p>
+      <p class="text-sm italic dark:text-zinc-500">
+        Markers are taken from the file and never from a provider — provider timestamps describe
+        their own edition, not this rip.
+      </p>
+    </section>
+
+    <%!-- ==================== FILES & DESTINATION ==================== --%>
+    <section class="space-y-2">
+      <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
+        Files &amp; destination
+      </h2>
+
+      <p class="text-sm">
+        <span class="font-bold">Custody:</span> {@destination.custody}
+      </p>
+      <p :if={@destination.summary} class="text-sm dark:text-zinc-400">{@destination.summary}</p>
+      <p :if={@destination.blocker} class="text-sm text-red-600" data-role="destination-blocker">
+        {@destination.blocker}
+      </p>
+
+      <ul class="pt-2">
+        <li :for={file <- @item.files} class="truncate text-xs dark:text-zinc-500">{file}</li>
+      </ul>
+    </section>
+
+    <%!-- ==================== THE BUTTON ==================== --%>
+    <section class="sticky bottom-0 border-t border-zinc-300 bg-white py-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <div class="flex items-center gap-4">
+        <.button
+          phx-click="import"
+          disabled={@unresolved != [] or @destination.blocker != nil}
+          data-role="import"
+        >
+          Add to the library
+        </.button>
+
+        <.button type="button" color={:zinc} phx-click="dismiss">Dismiss</.button>
+
+        <.brand_link navigate={~p"/admin/inbox"}>Back to the inbox</.brand_link>
+
+        <p :if={@unresolved != []} class="text-sm dark:text-zinc-500">
+          {length(@unresolved)} decision{if length(@unresolved) > 1, do: "s"} still to settle.
+        </p>
+      </div>
+    </section>
+  </div>
+</.layout>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -96,16 +96,29 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   def handle_event("filter-status", %{"status" => status}, socket) do
     {:noreply,
-     push_patch(socket, to: ~p"/admin/inbox?#{patch(socket, status: status, page: "1")}")}
+     push_patch(socket,
+       to: ~p"/admin/inbox?#{patch(socket, status: status, ready: nil, page: "1")}"
+     )}
+  end
+
+  def handle_event("filter-ready", _params, socket) do
+    ready = if !socket.assigns.ready, do: "true"
+
+    {:noreply,
+     push_patch(socket,
+       to: ~p"/admin/inbox?#{patch(socket, ready: ready, status: "pending", page: "1")}"
+     )}
   end
 
   defp load_items(socket, params) do
     list_opts = get_list_opts(params)
     status = parse_status(params["status"])
+    ready = parse_ready(params["ready"])
 
     {items, has_more?} =
       Inbox.list_items(
         status: status,
+        ready: ready,
         filter: list_opts.filter,
         offset: page_to_offset(list_opts.page),
         limit: limit()
@@ -117,6 +130,8 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       # one query for the page, not one per row
       progress: Inbox.progress(items),
       counts: Inbox.count_by_status(),
+      ready_count: Inbox.count_ready(),
+      ready: ready,
       status: status,
       list_opts: list_opts,
       has_next: has_more?,
@@ -149,7 +164,9 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       "filter" => Keyword.get(overrides, :filter, socket.assigns.list_opts.filter),
       "page" => Keyword.get(overrides, :page, to_string(socket.assigns.list_opts.page)),
       "status" =>
-        Keyword.get(overrides, :status, socket.assigns.status && to_string(socket.assigns.status))
+        Keyword.get(overrides, :status, socket.assigns.status && to_string(socket.assigns.status)),
+      "ready" =>
+        Keyword.get(overrides, :ready, socket.assigns.ready && to_string(socket.assigns.ready))
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Map.new()
@@ -159,6 +176,9 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     do: String.to_existing_atom(status)
 
   defp parse_status(_anything), do: nil
+
+  defp parse_ready("true"), do: true
+  defp parse_ready(_anything), do: nil
 
   defp status_color(:pending), do: :yellow
   defp status_color(:approved), do: :brand

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -16,7 +16,7 @@
         <span
           phx-click="filter-status"
           phx-value-status=""
-          class={["cursor-pointer text-sm", !@status && "font-bold underline"]}
+          class={["cursor-pointer text-sm", !@status && !@ready && "font-bold underline"]}
         >
           All
         </span>
@@ -24,9 +24,19 @@
           :for={status <- @statuses}
           phx-click="filter-status"
           phx-value-status={status}
-          class={["cursor-pointer text-sm", @status == status && "font-bold underline"]}
+          class={["cursor-pointer text-sm", !@ready && @status == status && "font-bold underline"]}
         >
           {status} ({Map.get(@counts, status, 0)})
+        </span>
+
+        <%!-- Everything settled, waiting on a click. The point of the whole
+              form is that this bucket is where items end up. --%>
+        <span
+          phx-click="filter-ready"
+          class={["cursor-pointer text-sm text-lime-600", @ready && "font-bold underline"]}
+          data-role="ready-filter"
+        >
+          ready ({@ready_count})
         </span>
       </div>
     </div>
@@ -39,7 +49,11 @@
 
     <:row :let={item}>
       <div class="min-w-0 flex-grow overflow-hidden">
-        <p class="overflow-hidden text-ellipsis whitespace-nowrap">{item_name(item)}</p>
+        <.link navigate={~p"/admin/inbox/#{item}"} class="hover:underline">
+          <p class="overflow-hidden text-ellipsis whitespace-nowrap font-semibold">
+            {item_name(item)}
+          </p>
+        </.link>
 
         <p
           :if={tag_summary(item) != ""}
@@ -104,6 +118,9 @@
 
       <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
         <div class="flex items-center gap-2 pb-2">
+          <.badge :if={item.ready and item.status == :pending} color={:brand} class="text-xs">
+            ready
+          </.badge>
           <.badge color={status_color(item.status)} class="text-xs">{item.status}</.badge>
 
           <span phx-click="rematch" phx-value-id={item.id} title="Look for matches again">
@@ -113,15 +130,29 @@
             />
           </span>
 
+          <%!-- Only a settled item can be imported from here. Anything else
+                opens the form, because the queue has no way to say what's
+                outstanding and the form's whole job is to. --%>
           <span
-            :if={item.status == :pending}
+            :if={item.status == :pending and item.ready}
             phx-click="approve"
             phx-value-id={item.id}
-            title="Add to the library (files stay where they are)"
-            data-confirm="Add this to the library? Files are referenced where they are — nothing is moved or copied."
+            title="Add to the library"
+            data-confirm="Add this to the library?"
           >
             <.icon name="fa-check" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-lime-500" />
           </span>
+
+          <.link
+            :if={item.status == :pending and not item.ready}
+            navigate={~p"/admin/inbox/#{item}"}
+            title="Settle what's outstanding"
+          >
+            <.icon
+              name="fa-pen-to-square"
+              class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-blue-400"
+            />
+          </.link>
 
           <span phx-click="reprobe" phx-value-id={item.id} title="Re-read the files">
             <.icon name="fa-rotate" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-blue-400" />

--- a/lib/ambry_web/live/admin/upload_helpers.ex
+++ b/lib/ambry_web/live/admin/upload_helpers.ex
@@ -10,7 +10,6 @@ defmodule AmbryWeb.Admin.UploadHelpers do
   import Phoenix.LiveView.Upload, only: [consume_uploaded_entries: 3]
 
   @accepted_extensions ~w(.jpg .jpeg .png .webp)
-  @accepted_mime ~w(image/jpeg image/png image/webp)
 
   def allow_image_upload(socket, name) do
     allow_upload(socket, name, accept: @accepted_extensions, max_entries: 1, auto_upload: true)
@@ -85,57 +84,12 @@ defmodule AmbryWeb.Admin.UploadHelpers do
     "#{uuid}.#{ext}"
   end
 
-  def handle_image_import(nil), do: {:ok, :no_image_url}
-  def handle_image_import(""), do: {:ok, :no_image_url}
-
-  def handle_image_import(url) do
-    if valid_image_url?(url) do
-      do_image_import(url)
-    else
-      {:error, :invalid_image_url}
-    end
-  end
-
-  defp do_image_import(url) do
-    with {:ok, response} <- Req.get(url: url, headers: [{"user-agent", http_user_agent()}]),
-         [mime | _rest] when mime in @accepted_mime <-
-           Req.Response.get_header(response, "content-type") do
-      filename = generate_filename(mime)
-      File.write!(images_disk_path(filename), response.body)
-
-      {:ok, ~p"/uploads/images/#{filename}"}
-    else
-      _term -> {:error, :failed_to_download_image}
-    end
-  end
-
-  def valid_image_url?(string) when is_binary(string) do
-    case URI.new(string) do
-      {:ok, %{scheme: scheme} = uri} when is_binary(scheme) ->
-        image?(MIME.from_path(string)) or valid_image?(uri)
-
-      _term ->
-        false
-    end
-  end
-
-  def valid_image_url?(_term), do: false
-
-  def valid_image?(uri) do
-    case Req.head(url: uri, headers: [{"user-agent", http_user_agent()}]) do
-      {:ok, response} ->
-        [mime | _rest] = Req.Response.get_header(response, "content-type")
-        image?(mime)
-
-      _else ->
-        false
-    end
-  end
-
-  defp http_user_agent, do: Ambry.Utils.http_user_agent()
-
-  def image?("image/" <> _rest), do: true
-  def image?(_mime), do: false
+  # The import itself lives in `Ambry.Images` — the inbox needs it too, and
+  # `Ambry.Inbox` can't reach into the web layer.
+  defdelegate handle_image_import(url), to: Ambry.Images, as: :import_url
+  defdelegate valid_image_url?(string), to: Ambry.Images, as: :valid_url?
+  defdelegate valid_image?(uri), to: Ambry.Images, as: :head_says_image?
+  defdelegate image?(mime), to: Ambry.Images, as: :image_mime?
 
   def upload_error_to_string(:too_large), do: "File is too large"
   def upload_error_to_string(:too_many_files), do: "Too many files"

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -191,6 +191,7 @@ defmodule AmbryWeb.Router do
       live "/universes/:id/edit", UniverseLive.Form, :edit
 
       live "/inbox", InboxLive.Index
+      live "/inbox/:id", InboxLive.Form
 
       live "/locations", LocationLive.Index
       live "/locations/new", LocationLive.Form, :new

--- a/priv/repo/migrations/20260803192042_inbox_item_drafts.exs
+++ b/priv/repo/migrations/20260803192042_inbox_item_drafts.exs
@@ -1,0 +1,20 @@
+defmodule Ambry.Repo.Migrations.InboxItemDrafts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:inbox_items) do
+      # The staged import: every decision this release implies, before any of
+      # it is real. Held here rather than in staging tables so half-curated
+      # discoveries never touch the library tables.
+      add :draft, :map
+
+      # Derived from the draft by `Draft.resolved?/1`, denormalized so the
+      # queue can filter and count in SQL. Written only by the draft-save
+      # path, which is what keeps it from drifting away from the function
+      # that defines it.
+      add :ready, :boolean, null: false, default: false
+    end
+
+    create index(:inbox_items, [:ready], where: "status = 'pending'")
+  end
+end

--- a/test/ambry/inbox/approval_test.exs
+++ b/test/ambry/inbox/approval_test.exs
@@ -99,7 +99,9 @@ defmodule Ambry.Inbox.ApprovalTest do
 
   describe "approve/1 refusals" do
     test "refuses a multi-file release rather than importing half of it" do
-      item = tagged_item(files: ["01.mp3", "02.mp3"])
+      # Checked before the draft: no amount of curation makes a multi-file
+      # release importable, so the operator must not be sent to the form.
+      item = tagged_item(files: ["01.mp3", "02.mp3"], settle: false)
 
       assert {:error, :multi_file_unsupported} = Inbox.approve_item(item)
       assert Repo.aggregate(Book, :count) == 0
@@ -108,20 +110,16 @@ defmodule Ambry.Inbox.ApprovalTest do
     # A work must have a publication date and the inbox has no business
     # inventing one — matching a work supplies it, as does tagging the file.
     test "keeps a matched work's date granularity instead of inventing a release day" do
-      item = tagged_item(dated: false)
-
       selection = %{
         "source" => "provider:x",
         "id" => "1",
         "title" => "Project Hail Mary",
         "published" => "2021-01-01",
-        "published_format" => "year"
+        "published_format" => "year",
+        "score" => 1.0
       }
 
-      {:ok, item} =
-        Inbox.update_item(item, %{
-          matches: %{"work" => %{"candidates" => [selection], "selected" => selection}}
-        })
+      item = tagged_item(dated: false, work_match: selection)
 
       assert {:ok, media} = Inbox.approve_item(item)
 
@@ -130,11 +128,30 @@ defmodule Ambry.Inbox.ApprovalTest do
       assert book.published_format == :year
     end
 
+    # The refusal that used to be thrown at the last moment is now a decision
+    # the operator can see in the form — a missing publication date is
+    # something to supply, not a mystery at the point of clicking import.
     test "refuses a release with no publication date anywhere" do
-      item = tagged_item(dated: false)
+      item = tagged_item(dated: false, settle: false)
+      {:ok, item} = Inbox.prepare_draft(item)
 
-      assert {:error, :no_published_date} = Inbox.approve_item(item)
+      assert {:error, {:unresolved, outstanding}} = Inbox.approve_item(item)
+      assert Enum.any?(outstanding, &(&1.label == "First published" and &1.state == :missing))
       assert Repo.aggregate(Book, :count) == 0
+    end
+
+    test "a required decision cannot be waived into approval" do
+      item = tagged_item(dated: false, settle: false)
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert {:error, changeset} =
+               Inbox.update_draft(item, %{
+                 "work" => %{
+                   "published" => %{"value" => "", "approved" => true, "required" => true}
+                 }
+               })
+
+      refute changeset.valid?
     end
 
     @tag :capture_log
@@ -171,20 +188,34 @@ defmodule Ambry.Inbox.ApprovalTest do
     {[item], false} = Inbox.list_items()
     {:ok, item} = Inbox.probe_item(item)
 
-    case Keyword.get(opts, :work_match) do
-      {"local", id} ->
-        selection = %{"source" => "local", "id" => id}
+    item =
+      case Keyword.get(opts, :work_match) do
+        nil ->
+          item
 
-        {:ok, item} =
-          Inbox.update_item(item, %{
-            matches: %{"work" => %{"candidates" => [selection], "selected" => selection}}
-          })
+        match ->
+          candidate =
+            case match do
+              {"local", id} -> %{"source" => "local", "id" => id, "score" => 1.0}
+              %{} = provider -> provider
+            end
 
-        item
+          {:ok, item} =
+            Inbox.update_item(item, %{
+              matches: %{
+                "work" => %{"candidates" => [candidate], "confidence" => 1.0},
+                "recording" => %{"candidates" => []}
+              }
+            })
 
-      nil ->
-        item
-    end
+          item
+      end
+
+    # Approval executes a resolved draft, so getting an item to the state the
+    # import form would leave it in is now part of arranging any approval
+    # test. `settle: false` is for the tests that care about what happens when
+    # it isn't.
+    if Keyword.get(opts, :settle, true), do: settle(item), else: item
   end
 
   defp tagged_fixture(dated?) do

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1,0 +1,391 @@
+defmodule Ambry.Inbox.DraftTest do
+  use Ambry.DataCase
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Seed
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Repo
+
+  defp item(attrs) do
+    %InboxItem{path: "/downloads/Some Release", files: ["/downloads/Some Release/book.m4b"]}
+    |> Map.merge(attrs)
+    |> then(&(%InboxItem{} |> InboxItem.changeset(Map.from_struct(&1)) |> Repo.insert!()))
+  end
+
+  defp provider_candidate(attrs) do
+    Map.merge(
+      %{
+        "source" => "provider:hardcover",
+        "provider_name" => "Hardcover",
+        "id" => "hc-1",
+        "title" => "Leviathan Wakes",
+        "authors" => ["James S.A. Corey"],
+        "published" => "2011-06-15",
+        "published_format" => "full",
+        "score" => 0.95
+      },
+      attrs
+    )
+  end
+
+  defp matches(work_candidates, opts \\ []) do
+    %{
+      "work" => %{
+        "candidates" => work_candidates,
+        "confidence" => Keyword.get(opts, :confidence, 0.95),
+        "query" => "q"
+      },
+      "recording" => %{"candidates" => Keyword.get(opts, :recording, []), "confidence" => 0.0}
+    }
+  end
+
+  describe "the invariant" do
+    test "a draft with an unresolved decision is not importable" do
+      item = item(%{matches: matches([]), tags: %{}})
+      draft = Seed.build(item)
+
+      refute Draft.resolved?(draft)
+      assert Enum.any?(Draft.unresolved(draft), &(&1.label == "Which book"))
+    end
+
+    test "unresolved names the missing decision rather than just failing" do
+      # a title but no date anywhere: the refusal approval used to throw at
+      # the last moment is a visible decision instead
+      item = item(%{matches: matches([]), tags: %{"book_title" => "Wool"}})
+      draft = Seed.build(item)
+
+      assert %{label: "First published", state: :missing} =
+               Enum.find(Draft.unresolved(draft), &(&1.label == "First published"))
+    end
+
+    test "a fully-seeded draft off a strong provider match is importable" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      draft = Seed.build(item)
+
+      assert Draft.unresolved(draft) == []
+      assert Draft.resolved?(draft)
+    end
+
+    test "progress counts resolved against total" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      %{resolved: resolved, total: total} = Draft.progress(Seed.build(item))
+
+      assert total > 0
+      assert resolved == total
+    end
+  end
+
+  describe "work identity" do
+    test "a strong local hit links the existing book rather than creating one" do
+      book = insert(:book, title: "Leviathan Wakes")
+
+      candidates = [
+        %{"source" => "local", "id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert draft.work.mode == :link
+      assert draft.work.book_id == book.id
+      assert draft.work.approved
+    end
+
+    test "a close runner-up leaves the identity for the operator" do
+      candidates = [
+        provider_candidate(%{"id" => "a", "score" => 0.92}),
+        provider_candidate(%{"id" => "b", "score" => 0.91})
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates, confidence: 0.5), tags: %{}}))
+
+      refute draft.work.approved
+      assert Enum.any?(Draft.unresolved(draft), &(&1.label == "Which book"))
+    end
+
+    test "linking a book does not re-decide the book's own fields" do
+      book = insert(:book, title: "Leviathan Wakes")
+
+      candidates = [
+        %{"source" => "local", "id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      refute Enum.any?(Draft.unresolved(draft), &(&1.label == "Title"))
+      refute Enum.any?(Draft.unresolved(draft), &(&1.section == :work and &1.label == "Author"))
+    end
+  end
+
+  describe "credits — the import resolves credits, not personhood" do
+    test "an exact identity match links it and settles" do
+      author = insert(:author, name: "Brandon Sanderson")
+
+      candidates = [provider_candidate(%{"authors" => [author.name]})]
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert [credit] = draft.work.authors
+      assert credit.mode == :link
+      assert credit.identity_id == author.id
+      assert Credit.resolved?(credit)
+    end
+
+    test "a brand-new provider name creates one identity backed by one new person" do
+      candidates = [provider_candidate(%{"authors" => ["Nobody In This Library"]})]
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert [credit] = draft.work.authors
+      assert credit.mode == :create
+      assert [person_ref] = credit.people
+      assert person_ref.person_id == nil
+      assert person_ref.name == "Nobody In This Library"
+      assert credit.approved
+    end
+
+    test "a name from tags alone never auto-creates a person" do
+      # tag splitting is knowingly imperfect ("Sanderson, Brandon"), so a
+      # tag-derived name is a proposal, never a settled decision
+      item = item(%{matches: matches([]), tags: %{"authors" => ["Sanderson, Brandon"]}})
+      draft = Seed.build(item)
+
+      assert [credit] = draft.work.authors
+      refute credit.approved
+      assert Enum.any?(Draft.unresolved(draft), &(&1.label =~ "Sanderson, Brandon"))
+    end
+
+    test "a Person exists but the identity does not — always the operator's call" do
+      # the person is a narrator; this book credits them as an author
+      person = insert(:person, name: "Neil Gaiman", authors: [], narrators: [])
+
+      candidates = [provider_candidate(%{"authors" => [person.name]})]
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert [credit] = draft.work.authors
+      refute credit.approved
+      assert credit.mode == :create
+    end
+
+    test "two or more people behind one credit is just a longer list" do
+      # the composite case, which needs no special pathway: one Author, two
+      # People, expressed as two entries in the same control
+      credit = %Credit{
+        name: "James S.A. Corey",
+        kind: :author,
+        mode: :create,
+        approved: true,
+        people: [
+          %Draft.PersonRef{name: "Daniel Abraham"},
+          %Draft.PersonRef{name: "Ty Franck"}
+        ]
+      }
+
+      assert Credit.resolved?(credit)
+      assert length(credit.people) == 2
+    end
+
+    # Validation gates *saving*, the invariant gates *importing*. A half-made
+    # credit has to be storable — otherwise the operator couldn't add a second
+    # person and then name them — so only an approved one is rejected.
+    test "a half-made credit saves; an approved one with nobody behind it does not" do
+      in_progress =
+        Credit.changeset(%Credit{}, %{name: "Somebody", kind: :author, mode: :create, people: []})
+
+      assert in_progress.valid?
+      refute Credit.resolved?(Ecto.Changeset.apply_changes(in_progress))
+
+      approved =
+        Credit.changeset(%Credit{}, %{
+          name: "Somebody",
+          kind: :author,
+          mode: :create,
+          people: [],
+          approved: true
+        })
+
+      refute approved.valid?
+      assert %{people: ["needs at least one person behind it"]} = errors_on(approved)
+    end
+
+    test "a person row nobody has named yet keeps the credit unresolved" do
+      credit = %Credit{
+        name: "James S.A. Corey",
+        kind: :author,
+        mode: :create,
+        approved: true,
+        people: [%Draft.PersonRef{name: "Daniel Abraham"}, %Draft.PersonRef{name: ""}]
+      }
+
+      refute Credit.resolved?(credit)
+    end
+  end
+
+  describe "series numbers are never invented" do
+    test "a series with no number anywhere stays unresolved" do
+      candidates = [provider_candidate(%{"series" => ["The Expanse"]})]
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert [link] = draft.work.series
+      refute SeriesLink.resolved?(link)
+      assert link.number == nil
+      assert SeriesLink.state(link) == :missing
+    end
+
+    test "a number from the tags settles it" do
+      candidates = [provider_candidate(%{"series" => ["The Expanse"]})]
+
+      draft =
+        Seed.build(item(%{matches: matches(candidates), tags: %{"series_number" => "1"}}))
+
+      assert [link] = draft.work.series
+      assert link.number == "1"
+      assert SeriesLink.resolved?(link)
+      assert Decimal.equal?(SeriesLink.decimal(link), Decimal.new(1))
+    end
+
+    test "each series is its own decision" do
+      candidates = [
+        provider_candidate(%{"series" => ["The Expanse", "The Expanse (Chronological)"]})
+      ]
+
+      draft =
+        Seed.build(item(%{matches: matches(candidates), tags: %{"series_number" => "1"}}))
+
+      assert length(draft.work.series) == 2
+    end
+
+    test "a series the linked book already has is not offered again" do
+      series = insert(:series)
+      book = insert(:book, series_books: [build(:series_book, series: series, book_number: 1)])
+
+      candidates = [
+        %{"source" => "local", "id" => book.id, "title" => book.title, "score" => 1.0}
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches(candidates),
+            tags: %{"series" => series.name, "series_number" => "1"}
+          })
+        )
+
+      assert draft.work.series == []
+    end
+  end
+
+  describe "scalars" do
+    test "sources that agree settle the field" do
+      candidates = [provider_candidate(%{"title" => "Leviathan Wakes"})]
+
+      draft =
+        Seed.build(
+          item(%{matches: matches(candidates), tags: %{"book_title" => "leviathan wakes"}})
+        )
+
+      assert draft.work.title.approved
+      assert draft.work.title.value == "Leviathan Wakes"
+    end
+
+    test "sources that disagree do not" do
+      candidates = [provider_candidate(%{"title" => "Leviathan Wakes"})]
+
+      draft =
+        Seed.build(
+          item(%{matches: matches(candidates), tags: %{"book_title" => "Caliban's War"}})
+        )
+
+      refute draft.work.title.approved
+      assert length(draft.work.title.candidates) >= 2
+    end
+
+    test "an optional field nobody proposed is waived, not outstanding" do
+      draft = Seed.build(item(%{matches: matches([provider_candidate(%{})]), tags: %{}}))
+
+      assert draft.recording.publisher.approved
+      assert draft.recording.publisher.value == nil
+      refute Enum.any?(Draft.unresolved(draft), &(&1.label == "Publisher"))
+    end
+
+    test "embedded art and a provider cover is a choice, not a winner" do
+      candidates = [provider_candidate(%{})]
+
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "provider_name" => "Audible",
+          "id" => "B01",
+          "cover_url" => "https://example.test/cover.jpg",
+          "score" => 0.9
+        }
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches(candidates, recording: recording),
+            tags: %{"has_cover_art" => true}
+          })
+        )
+
+      refute draft.recording.cover.approved
+      assert length(draft.recording.cover.candidates) == 2
+    end
+  end
+
+  describe "persistence" do
+    test "a draft survives a round trip through the database" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      reloaded = Repo.get!(InboxItem, item.id)
+
+      assert reloaded.draft.work.title.value == "Leviathan Wakes"
+      assert [credit] = reloaded.draft.work.authors
+      assert credit.name == "James S.A. Corey"
+      assert Draft.resolved?(reloaded.draft)
+    end
+
+    test "ready is stored to match what the draft says" do
+      resolved = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, resolved} = Inbox.prepare_draft(resolved)
+      assert resolved.ready
+
+      unresolved =
+        item(%{path: "/downloads/Another", matches: matches([]), tags: %{}})
+
+      {:ok, unresolved} = Inbox.prepare_draft(unresolved)
+      refute unresolved.ready
+    end
+
+    test "preparing never overwrites a draft the operator has touched" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      {:ok, edited} =
+        Inbox.update_draft(item, %{
+          "work" => %{
+            "title" => %{"value" => "Hand Typed", "source" => "manual", "approved" => true}
+          }
+        })
+
+      assert edited.draft.work.title.value == "Hand Typed"
+
+      {:ok, again} = Inbox.prepare_draft(edited)
+      assert again.draft.work.title.value == "Hand Typed"
+    end
+
+    test "files changing under a draft marks it stale rather than re-seeding" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      moved = %{item | files: ["/downloads/Some Release/moved.m4b"]}
+      stale = Seed.restale(item.draft, moved)
+
+      assert stale.stale
+      refute Draft.resolved?(stale)
+      assert Enum.any?(Draft.unresolved(stale), &(&1.state == :stale))
+    end
+  end
+end

--- a/test/ambry/inbox/managed_approval_test.exs
+++ b/test/ambry/inbox/managed_approval_test.exs
@@ -253,6 +253,11 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     {[item], false} = Inbox.list_items()
     {:ok, item} = Inbox.probe_item(item)
 
+    # Approval executes a resolved draft, so these tests arrange one the way
+    # the import form would leave it — what they're actually about is what
+    # happens to the bytes afterwards.
+    item = settle(item)
+
     %{item: item, root: root, source: source, location: location, downloads: downloads}
   end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1,0 +1,264 @@
+defmodule AmbryWeb.Admin.InboxLive.FormTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Repo
+
+  setup :register_and_log_in_admin_user
+
+  describe "the invariant" do
+    test "an unsettled item can't be imported", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Still to settle"
+      assert has_element?(view, "button[data-role='import'][disabled]")
+    end
+
+    test "a settled item can", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute html =~ "Still to settle"
+      refute has_element?(view, "button[data-role='import'][disabled]")
+    end
+
+    test "importing creates the library records and returns to the queue", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view |> element("button[data-role='import']") |> render_click()
+
+      assert %{status: :approved, media_id: media_id} = Inbox.get_item!(item.id)
+      assert media_id
+    end
+
+    test "each outstanding decision is named, not just counted", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # tag-derived credits are never auto-settled, so the narrators from the
+      # fixture's `composer` tag are listed by name
+      assert html =~ "Michael Kramer"
+      assert html =~ "needs a look"
+    end
+  end
+
+  describe "settling decisions" do
+    test "accept-everything settles what's only waiting on a nod", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html = view |> element("button", "Accept everything") |> render_click()
+
+      refute html =~ "Still to settle"
+      assert Inbox.get_item!(item.id).ready
+    end
+
+    test "accept-everything never invents a missing required value", %{conn: conn} do
+      item = probed_item(dated: false)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      assert html =~ "First published"
+
+      html = view |> element("button", "Accept everything") |> render_click()
+
+      # the date nobody supplied is still outstanding — this button settles
+      # choices, it does not fabricate facts
+      assert html =~ "Still to settle"
+      assert html =~ "First published"
+      refute Inbox.get_item!(item.id).ready
+    end
+
+    test "typing a value records it as the operator's, and locks it", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> form("#work-form")
+      |> render_change(%{
+        "inbox_item" => %{
+          "draft" => %{"work" => %{"title" => %{"value" => "A Title I Typed"}}}
+        }
+      })
+
+      item = Inbox.get_item!(item.id)
+
+      assert item.draft.work.title.value == "A Title I Typed"
+      # 1d's lock semantics: editing a value is curation, so it records as the
+      # operator's and a later refresh must not overwrite it
+      assert item.draft.work.title.source == "manual"
+      assert item.draft.work.title.approved
+    end
+
+    test "an accepted provider value records that provider, and stays unlocked", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element(
+        "button[phx-click='choose-field'][phx-value-field='title'][phx-value-source='tags']"
+      )
+      |> render_click()
+
+      item = Inbox.get_item!(item.id)
+
+      assert item.draft.work.title.source == "tags"
+      assert item.draft.work.title.approved
+    end
+
+    test "a credit can be dropped when the source proposed the wrong person", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      before = length(Inbox.get_item!(item.id).draft.recording.narrators)
+
+      view
+      |> element(
+        "button[phx-click='remove-credit'][phx-value-section='recording'][phx-value-index='0']"
+      )
+      |> render_click()
+
+      assert length(Inbox.get_item!(item.id).draft.recording.narrators) == before - 1
+    end
+  end
+
+  describe "credits — credited as / written by" do
+    test "the composite case is two people behind one credit", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element(
+          "button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']"
+        )
+        |> render_click()
+
+      assert html =~ "A shared pen name"
+
+      credit = hd(Inbox.get_item!(item.id).draft.work.authors)
+      assert length(credit.people) == 2
+    end
+
+    test "naming both people creates one author and two people on import", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']")
+      |> render_click()
+
+      {:ok, item} = Inbox.fetch_item(item.id)
+
+      item =
+        update_in(item.draft.work.authors, fn [credit | rest] ->
+          [
+            %{
+              credit
+              | name: "James S.A. Corey",
+                people: [
+                  %Draft.PersonRef{name: "Daniel Abraham"},
+                  %Draft.PersonRef{name: "Ty Franck"}
+                ]
+            }
+            | rest
+          ]
+        end)
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(item.draft))
+      item = settle(item)
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      book = media.book_id |> Ambry.Books.get_book!() |> Repo.preload(authors: :people)
+      assert [author] = book.authors
+      assert author.name == "James S.A. Corey"
+      assert Enum.map(author.people, & &1.name) |> Enum.sort() == ["Daniel Abraham", "Ty Franck"]
+    end
+
+    test "an existing identity is linked rather than duplicated", %{conn: conn} do
+      author = insert(:author, name: "Brandon Sanderson")
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#credit-work-0-identity")
+      |> render_change(%{
+        "section" => "work",
+        "index" => "0",
+        "identity_id" => to_string(author.id)
+      })
+
+      credit = hd(Inbox.get_item!(item.id).draft.work.authors)
+      assert credit.mode == :link
+      assert credit.identity_id == author.id
+    end
+  end
+
+  describe "destination" do
+    test "says where the file is going before anything is committed", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Referenced where it lies"
+      assert html =~ "never move, rename or delete"
+    end
+  end
+
+  defp probed_item(opts \\ []) do
+    name = Keyword.get(opts, :name, "The Way of Kings [M4B]")
+
+    root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
+    release = Path.join(root, name)
+    File.mkdir_p!(release)
+    File.cp!(tagged_fixture(Keyword.get(opts, :dated, true)), Path.join(release, "book.m4b"))
+
+    {:ok, _counts} = Inbox.discover(root)
+    {items, _more} = Inbox.list_items(filter: name)
+    {:ok, item} = items |> hd() |> Inbox.probe_item()
+
+    item
+  end
+
+  defp tagged_fixture(dated?) do
+    dir = Ambry.Paths.source_media_disk_path("tagged-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    path = Path.join(dir, "tagged.m4b")
+
+    {_output, 0} =
+      System.cmd(
+        "ffmpeg",
+        [
+          "-v",
+          "quiet",
+          "-i",
+          valid_audio(:m4a),
+          "-c",
+          "copy",
+          "-metadata",
+          "album=The Way of Kings",
+          "-metadata",
+          "artist=Brandon Sanderson",
+          "-metadata",
+          "composer=Michael Kramer, Kate Reading"
+        ] ++ if(dated?, do: ["-metadata", "date=2010-08-31"], else: []) ++ [path]
+      )
+
+    path
+  end
+end

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -109,8 +109,8 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert Inbox.get_item!(item.id).status == :pending
   end
 
-  test "approves an item into the library, leaving files alone", %{conn: conn} do
-    item = probed_item()
+  test "approves a settled item into the library, leaving files alone", %{conn: conn} do
+    item = probed_item() |> settle()
     file = hd(item.files)
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
@@ -124,16 +124,38 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert File.exists?(file)
   end
 
-  test "explains a refusal instead of failing silently", %{conn: conn} do
-    item = probed_item(files: ["01.mp3", "02.mp3"])
+  # The queue can't say *what* is outstanding, so it doesn't offer a button
+  # that would fail — it sends you to the form, which can.
+  test "an unsettled item offers the form rather than an import button", %{conn: conn} do
+    item = probed_item()
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
-    html =
-      view |> element("span[phx-click='approve'][phx-value-id='#{item.id}']") |> render_click()
+    refute has_element?(view, "span[phx-click='approve'][phx-value-id='#{item.id}']")
+    assert has_element?(view, "a[href='/admin/inbox/#{item.id}']")
+  end
 
-    assert html =~ "single-file recordings"
+  test "a refusal no curation can fix is visible before anything is clicked", %{conn: conn} do
+    item = probed_item(files: ["01.mp3", "02.mp3"])
+
+    {:ok, view, html} = live(conn, ~p"/admin/inbox")
+
+    assert html =~ "direct play handles single-file recordings"
+    refute has_element?(view, "span[phx-click='approve'][phx-value-id='#{item.id}']")
     assert Inbox.get_item!(item.id).status == :pending
+  end
+
+  test "the ready bucket counts what is waiting on a click", %{conn: conn} do
+    ready = probed_item(name: "Settled") |> settle()
+    _outstanding = probed_item(name: "Outstanding")
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox")
+
+    html = view |> element("span[data-role='ready-filter']") |> render_click()
+
+    assert html =~ "Settled"
+    refute html =~ "Outstanding"
+    assert Inbox.count_ready() == 1
   end
 
   test "filters by status", %{conn: conn} do

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -156,6 +156,9 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert html =~ "Settled"
     refute html =~ "Outstanding"
     assert Inbox.count_ready() == 1
+    # the flag is stored, not recomputed per render — that's what lets the
+    # bucket be a plain SQL filter
+    assert Inbox.get_item!(ready.id).ready
   end
 
   test "filters by status", %{conn: conn} do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -24,6 +24,7 @@ defmodule AmbryWeb.ConnCase do
 
       # Import conveniences for testing with connections
       import Ambry.Factory
+      import Ambry.InboxHelpers
       import AmbryWeb.ConnCase
       import Phoenix.ConnTest
       import Plug.Conn

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -25,6 +25,7 @@ defmodule Ambry.DataCase do
 
       import Ambry.DataCase
       import Ambry.Factory
+      import Ambry.InboxHelpers
       import Ecto
       import Ecto.Changeset
       import Ecto.Query

--- a/test/support/inbox_helpers.ex
+++ b/test/support/inbox_helpers.ex
@@ -1,0 +1,130 @@
+defmodule Ambry.InboxHelpers do
+  @moduledoc """
+  Standing in for the operator at the import form.
+
+  Approval now executes a resolved draft rather than deciding anything, so a
+  test that wants to exercise approval has to get an item to the state the
+  form would leave it in. `settle/2` does what an operator clicking through
+  every outstanding decision does — no more, so a test can still assert that
+  something specific was left unresolved.
+  """
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.InboxItem
+
+  @doc """
+  Prepares a draft and approves every decision still outstanding.
+
+  Options mirror the choices the form offers:
+
+    * `:title`, `:published` — override a scalar as the operator typing it
+    * `:series_number` — settle a series membership's number
+  """
+  def settle(%InboxItem{} = item, opts \\ []) do
+    {:ok, item} = Inbox.prepare_draft(item)
+    {:ok, item} = Inbox.update_draft(item, settled(item.draft, opts))
+
+    item
+  end
+
+  defp settled(%Draft{} = draft, opts) do
+    %{
+      "work" => settled_work(draft.work, opts),
+      "recording" => settled_recording(draft.recording, opts)
+    }
+  end
+
+  defp settled_work(work, opts) do
+    %{
+      "mode" => to_string(work.mode),
+      "book_id" => work.book_id,
+      "approved" => true,
+      "candidates" => work.candidates,
+      "title" => settled_field(work.title, opts[:title]),
+      "published" => settled_field(work.published, opts[:published]),
+      "published_format" => settled_field(work.published_format, nil),
+      "authors" => Enum.map(work.authors, &settled_credit/1),
+      "series" => Enum.map(work.series, &settled_series(&1, opts[:series_number]))
+    }
+  end
+
+  defp settled_recording(recording, opts) do
+    %{
+      "approved" => true,
+      "candidates" => recording.candidates,
+      "title" => settled_field(recording.title, nil),
+      "published" => settled_field(recording.published, nil),
+      "publisher" => settled_field(recording.publisher, nil),
+      "description" => settled_field(recording.description, nil),
+      "cover" => settled_field(recording.cover, opts[:cover]),
+      "narrators" => Enum.map(recording.narrators, &settled_credit/1)
+    }
+  end
+
+  # An override is the operator typing a value, so it records `manual`; with
+  # no override, whatever the seeder proposed is simply accepted.
+  defp settled_field(%Field{} = field, nil) do
+    value = field.value || first_candidate(field)
+
+    %{
+      "value" => value,
+      "source" => field.source || source_of(field, value),
+      "approved" => true,
+      "required" => field.required,
+      "candidates" => Enum.map(field.candidates, &Map.from_struct/1)
+    }
+  end
+
+  defp settled_field(%Field{} = field, override) do
+    %{
+      "value" => override,
+      "source" => "manual",
+      "approved" => true,
+      "required" => field.required,
+      "candidates" => Enum.map(field.candidates, &Map.from_struct/1)
+    }
+  end
+
+  defp first_candidate(%Field{candidates: [first | _rest]}), do: first.value
+  defp first_candidate(%Field{}), do: nil
+
+  defp source_of(%Field{candidates: candidates}, value) do
+    Enum.find_value(candidates, &(&1.value == value && &1.source))
+  end
+
+  defp settled_credit(%Credit{} = credit) do
+    %{
+      "name" => credit.name,
+      "kind" => to_string(credit.kind),
+      "mode" => to_string(credit.mode),
+      "identity_id" => credit.identity_id,
+      "source" => credit.source,
+      "approved" => true,
+      "people" => people_for(credit)
+    }
+  end
+
+  # Linking needs nobody behind it — the identity already has whoever it has.
+  defp people_for(%Credit{mode: :link}), do: []
+
+  defp people_for(%Credit{people: []} = credit),
+    do: [%{"name" => credit.name, "person_id" => nil}]
+
+  defp people_for(%Credit{people: people}),
+    do: Enum.map(people, &%{"name" => &1.name, "person_id" => &1.person_id})
+
+  defp settled_series(%SeriesLink{} = link, number) do
+    %{
+      "name" => link.name,
+      "mode" => to_string(link.mode),
+      "series_id" => link.series_id,
+      "number" => number || link.number || "1",
+      "source" => link.source,
+      "approved" => true
+    }
+  end
+end


### PR DESCRIPTION
Turns the inbox from a row-level queue — whose approve button meant "trust the top match or don't import" — into a full import approval form, built on one invariant:

> **An import is a tree of decisions, and import is possible iff every decision is resolved.**

`Draft.unresolved/1` is the single expression of that. The import button, the queue's Ready badge and the tests all read it, so they cannot disagree about whether an item is finished. `Approval` now *executes* a resolved draft and refuses otherwise — it decides nothing.

Design and decisions are recorded in `ROADMAP.md` under 3e, "The staged import form".

## What's here

- **`Ambry.Inbox.Draft`** — the decision tree, as embedded schemas in a jsonb column on `inbox_items`, so half-curated discoveries still never touch the library tables while changesets and `inputs_for` make the form ordinary nested LiveView. `Draft.{Field, Candidate, Credit, PersonRef, SeriesLink, Work, Recording}`, plus `Seed` (the auto-approve rules) and `Edit` (the operator's non-text choices).
- **`inbox_items.ready`** — denormalized from `Draft.resolved?/1`, single writer (`InboxItem.put_draft/2`), drives a Ready bucket in the queue.
- **`Approval` rewritten** to execute the draft, write `field_provenance` from each decision's source, and land the cover.
- **`Ambry.Images`** — URL import + embedded cover-art extraction, moved into the core because `Ambry.Inbox` can't reach `AmbryWeb`; `UploadHelpers` delegates.
- **`/admin/inbox/:id`** + `AmbryWeb.Admin.Decisions` (`decision_row`, `credit_row`, `series_row`) — the components today's book/media/person forms should converge on.

## Credits resolve to identities, not people

A link decision always targets an `Author`/`Narrator`, never a `Person` — the generalized fix for the v1.9.0 pen-name bug. The import deliberately **does not gate on personhood**: no provider reports it, so "who is behind this credit" defaults to one new person of the same name, and two or more entries in that same control *is* the composite-author case. There is no separate composite mode anywhere.

## Fixes two live defects

- **Invented series numbers.** `series_params` defaulted `book_number` to `1` whenever tags carried no number — and only 36% of releases carry a series tag, so most series-bearing imports silently became "book 1".
- **Never landed a cover.** `create_media` set no `image_path` at all, despite candidates carrying `cover_url` and 1b having verified embedded extraction works.

## Notable, learned building it

- **Validation gates saving; the invariant gates importing.** A half-made credit must be storable or the operator can't add a second person and *then* name them. Only an approved credit with nobody behind it is rejected.
- **A required field cannot be waived**, enforced in `Field.changeset` — otherwise the form could approve past a missing title and hand approval something it can't execute.
- **The release name is a fallback, not a peer.** As an equal candidate it made nearly every import ambiguous on its title.
- **Typing records `manual` and locks**, exactly 1d's semantics — otherwise a retyped value keeps claiming the provider that proposed the old one.
- **A `<form>` inside a `<form>` is silently dropped by the parser**, which ate the credit controls once. Typing and choosing now live in separate DOM subtrees; better architecture regardless.
- **Identities can't be created through their own changesets** — they're normally created *through* a Person, which can't express "this pen name is two people". Approval inserts the `authors_people` rows explicitly.
- **File-level facts are checked before the draft** — no curation fixes a multi-file release, so it must not send the operator to the form.

## Deliberately thin

Cover picker grid, chapter-title merge (1h), replace-media mode, per-item re-search.

## Migration

`20260803192042_inbox_item_drafts` adds `draft` (jsonb) and `ready` (boolean, default false) to `inbox_items`, plus a partial index. Additive; existing items get a draft seeded on next match or when first opened.

## Verification

`mix check` clean — format, compile, credo, dialyzer. 1045 tests pass.
Not yet exercised against a real downloads folder — that's what staging is for.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek