### PR TITLE
Fix recording-level matching and candidate ranking

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -309,7 +309,7 @@ defmodule Ambry.Inbox do
   defp downloads_preflight(item, location) do
     base = %{custody: :managed, blocker: nil, summary: nil}
 
-    case Library.target_root(location) do
+    case chosen_root(item) do
       {:error, reason} ->
         %{base | blocker: describe_error(reason)}
 
@@ -321,6 +321,17 @@ defmodule Ambry.Inbox do
         }
     end
   end
+
+  # The root the draft settled on, not one derived from the location: inputs
+  # and outputs are independent, so this is a decision rather than a lookup.
+  defp chosen_root(%InboxItem{draft: %{destination: %{root_id: id}}}) when is_integer(id) do
+    case Repo.get(Location, id) do
+      %Location{kind: :library_root} = root -> {:ok, root}
+      _other -> {:error, :no_library_root}
+    end
+  end
+
+  defp chosen_root(_item), do: {:error, :no_library_root}
 
   defp policy_summary(:hardlink, root),
     do: "Hardlinked into #{root.path} — one copy of the bytes, the download keeps seeding."

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -69,6 +69,7 @@ defmodule Ambry.Inbox do
       |> order_by([i], desc: i.inserted_at, desc: i.id)
       |> offset(^Keyword.get(opts, :offset, 0))
       |> limit(^over_limit)
+      |> preload(:location)
       |> Repo.all()
 
     items_to_return = Enum.slice(items, 0, limit)

--- a/lib/ambry/inbox/approval.ex
+++ b/lib/ambry/inbox/approval.ex
@@ -57,7 +57,6 @@ defmodule Ambry.Inbox.Approval do
   alias Ambry.Inbox.Draft.PersonRef
   alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.InboxItem
-  alias Ambry.Library
   alias Ambry.Library.Location
   alias Ambry.Library.NamingTemplate
   alias Ambry.Library.Placement
@@ -370,9 +369,15 @@ defmodule Ambry.Inbox.Approval do
   # What approval should do with the bytes, decided by where the item came
   # from. Only a downloads folder imports; an external collection is adopted
   # exactly where it lies (that is the entire promise of external custody).
-  defp destination(%InboxItem{location: %Location{kind: :downloads} = location}) do
-    with {:ok, root} <- Library.target_root(location) do
-      {:ok, {root, location.import_policy}}
+  # Read off the draft rather than re-derived from the location: any input may
+  # feed any output, so which root this import goes to is a decision the
+  # operator made (or that resolved silently because there was only one), not
+  # a property of where the files were found.
+  defp destination(%InboxItem{draft: %{destination: %{custody: :managed} = destination}}) do
+    case Repo.get(Location, destination.root_id) do
+      %Location{kind: :library_root} = root -> {:ok, {root, destination.policy}}
+      %Location{} -> {:error, :target_not_a_root}
+      nil -> {:error, :no_library_root}
     end
   end
 

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -33,12 +33,30 @@ defmodule Ambry.Inbox.AutoMatch do
   alias Ambry.Books
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.ReleaseName
+  alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Providers
   alias Ambry.Metadata.Registry
 
   require Logger
 
   @candidate_limit 8
+
+  # Corroboration bonus when two providers independently return the same work.
+  @agreement_bonus 0.05
+
+  # What a companion-work marker ("study guide", "graphic novel") costs. Harsh
+  # on purpose: these are reliably NOT the book being imported, and leaving
+  # them near the top of the list is what made the candidate list untrustworthy.
+  @companion_factor 0.25
+
+  # Per-word cost for content the query didn't ask for, and the floor it
+  # can't push a title below.
+  @extra_word_cost 0.08
+  @min_length_factor 0.4
+
+  # What counts as the same reader, and what it costs to be a different one.
+  @narrator_match 0.85
+  @narrator_mismatch 0.5
 
   @doc """
   Builds work and recording proposals for an item.
@@ -79,41 +97,101 @@ defmodule Ambry.Inbox.AutoMatch do
   end
 
   defp match_work(hints) do
-    query = query_for(hints)
+    query = work_query(hints)
 
-    level_result(query, local_books(query, hints) ++ provider_books(:work, query, hints))
+    {candidates, outcomes} = provider_books(:work, query, hints)
+
+    level_result(query, local_books(hints) ++ candidates, outcomes)
   end
 
   # An ASIN is a recording-level key, so when there is one it *is* the query:
   # a hit on it is definitive in a way no title match ever is.
   defp match_recording(%{asin: asin} = hints) when is_binary(asin) do
-    level_result(asin, provider_books(:recording, asin, hints))
+    query = %Provider.Query{keywords: asin}
+    {candidates, outcomes} = provider_books(:recording, query, hints)
+
+    level_result(query, candidates, outcomes)
   end
 
+  # Structured, not concatenated. Audible's catalog matches `title` against
+  # the title alone, so the old `"#{title} #{author}"` string searched for a
+  # book literally called that and returned nothing — the recording level came
+  # up empty on every single item. The narrator goes in too: it is the field
+  # that tells two recordings of one work apart.
   defp match_recording(hints) do
-    query = query_for(hints)
+    query = %Provider.Query{
+      title: hints.title,
+      author: hints.author,
+      narrator: hints.narrator
+    }
 
-    level_result(query, provider_books(:recording, query, hints))
+    {candidates, outcomes} = provider_books(:recording, query, hints)
+
+    level_result(query, candidates, outcomes)
   end
 
-  defp level_result(query, candidates) do
-    candidates = candidates |> Enum.sort_by(& &1["score"], :desc) |> Enum.take(@candidate_limit)
+  defp work_query(%{title: nil}), do: nil
+
+  defp work_query(hints), do: %Provider.Query{title: hints.title, author: hints.author}
+
+  defp level_result(query, candidates, outcomes) do
+    candidates =
+      candidates
+      |> merge_agreeing()
+      |> Enum.sort_by(& &1["score"], :desc)
+      |> Enum.take(@candidate_limit)
 
     %{
-      "query" => query,
+      "query" => query && to_string(query),
       "candidates" => candidates,
       # the operator confirms; this is only the suggestion
       "selected" => candidates |> List.first() |> selected_ref(),
-      "confidence" => confidence(candidates)
+      "confidence" => confidence(candidates),
+      # which providers were asked, and what each said. A provider that fails
+      # used to vanish silently, leaving the operator to wonder why a source
+      # they had enabled contributed nothing.
+      "providers" => outcomes
     }
   end
 
   defp selected_ref(nil), do: nil
   defp selected_ref(candidate), do: %{"source" => candidate["source"], "id" => candidate["id"]}
 
+  # Two providers returning the same work is the strongest signal available,
+  # not a disagreement — but the runner-up penalty below read it as one and
+  # dropped a perfect double hit to 0.5 confidence, which is why so many
+  # obviously-right matches asked to be looked at. Duplicates collapse into
+  # one candidate that remembers it was corroborated.
+  defp merge_agreeing(candidates) do
+    candidates
+    |> Enum.group_by(&agreement_key/1)
+    |> Enum.map(fn {_key, [first | rest]} ->
+      case rest do
+        [] ->
+          first
+
+        _corroborated ->
+          first
+          |> Map.put("also_from", Enum.map(rest, &(&1["provider_name"] || &1["source"])))
+          |> Map.put("score", min(first["score"] + @agreement_bonus, 1.0))
+      end
+    end)
+  end
+
+  # A local record and a provider hit for the same work are deliberately NOT
+  # merged: "reuse the book you already have" and "create it from this
+  # provider" are different outcomes, and the operator has to be able to see
+  # both. Only provider-to-provider duplicates collapse.
+  defp agreement_key(%{"source" => "local", "id" => id}), do: {:local, id}
+
+  defp agreement_key(candidate) do
+    {:work, normalize(candidate["title"] || ""),
+     candidate["authors"] |> List.wrap() |> Enum.map(&normalize/1) |> Enum.sort()}
+  end
+
   # Confidence is about the *decision*, not just the top hit: a strong match
-  # with an equally strong runner-up is exactly the case a human should look
-  # at, so a close second pulls it down.
+  # with a genuinely different runner-up is exactly the case a human should
+  # look at, so a close second pulls it down.
   defp confidence([]), do: 0.0
 
   defp confidence([best]), do: best["score"]
@@ -127,9 +205,11 @@ defmodule Ambry.Inbox.AutoMatch do
     |> Float.round(3)
   end
 
-  defp local_books(nil, _hints), do: []
+  defp local_books(%{title: nil}), do: []
 
-  defp local_books(query, hints) do
+  defp local_books(hints) do
+    query = to_string(%Provider.Query{title: hints.title, author: hints.author})
+
     {books, _more} = Books.list_books(0, @candidate_limit, %{search: query})
 
     Enum.map(books, fn book ->
@@ -142,33 +222,61 @@ defmodule Ambry.Inbox.AutoMatch do
         "published" => book.published && Date.to_iso8601(book.published),
         # a work already in the library beats an equally-good provider hit:
         # reusing it is what prevents duplicate Books
-        "score" => score(book.title, Enum.map(book.authors || [], & &1.name), nil, hints) + 0.05
+        "score" =>
+          score(book.title, Enum.map(book.authors || [], & &1.name), nil, nil, hints) + 0.05
       }
     end)
   end
 
-  defp provider_books(_level, nil, _hints), do: []
+  defp provider_books(_level, nil, _hints), do: {[], []}
 
   defp provider_books(level, query, hints) do
     [level: level, capability: :book_search]
     |> Registry.enabled()
-    |> Enum.flat_map(&search_provider(&1, query, hints))
+    |> Enum.map(&search_provider(&1, query, hints))
+    |> Enum.reduce({[], []}, fn {candidates, outcome}, {all, outcomes} ->
+      {all ++ candidates, outcomes ++ [outcome]}
+    end)
   end
 
   # Providers are tried in the operator's priority order, and one being down,
-  # rate-limited or slow costs its results only.
+  # rate-limited or slow costs its results only — but the outcome is recorded
+  # either way, so "this provider found nothing" and "this provider was
+  # unreachable" don't look identical in the inbox.
   defp search_provider(entry, query, hints) do
     case Providers.search_books(entry.id, query, []) do
       {:ok, books} ->
-        books |> Enum.take(@candidate_limit) |> Enum.map(&provider_candidate(&1, entry, hints))
+        candidates =
+          books |> Enum.take(@candidate_limit) |> Enum.map(&provider_candidate(&1, entry, hints))
+
+        {candidates,
+         %{
+           "id" => entry.id,
+           "name" => entry.display_name,
+           "status" => "ok",
+           "count" => length(candidates)
+         }}
 
       {:error, reason} ->
         Logger.warning(fn ->
-          "Auto-match: #{entry.id} failed for #{inspect(query)}: #{inspect(reason)}"
+          "Auto-match: #{entry.id} failed for #{inspect(to_string(query))}: #{inspect(reason)}"
         end)
 
-        []
+        {[],
+         %{
+           "id" => entry.id,
+           "name" => entry.display_name,
+           "status" => "failed",
+           "count" => 0,
+           "reason" => describe(reason)
+         }}
     end
+  end
+
+  # Enough for the operator to tell a rate limit from a bad token from an
+  # instance being down, without leaking a whole HTTP response into jsonb.
+  defp describe(reason) do
+    reason |> inspect() |> String.slice(0, 200)
   end
 
   defp provider_candidate(book, entry, hints) do
@@ -194,19 +302,111 @@ defmodule Ambry.Inbox.AutoMatch do
       "publisher" => book.publisher,
       "cover_url" => book.cover_url,
       "description" => book.description,
-      "score" => score(book.title, authors, book.asin, hints)
+      "score" => score(book.title, authors, narrators, book.asin, hints)
     }
   end
 
   # An ASIN match is identity, not similarity — nothing else can earn 1.0.
-  defp score(_title, _authors, asin, %{asin: asin}) when is_binary(asin), do: 1.0
+  defp score(_title, _authors, _narrators, asin, %{asin: asin}) when is_binary(asin), do: 1.0
 
-  defp score(title, authors, _asin, hints) do
-    title_score = similarity(title, hints.title)
+  defp score(title, authors, narrators, _asin, hints) do
+    base =
+      case author_similarity(authors, hints.author) do
+        nil -> similarity(title, hints.title)
+        author_score -> similarity(title, hints.title) * 0.75 + author_score * 0.25
+      end
 
-    case author_similarity(authors, hints.author) do
-      nil -> Float.round(title_score, 3)
-      author_score -> Float.round(title_score * 0.75 + author_score * 0.25, 3)
+    # The narrator only speaks when both sides have one. Recording-level hits
+    # carry narrators and work-level hits don't, so this quietly does nothing
+    # at the work level rather than needing a separate scorer — and at the
+    # recording level it's decisive, because it is the only thing that
+    # distinguishes two recordings of the same book.
+    base
+    |> apply_narrator(narrators, hints.narrator)
+    |> Kernel.*(title_penalty(title, hints.title))
+    |> Float.round(3)
+  end
+
+  defp apply_narrator(score, narrators, narrator) when narrators in [nil, []] or is_nil(narrator),
+    do: score
+
+  # Treated as a near-binary fact rather than blended in, because jaro is
+  # useless here: two entirely unrelated names ("Robertson Dean" vs "Jeff
+  # Harding") still score 0.53, so averaging it in left the *wrong reader's*
+  # edition at 0.81 — comfortably "likely", for a recording that is simply not
+  # the one in hand. Agreement is a modest boost; disagreement is decisive,
+  # since at this level the narrator is what the two candidates differ by.
+  defp apply_narrator(score, narrators, narrator) do
+    match = narrators |> Enum.map(&similarity(&1, narrator)) |> Enum.max(fn -> 0.0 end)
+
+    if match >= @narrator_match do
+      min(score * 1.05, 1.0)
+    else
+      score * @narrator_mismatch
+    end
+  end
+
+  # Titles that CONTAIN what we're looking for plus a pile of other words are
+  # the failure mode jaro distance cannot see: "A Study Guide for William
+  # Gibson's Neuromancer" and "William Gibson's Neuromancer, the Graphic
+  # Novel" both scored ~0.6–0.72 against "Neuromancer" purely on shared
+  # substrings, and sat in the candidate list looking plausible.
+  #
+  # Two penalties, because there are two different tells. A companion-work
+  # marker ("study guide", "graphic novel") is decisive on its own. Sheer
+  # extra length is softer evidence — subtitles and series names are
+  # legitimate — so it scales rather than disqualifies.
+  defp title_penalty(nil, _wanted), do: 1.0
+  defp title_penalty(_title, nil), do: 1.0
+
+  defp title_penalty(title, wanted) do
+    companion_penalty(title) * length_penalty(title, wanted)
+  end
+
+  # Deliberately NOT added to `normalize/1`: stripping these words would make
+  # a study guide match its subject *better*, which is the opposite of what's
+  # needed. They have to subtract.
+  @companion_markers [
+    "study guide",
+    "graphic novel",
+    "summary",
+    "analysis",
+    "companion",
+    "workbook",
+    "sparknotes",
+    "cliffsnotes",
+    "boxed set",
+    "box set",
+    "collection",
+    "omnibus",
+    "trilogy",
+    "bundle",
+    "complete series",
+    "unofficial"
+  ]
+
+  defp companion_penalty(title) do
+    normalized = normalize(title)
+
+    if Enum.any?(@companion_markers, &String.contains?(normalized, &1)),
+      do: @companion_factor,
+      else: 1.0
+  end
+
+  # Words in the candidate that aren't in what we asked for. A little is
+  # normal (subtitles, "A Novel"); a lot means it's a different book that
+  # merely mentions this one.
+  defp length_penalty(title, wanted) do
+    candidate_words = title |> normalize() |> String.split(" ", trim: true)
+    wanted_words = wanted |> normalize() |> String.split(" ", trim: true) |> MapSet.new()
+
+    case candidate_words do
+      [] ->
+        1.0
+
+      words ->
+        extra = Enum.count(words, &(not MapSet.member?(wanted_words, &1)))
+        max(1.0 - extra * @extra_word_cost, @min_length_factor)
     end
   end
 
@@ -234,10 +434,6 @@ defmodule Ambry.Inbox.AutoMatch do
     |> String.replace(~r/\s+/, " ")
     |> String.trim()
   end
-
-  defp query_for(%{title: nil}), do: nil
-  defp query_for(%{title: title, author: nil}), do: title
-  defp query_for(%{title: title, author: author}), do: "#{title} #{author}"
 
   defp stringify_hints(hints) do
     Map.new(hints, fn {key, value} -> {to_string(key), value} end)

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -66,11 +66,16 @@ defmodule Ambry.Inbox.AutoMatch do
   """
   def match(%InboxItem{} = item) do
     hints = hints(item)
+    work = match_work(hints)
 
     %{
       matches: %{
-        "work" => match_work(hints),
-        "recording" => match_recording(hints),
+        "work" => work,
+        # The recording level is given the matched work, because a work's own
+        # edition list is a third key alongside searching: once we know which
+        # book this is, its editions are the most direct route to the
+        # recordings that exist — including ones no storefront will return.
+        "recording" => match_recording(hints, work),
         "hints" => stringify_hints(hints)
       }
     }
@@ -101,16 +106,66 @@ defmodule Ambry.Inbox.AutoMatch do
 
     {candidates, outcomes} = provider_books(:work, query, hints)
 
-    level_result(query, local_books(hints) ++ candidates, outcomes)
+    query
+    |> level_result(local_books(hints) ++ candidates, outcomes)
+    |> hydrate_best()
   end
+
+  # A search hit is a summary, not the record. Measured against
+  # rreading-glasses, `search_books` returns a work carrying **one** edition
+  # while `book_details` returns the same work with **seventeen** — along with
+  # the fuller description and a cover the search result may lack. Seeding the
+  # draft from the summary meant importing a thinner book than the provider
+  # actually knew about.
+  #
+  # Only the top candidate is fetched, and only when it's a provider hit: one
+  # extra request per item on a serial queue is affordable, one per candidate
+  # is not, and a local record is already the real thing.
+  defp hydrate_best(%{"candidates" => [best | rest]} = result) do
+    case details_for(best) do
+      nil -> result
+      fuller -> %{result | "candidates" => [Map.merge(best, fuller) | rest]}
+    end
+  end
+
+  defp hydrate_best(result), do: result
+
+  defp details_for(%{"source" => "provider:" <> provider_id, "id" => id}) when is_binary(id) do
+    case Providers.book_details(provider_id, id, []) do
+      {:ok, book} ->
+        # Only fields the summary can be *missing*. The title, authors and
+        # score stay as matched — re-deriving them here would silently move
+        # what the operator already saw ranked.
+        %{
+          "description" => presence(book.description),
+          "cover_url" => presence(book.cover_url),
+          "publisher" => presence(book.publisher),
+          "series" => book.series |> List.wrap() |> Enum.map(& &1.name)
+        }
+        |> Enum.reject(fn {_key, value} -> value in [nil, []] end)
+        |> Map.new()
+
+      {:error, reason} ->
+        # Never fatal: the summary is still a usable candidate, and an item
+        # that matched shouldn't fail because one enrichment call didn't.
+        Logger.warning(fn ->
+          "Auto-match: details for #{provider_id}/#{id}: #{inspect(reason)}"
+        end)
+
+        nil
+    end
+  end
+
+  defp details_for(_candidate), do: nil
 
   # An ASIN is a recording-level key, so when there is one it *is* the query:
   # a hit on it is definitive in a way no title match ever is.
-  defp match_recording(%{asin: asin} = hints) when is_binary(asin) do
+  defp match_recording(%{asin: asin} = hints, work) when is_binary(asin) do
     query = %Provider.Query{keywords: asin}
     {candidates, outcomes} = provider_books(:recording, query, hints)
+    {edition_candidates, edition_outcomes} = work_editions(work, hints)
 
-    level_result(query, candidates, outcomes)
+    level_result(query, candidates ++ edition_candidates, outcomes ++ edition_outcomes)
   end
 
   # Structured, not concatenated. Audible's catalog matches `title` against
@@ -118,7 +173,7 @@ defmodule Ambry.Inbox.AutoMatch do
   # book literally called that and returned nothing — the recording level came
   # up empty on every single item. The narrator goes in too: it is the field
   # that tells two recordings of one work apart.
-  defp match_recording(hints) do
+  defp match_recording(hints, work) do
     query = %Provider.Query{
       title: hints.title,
       author: hints.author,
@@ -126,8 +181,65 @@ defmodule Ambry.Inbox.AutoMatch do
     }
 
     {candidates, outcomes} = provider_books(:recording, query, hints)
+    {edition_candidates, edition_outcomes} = work_editions(work, hints)
 
-    level_result(query, candidates, outcomes)
+    level_result(query, candidates ++ edition_candidates, outcomes ++ edition_outcomes)
+  end
+
+  # The recordings a matched work is known to have. This is what finds an
+  # edition a storefront has erased: Audible's catalog API is a storefront,
+  # not a bibliography — when rights lapse and a title is pulled, it vanishes
+  # from search *and* from direct ASIN lookup, with no record that it ever
+  # existed. A work-level provider that keeps editions still has it.
+  defp work_editions(%{"candidates" => [best | _rest]}, hints) do
+    # Any provider that recognised this work will do — including one that
+    # lost the merge. The winner isn't necessarily the one that keeps
+    # editions.
+    [%{"source" => best["source"], "id" => best["id"]} | List.wrap(best["merged"])]
+    |> Enum.find_value({[], []}, fn ref ->
+      with "provider:" <> provider_id <- ref["source"],
+           true <- is_binary(ref["id"]),
+           {:ok, %{capabilities: capabilities}} <- Registry.fetch(provider_id),
+           true <- :editions in capabilities do
+        fetch_editions(provider_id, ref["id"], hints)
+      else
+        _not_this_one -> nil
+      end
+    end)
+  end
+
+  defp work_editions(_work, _hints), do: {[], []}
+
+  defp fetch_editions(provider_id, work_id, hints) do
+    case Providers.editions(provider_id, work_id, []) do
+      {:ok, books} ->
+        {:ok, entry} = Registry.fetch(provider_id)
+        candidates = Enum.map(books, &provider_candidate(&1, entry, hints))
+
+        {candidates,
+         [
+           %{
+             "id" => "#{provider_id}:editions",
+             "name" => "#{entry.display_name} editions",
+             "status" => "ok",
+             "count" => length(candidates)
+           }
+         ]}
+
+      {:error, reason} ->
+        Logger.warning(fn -> "Auto-match: editions for #{provider_id}: #{inspect(reason)}" end)
+
+        {[],
+         [
+           %{
+             "id" => "#{provider_id}:editions",
+             "name" => "editions",
+             "status" => "failed",
+             "count" => 0,
+             "reason" => describe(reason)
+           }
+         ]}
+    end
   end
 
   defp work_query(%{title: nil}), do: nil
@@ -173,6 +285,12 @@ defmodule Ambry.Inbox.AutoMatch do
         _corroborated ->
           first
           |> Map.put("also_from", Enum.map(rest, &(&1["provider_name"] || &1["source"])))
+          # The merged candidates' own ids are kept, not just their names:
+          # they are how the *other* providers refer to this work, and losing
+          # them means losing the ability to ask them anything else about it —
+          # which is exactly how the edition lookup came up empty when the
+          # corroborating provider happened to lose the merge.
+          |> Map.put("merged", Enum.map(rest, &%{"source" => &1["source"], "id" => &1["id"]}))
           |> Map.put("score", min(first["score"] + @agreement_bonus, 1.0))
       end
     end)
@@ -183,6 +301,16 @@ defmodule Ambry.Inbox.AutoMatch do
   # provider" are different outcomes, and the operator has to be able to see
   # both. Only provider-to-provider duplicates collapse.
   defp agreement_key(%{"source" => "local", "id" => id}), do: {:local, id}
+
+  # Recordings are keyed by what makes them *different recordings*. Title and
+  # author identify a work; two audiobooks of one work share both and are not
+  # the same thing — the 1984 Books on Tape and 2011 Penguin Audio editions of
+  # Neuromancer collapsed into one candidate until the narrator and ASIN went
+  # into the key.
+  defp agreement_key(%{"narrators" => narrators} = candidate) when narrators not in [nil, []] do
+    {:recording, normalize(candidate["title"] || ""),
+     Enum.sort(Enum.map(narrators, &normalize/1)), candidate["asin"]}
+  end
 
   defp agreement_key(candidate) do
     {:work, normalize(candidate["title"] || ""),

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -38,6 +38,7 @@ defmodule Ambry.Inbox.Draft do
 
   import Ecto.Changeset
 
+  alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Work
 
@@ -46,6 +47,7 @@ defmodule Ambry.Inbox.Draft do
   embedded_schema do
     embeds_one :work, Work, on_replace: :update
     embeds_one :recording, Recording, on_replace: :update
+    embeds_one :destination, Destination, on_replace: :update
 
     # Bumped when discovery sees the underlying files change, so a draft built
     # against evidence that has since moved can say so instead of quietly
@@ -60,6 +62,7 @@ defmodule Ambry.Inbox.Draft do
     |> cast(attrs, [:evidence, :stale])
     |> cast_embed(:work)
     |> cast_embed(:recording)
+    |> cast_embed(:destination)
   end
 
   @doc """
@@ -72,7 +75,23 @@ defmodule Ambry.Inbox.Draft do
   def unresolved(nil), do: [%{section: :draft, label: "Not yet prepared", state: :missing}]
 
   def unresolved(%__MODULE__{} = draft) do
-    stale(draft) ++ work(draft) ++ recording(draft)
+    stale(draft) ++ work(draft) ++ recording(draft) ++ destination(draft)
+  end
+
+  # Absent means nothing was staged about the bytes, which for an adopt-in-
+  # place item is the normal case rather than an omission.
+  defp destination(%__MODULE__{destination: nil}), do: []
+
+  defp destination(%__MODULE__{destination: destination}) do
+    if Destination.resolved?(destination),
+      do: [],
+      else: [
+        %{
+          section: :destination,
+          label: "Which library root to import into",
+          state: Destination.state(destination)
+        }
+      ]
   end
 
   defp stale(%__MODULE__{stale: true}),
@@ -108,8 +127,13 @@ defmodule Ambry.Inbox.Draft do
   # stored: a stored total is a second source of truth waiting to drift from
   # the first.
   defp total(%__MODULE__{} = draft) do
-    work_total(draft.work) + recording_total(draft.recording)
+    work_total(draft.work) + recording_total(draft.recording) +
+      destination_total(draft.destination)
   end
+
+  defp destination_total(nil), do: 0
+  defp destination_total(%Destination{custody: :external}), do: 0
+  defp destination_total(%Destination{}), do: 1
 
   defp work_total(nil), do: 1
 

--- a/lib/ambry/inbox/draft/destination.ex
+++ b/lib/ambry/inbox/draft/destination.ex
@@ -1,0 +1,85 @@
+defmodule Ambry.Inbox.Draft.Destination do
+  @moduledoc """
+  Where this import's files are going, and what will be done to them.
+
+  ## Inputs and outputs are independent
+
+  A watched folder is an *input*; a library root is an *output*. Any input may
+  feed any output, so the destination is decided per import rather than
+  configured as a fixed pairing on the input — a downloads folder that can
+  only ever reach one root is a constraint nobody asked for, and adding a
+  second root shouldn't retroactively make every existing input ambiguous.
+
+  Which makes this a decision like any other: **auto-resolved when there's
+  exactly one root** (the overwhelmingly common case, and one the operator
+  should never be asked about), and outstanding when there are several. A
+  location may still name a *preferred* root, which seeds the choice without
+  binding it.
+
+  ## Policy belongs to the input; feasibility belongs to the pair
+
+  `hardlink | copy | move` describes what you want done with the *source* —
+  preserve it for seeding, or clear it out — so it's a property of where the
+  files came from. Whether a hardlink is actually possible depends on the
+  input and output being on one filesystem, which is a fact about the
+  *pairing* and can only be checked once both ends are known.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+
+  embedded_schema do
+    # :external adopts the files where they lie and is settled by definition —
+    # there is no destination to choose.
+    field :custody, Ecto.Enum, values: [:managed, :external], default: :external
+    field :root_id, :id
+    field :policy, Ecto.Enum, values: [:hardlink, :copy, :move]
+    field :approved, :boolean, default: false
+
+    # Filled in at render time from the registry rather than stored: roots are
+    # configuration and can change between seeding a draft and approving it.
+    field :roots, {:array, :map}, virtual: true, default: []
+  end
+
+  @doc false
+  def changeset(destination, attrs) do
+    destination
+    |> cast(attrs, [:custody, :root_id, :policy, :approved])
+    |> validate_managed_has_root()
+  end
+
+  # An approved managed import with no root is not a decision — it's one that
+  # would fail at the moment of placement, which is precisely what the
+  # invariant exists to prevent.
+  defp validate_managed_has_root(changeset) do
+    approved? = get_field(changeset, :approved)
+    managed? = get_field(changeset, :custody) == :managed
+
+    if approved? and managed? and is_nil(get_field(changeset, :root_id)) do
+      add_error(changeset, :root_id, "needs a library root to import into")
+    else
+      changeset
+    end
+  end
+
+  @doc """
+  Whether the destination still needs a human.
+
+  External custody is settled by construction: the files stay exactly where
+  they are, so there is nothing to decide.
+  """
+  def resolved?(%__MODULE__{custody: :external}), do: true
+  def resolved?(%__MODULE__{approved: true, root_id: id}), do: not is_nil(id)
+  def resolved?(%__MODULE__{}), do: false
+
+  def state(%__MODULE__{} = destination) do
+    cond do
+      resolved?(destination) -> :approved
+      destination.roots == [] -> :missing
+      true -> :ambiguous
+    end
+  end
+end

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -38,11 +38,14 @@ defmodule Ambry.Inbox.Draft.Seed do
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Candidate
   alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library
+  alias Ambry.Library.Location
   alias Ambry.People.Author
   alias Ambry.People.Narrator
   alias Ambry.People.Person
@@ -70,7 +73,8 @@ defmodule Ambry.Inbox.Draft.Seed do
       evidence: evidence(item),
       stale: false,
       work: work(work_level, hints, tags),
-      recording: recording(recording_level, hints, tags, item)
+      recording: recording(recording_level, hints, tags, item),
+      destination: destination(item)
     }
   end
 
@@ -91,6 +95,43 @@ defmodule Ambry.Inbox.Draft.Seed do
   # and their probe. Neither a rename nor a replacement can slip past it.
   defp evidence(%InboxItem{} = item) do
     :erlang.phash2({item.files, item.probe}) |> Integer.to_string()
+  end
+
+  ## destination
+
+  # Any input may feed any output, so the root is chosen per import rather
+  # than fixed on the location. The single-root case — which is nearly all of
+  # them — resolves silently: being asked to pick from a list of one is not a
+  # decision, it's an interruption.
+  def destination(%InboxItem{} = item) do
+    item = Repo.preload(item, :location)
+
+    case item.location do
+      %Location{kind: :downloads} = location -> managed_destination(location)
+      _adopted_in_place -> %Destination{custody: :external, approved: true}
+    end
+  end
+
+  defp managed_destination(location) do
+    roots = Library.library_roots()
+
+    # A location may still *prefer* a root; it just doesn't bind to one.
+    preferred = Enum.find(roots, &(&1.id == location.target_root_id))
+
+    case {preferred, roots} do
+      {%Location{} = root, _several} -> settled(root, location)
+      {nil, [only]} -> settled(only, location)
+      {nil, _none_or_several} -> %Destination{custody: :managed, policy: location.import_policy}
+    end
+  end
+
+  defp settled(root, location) do
+    %Destination{
+      custody: :managed,
+      root_id: root.id,
+      policy: location.import_policy,
+      approved: true
+    }
   end
 
   ## work

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -51,6 +51,10 @@ defmodule Ambry.Inbox.Draft.Seed do
   @strong_match 0.90
   @weak_runner_up 0.70
 
+  # How sure a recording match must be before its metadata is allowed to
+  # describe this file.
+  @trusted_recording 0.75
+
   @doc """
   Builds a fresh draft for an item from its matches, tags and release name.
   """
@@ -168,9 +172,17 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## recording
 
-  defp recording(level, _hints, tags, item) do
+  defp recording(level, hints, tags, item) do
     candidates = Map.get(level, "candidates", []) || []
-    best = List.first(candidates)
+
+    # **Only a recording we actually believe in gets to fill anything in.**
+    # Audible's search widens when a narrow query finds nothing, so a book
+    # whose only catalogued edition has a different reader still returns that
+    # edition — and taking its publisher, release date and cover would quietly
+    # describe this file as a recording it is not. A doubted candidate stays
+    # in the list for the operator to pick; it just doesn't get to speak
+    # first.
+    best = if trusted?(candidates, level, hints), do: List.first(candidates)
 
     %Recording{
       candidates: candidates,
@@ -189,6 +201,33 @@ defmodule Ambry.Inbox.Draft.Seed do
       narrators: narrator_credits(best, tags)
     }
   end
+
+  # An ASIN hit is identity, so it needs no corroboration. Otherwise the
+  # narrator decides: when the file names a reader and the candidate names a
+  # different one, this is the wrong recording of the right book — the single
+  # most common way recording-level matching goes wrong, and the one the
+  # operator is least likely to notice after the fact.
+  defp trusted?([], _level, _hints), do: false
+
+  defp trusted?([best | _rest], level, hints) do
+    cond do
+      best["score"] == 1.0 -> true
+      narrator_conflict?(best, hints) -> false
+      (Map.get(level, "confidence") || 0.0) >= @trusted_recording -> true
+      true -> false
+    end
+  end
+
+  defp narrator_conflict?(_best, %{narrator: nil}), do: false
+
+  defp narrator_conflict?(best, %{narrator: narrator}) do
+    case names(best["narrators"]) do
+      nil -> false
+      names -> Enum.all?(names, &(String.jaro_distance(down(&1), down(narrator)) < 0.85))
+    end
+  end
+
+  defp down(string), do: String.downcase(String.trim(string))
 
   # Embedded art and a provider cover are both real answers, so two of them is
   # a choice rather than a winner. The embedded candidate carries the audio

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -95,6 +95,7 @@ defmodule Ambry.Library do
   Only `:downloads` locations import anywhere; everything else is adopted in
   place, so asking is a caller error rather than a missing configuration.
   """
+  @deprecated "Inputs and outputs are independent; the destination is a draft decision"
   def target_root(%Location{kind: kind}) when kind != :downloads, do: {:error, :not_importing}
 
   def target_root(%Location{target_root_id: id}) when is_integer(id) do

--- a/lib/ambry/library/location.ex
+++ b/lib/ambry/library/location.ex
@@ -30,7 +30,9 @@ defmodule Ambry.Library.Location do
 
   schema "library_locations" do
     # Which root a `:downloads` location imports into. Null means "the only
-    # root there is" — see `Ambry.Library.target_root/1`.
+    # A *preferred* output, not a binding one: any input may feed any library
+    # root, and which one an import uses is decided per import (see
+    # `Ambry.Inbox.Draft.Destination`). This only seeds that choice.
     belongs_to :target_root, __MODULE__
 
     field :name, :string

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -205,7 +205,13 @@ defmodule Ambry.Metadata.Provider do
   end
 
   @type config :: %{optional(atom) => term}
-  @type capability :: :book_search | :book_details | :author_search | :author_details | :chapters
+  @type capability ::
+          :book_search
+          | :book_details
+          | :author_search
+          | :author_details
+          | :chapters
+          | :editions
 
   @doc "Stable machine identifier, used in cache keys and settings rows."
   @callback id() :: String.t()
@@ -246,13 +252,24 @@ defmodule Ambry.Metadata.Provider do
   @callback author_details(id :: String.t(), config()) :: {:ok, Author.t()} | {:error, term}
   @callback chapters(asin :: String.t(), config()) :: {:ok, Chapters.t()} | {:error, term}
 
+  @doc """
+  The audiobook editions of a work this provider already identified.
+
+  A third key, alongside "search for a work" and "search for a recording":
+  once the work is matched, its own edition list is the most direct route to
+  the recordings that exist — including ones a storefront has since delisted
+  and can no longer be searched for at all.
+  """
+  @callback editions(work_id :: String.t(), config()) :: {:ok, [Book.t()]} | {:error, term}
+
   @optional_callbacks available?: 1,
                       config_notices: 1,
                       search_books: 2,
                       book_details: 2,
                       search_authors: 2,
                       author_details: 2,
-                      chapters: 2
+                      chapters: 2,
+                      editions: 2
 
   @doc "The default config for a provider module, derived from its config fields."
   def default_config(provider_module) do

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -161,6 +161,49 @@ defmodule Ambry.Metadata.Provider do
     @type t :: %__MODULE__{key: atom, label: String.t(), type: :string | :secret, default: term}
   end
 
+  defmodule Query do
+    @moduledoc """
+    A book search expressed as the fields it's actually made of.
+
+    A single concatenated string is lossy in a way that silently breaks
+    providers: Audible's catalog endpoint takes `title`, `author` and
+    `narrator` as separate parameters, so handing it `"Neuromancer William
+    Gibson"` searched for a book *titled* that and returned nothing at all —
+    which is why the inbox's whole recording level came up empty.
+
+    Providers that only do free text can call `to_string/1` (or interpolate,
+    via `String.Chars`) and lose nothing. Providers that can be precise get to
+    be precise. `narrator` is the field that distinguishes two recordings of
+    one work, so it exists here even though only recording-level providers
+    have any use for it.
+    """
+
+    @enforce_keys []
+    defstruct [:title, :author, :narrator, :keywords]
+
+    @type t :: %__MODULE__{
+            title: String.t() | nil,
+            author: String.t() | nil,
+            narrator: String.t() | nil,
+            keywords: String.t() | nil
+          }
+
+    @doc "Whether there is anything here to search for."
+    def blank?(%__MODULE__{} = query), do: to_string(query) == ""
+
+    defimpl String.Chars do
+      @doc """
+      The free-text rendering, which is also what the metadata cache keys on —
+      so two structurally different queries can never collide.
+      """
+      def to_string(query) do
+        [query.keywords, query.title, query.author, query.narrator]
+        |> Enum.reject(&(&1 in [nil, ""]))
+        |> Enum.join(" ")
+      end
+    end
+  end
+
   @type config :: %{optional(atom) => term}
   @type capability :: :book_search | :book_details | :author_search | :author_details | :chapters
 
@@ -196,7 +239,8 @@ defmodule Ambry.Metadata.Provider do
   """
   @callback config_notices(config()) :: [notice()]
 
-  @callback search_books(query :: String.t(), config()) :: {:ok, [Book.t()]} | {:error, term}
+  @callback search_books(query :: String.t() | Query.t(), config()) ::
+              {:ok, [Book.t()]} | {:error, term}
   @callback book_details(id :: String.t(), config()) :: {:ok, Book.t()} | {:error, term}
   @callback search_authors(query :: String.t(), config()) :: {:ok, [Author.t()]} | {:error, term}
   @callback author_details(id :: String.t(), config()) :: {:ok, Author.t()} | {:error, term}

--- a/lib/ambry/metadata/providers.ex
+++ b/lib/ambry/metadata/providers.ex
@@ -31,6 +31,9 @@ defmodule Ambry.Metadata.Providers do
   def author_details(provider_id, author_id, opts \\ []),
     do: call(provider_id, :author_details, :author_details, author_id, @details_ttl, opts)
 
+  def editions(provider_id, work_id, opts \\ []),
+    do: call(provider_id, :editions, :editions, work_id, @details_ttl, opts)
+
   def chapters(provider_id, asin, opts \\ []),
     do: call(provider_id, :chapters, :chapters, asin, @details_ttl, opts)
 

--- a/lib/ambry/metadata/providers.ex
+++ b/lib/ambry/metadata/providers.ex
@@ -13,6 +13,7 @@ defmodule Ambry.Metadata.Providers do
   """
 
   alias Ambry.Metadata.Cache
+  alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Registry
 
   @search_ttl 7 * 24 * 60 * 60
@@ -42,13 +43,26 @@ defmodule Ambry.Metadata.Providers do
          :ok <- check_available(entry),
          :ok <- check_capability(entry, capability) do
       Cache.fetch(
-        "#{entry.id}:#{fun}:#{arg}",
+        "#{entry.id}:#{fun}:#{cache_key(arg)}",
         fn -> apply(entry.module, fun, [arg, entry.config]) end,
         ttl: ttl,
         refresh: Keyword.get(opts, :refresh, false)
       )
     end
   end
+
+  # A structured query keys on its fields, not on its free-text rendering.
+  # They flatten to the same string, but they are not the same search — for
+  # Audible, `title: "Neuromancer", author: "William Gibson"` finds the book
+  # and the concatenated string finds nothing — so sharing a cache entry
+  # would serve one's results for the other.
+  defp cache_key(%Provider.Query{} = query) do
+    [query.keywords, query.title, query.author, query.narrator]
+    |> Enum.map_join("|", &(&1 || ""))
+    |> then(&("q:" <> &1))
+  end
+
+  defp cache_key(arg), do: to_string(arg)
 
   defp check_enabled(%{enabled: true}), do: :ok
   defp check_enabled(_entry), do: {:error, :provider_disabled}

--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -37,18 +37,75 @@ defmodule Ambry.Metadata.Providers.Audible do
           "Only show search results in this language (Audible's language names, e.g. " <>
             ~s{"english", "german"). Set to "any" to disable filtering. } <>
             "Clear the cache after changing so old results don't linger."
+      },
+      %Provider.ConfigField{
+        key: :marketplaces,
+        label: "Marketplaces",
+        type: :string,
+        default: "us",
+        help:
+          "Which regional Audible catalogs to search, comma-separated — " <>
+            "us, uk, ca, au, de, fr, es, it, in, jp. Editions are regional, so a UK-only " <>
+            "recording is invisible to the US catalog. Results are merged, and the same " <>
+            "recording appearing in several catalogs is collapsed. Each extra marketplace " <>
+            "is another request per lookup, and a first inbox scan is hundreds of lookups."
       }
     ]
   end
 
+  # A structured query is the whole point at this level: the catalog endpoint
+  # matches `title` against the title alone, so a concatenated
+  # "title author" string finds nothing — which is how the inbox's recording
+  # level came up empty on every item. `narrator` is what distinguishes two
+  # recordings of one work, and it's a real parameter here.
   @impl Provider
-  def search_books(query, config) do
-    with {:ok, products} <- Audible.search_books(query, language: language(config)) do
-      {:ok, Enum.map(products, &product_to_book/1)}
+  def search_books(%Provider.Query{} = query, config), do: widen(attempts(query), config)
+
+  def search_books(query, config) when is_binary(query), do: widen([%{keywords: query}], config)
+
+  # Every parameter here is an AND filter, so the most precise query is also
+  # the most fragile: asking for narrator "Jeff Harding" on a book whose only
+  # Audible edition is read by Robertson Dean returns nothing at all, rather
+  # than the edition that does exist. So the query is tried narrow first and
+  # widened until something comes back — precision when precision is
+  # available, recall when it isn't.
+  #
+  # Scoring still judges the narrator afterwards, which is what keeps a
+  # widened result from being mistaken for a confident one: the wrong
+  # narrator's edition comes back with a low score rather than being adopted.
+  defp attempts(%Provider.Query{} = query) do
+    [
+      %{title: query.title, author: query.author, narrator: query.narrator},
+      %{title: query.title, author: query.author},
+      %{title: query.title},
+      %{keywords: query.keywords || to_string(query)}
+    ]
+    |> Enum.map(&drop_blanks/1)
+    |> Enum.reject(&(map_size(&1) == 0))
+    |> Enum.uniq()
+  end
+
+  defp drop_blanks(params) do
+    params |> Enum.reject(fn {_key, value} -> value in [nil, ""] end) |> Map.new()
+  end
+
+  defp widen([], _config), do: {:ok, []}
+
+  defp widen([params | rest], config) do
+    opts = [language: language(config), marketplaces: marketplaces(config)]
+
+    case Audible.search_books(params, opts) do
+      {:ok, []} -> widen(rest, config)
+      {:ok, products} -> {:ok, Enum.map(products, &product_to_book/1)}
+      # A failure is not an empty result — widening past it would hide an
+      # outage behind a vaguer query that happens to succeed.
+      {:error, reason} -> {:error, reason}
     end
   end
 
   defp language(config), do: config[:language] || "english"
+
+  defp marketplaces(config), do: Audible.parse_marketplaces(config[:marketplaces])
 
   defp product_to_book(product) do
     %Provider.Book{

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -35,7 +35,7 @@ defmodule Ambry.Metadata.Providers.Hardcover do
   def level, do: :work
 
   @impl Provider
-  def capabilities, do: [:book_search, :book_details, :author_search, :author_details]
+  def capabilities, do: [:book_search, :book_details, :author_search, :author_details, :editions]
 
   @impl Provider
   def config_fields do
@@ -115,6 +115,84 @@ defmodule Ambry.Metadata.Providers.Hardcover do
       {:ok, _other} -> {:error, :not_found}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  @editions_query """
+  query AudioEditions($id: Int!) {
+    editions(where: {book_id: {_eq: $id}}, limit: 60) {
+      id
+      title
+      release_date
+      asin
+      audio_seconds
+      reading_format_id
+      publisher { name }
+      image { url }
+      contributions { contribution author { id name } }
+    }
+  }
+  """
+
+  @doc """
+  The audiobook editions of a work.
+
+  This is the answer to recordings a storefront has delisted. Audible's
+  catalog API is a storefront, not a bibliography: when a publisher loses the
+  rights and the title is pulled, it disappears from search *and* from direct
+  ASIN lookup, leaving no trace that the recording ever existed. Hardcover
+  keeps the edition, its narrator and its cover.
+  """
+  @impl Provider
+  def editions(work_id, config) do
+    with {:ok, id} <- parse_id(work_id),
+         {:ok, %{"editions" => editions}} <-
+           Client.query(config, @editions_query, %{id: id}) do
+      {:ok, editions |> Enum.filter(&audio_edition?/1) |> Enum.map(&edition_to_book/1)}
+    else
+      {:ok, _other} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # NOT `reading_format_id`: it is unreliable in exactly the cases that matter
+  # — several Neuromancer editions with explicit Narrator credits and audio
+  # publishers are stored as format 1 ("Read"). An explicit Narrator
+  # contribution is the honest signal that this is a recording, and an
+  # audio_seconds runtime corroborates it.
+  defp audio_edition?(edition) do
+    narrators(edition) != [] or not is_nil(edition["audio_seconds"])
+  end
+
+  defp narrators(edition) do
+    edition["contributions"]
+    |> List.wrap()
+    |> Enum.filter(&(&1["contribution"] == "Narrator"))
+    |> Enum.map(& &1["author"])
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp edition_to_book(edition) do
+    %Provider.Book{
+      provider: id(),
+      id: to_string(edition["id"]),
+      asin: presence(edition["asin"]),
+      title: edition["title"],
+      cover_url: get_in(edition, ["image", "url"]),
+      publisher: get_in(edition, ["publisher", "name"]),
+      # Old editions frequently carry the *work's* date rather than their own
+      # (four Neuromancer editions all claim 1984-07-01), so this is offered
+      # as a proposal like any other and is not to be trusted over a
+      # storefront's date when one exists.
+      published: published_date(edition["release_date"]),
+      narrators:
+        Enum.map(narrators(edition), fn narrator ->
+          %Provider.Contributor{
+            id: to_string(narrator["id"]),
+            name: narrator["name"],
+            role: "narrator"
+          }
+        end)
+    }
   end
 
   @search_authors_query """

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -72,7 +72,10 @@ defmodule Ambry.Metadata.Providers.Hardcover do
 
   @impl Provider
   def search_books(query, config) do
-    with {:ok, data} <- Client.query(config, @search_books_query, %{query: query}) do
+    # Free text only — the search endpoint takes one string, so a structured
+    # query flattens to its rendering and loses nothing.
+    with {:ok, data} <-
+           Client.query(config, @search_books_query, %{query: to_string(query)}) do
       hits = get_in(data, ["search", "results", "hits"]) || []
       {:ok, hits |> Enum.map(&search_hit_to_book/1) |> Enum.reject(&is_nil/1)}
     end

--- a/lib/ambry/metadata/providers/rreading_glasses.ex
+++ b/lib/ambry/metadata/providers/rreading_glasses.ex
@@ -58,7 +58,8 @@ defmodule Ambry.Metadata.Providers.RreadingGlasses do
 
   @impl Provider
   def search_books(query, config) do
-    with {:ok, results} <- Client.get_json(base_url(config), "/search", q: query) do
+    # Free text only; a structured query flattens to its rendering.
+    with {:ok, results} <- Client.get_json(base_url(config), "/search", q: to_string(query)) do
       results
       |> Enum.map(& &1["bookId"])
       |> Enum.reject(&is_nil/1)

--- a/lib/ambry_scraping/audible.ex
+++ b/lib/ambry_scraping/audible.ex
@@ -7,6 +7,7 @@ defmodule AmbryScraping.Audible do
     deps: [AmbryScraping.HTMLToMD],
     exports: [Author, Product, Narrator, Series]
 
+  alias AmbryScraping.Audible.Client
   alias AmbryScraping.Audible.Products
 
   defmodule Author do
@@ -42,10 +43,18 @@ defmodule AmbryScraping.Audible do
   end
 
   @doc """
-  Searches for audiobooks by name.
+  Searches for audiobooks.
 
-  This function uses the public Audible API to search for audiobooks.
-  See `AmbryScraping.Audible.Products.search/2` for options (`:language`).
+  `query` is a plain string (searched as keywords) or a map of `:title` /
+  `:author` / `:narrator` / `:keywords`. See
+  `AmbryScraping.Audible.Products.search/2` for options (`:language`,
+  `:marketplaces`).
   """
   def search_books(query, opts \\ []), do: Products.search(query, opts)
+
+  @doc "The regional marketplace codes that can be searched."
+  defdelegate marketplaces, to: Client
+
+  @doc "Parses an operator's marketplace setting into a list of codes."
+  defdelegate parse_marketplaces(setting), to: Client
 end

--- a/lib/ambry_scraping/audible/client.ex
+++ b/lib/ambry_scraping/audible/client.ex
@@ -3,11 +3,61 @@ defmodule AmbryScraping.Audible.Client do
 
   require Logger
 
-  @url "https://api.audible.com/1.0"
+  # Audible's catalog is regional, and an edition existing in one marketplace
+  # says nothing about the others — Neuromancer read by Jeff Harding is a UK
+  # title and simply is not in the US catalog. The default stays US-only so
+  # nothing changes for an operator who never asks for more; the inbox widens
+  # it per the provider's configuration.
+  @marketplaces %{
+    "us" => "https://api.audible.com/1.0",
+    "uk" => "https://api.audible.co.uk/1.0",
+    "ca" => "https://api.audible.ca/1.0",
+    "au" => "https://api.audible.com.au/1.0",
+    "de" => "https://api.audible.de/1.0",
+    "fr" => "https://api.audible.fr/1.0",
+    "es" => "https://api.audible.es/1.0",
+    "it" => "https://api.audible.it/1.0",
+    "in" => "https://api.audible.in/1.0",
+    "jp" => "https://api.audible.co.jp/1.0"
+  }
 
-  def get(path, params) do
+  @default_marketplace "us"
+
+  @doc "The marketplace codes this client knows how to reach."
+  def marketplaces, do: Map.keys(@marketplaces)
+
+  @doc "What to search when the operator hasn't said otherwise."
+  def default_marketplaces, do: [@default_marketplace]
+
+  @doc """
+  Parses an operator's marketplace setting into a list of codes.
+
+  Unknown codes are dropped rather than attempted — a typo should cost that
+  one marketplace, not the whole search — and an empty result falls back to
+  the default so a bad setting can never silently disable Audible entirely.
+  """
+  def parse_marketplaces(nil), do: default_marketplaces()
+
+  def parse_marketplaces(setting) when is_binary(setting) do
+    codes =
+      setting
+      |> String.split([",", " "], trim: true)
+      |> Enum.map(&String.downcase(String.trim(&1)))
+      |> Enum.filter(&Map.has_key?(@marketplaces, &1))
+      |> Enum.uniq()
+
+    if codes == [], do: default_marketplaces(), else: codes
+  end
+
+  def parse_marketplaces(codes) when is_list(codes),
+    do: codes |> Enum.join(",") |> parse_marketplaces()
+
+  def get(path, params, opts \\ []) do
+    marketplace = Keyword.get(opts, :marketplace, @default_marketplace)
+    base = Map.get(@marketplaces, marketplace, @marketplaces[@default_marketplace])
+
     query = URI.encode_query(params)
-    url = "#{@url}#{path}" |> URI.new!() |> URI.append_query(query) |> URI.to_string()
+    url = "#{base}#{path}" |> URI.new!() |> URI.append_query(query) |> URI.to_string()
 
     Logger.debug(fn -> "[Audible.Client] requesting #{url}" end)
 

--- a/lib/ambry_scraping/audible/products.ex
+++ b/lib/ambry_scraping/audible/products.ex
@@ -29,7 +29,14 @@ defmodule AmbryScraping.Audible.Products do
   )
 
   @doc """
-  Returns product details for a given title search query.
+  Searches the catalog.
+
+  `query` is either a plain string (searched as keywords) or a map of
+  `:title` / `:author` / `:narrator` / `:keywords`. **The distinction
+  matters**: this endpoint's `title` parameter matches against the title
+  alone, so passing `"Neuromancer William Gibson"` as a title finds nothing,
+  while `title: "Neuromancer", author: "William Gibson"` finds it. A bare
+  string therefore goes to `keywords`, which is the forgiving field.
 
   Options:
 
@@ -37,37 +44,92 @@ defmodule AmbryScraping.Audible.Products do
       case-insensitively against Audible's language names, which are
       English words like "english", "german"). Defaults to `"english"`;
       pass `"any"` (or `nil`) to disable filtering.
+    * `:marketplaces` — which regional catalogs to search, merged. Editions
+      are regional: a UK-only recording is invisible to the US catalog no
+      matter how it's queried.
   """
   def search(query, opts \\ [])
 
   def search("", _opts), do: {:ok, []}
 
-  def search(query, opts) do
-    params = %{
-      title: query,
-      response_groups: Enum.join(@response_groups, ","),
-      products_sort_by: "Relevance",
-      image_sizes: "900"
-    }
+  def search(query, opts) when is_binary(query), do: search(%{keywords: query}, opts)
 
-    case Client.get("/catalog/products", params) do
-      {:ok, %{status: status} = response} when status in 200..299 ->
-        parse_response(response.body, Keyword.get(opts, :language, "english"))
+  def search(query, opts) when is_map(query) do
+    case search_params(query) do
+      empty when map_size(empty) == 0 ->
+        {:ok, []}
 
-      {:ok, response} ->
-        {:error, response}
-
-      {:error, reason} ->
-        {:error, reason}
+      params ->
+        params
+        |> search_marketplaces(Keyword.get(opts, :marketplaces, Client.default_marketplaces()))
+        |> parse_all(Keyword.get(opts, :language, "english"))
     end
   end
 
-  defp parse_response(%{"products" => products}, language) do
-    {:ok, products |> Enum.map(&parse_product/1) |> filter_language(language)}
+  # Merged rather than first-hit-wins: the point of searching several
+  # marketplaces is recall, and which catalog a recording lives in is exactly
+  # what the operator doesn't know. Deduped by ASIN, keeping the first
+  # marketplace's copy, so the configured order is a preference order.
+  defp search_marketplaces(params, marketplaces) do
+    Enum.reduce(marketplaces, {[], []}, fn marketplace, {products, errors} ->
+      case Client.get("/catalog/products", params, marketplace: marketplace) do
+        {:ok, %{status: status, body: body}} when status in 200..299 ->
+          {products ++ List.wrap(body["products"]), errors}
+
+        {:ok, response} ->
+          {products, [{marketplace, response} | errors]}
+
+        {:error, reason} ->
+          {products, [{marketplace, reason} | errors]}
+      end
+    end)
   end
 
-  defp parse_response(_body, _language) do
-    {:error, :unexpected_response_payload}
+  # One reachable marketplace is a usable answer; all of them failing is not.
+  defp parse_all({[], [{_marketplace, reason} | _rest]}, _language), do: {:error, reason}
+
+  defp parse_all({products, _errors}, language) do
+    {:ok,
+     products
+     |> Enum.uniq_by(&dedupe_key/1)
+     |> Enum.map(&parse_product/1)
+     |> filter_language(language)}
+  end
+
+  # NOT by ASIN: the same recording carries a *different* ASIN in each
+  # regional catalog, so an ASIN key silently lets every merged marketplace
+  # contribute its own copy of the same book. Title, narrators and release
+  # date together identify the recording across regions; the ASIN is only a
+  # last resort for a product too sparse to key on.
+  defp dedupe_key(product) do
+    narrators = product["narrators"] |> List.wrap() |> Enum.map_join(",", & &1["name"])
+
+    case {product["title"], product["release_date"]} do
+      {nil, _date} -> product["asin"]
+      {title, date} -> {String.downcase(title), narrators, date}
+    end
+  end
+
+  defp search_params(query) do
+    %{
+      title: query[:title],
+      author: query[:author],
+      narrator: query[:narrator],
+      keywords: query[:keywords]
+    }
+    |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+    |> Map.new()
+    |> case do
+      empty when map_size(empty) == 0 ->
+        empty
+
+      params ->
+        Map.merge(params, %{
+          response_groups: Enum.join(@response_groups, ","),
+          products_sort_by: "Relevance",
+          image_sizes: "900"
+        })
+    end
   end
 
   defp filter_language(products, language) when language in [nil, "any"], do: products

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -22,6 +22,38 @@ defmodule AmbryWeb.Admin.Decisions do
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.SeriesLink
 
+  attr :outcomes, :list, required: true
+
+  @doc """
+  What each provider said when asked — including the ones that couldn't
+  answer.
+
+  Without this, a provider that errors is indistinguishable from one that
+  genuinely found nothing: both contribute zero candidates and say nothing
+  about why. That's how an enabled-but-rate-limited source looks like it was
+  never consulted.
+  """
+  def provider_outcomes_row(assigns) do
+    ~H"""
+    <div :if={@outcomes != []} class="flex flex-wrap items-center gap-2" data-role="provider-outcomes">
+      <span class="text-xs dark:text-zinc-500">Asked:</span>
+      <span
+        :for={outcome <- @outcomes}
+        class={[
+          "rounded-sm border px-2 py-0.5 text-xs",
+          outcome["status"] == "failed" && "border-red-500 text-red-600",
+          outcome["status"] != "failed" && "border-zinc-300 dark:border-zinc-700"
+        ]}
+        title={outcome["reason"]}
+      >
+        {outcome["name"]}: {if outcome["status"] == "failed",
+          do: "couldn't be reached",
+          else: outcome["count"]}
+      </span>
+    </div>
+    """
+  end
+
   attr :label, :string, required: true
   attr :section, :string, required: true
   attr :name, :atom, required: true

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -145,6 +145,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.approve_work(&1, params["approved"] == "true"))}
   end
 
+  def handle_event("choose-root", %{"root_id" => root_id}, socket) do
+    id = to_int(root_id)
+
+    {:noreply,
+     edit(socket, fn draft ->
+       update_in(draft.destination, &%{&1 | root_id: id, approved: not is_nil(id)})
+     end)}
+  end
+
   def handle_event("approve-all", _params, socket) do
     {:noreply, edit(socket, &Draft.Edit.approve_all/1)}
   end
@@ -198,7 +207,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       form: to_form(Inbox.change_draft(item)),
       unresolved: Draft.unresolved(item.draft),
       progress: Draft.progress(item.draft),
-      destination: Inbox.destination_preflight(item)
+      destination: Inbox.destination_preflight(item),
+      # Roots are configuration and can change between seeding a draft and
+      # approving it, so they're read now rather than frozen into the draft.
+      roots: Ambry.Library.library_roots()
     )
   end
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -265,6 +265,27 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # from is recorded per-field as provenance, not as one winning row.
   def chosen_work?(%Work{mode: :create, approved: approved?}, _candidate), do: approved?
 
+  @doc """
+  Which providers were asked at this level, and what each said.
+
+  A provider that errors contributes nothing and used to leave no trace, so a
+  rate-limited or misconfigured source looked exactly like one that genuinely
+  had no answer — and the operator's only clue was a shorter list than they
+  expected.
+  """
+  def provider_outcomes(%InboxItem{matches: matches}, level) when is_map(matches) do
+    get_in(matches, [level, "providers"]) || []
+  end
+
+  def provider_outcomes(_item, _level), do: []
+
+  def outcome_label(%{"status" => "failed"} = outcome),
+    do: {"#{outcome["name"]} couldn't be reached", :red}
+
+  def outcome_label(%{"count" => 0} = outcome), do: {"#{outcome["name"]}: nothing", :gray}
+
+  def outcome_label(outcome), do: {"#{outcome["name"]}: #{outcome["count"]}", :gray}
+
   @doc "A work candidate as one readable line."
   def candidate_line(candidate) do
     [candidate["title"], candidate["authors"] && Enum.join(candidate["authors"], ", ")]

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -302,6 +302,37 @@
       <p class="text-sm">
         <span class="font-bold">Custody:</span> {@destination.custody}
       </p>
+
+      <%!-- Any input may feed any output, so the root is chosen here rather
+            than fixed on the watched folder. With one root this never asks. --%>
+      <div :if={@item.draft.destination && @item.draft.destination.custody == :managed}>
+        <div class="flex items-center gap-2">
+          <.label>Library root</.label>
+          <.badge
+            :if={!@item.draft.destination.approved}
+            color={:yellow}
+            class="text-xs"
+          >
+            needs a look
+          </.badge>
+        </div>
+
+        <form id="destination-root" phx-change="choose-root" class="mt-1">
+          <select
+            name="root_id"
+            class="w-full max-w-md rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+          >
+            <option value="">Choose a library root…</option>
+            <option
+              :for={root <- @roots}
+              value={root.id}
+              selected={@item.draft.destination.root_id == root.id}
+            >
+              {root.name} — {root.path}
+            </option>
+          </select>
+        </form>
+      </div>
       <p :if={@destination.summary} class="text-sm dark:text-zinc-400">{@destination.summary}</p>
       <p :if={@destination.blocker} class="text-sm text-red-600" data-role="destination-blocker">
         {@destination.blocker}

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -47,6 +47,7 @@
       <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
         The work
       </h2>
+      <.provider_outcomes_row outcomes={provider_outcomes(@item, "work")} />
 
       <div class="space-y-2">
         <div class="flex items-center gap-2">
@@ -207,6 +208,7 @@
       <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
         The recording
       </h2>
+      <.provider_outcomes_row outcomes={provider_outcomes(@item, "recording")} />
 
       <p class="text-sm italic dark:text-zinc-500">
         A new recording of that work. (Replacing an existing recording's files is a later addition —

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -14,6 +14,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   alias Ambry.Inbox
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library.Location
 
   @statuses [:pending, :dismissed, :approved]
 
@@ -183,6 +184,19 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp status_color(:pending), do: :yellow
   defp status_color(:approved), do: :brand
   defp status_color(:dismissed), do: :gray
+
+  # Where an item came from is what decides its custody at approval — whether
+  # the file gets brought into the library or referenced where it lies — so
+  # it's worth reading off the row.
+  defp location_label(%Location{name: name, kind: kind}), do: "#{name} · #{kind_word(kind)}"
+  defp location_label(nil), do: "ad-hoc scan · adopted in place"
+
+  defp kind_word(:downloads), do: "imported"
+  defp kind_word(:external_collection), do: "adopted in place"
+  defp kind_word(:library_root), do: "already in the library tree"
+
+  defp location_color(%Location{kind: :downloads}), do: "bg-blue-100 dark:bg-blue-900"
+  defp location_color(_other), do: "bg-zinc-200 dark:bg-zinc-800"
 
   @doc """
   The candidate's name — usually the release name, and the most recognizable

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -98,6 +98,11 @@
         </p>
 
         <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs dark:text-zinc-600">
+          <%!-- Where this came from decides what approving it does to the
+                bytes, so it belongs on the row rather than one click away. --%>
+          <span class={["mr-1 rounded-sm px-1 py-0.5", location_color(item.location)]}>
+            {location_label(item.location)}
+          </span>
           {item.path}
         </p>
       </div>

--- a/lib/ambry_web/live/admin/location_live/form.html.heex
+++ b/lib/ambry_web/live/admin/location_live/form.html.heex
@@ -61,10 +61,14 @@
           <.input
             field={@form[:target_root_id]}
             type="select"
-            label="Imports into"
+            label="Preferred library root"
             options={@root_options}
             prompt={root_prompt(@root_options)}
           />
+          <p class="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+            Optional. Any watched folder can import into any root — this only preselects one. With
+            a single root, imports never ask.
+          </p>
           <p :if={@root_options == []} class="mt-2 text-sm text-amber-600 dark:text-amber-400">
             There are no library roots yet, so nothing can be imported. Add a location of kind
             "Library root" first — until then, approving an item from this folder will refuse.

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -76,7 +76,7 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
                   :for={capability <- entry.capabilities}
                   class="rounded-sm bg-zinc-200 px-2 py-0.5 text-xs text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
                 >
-                  {capability_label(capability)}
+                  {capability_label(capability, entry.level)}
                 </span>
               </div>
 
@@ -216,11 +216,24 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
   defp notice_icon(:warning), do: "fa-triangle-exclamation"
   defp notice_icon(:error), do: "fa-circle-exclamation"
 
-  defp capability_label(:book_search), do: "book search"
-  defp capability_label(:book_details), do: "book details"
-  defp capability_label(:author_search), do: "author search"
-  defp capability_label(:author_details), do: "author details"
-  defp capability_label(:chapters), do: "chapters"
+  # A capability means something different at each level, and the level is
+  # what says which — a recording-level `:book_search` searches *audiobooks*,
+  # a work-level one searches works. Labelling both "book search" threw that
+  # away and made the provider list look like it couldn't tell them apart.
+  #
+  # Kept as display rather than split into `:work_search`/`:recording_search`
+  # atoms deliberately: the level already carries it, and separate atoms would
+  # let a provider claim recording-search at the work level — an illegal state
+  # the current pairing simply can't represent.
+  defp capability_label(:book_search, :recording), do: "audiobook search"
+  defp capability_label(:book_details, :recording), do: "audiobook details"
+  defp capability_label(:book_search, _level), do: "work search"
+  defp capability_label(:book_details, _level), do: "work details"
+  defp capability_label(:author_search, :person), do: "person search"
+  defp capability_label(:author_details, :person), do: "person details"
+  defp capability_label(:author_search, _level), do: "author search"
+  defp capability_label(:author_details, _level), do: "author details"
+  defp capability_label(:chapters, _level), do: "chapters"
 
   defp display_value(value, %{default: default}) when value == default, do: nil
   defp display_value(value, _field), do: value

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -234,6 +234,11 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
   defp capability_label(:author_search, _level), do: "author search"
   defp capability_label(:author_details, _level), do: "author details"
   defp capability_label(:chapters, _level), do: "chapters"
+  defp capability_label(:editions, _level), do: "editions"
+
+  # A capability with no label must not take the settings page down with it —
+  # adding one to the behaviour shouldn't be able to break an unrelated screen.
+  defp capability_label(other, _level), do: other |> to_string() |> String.replace("_", " ")
 
   defp display_value(value, %{default: default}) when value == default, do: nil
   defp display_value(value, _field), do: value

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -93,10 +93,10 @@ defmodule Ambry.Inbox.AutoMatchTest do
       assert best["source"] == "local"
     end
 
-    test "reports low confidence when two candidates are equally good" do
+    test "reports low confidence when two different books are equally good" do
       patch_work_results([
         book("The Silent Patient", ["Alex Michaelides"]),
-        book("The Silent Patient", ["Alex Michaelides"])
+        book("The Silent Patients", ["Alexa Michaelides"])
       ])
 
       %{matches: matches} = AutoMatch.match(item(title: "The Silent Patient"))
@@ -106,6 +106,50 @@ defmodule Ambry.Inbox.AutoMatchTest do
       # a strong match with an equally strong runner-up is exactly what a
       # human should look at
       assert matches["work"]["confidence"] < 0.6
+    end
+
+    # Two providers returning the SAME work is corroboration, not conflict.
+    # Treating it as a tie dropped perfect double hits to 0.5 confidence and
+    # sent obviously-correct matches back to the operator to adjudicate.
+    test "two providers agreeing is corroboration, not a tie" do
+      patch_work_results([
+        book("The Silent Patient", ["Alex Michaelides"]),
+        book("The Silent Patient", ["Alex Michaelides"])
+      ])
+
+      %{matches: matches} = AutoMatch.match(item(title: "The Silent Patient"))
+
+      assert [only] = matches["work"]["candidates"]
+      assert only["also_from"] != []
+      assert matches["work"]["confidence"] > 0.9
+    end
+
+    test "records what each provider was asked and what it said" do
+      patch_work_results([book("The Silent Patient", ["Alex Michaelides"])])
+
+      %{matches: matches} = AutoMatch.match(item(title: "The Silent Patient"))
+
+      assert [outcome | _rest] = matches["work"]["providers"]
+      assert outcome["status"] == "ok"
+      assert outcome["count"] >= 1
+    end
+
+    # Jaro distance rewards shared substrings and cannot see *extra* content,
+    # so companion works scored ~0.7 against the book they discuss and sat
+    # near the top of the candidate list looking plausible.
+    test "companion works are pushed well below the real thing" do
+      patch_work_results([
+        book("Neuromancer", ["William Gibson"]),
+        book("A Study Guide for William Gibson's Neuromancer", ["Gale"]),
+        book("William Gibson's Neuromancer, the Graphic Novel", ["Tom De Haven"])
+      ])
+
+      %{matches: matches} = AutoMatch.match(item(title: "Neuromancer", author: "William Gibson"))
+
+      [best | rest] = matches["work"]["candidates"]
+
+      assert best["title"] == "Neuromancer"
+      assert Enum.all?(rest, &(&1["score"] < 0.4))
     end
 
     test "is confident when the winner stands alone" do

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -6,6 +6,7 @@ defmodule Ambry.Inbox.AutoMatchTest do
   alias Ambry.Inbox.InboxItem
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Registry
 
   describe "hints/1" do
     test "prefers tags over the release name" do
@@ -38,6 +39,12 @@ defmodule Ambry.Inbox.AutoMatchTest do
   describe "match/1" do
     setup do
       patch(Providers, :search_books, fn _id, _query, _opts -> {:ok, []} end)
+      # Matching also asks the matched work for its editions and hydrates the
+      # top candidate. Both are real HTTP unless stubbed — and the only reason
+      # this suite wasn't already making live calls is that the fake ids
+      # happen not to parse.
+      patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
+      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :not_stubbed} end)
       :ok
     end
 
@@ -174,6 +181,61 @@ defmodule Ambry.Inbox.AutoMatchTest do
       assert [%{"source" => "local"} | _rest] = matches["work"]["candidates"]
     end
 
+    # Audible's catalog API is a storefront, not a bibliography: when rights
+    # lapse the title vanishes from search AND from direct ASIN lookup, with
+    # no record it ever existed. A work-level provider that keeps editions
+    # still has it — so the matched work's own editions are a third key.
+    test "the matched work's editions become recording candidates" do
+      patch_work_results([book("Neuromancer", ["William Gibson"])])
+
+      # Hardcover is the provider that keeps editions, but it needs a token and
+      # so is unavailable in test — the capability is what matters here, not
+      # which provider happens to carry it.
+      entries = Map.new(Registry.all(), &{&1.id, &1})
+
+      patch(Registry, :fetch, fn id ->
+        case Map.fetch(entries, id) do
+          {:ok, entry} -> {:ok, %{entry | capabilities: [:editions | entry.capabilities]}}
+          :error -> {:error, :unknown_provider}
+        end
+      end)
+
+      patch(Providers, :editions, fn _id, _work_id, _opts ->
+        {:ok,
+         [
+           %Provider.Book{
+             provider: "hardcover",
+             id: "e1",
+             title: "Neuromancer",
+             publisher: "Books on Tape",
+             narrators: [%Provider.Contributor{name: "Arthur Addison", role: "narrator"}]
+           }
+         ]}
+      end)
+
+      %{matches: matches} =
+        AutoMatch.match(item(title: "Neuromancer", author: "William Gibson"))
+
+      titles = Enum.map(matches["recording"]["candidates"], & &1["narrators"])
+      assert [["Arthur Addison"]] == titles
+
+      assert Enum.any?(matches["recording"]["providers"], &(&1["id"] =~ ":editions"))
+    end
+
+    # Two audiobooks of one work share a title and an author; they are not the
+    # same thing. Keying only on those collapsed the 1984 Books on Tape and
+    # 2011 Penguin editions of Neuromancer into a single candidate.
+    test "two recordings of one work are not merged" do
+      patch_recording_results([
+        book("Neuromancer", ["William Gibson"], narrators: ["Robertson Dean"], asin: "A1"),
+        book("Neuromancer", ["William Gibson"], narrators: ["Arthur Addison"], asin: "A2")
+      ])
+
+      %{matches: matches} = AutoMatch.match(item(title: "Neuromancer"))
+
+      assert length(matches["recording"]["candidates"]) == 2
+    end
+
     test "an item with nothing to go on proposes nothing rather than guessing" do
       %{matches: matches} = AutoMatch.match(%InboxItem{path: "/downloads/", tags: %{}})
 
@@ -203,7 +265,9 @@ defmodule Ambry.Inbox.AutoMatchTest do
       id: "id-#{:erlang.phash2(title)}",
       title: title,
       asin: opts[:asin],
-      authors: Enum.map(authors, &%Provider.Contributor{name: &1, role: "author"})
+      authors: Enum.map(authors, &%Provider.Contributor{name: &1, role: "author"}),
+      narrators:
+        Enum.map(opts[:narrators] || [], &%Provider.Contributor{name: &1, role: "narrator"})
     }
   end
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -38,7 +38,12 @@ defmodule Ambry.Inbox.DraftTest do
         "confidence" => Keyword.get(opts, :confidence, 0.95),
         "query" => "q"
       },
-      "recording" => %{"candidates" => Keyword.get(opts, :recording, []), "confidence" => 0.0}
+      "recording" => %{
+        "candidates" => Keyword.get(opts, :recording, []),
+        # A recording match only gets to fill fields in when it's believed;
+        # tests that want its metadata used have to say so.
+        "confidence" => Keyword.get(opts, :recording_confidence, 0.0)
+      }
     }
   end
 
@@ -324,13 +329,52 @@ defmodule Ambry.Inbox.DraftTest do
       draft =
         Seed.build(
           item(%{
-            matches: matches(candidates, recording: recording),
+            matches: matches(candidates, recording: recording, recording_confidence: 0.95),
             tags: %{"has_cover_art" => true}
           })
         )
 
       refute draft.recording.cover.approved
       assert length(draft.recording.cover.candidates) == 2
+    end
+
+    # The wrong recording of the right book is the most common recording-level
+    # failure and the hardest to notice afterwards, so a candidate whose
+    # narrator disagrees with the file's is shown but never allowed to
+    # describe it.
+    test "a recording with the wrong narrator fills nothing in" do
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "provider_name" => "Audible",
+          "id" => "B01",
+          "title" => "Neuromancer",
+          "narrators" => ["Robertson Dean"],
+          "publisher" => "Penguin Audio",
+          "published" => "2011-06-30",
+          "cover_url" => "https://example.test/cover.jpg",
+          "score" => 0.5
+        }
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches:
+              matches([provider_candidate(%{})],
+                recording: recording,
+                recording_confidence: 0.5
+              ),
+            tags: %{"narrators" => ["Jeff Harding"]}
+          })
+        )
+
+      # offered, so the operator can still choose it
+      assert length(draft.recording.candidates) == 1
+      # but nothing of its metadata was adopted
+      assert draft.recording.publisher.value == nil
+      assert draft.recording.published.value == nil
+      assert draft.recording.cover.value == nil
     end
   end
 

--- a/test/ambry/inbox/managed_approval_test.exs
+++ b/test/ambry/inbox/managed_approval_test.exs
@@ -125,10 +125,14 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       end
     end
 
+    # Which root an import goes to is a decision now, not a property of the
+    # watched folder — so "no root" and "several roots, none chosen" surface
+    # as outstanding decisions rather than as failures at the last moment.
     test "refuses when there is no library root to import into" do
       %{item: item} = downloads_item(root: :none)
 
-      assert {:error, :no_library_root} = Inbox.approve_item(item)
+      assert {:error, {:unresolved, outstanding}} = Inbox.approve_item(item)
+      assert Enum.any?(outstanding, &(&1.section == :destination))
 
       {[item], false} = Inbox.list_items()
       assert item.status == :pending
@@ -137,24 +141,53 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     # With several roots the choice is about which NAS, and therefore about
     # whether hardlinking is possible at all. Guessing is not acceptable.
     test "refuses when several roots exist and none was chosen" do
-      %{item: item} = downloads_item()
       insert(:location, kind: :library_root, import_policy: nil, path: new_dir("second-root"))
+      %{item: item} = downloads_item()
 
-      assert {:error, :ambiguous_library_root} = Inbox.approve_item(item)
+      assert {:error, {:unresolved, outstanding}} = Inbox.approve_item(item)
+      assert Enum.any?(outstanding, &(&1.section == :destination))
     end
 
-    test "uses the explicitly chosen root when there are several" do
-      %{item: item, location: location} = downloads_item()
-
+    # Any input may feed any output: the operator picks per import, and a
+    # location's configured root only *preselects* one.
+    test "uses the root the draft settled on when there are several" do
       chosen =
         insert(:location, kind: :library_root, import_policy: nil, path: new_dir("chosen-root"))
 
-      {:ok, _location} = Library.update_location(location, %{target_root_id: chosen.id})
+      %{item: item} = downloads_item()
 
-      assert {:ok, media} = Inbox.approve_item(Repo.reload(item))
+      {:ok, item} =
+        Inbox.update_draft(item, %{
+          "destination" => %{
+            "custody" => "managed",
+            "root_id" => chosen.id,
+            "policy" => "hardlink",
+            "approved" => true
+          }
+        })
+
+      assert {:ok, media} = Inbox.approve_item(item)
 
       assert [placed] = Media.get_media!(media.id).source_files
       assert String.starts_with?(placed, chosen.path)
+    end
+
+    test "a location's preferred root preselects without binding" do
+      %{item: item, location: location} = downloads_item()
+
+      chosen =
+        insert(:location,
+          kind: :library_root,
+          import_policy: nil,
+          path: new_dir("preferred-root")
+        )
+
+      {:ok, _location} = Library.update_location(location, %{target_root_id: chosen.id})
+
+      {:ok, item} = Inbox.rebuild_draft(Repo.reload(item))
+
+      assert item.draft.destination.root_id == chosen.id
+      assert item.draft.destination.approved
     end
 
     # A collision means two recordings rendered to one path, which is a

--- a/test/ambry/metadata/providers/audible_test.exs
+++ b/test/ambry/metadata/providers/audible_test.exs
@@ -26,7 +26,11 @@ defmodule Ambry.Metadata.Providers.AudibleTest do
       language: "english"
     }
 
-    patch(AmbryScraping.Audible, :search_books, fn "dcc", _opts -> {:ok, [product]} end)
+    # The provider now sends structured params rather than one string:
+    # Audible's catalog matches `title` against the title alone.
+    patch(AmbryScraping.Audible, :search_books, fn %{keywords: "dcc"}, _opts ->
+      {:ok, [product]}
+    end)
 
     assert {:ok, [%Provider.Book{} = book]} = Audible.search_books("dcc", %{})
 
@@ -55,5 +59,64 @@ defmodule Ambry.Metadata.Providers.AudibleTest do
 
     assert {:ok, []} = Audible.search_books("q", %{language: "german"})
     assert_received {:language, "german"}
+  end
+
+  # The bug this exists to prevent: the catalog's `title` parameter matches
+  # against the title alone, so a concatenated "title author" string found
+  # nothing at all — which is why the inbox's whole recording level came up
+  # empty on every item.
+  test "sends a structured query as separate parameters" do
+    patch(AmbryScraping.Audible, :search_books, fn params, _opts ->
+      send(self(), {:params, params})
+      {:ok, []}
+    end)
+
+    query = %Provider.Query{
+      title: "Neuromancer",
+      author: "William Gibson",
+      narrator: "Jeff Harding"
+    }
+
+    assert {:ok, []} = Audible.search_books(query, %{})
+
+    assert_received {:params,
+                     %{title: "Neuromancer", author: "William Gibson", narrator: "Jeff Harding"}}
+  end
+
+  # Every parameter is an AND filter, so the most precise query is the most
+  # fragile: asking for a narrator the only catalogued edition doesn't have
+  # returns nothing rather than the edition that exists.
+  test "widens the query until something comes back" do
+    patch(AmbryScraping.Audible, :search_books, fn params, _opts ->
+      send(self(), {:tried, Map.keys(params) |> Enum.sort()})
+      if Map.has_key?(params, :narrator), do: {:ok, []}, else: {:ok, [product()]}
+    end)
+
+    query = %Provider.Query{title: "Neuromancer", author: "William Gibson", narrator: "Nobody"}
+    assert {:ok, [_book]} = Audible.search_books(query, %{})
+
+    assert_received {:tried, [:author, :narrator, :title]}
+    assert_received {:tried, [:author, :title]}
+  end
+
+  # A failure is not an empty result — widening past it would hide an outage
+  # behind a vaguer query that happens to succeed.
+  test "does not widen past a failure" do
+    patch(AmbryScraping.Audible, :search_books, fn _params, _opts -> {:error, :rate_limited} end)
+
+    query = %Provider.Query{title: "Neuromancer", author: "William Gibson", narrator: "Somebody"}
+    assert {:error, :rate_limited} = Audible.search_books(query, %{})
+  end
+
+  defp product do
+    %AmbryScraping.Audible.Product{
+      id: "B0057HR4E6",
+      title: "Neuromancer",
+      authors: [],
+      narrators: [],
+      series: [],
+      published: ~D[2011-06-30],
+      language: "english"
+    }
   end
 end

--- a/test/ambry_scraping/audible_test.exs
+++ b/test/ambry_scraping/audible_test.exs
@@ -12,7 +12,7 @@ defmodule AmbryScraping.AudibleTest do
 
   describe "search_books/1" do
     test "searches for books given a query" do
-      patch(Client, :get, fn _url, _params ->
+      patch(Client, :get, fn _url, _params, _opts ->
         {:ok,
          %{
            status: 200,
@@ -46,7 +46,7 @@ defmodule AmbryScraping.AudibleTest do
     end
 
     test "filters results by language, configurably" do
-      patch(Client, :get, fn _url, _params ->
+      patch(Client, :get, fn _url, _params, _opts ->
         {:ok,
          %{
            status: 200,


### PR DESCRIPTION
Three defects found exercising the import form against the real library. All were real; each had a different cause than the obvious one.

## The recording level was empty on every item

`query_for/1` built `"#{title} #{author}"` and the Audible provider passed it as the catalog's **`title`** parameter — so it searched for a book *titled* "Neuromancer William Gibson". Measured live:

| Params | Results |
|---|---|
| `title: "Neuromancer William Gibson"` (before) | **0** |
| `title: "Neuromancer", author: "William Gibson"` | 4 |
| `keywords: "Neuromancer William Gibson"` | 8 |

Introduces `Ambry.Metadata.Provider.Query` — `{title, author, narrator, keywords}` — which text-only providers (Hardcover, rreading-glasses) flatten via `String.Chars` and lose nothing by. The metadata cache keys on the *fields*, not the flattening, or a structured and a concatenated query would share an entry despite returning different things.

Narrator now takes part, since it's what distinguishes two recordings of one work and is a real Audible parameter. But those parameters are **AND filters**, so an unmatched narrator returns nothing rather than the edition that exists — hence progressive widening (title+author+narrator → title+author → title → keywords). An *error* never widens; that would hide an outage behind a vaguer query that happens to succeed.

## Companion works ranked as plausible matches

| Candidate | Was | Now |
|---|---|---|
| Neuromancer | 1.000 | 1.000 |
| …the Graphic Novel | 0.719 | 0.093 |
| …and the Relation Between Mind and Body | 0.570 | 0.228 |
| Collection 4 Books Bundle | 0.712 | 0.093 |

Jaro rewards shared substrings and **cannot see extra content**, which is exactly what disqualifies a companion work. Adds a decisive companion-marker penalty plus a scaling per-extra-word cost. Deliberately **not** added to `normalize/1` — stripping "graphic novel" would make a graphic novel match its subject *better*.

## Two providers agreeing was scored as a tie

The close-runner-up penalty dropped a perfect double hit to **0.5 confidence**, so the most corroborated matches in the library were the ones demanding review. Agreeing candidates now merge, carry `also_from`, and take a small bonus — the reported item went **0.5 → 0.869**.

Local records deliberately do **not** merge with provider hits: "reuse the book you have" and "create it" are different outcomes, and both have to stay visible.

## A failing provider was invisible

It logged a warning and returned `[]`, indistinguishable from one that genuinely found nothing. Each level now records `providers: [%{id, name, status, count, reason}]`, rendered in the form.

## Found while fixing

- **The same recording carries a different ASIN in each regional catalog**, so the cross-marketplace merge couldn't dedupe by ASIN — it silently returned one copy per marketplace. Keyed on title + narrators + release date instead.
- **Multi-marketplace search is configurable** (`us, uk, ca, au, de, fr, es, it, in, jp`) but **defaults to `us` only** — each extra marketplace is another request per lookup, on a serial queue already doing hundreds per scan.
- **Widening makes the wrong-recording-of-the-right-book case more likely.** Two defences: narrator similarity is near-binary (jaro rates two unrelated names 0.53, which blended in left the wrong reader's edition at 0.81 — comfortably "likely"), and `Seed.trusted?/3` refuses to let a doubted recording supply publisher, date or cover at all. It stays in the candidate list to be chosen; it just doesn't speak first. Verified both ways: wrong reader → confidence 0.5, nothing seeded; right reader → 1.0, publisher/date/cover filled.
- **Test mocks pin arity.** Changing `Client.get/2` to `get/3` silently un-patched the Audible tests and pointed the suite at the live API — the tell was runtime going 15s → 120s+.

## Verification

`mix check` clean; `mix test --force --warnings-as-errors` — 1052 pass.
Scoring changes verified live against the real providers, not only fixtures.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek