### PR TITLE
Make the inbox form ask one question with one answer

### DIFF
--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -140,7 +140,7 @@ defmodule Ambry.Inbox.AutoMatch do
           "description" => presence(book.description),
           "cover_url" => presence(book.cover_url),
           "publisher" => presence(book.publisher),
-          "series" => book.series |> List.wrap() |> Enum.map(& &1.name)
+          "series" => series_refs(book.series)
         }
         |> Enum.reject(fn {_key, value} -> value in [nil, []] end)
         |> Map.new()
@@ -201,7 +201,7 @@ defmodule Ambry.Inbox.AutoMatch do
            true <- is_binary(ref["id"]),
            {:ok, %{capabilities: capabilities}} <- Registry.fetch(provider_id),
            true <- :editions in capabilities do
-        fetch_editions(provider_id, ref["id"], hints)
+        fetch_editions(provider_id, ref["id"], hints, work_ref(best))
       else
         _not_this_one -> nil
       end
@@ -210,11 +210,22 @@ defmodule Ambry.Inbox.AutoMatch do
 
   defp work_editions(_work, _hints), do: {[], []}
 
-  defp fetch_editions(provider_id, work_id, hints) do
+  # A recording is a recording of exactly one work, so an edition that came
+  # out of a work's own list carries that work with it. Choosing such a
+  # recording in the form settles the book too, instead of asking the operator
+  # the same question twice.
+  defp work_ref(%{"source" => source, "id" => id}), do: %{"source" => source, "id" => id}
+
+  defp fetch_editions(provider_id, work_id, hints, of_work) do
     case Providers.editions(provider_id, work_id, []) do
       {:ok, books} ->
         {:ok, entry} = Registry.fetch(provider_id)
-        candidates = Enum.map(books, &provider_candidate(&1, entry, hints))
+
+        candidates =
+          Enum.map(
+            books,
+            &(&1 |> provider_candidate(entry, hints) |> Map.put("of_work", of_work))
+          )
 
         {candidates,
          [
@@ -255,6 +266,10 @@ defmodule Ambry.Inbox.AutoMatch do
 
     %{
       "query" => query && to_string(query),
+      # The flattened string is what the cache keys on and what text-only
+      # providers see, but it isn't what was *asked* — the fields are, and
+      # they're what the operator needs to read when a match looks wrong.
+      "query_fields" => query_fields(query),
       "candidates" => candidates,
       # the operator confirms; this is only the suggestion
       "selected" => candidates |> List.first() |> selected_ref(),
@@ -268,6 +283,19 @@ defmodule Ambry.Inbox.AutoMatch do
 
   defp selected_ref(nil), do: nil
   defp selected_ref(candidate), do: %{"source" => candidate["source"], "id" => candidate["id"]}
+
+  defp query_fields(nil), do: %{}
+
+  defp query_fields(%Provider.Query{} = query) do
+    %{
+      "title" => presence(query.title),
+      "author" => presence(query.author),
+      "narrator" => presence(query.narrator),
+      "keywords" => presence(query.keywords)
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
 
   # Two providers returning the same work is the strongest signal available,
   # not a disagreement — but the runner-up penalty below read it as one and
@@ -346,7 +374,7 @@ defmodule Ambry.Inbox.AutoMatch do
         "id" => book.id,
         "title" => book.title,
         "authors" => Enum.map(book.authors || [], & &1.name),
-        "series" => Enum.map(book.series || [], & &1.name),
+        "series" => series_refs(book.series),
         "published" => book.published && Date.to_iso8601(book.published),
         # a work already in the library beats an equally-good provider hit:
         # reusing it is what prevents duplicate Books
@@ -419,7 +447,7 @@ defmodule Ambry.Inbox.AutoMatch do
       "title" => book.title,
       "authors" => authors,
       "narrators" => narrators,
-      "series" => Enum.map(book.series || [], & &1.name),
+      "series" => series_refs(book.series),
       "published" =>
         book.published && book.published.date && Date.to_iso8601(book.published.date),
       # carried alongside the date because it is not derivable from it:
@@ -433,6 +461,22 @@ defmodule Ambry.Inbox.AutoMatch do
       "score" => score(book.title, authors, narrators, book.asin, hints)
     }
   end
+
+  # A series membership is a name AND a position, and the position was being
+  # thrown away here — every provider we use reports it (Hardcover's
+  # `position`/`details`, rreading-glasses' `PositionInSeries`, Audible's
+  # `sequence`), and the inbox then asked the operator for a number nobody had
+  # to look up. Kept as maps rather than two parallel lists so a book that is
+  # #10.5 in one series and #3 in another survives the trip.
+  defp series_refs(series) do
+    for entry <- List.wrap(series), is_binary(entry.name) do
+      %{"name" => entry.name, "number" => number_string(entry.number)}
+    end
+  end
+
+  defp number_string(nil), do: nil
+  defp number_string(%Decimal{} = number), do: Decimal.to_string(number, :normal)
+  defp number_string(number), do: presence(to_string(number))
 
   # An ASIN match is identity, not similarity — nothing else can earn 1.0.
   defp score(_title, _authors, _narrators, asin, %{asin: asin}) when is_binary(asin), do: 1.0

--- a/lib/ambry/inbox/draft/credit.ex
+++ b/lib/ambry/inbox/draft/credit.ex
@@ -142,7 +142,6 @@ defmodule Ambry.Inbox.Draft.Credit do
     cond do
       resolved?(credit) -> :approved
       length(credit.candidates) > 1 -> :ambiguous
-      credit.candidates != [] -> :ambiguous
       true -> :unconfirmed
     end
   end

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -13,11 +13,16 @@ defmodule Ambry.Inbox.Draft.Edit do
   the params on the way back in.
   """
 
+  alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.PersonRef
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.Work
+  alias Ambry.Inbox.InboxItem
 
   @doc """
   Accepts one of a scalar's proposed candidates.
@@ -34,15 +39,89 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   @doc """
-  Settles which Book this is — an existing one, or a new one.
+  Settles which Book this is, and fills the work's fields from that answer.
+
+  Choosing used to only flip `mode`, which is why every provider row rendered
+  as chosen and clicking one appeared to do nothing: the fields had been
+  seeded from the top hit at build time and no later choice could move them.
+  A release is a recording of exactly one work, so picking a different
+  candidate has to change what the book will say.
   """
-  def choose_work(draft, "local", id) do
-    update_in(draft.work, &%{&1 | mode: :link, book_id: id, approved: true})
+  def choose_work(draft, %InboxItem{} = item, source, id) do
+    case find_candidate(draft.work.candidates, source, id) do
+      nil ->
+        draft
+
+      candidate ->
+        # Clicking the row that's already chosen is a confirmation, not a
+        # change — re-seeding there would silently discard every credit and
+        # series the operator has settled since.
+        if Work.selected?(draft.work, candidate) do
+          update_in(draft.work, &%{&1 | approved: true})
+        else
+          update_in(draft.work, &Seed.reseed_work(&1, candidate, hints(item), tags(item)))
+        end
+    end
   end
 
-  def choose_work(draft, _provider_source, _id) do
-    update_in(draft.work, &%{&1 | mode: :create, book_id: nil, approved: true})
+  @doc """
+  Settles the work as a book nothing matched, described by the file alone.
+  """
+  def choose_new_work(draft, %InboxItem{} = item) do
+    update_in(draft.work, &Seed.reseed_new_work(&1, hints(item), tags(item)))
   end
+
+  @doc """
+  Settles which catalogued recording this release is.
+
+  Because a recording is a recording of exactly one work, a candidate that
+  came out of a work's own edition list answers the book question too — so
+  choosing it settles the work rather than asking again.
+  """
+  def choose_recording(draft, %InboxItem{} = item, source, id) do
+    case find_candidate(draft.recording.candidates, source, id) do
+      nil ->
+        draft
+
+      candidate ->
+        draft
+        |> update_in([Access.key(:recording)], fn recording ->
+          if Recording.selected?(recording, candidate),
+            do: %{recording | approved: true, doubt: :none, doubt_detail: nil},
+            else: Seed.reseed_recording(recording, candidate, tags(item), item)
+        end)
+        |> follow_work(item, candidate)
+    end
+  end
+
+  @doc """
+  Settles the recording as one no catalogue lists.
+
+  A real answer, not a failure: a delisted edition disappears from Audible's
+  search *and* from direct ASIN lookup, so plenty of perfectly good rips are
+  in no storefront at all.
+  """
+  def choose_uncatalogued(draft, %InboxItem{} = item) do
+    update_in(draft.recording, &Seed.reseed_uncatalogued(&1, tags(item), item))
+  end
+
+  defp follow_work(draft, item, %{"of_work" => %{"source" => source, "id" => id}})
+       when is_binary(source) do
+    if Work.selected?(draft.work, %{"source" => source, "id" => id}),
+      do: draft,
+      else: choose_work(draft, item, source, id)
+  end
+
+  defp follow_work(draft, _item, _candidate), do: draft
+
+  defp find_candidate(candidates, source, id) do
+    Enum.find(candidates, fn candidate ->
+      candidate["source"] == source and to_string(candidate["id"]) == to_string(id)
+    end)
+  end
+
+  defp hints(%InboxItem{} = item), do: AutoMatch.hints(item)
+  defp tags(%InboxItem{tags: tags}), do: tags || %{}
 
   @doc """
   Points a credit at an identity that already exists.
@@ -149,11 +228,12 @@ defmodule Ambry.Inbox.Draft.Edit do
     do: update_in(draft.recording.approved, fn _ -> approved? end)
 
   @doc """
-  Approves every decision that is only waiting on a nod.
+  Takes the leading suggestion for everything still outstanding.
 
-  The "looks right, take it" button. Deliberately does NOT invent values —
-  anything genuinely missing or contradictory stays outstanding, so this can
-  never turn a `:missing` title into an imported book with no title.
+  Three things it deliberately will not do, because each would be the system
+  writing a fact nobody actually has: invent a value nothing proposed, invent
+  a series number, or pick a recording we already said we doubt. Those stay
+  outstanding, which is the difference between a shortcut and a rubber stamp.
   """
   def approve_all(%Draft{} = draft) do
     draft
@@ -178,7 +258,11 @@ defmodule Ambry.Inbox.Draft.Edit do
   defp approve_all_recording(recording) do
     %{
       recording
-      | approved: true,
+      | # A doubted match is the one thing here that must stay a question. The
+        # leading candidate for a narrator conflict is, by construction, the
+        # wrong recording of the right book — precisely what nobody would
+        # notice after the fact.
+        approved: recording.approved or recording.doubt in [nil, :none, :nothing_found],
         title: settle_if_possible(recording.title),
         published: settle_if_possible(recording.published),
         publisher: settle_if_possible(recording.publisher),

--- a/lib/ambry/inbox/draft/field.ex
+++ b/lib/ambry/inbox/draft/field.ex
@@ -116,12 +116,22 @@ defmodule Ambry.Inbox.Draft.Field do
 
   `:missing` and `:ambiguous` are genuinely different problems — one needs a
   value from somewhere, the other needs a choice between values already in
-  hand — and the form should not describe them the same way.
+  hand — and the form should not describe them the same way. Which is exactly
+  why this counts *distinct* proposals: it used to report "sources disagree"
+  for a field with one proposal, and for a field with none at all.
   """
   def state(%__MODULE__{approved: true}), do: :approved
-  def state(%__MODULE__{candidates: [], required: true}), do: :missing
-  def state(%__MODULE__{candidates: [_one]}), do: :ambiguous
-  def state(%__MODULE__{}), do: :ambiguous
+
+  def state(%__MODULE__{} = field) do
+    field.candidates
+    |> Enum.map(& &1.value)
+    |> Enum.uniq()
+    |> case do
+      [] -> if field.required, do: :missing, else: :unconfirmed
+      [_one] -> :unconfirmed
+      _several -> :ambiguous
+    end
+  end
 
   @doc """
   The settled value, as the string it's staged as.

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -21,7 +21,23 @@ defmodule Ambry.Inbox.Draft.Recording do
     field :candidates, {:array, :map}, default: []
     field :confidence, :float
     field :query, :string
+    field :query_fields, :map, default: %{}
     field :approved, :boolean, default: false
+
+    # Which catalogue entry describes this recording — the sharpest fact
+    # available about an import, because a file is a recording of exactly one
+    # thing. `nil` with candidates present means the operator has said none of
+    # them is it; the fields below then come from the file alone.
+    field :selected_source, :string
+    field :selected_id, :string
+
+    # Why nothing was filled in from a match. A doubted candidate stays in the
+    # list to be chosen but is not allowed to describe the file, and the
+    # operator was previously given no way to tell that apart from "no
+    # provider had anything" — the two look identical once the fields are
+    # empty.
+    field :doubt, Ecto.Enum, values: [:none, :nothing_found, :narrator_conflict, :low_confidence]
+    field :doubt_detail, :string
 
     embeds_one :title, Field, on_replace: :update
     embeds_one :published, Field, on_replace: :update
@@ -35,7 +51,17 @@ defmodule Ambry.Inbox.Draft.Recording do
   @doc false
   def changeset(recording, attrs) do
     recording
-    |> cast(attrs, [:candidates, :confidence, :query, :approved])
+    |> cast(attrs, [
+      :candidates,
+      :confidence,
+      :query,
+      :query_fields,
+      :approved,
+      :selected_source,
+      :selected_id,
+      :doubt,
+      :doubt_detail
+    ])
     |> cast_embed(:title)
     |> cast_embed(:published)
     |> cast_embed(:publisher)
@@ -60,7 +86,30 @@ defmodule Ambry.Inbox.Draft.Recording do
   defp identity(%__MODULE__{approved: true}), do: []
 
   defp identity(%__MODULE__{}),
-    do: [%{section: :recording, label: "Which recording", state: :unconfirmed}]
+    do: [%{section: :recording, label: "Which recording this is", state: :unconfirmed}]
+
+  @doc """
+  Whether a candidate is the one this recording was identified as.
+  """
+  def selected?(%__MODULE__{selected_source: nil}, _candidate), do: false
+
+  def selected?(%__MODULE__{} = recording, candidate) do
+    recording.selected_source == candidate["source"] and
+      recording.selected_id == to_string(candidate["id"])
+  end
+
+  @doc """
+  Whether the operator has said this release is in no catalogue.
+
+  A real answer, and the one that settles the identity for the many recordings
+  that genuinely aren't listed anywhere — a delisted edition disappears from
+  Audible's search *and* from direct ASIN lookup, so "not found" is a fact
+  about the catalogue, not a failure of the import.
+  """
+  def uncatalogued?(%__MODULE__{selected_source: nil, approved: true, candidates: [_ | _]}),
+    do: true
+
+  def uncatalogued?(%__MODULE__{}), do: false
 
   defp field(nil, _label), do: []
 

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -15,9 +15,16 @@ defmodule Ambry.Inbox.Draft.Seed do
       match, or a top score ≥ 0.90 whose runner-up is ≤ 0.70. Local books
       already outrank equal provider hits in `AutoMatch`, so "reuse the work"
       wins by default.
+    * **recording identity** — settled when an ASIN or a confident match says
+      which catalogue entry this is, and settled when nothing was found at all
+      (plenty of good rips are in no storefront). A *doubted* match settles
+      nothing and records why: the wrong recording of the right book is the
+      most expensive mistake available here and the hardest to notice later.
     * **scalar** — nothing proposed and optional: waived. One proposal: taken.
       Several that agree once normalized: taken. Several that disagree:
-      the operator's.
+      the operator's. Format labels are not a disagreement — "Neuromancer" and
+      "Neuromancer (Unabridged)" are one answer written two ways, and the
+      cleaner spelling wins.
     * **credit** — one exact identity match: linked. No match at all, name
       from a provider-matched work: created 1:1. A *Person* matches but the
       identity doesn't: always the operator's, because "is this the same
@@ -26,8 +33,18 @@ defmodule Ambry.Inbox.Draft.Seed do
       multi-value splitting 1b calls knowingly imperfect ("Sanderson,
       Brandon"). This is the rule that stops the inbox quietly filling the
       library with malformed people.
-    * **series number** — never invented. Only a number an actual source
-      supplied can settle it.
+    * **series number** — never invented, but every provider we use reports
+      one, so it usually arrives with the match. A tag's number belongs to the
+      series the tag named; it is borrowed for a provider's series only when
+      the file named none and there is exactly one proposal.
+
+  ## Re-seeding
+
+  The candidate list is a question with one right answer — the file is a
+  recording of exactly one work — so choosing a different candidate refills
+  the fields from it (`reseed_work/4`, `reseed_recording/4`). Anything the
+  operator typed survives, because 1d's whole point is that curation outranks
+  any source.
   """
 
   import Ecto.Query
@@ -150,13 +167,68 @@ defmodule Ambry.Inbox.Draft.Seed do
       candidates: candidates,
       confidence: confidence,
       query: Map.get(level, "query"),
-      title: title_field(best, hints, tags),
-      published: published_field(best, tags),
-      published_format: published_format_field(best, tags),
-      authors: author_credits(best, tags),
-      series: series_links(best, tags, book_id)
+      query_fields: Map.get(level, "query_fields") || %{},
+      selected_source: best && best["source"],
+      selected_id: best && to_string(best["id"])
+    }
+    |> put_work_fields(best, hints, tags)
+  end
+
+  @doc """
+  Fills a work's fields from one candidate, keeping anything the operator
+  typed.
+
+  This is what makes the candidate list a question rather than a display: a
+  release is a recording of exactly one work, so picking a different candidate
+  has to change what the book will say. Manual edits survive, because 1d's
+  whole point is that curation outranks any source.
+  """
+  def reseed_work(%Work{} = work, candidate, hints, tags) do
+    %{
+      work
+      | mode: if(candidate["source"] == "local", do: :link, else: :create),
+        book_id: if(candidate["source"] == "local", do: candidate["id"]),
+        approved: true,
+        selected_source: candidate["source"],
+        selected_id: to_string(candidate["id"])
+    }
+    |> put_work_fields(candidate, hints, tags)
+  end
+
+  @doc """
+  Detaches a work from every candidate — a book nothing matched, described by
+  the file alone.
+  """
+  def reseed_new_work(%Work{} = work, hints, tags) do
+    %{
+      work
+      | mode: :create,
+        book_id: nil,
+        approved: true,
+        selected_source: nil,
+        selected_id: nil
+    }
+    |> put_work_fields(nil, hints, tags)
+  end
+
+  defp put_work_fields(%Work{} = work, best, hints, tags) do
+    book_id = if best && best["source"] == "local", do: best["id"]
+
+    %{
+      work
+      | title: keep_manual(work.title, title_field(best, hints, tags)),
+        published: keep_manual(work.published, published_field(best, tags)),
+        published_format: keep_manual(work.published_format, published_format_field(best, tags)),
+        authors: author_credits(best, tags),
+        series: series_links(best, tags, book_id)
     }
   end
+
+  # A field the operator typed is theirs; re-seeding from another candidate
+  # must not quietly undo a correction. Everything else is provider data being
+  # replaced by other provider data, which is exactly what was asked for.
+  defp keep_manual(%Field{source: "manual"} = existing, _fresh), do: existing
+  defp keep_manual(_existing, fresh), do: fresh
 
   # An existing Book is the best outcome there is — it's what stops a second
   # recording of a work splitting the library — so a confident local hit links
@@ -188,8 +260,35 @@ defmodule Ambry.Inbox.Draft.Seed do
   # make nearly every import ambiguous on its title for no gain.
   defp title_field(best, hints, tags) do
     [candidate(best, "title"), tag_candidate(tags, "book_title")]
-    |> scalar(required: true, fallback: release_candidate(hints.title))
+    |> scalar(
+      required: true,
+      equivalence: &title_key/1,
+      fallback: release_candidate(hints.title)
+    )
   end
+
+  # "Neuromancer" and "Neuromancer (Unabridged)" are one answer written two
+  # ways, and treating that as a disagreement made the operator arbitrate a
+  # non-question on a large share of imports — Audible titles carry the format
+  # label and work-level providers don't. Only *format* labels are set aside,
+  # and only for deciding whether two proposals mean the same thing: both
+  # strings stay in the candidate list, and the shorter one wins the field.
+  #
+  # Deliberately not stripped: "Dramatized Adaptation", "(1 of 3)" and the
+  # like. Those name a genuinely different recording, and collapsing them
+  # would hide the very distinction the recording level exists to make.
+  @format_labels ~r/\b(?:un)?abridged(?:\s+edition)?\b|\baudio\s?book\b|\baudio\s+edition\b/iu
+
+  defp title_key(value) when is_binary(value) do
+    value
+    |> String.replace(@format_labels, " ")
+    # a bracket that held nothing but a format label is now empty
+    |> String.replace(~r/[(\[{]\s*[)\]}]/u, " ")
+    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
+    |> normalize()
+  end
+
+  defp title_key(other), do: normalize(other)
 
   defp published_field(best, tags) do
     [candidate(best, "published"), tag_candidate(tags, "published")]
@@ -223,23 +322,67 @@ defmodule Ambry.Inbox.Draft.Seed do
     # describe this file as a recording it is not. A doubted candidate stays
     # in the list for the operator to pick; it just doesn't get to speak
     # first.
-    best = if trusted?(candidates, level, hints), do: List.first(candidates)
+    {doubt, detail, best} = trust(candidates, level, hints)
 
     %Recording{
       candidates: candidates,
       confidence: Map.get(level, "confidence"),
       query: Map.get(level, "query"),
-      # A new recording is what an inbox item almost always is, and the
-      # skeleton has no other option to offer — so the identity is settled by
-      # construction. Replace-an-existing-recording is the option this grows.
-      approved: true,
-      title: [] |> scalar(required: false),
-      published: [candidate(best, "published")] |> scalar(required: false),
-      publisher: [candidate(best, "publisher"), tag_candidate(tags, "publisher")] |> scalar(),
-      description:
-        [candidate(best, "description"), tag_candidate(tags, "description")] |> scalar(),
-      cover: cover_field(best, tags, item),
-      narrators: narrator_credits(best, tags)
+      query_fields: Map.get(level, "query_fields") || %{},
+      doubt: doubt,
+      doubt_detail: detail,
+      selected_source: best && best["source"],
+      selected_id: best && to_string(best["id"]),
+      # Which recording this is is a fact with one right answer, so it settles
+      # only when we actually know it: a trusted match, or nothing to choose
+      # between. A doubted candidate leaves the question open rather than
+      # being adopted quietly — that ambiguity was previously invisible,
+      # showing up only as fields that mysteriously stayed empty.
+      approved: doubt in [:none, :nothing_found]
+    }
+    |> put_recording_fields(best, tags, item)
+  end
+
+  @doc """
+  Fills a recording's fields from one catalogue entry, keeping typed values.
+  """
+  def reseed_recording(%Recording{} = recording, candidate, tags, item) do
+    %{
+      recording
+      | approved: true,
+        selected_source: candidate["source"],
+        selected_id: to_string(candidate["id"]),
+        doubt: :none,
+        doubt_detail: nil
+    }
+    |> put_recording_fields(candidate, tags, item)
+  end
+
+  @doc """
+  Settles a recording as one no catalogue lists, described by the file alone.
+  """
+  def reseed_uncatalogued(%Recording{} = recording, tags, item) do
+    %{recording | approved: true, selected_source: nil, selected_id: nil}
+    |> put_recording_fields(nil, tags, item)
+  end
+
+  defp put_recording_fields(%Recording{} = recording, best, tags, item) do
+    %{
+      recording
+      | title: keep_manual(recording.title, scalar([], required: false)),
+        published: keep_manual(recording.published, scalar([candidate(best, "published")])),
+        publisher:
+          keep_manual(
+            recording.publisher,
+            scalar([candidate(best, "publisher"), tag_candidate(tags, "publisher")])
+          ),
+        description:
+          keep_manual(
+            recording.description,
+            scalar([candidate(best, "description"), tag_candidate(tags, "description")])
+          ),
+        cover: keep_manual(recording.cover, cover_field(best, tags, item)),
+        narrators: narrator_credits(best, tags)
     }
   end
 
@@ -248,23 +391,56 @@ defmodule Ambry.Inbox.Draft.Seed do
   # different one, this is the wrong recording of the right book — the single
   # most common way recording-level matching goes wrong, and the one the
   # operator is least likely to notice after the fact.
-  defp trusted?([], _level, _hints), do: false
+  #
+  # Returns why it isn't trusted as well as whether, because "no provider
+  # listed this" and "a provider listed a different reader's edition" call for
+  # completely different things from the operator, and an empty form says
+  # neither.
+  defp trust([], _level, _hints), do: {:nothing_found, nil, nil}
 
-  defp trusted?([best | _rest], level, hints) do
+  defp trust([best | _rest], level, hints) do
+    confidence = Map.get(level, "confidence") || 0.0
+
     cond do
-      best["score"] == 1.0 -> true
-      narrator_conflict?(best, hints) -> false
-      (Map.get(level, "confidence") || 0.0) >= @trusted_recording -> true
-      true -> false
+      best["score"] == 1.0 ->
+        {:none, nil, best}
+
+      conflict = narrator_conflict(best, hints) ->
+        {:narrator_conflict, conflict, nil}
+
+      confidence >= @trusted_recording ->
+        {:none, nil, best}
+
+      true ->
+        {:low_confidence, low_confidence_detail(best, confidence), nil}
     end
   end
 
-  defp narrator_conflict?(_best, %{narrator: nil}), do: false
+  defp low_confidence_detail(best, confidence) do
+    "The closest is #{best["title"]}#{narrated_by(best["narrators"])}, and it isn't a close " <>
+      "enough match (#{round(confidence * 100)}%) to describe this file."
+  end
 
-  defp narrator_conflict?(best, %{narrator: narrator}) do
+  defp narrated_by(narrators) do
+    case names(narrators) do
+      nil -> ""
+      names -> " read by #{Enum.join(names, ", ")}"
+    end
+  end
+
+  defp narrator_conflict(_best, %{narrator: nil}), do: nil
+
+  defp narrator_conflict(best, %{narrator: narrator}) do
     case names(best["narrators"]) do
-      nil -> false
-      names -> Enum.all?(names, &(String.jaro_distance(down(&1), down(narrator)) < 0.85))
+      nil ->
+        nil
+
+      names ->
+        if Enum.all?(names, &(String.jaro_distance(down(&1), down(narrator)) < 0.85)) do
+          "The file says #{narrator} reads this; the closest catalogue entry " <>
+            "(#{best["title"]}) is read by #{Enum.join(names, ", ")}. Those are " <>
+            "different recordings of the same book."
+        end
     end
   end
 
@@ -377,13 +553,68 @@ defmodule Ambry.Inbox.Draft.Seed do
   # book doesn't already have it: an import may fill a blank, never overwrite
   # curation.
   defp series_links(best, tags, book_id) do
-    names = names(best && best["series"]) || names(tags["series"]) || []
-    number = tags["series_number"]
-    source = if names == names(best && best["series"]), do: source_of(best), else: "tags"
+    {proposals, source} =
+      case series_proposals(best && best["series"]) do
+        [] -> {series_proposals_from_tags(tags), "tags"}
+        from_provider -> {from_provider, source_of(best)}
+      end
 
-    names
-    |> Enum.reject(&already_on_book?(&1, book_id))
-    |> Enum.map(&series_link(&1, number, source))
+    proposals
+    |> Enum.reject(&already_on_book?(&1.name, book_id))
+    |> then(fn kept ->
+      Enum.map(kept, &series_link(&1.name, &1.number || tag_number(&1.name, tags, kept), source))
+    end)
+  end
+
+  # The file's series number describes this book's position in the series the
+  # file names. Applying it to a series the file did NOT name is inventing a
+  # fact — safe only when the file named no series at all and there's exactly
+  # one proposal for it to have been about.
+  defp tag_number(name, tags, proposals) do
+    tagged = presence(tags["series"])
+
+    cond do
+      is_nil(tagged) and length(proposals) == 1 -> presence(tags["series_number"])
+      tagged && normalize(tagged) == normalize(name) -> presence(tags["series_number"])
+      true -> nil
+    end
+  end
+
+  # Candidates carry series as `%{"name", "number"}`. Older stored matches
+  # carry bare strings, and a rescan is not something to require just to read
+  # an item, so both shapes are accepted.
+  defp series_proposals(nil), do: []
+
+  defp series_proposals(entries) when is_list(entries) do
+    entries
+    |> Enum.map(&series_proposal/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp series_proposals(value) when is_binary(value), do: series_proposals([value])
+  defp series_proposals(_other), do: []
+
+  defp series_proposal(%{"name" => name} = entry) when is_binary(name) do
+    case presence(name) do
+      nil -> nil
+      name -> %{name: name, number: presence(entry["number"])}
+    end
+  end
+
+  defp series_proposal(name) when is_binary(name) do
+    case presence(name) do
+      nil -> nil
+      name -> %{name: name, number: nil}
+    end
+  end
+
+  defp series_proposal(_other), do: nil
+
+  defp series_proposals_from_tags(tags) do
+    case presence(tags["series"]) do
+      nil -> []
+      name -> [%{name: name, number: presence(tags["series_number"])}]
+    end
   end
 
   defp already_on_book?(_name, nil), do: false
@@ -436,24 +667,27 @@ defmodule Ambry.Inbox.Draft.Seed do
   # into a choice.
   defp scalar(candidates, opts \\ []) do
     required = Keyword.get(opts, :required, false)
+    same? = Keyword.get(opts, :equivalence, &normalize/1)
     candidates = Enum.reject(candidates, &is_nil/1)
 
     candidates =
-      case {distinct(candidates), Keyword.get(opts, :fallback)} do
+      case {groups(candidates, same?), Keyword.get(opts, :fallback)} do
         {[], fallback} when not is_nil(fallback) -> [fallback]
         _primary_had_something -> candidates
       end
 
     field = %Field{required: required, candidates: candidates}
 
-    case distinct(candidates) do
+    case groups(candidates, same?) do
       # nothing proposed it. Optional means waived — an explicit "none", which
       # is what makes "every piece resolved" reachable at all.
       [] ->
         %{field | approved: not required}
 
-      # one answer, whether from one source or several that agree
-      [value] ->
+      # one answer, whether from one source, several that agree exactly, or
+      # several that agree once format labels are set aside
+      [group] ->
+        value = preferred(group)
         %{field | value: value, source: source_for(candidates, value), approved: true}
 
       _several ->
@@ -461,12 +695,19 @@ defmodule Ambry.Inbox.Draft.Seed do
     end
   end
 
-  defp distinct(candidates) do
+  # Proposals that mean the same thing, gathered. Every group is one answer;
+  # more than one group is a genuine disagreement for the operator to settle.
+  defp groups(candidates, same?) do
     candidates
     |> Enum.map(& &1.value)
     |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.uniq_by(&normalize/1)
+    |> Enum.group_by(same?)
+    |> Map.values()
   end
+
+  # Given two spellings of one answer, the shorter is the title and the longer
+  # is the title with a format label bolted on.
+  defp preferred(values), do: values |> Enum.uniq() |> Enum.min_by(&String.length/1)
 
   defp source_for(candidates, value) do
     Enum.find_value(candidates, fn candidate ->

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -28,6 +28,15 @@ defmodule Ambry.Inbox.Draft.Work do
     field :candidates, {:array, :map}, default: []
     field :confidence, :float
     field :query, :string
+    field :query_fields, :map, default: %{}
+
+    # WHICH candidate the fields below were filled from. Without it the form
+    # could only ask "is this a new book or an existing one?", so every
+    # provider row rendered as chosen and clicking one changed nothing
+    # visible. Ids are held as strings because a local candidate's is an
+    # integer and a provider's is not.
+    field :selected_source, :string
+    field :selected_id, :string
 
     embeds_one :title, Field, on_replace: :update
     embeds_one :published, Field, on_replace: :update
@@ -40,7 +49,17 @@ defmodule Ambry.Inbox.Draft.Work do
   @doc false
   def changeset(work, attrs) do
     work
-    |> cast(attrs, [:mode, :book_id, :approved, :candidates, :confidence, :query])
+    |> cast(attrs, [
+      :mode,
+      :book_id,
+      :approved,
+      :candidates,
+      :confidence,
+      :query,
+      :query_fields,
+      :selected_source,
+      :selected_id
+    ])
     |> cast_embed(:title)
     |> cast_embed(:published)
     |> cast_embed(:published_format)
@@ -98,4 +117,17 @@ defmodule Ambry.Inbox.Draft.Work do
 
   defp state_of(%Credit{} = credit), do: Credit.state(credit)
   defp state_of(%SeriesLink{} = link), do: SeriesLink.state(link)
+
+  @doc """
+  Whether a candidate is the one this work's fields were filled from.
+
+  Exactly one can be, which is the whole point: the candidate list is a
+  question with one right answer, not a set of things that all matched.
+  """
+  def selected?(%__MODULE__{selected_source: nil}, _candidate), do: false
+
+  def selected?(%__MODULE__{} = work, candidate) do
+    work.selected_source == candidate["source"] and
+      work.selected_id == to_string(candidate["id"])
+  end
 end

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -54,6 +54,141 @@ defmodule AmbryWeb.Admin.Decisions do
     """
   end
 
+  attr :query, :string, default: nil
+  attr :fields, :map, default: %{}
+
+  @doc """
+  The search that produced this level's candidates.
+
+  Shown because the first question anyone asks a bad match is "what did you
+  even search for?" — and the answer is not obvious: the hints come from tags
+  first and the release name second, so a wrong author in an ID3 frame sends
+  the whole level somewhere strange with no visible cause.
+  """
+  def query_row(assigns) do
+    ~H"""
+    <div :if={@query || @fields != %{}} class="text-xs dark:text-zinc-500" data-role="query">
+      <span>Searched for</span>
+      <span :for={{key, value} <- ordered_fields(@fields)} class="ml-1">
+        <span class="dark:text-zinc-600">{key}:</span>
+        <span class="font-mono dark:text-zinc-400">{value}</span>
+      </span>
+      <span :if={@fields == %{}} class="font-mono ml-1 dark:text-zinc-400">{@query}</span>
+      <p class="italic">
+        A provider whose narrow search comes back empty may widen it, so what matched can be broader
+        than this.
+      </p>
+    </div>
+    """
+  end
+
+  # Same order every time, and the order the query is actually built in.
+  defp ordered_fields(fields) do
+    for key <- ~w(title author narrator keywords),
+        value = fields[key],
+        value not in [nil, ""],
+        do: {key, value}
+  end
+
+  attr :candidate, :map, required: true
+  attr :selected, :boolean, required: true
+  attr :event, :string, required: true
+  attr :subtitle, :string, default: nil
+
+  @doc """
+  One candidate for an identity decision — a book, or a catalogued recording.
+
+  A list where every row wore a checkmark was the clearest symptom of the
+  decision model not reaching the UI: the item is a recording of exactly ONE
+  work, so exactly one row can be the answer and the rest are what it isn't.
+  """
+  def candidate_option(assigns) do
+    ~H"""
+    <div
+      class={[
+        "flex cursor-pointer items-start gap-3 rounded-sm border p-2",
+        @selected && "border-brand bg-brand/5 dark:border-brand-dark dark:bg-brand-dark/10",
+        !@selected && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+      ]}
+      phx-click={@event}
+      phx-value-source={@candidate["source"]}
+      phx-value-id={@candidate["id"]}
+      data-role="candidate"
+      data-selected={@selected && "true"}
+    >
+      <.icon
+        name={if @selected, do: "fa-circle-check", else: "fa-circle"}
+        class={[
+          "mt-0.5 h-4 w-4 flex-none",
+          @selected && "text-brand dark:text-brand-dark",
+          !@selected && "text-zinc-300 dark:text-zinc-700"
+        ]}
+      />
+      <div class="min-w-0 flex-grow">
+        <p class="truncate text-sm">{candidate_title(@candidate)}</p>
+        <p class="truncate text-xs dark:text-zinc-500">{@subtitle || candidate_facts(@candidate)}</p>
+      </div>
+      <span :if={@candidate["score"]} class="flex-none pt-0.5 text-xs dark:text-zinc-600">
+        {round(@candidate["score"] * 100)}%
+      </span>
+    </div>
+    """
+  end
+
+  @doc "A candidate's headline: what it is."
+  def candidate_title(candidate) do
+    [candidate["title"], candidate["authors"] && Enum.join(candidate["authors"], ", ")]
+    |> Enum.reject(&(&1 in [nil, "", []]))
+    |> Enum.join(" — ")
+  end
+
+  @doc """
+  A candidate's distinguishing facts, in one line.
+
+  Narrator and year lead because they are what tell two recordings of one work
+  apart — the whole reason the recording level exists.
+  """
+  def candidate_facts(candidate) do
+    [
+      candidate["narrators"] not in [nil, []] &&
+        "read by #{Enum.join(candidate["narrators"], ", ")}",
+      year(candidate["published"]),
+      candidate["publisher"],
+      series_line(candidate["series"]),
+      candidate["asin"],
+      candidate_origin(candidate),
+      candidate["also_from"] not in [nil, []] &&
+        "also #{Enum.join(List.wrap(candidate["also_from"]), ", ")}"
+    ]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.join(" · ")
+  end
+
+  defp year(nil), do: nil
+  defp year(published) when is_binary(published), do: String.slice(published, 0, 4)
+  defp year(_other), do: nil
+
+  # Series arrive as `%{"name", "number"}` now and as bare strings in matches
+  # stored before that; both render.
+  defp series_line(nil), do: nil
+  defp series_line([]), do: nil
+
+  defp series_line(series) when is_list(series) do
+    Enum.map_join(series, ", ", fn
+      %{"name" => name, "number" => number} when number not in [nil, ""] -> "#{name} ##{number}"
+      %{"name" => name} -> name
+      name when is_binary(name) -> name
+    end)
+  end
+
+  defp series_line(_other), do: nil
+
+  @doc "Where a candidate came from, in words rather than an id."
+  def candidate_origin(%{"source" => "local"}), do: "already in the library"
+  def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
+  def candidate_origin(%{"source" => "provider:" <> id}), do: id
+  def candidate_origin(_candidate), do: nil
+
   attr :label, :string, required: true
   attr :section, :string, required: true
   attr :name, :atom, required: true
@@ -62,6 +197,8 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :type, :string, default: "text"
   attr :options, :list, default: nil
   attr :placeholder, :string, default: nil
+  attr :hint, :string, default: nil
+  attr :preview, :boolean, default: false
 
   @doc """
   One scalar decision: what the sources proposed, what it will be, and where
@@ -89,22 +226,48 @@ defmodule AmbryWeb.Admin.Decisions do
         <span :if={@field.approved && @field.source} class="text-xs dark:text-zinc-500">
           from {source_words(@field.source)}
         </span>
+
+        <span :if={@field.approved && is_nil(@field.source)} class="text-xs dark:text-zinc-500">
+          left empty on purpose
+        </span>
       </div>
 
-      <.inputs_for :let={decision} field={@form[@name]}>
-        <.input
-          :if={@type == "select"}
-          field={decision[:value]}
-          type="select"
-          options={@options}
+      <p :if={@hint} class="text-xs italic dark:text-zinc-500">{@hint}</p>
+
+      <div class="flex items-start gap-3">
+        <%!-- A URL in a text box is not a cover. Seeing the image is the only
+              way to catch a provider that returned the wrong edition's art,
+              and it costs one tag. --%>
+        <img
+          :if={@preview && @field.value not in [nil, ""] && web_image?(@field.value)}
+          src={@field.value}
+          alt=""
+          class="h-24 w-24 flex-none rounded-sm object-cover"
         />
-        <.input
-          :if={@type != "select"}
-          field={decision[:value]}
-          type={@type}
-          placeholder={@placeholder}
-        />
-      </.inputs_for>
+        <p
+          :if={@preview && @field.value not in [nil, ""] && !web_image?(@field.value)}
+          class="flex h-24 w-24 flex-none items-center justify-center rounded-sm border border-zinc-300 text-center text-xs dark:border-zinc-700 dark:text-zinc-500"
+        >
+          embedded in the file
+        </p>
+
+        <div class="min-w-0 flex-grow">
+          <.inputs_for :let={decision} field={@form[@name]}>
+            <.input
+              :if={@type == "select"}
+              field={decision[:value]}
+              type="select"
+              options={@options}
+            />
+            <.input
+              :if={@type != "select"}
+              field={decision[:value]}
+              type={@type}
+              placeholder={@placeholder}
+            />
+          </.inputs_for>
+        </div>
+      </div>
 
       <div :if={@field.candidates != []} class="flex flex-wrap items-center gap-2 pt-1">
         <span class="text-xs dark:text-zinc-500">Proposed:</span>
@@ -199,7 +362,7 @@ defmodule AmbryWeb.Admin.Decisions do
             phx-value-approved="true"
             class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
           >
-            Looks right
+            Confirm
           </button>
 
           <button
@@ -367,7 +530,7 @@ defmodule AmbryWeb.Admin.Decisions do
         phx-value-approved="true"
         class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
       >
-        Looks right
+        Confirm
       </button>
 
       <button type="button" phx-click="remove-series" phx-value-index={@index} title="Not in this series">
@@ -385,11 +548,16 @@ defmodule AmbryWeb.Admin.Decisions do
   Calling both "unresolved" throws that distinction away.
   """
   def state_words(:approved), do: {"settled", :brand}
-  def state_words(:missing), do: {"needs a value", :red}
+  def state_words(:missing), do: {"nothing proposed it", :red}
   def state_words(:ambiguous), do: {"sources disagree", :yellow}
-  def state_words(:unconfirmed), do: {"needs a look", :yellow}
+  def state_words(:unconfirmed), do: {"needs confirming", :yellow}
   def state_words(:stale), do: {"files changed", :red}
-  def state_words(_other), do: {"needs a look", :yellow}
+  def state_words(_other), do: {"needs confirming", :yellow}
+
+  @doc "Whether a cover value is something a browser can render inline."
+  def web_image?("http://" <> _rest), do: true
+  def web_image?("https://" <> _rest), do: true
+  def web_image?(_other), do: false
 
   @doc "Whose proposal this is, in words rather than an id."
   def source_words(nil), do: "nothing"

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -34,6 +34,8 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Books
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
   alias Ambry.People
@@ -72,7 +74,23 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def handle_event("choose-work", %{"source" => source} = params, socket) do
-    {:noreply, edit(socket, &Draft.Edit.choose_work(&1, source, to_int(params["id"])))}
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.choose_work(&1, item, source, params["id"]))}
+  end
+
+  def handle_event("new-work", _params, socket) do
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.choose_new_work(&1, item))}
+  end
+
+  def handle_event("choose-recording", %{"source" => source} = params, socket) do
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.choose_recording(&1, item, source, params["id"]))}
+  end
+
+  def handle_event("uncatalogued", _params, socket) do
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.choose_uncatalogued(&1, item))}
   end
 
   def handle_event("link-credit", %{"section" => section, "index" => i} = params, socket) do
@@ -267,15 +285,88 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def chapter_summary(_item), do: "Not read yet."
 
   @doc """
-  Whether this candidate is the one the work decision currently points at.
-  """
-  def chosen_work?(%Work{mode: :link, book_id: id}, %{"source" => "local", "id" => id}), do: true
-  def chosen_work?(%Work{mode: :link}, _candidate), do: false
-  def chosen_work?(%Work{mode: :create}, %{"source" => "local"}), do: false
+  What this import says the release is, in one line.
 
-  # Any non-local candidate means "create a new book"; which provider it came
-  # from is recorded per-field as provenance, not as one winning row.
-  def chosen_work?(%Work{mode: :create, approved: approved?}, _candidate), do: approved?
+  The form asks two questions — which book, which recording — but they are two
+  halves of one fact: a file is a recording of exactly one work. Stating the
+  answer as a sentence is how the operator checks it at a glance instead of
+  reassembling it from six fields.
+  """
+  def identity_summary(%Draft{} = draft) do
+    title = Field.value(draft.work.title) || "an unidentified book"
+    authors = names_of(draft.work.authors)
+    narrators = names_of(draft.recording.narrators)
+
+    [
+      title,
+      authors != "" && "by #{authors}",
+      narrators != "" && "read by #{narrators}"
+    ]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.join(" ")
+  end
+
+  def identity_summary(_draft), do: nil
+
+  defp names_of(credits), do: Enum.map_join(credits, ", ", & &1.name)
+
+  @doc """
+  What the files themselves said, before anybody interpreted it.
+
+  The tags are the primary source — 98% of the operator's real releases carry
+  a usable one — so when a match goes somewhere strange this is where the
+  cause is, and it was previously visible nowhere in the form.
+  """
+  def tag_rows(%InboxItem{tags: tags}) when is_map(tags) do
+    for key <- ~w(book_title authors narrators series series_number published publisher asin),
+        value = tags[key],
+        value not in [nil, "", []] do
+      {tag_label(key), format_tag(value)}
+    end
+  end
+
+  def tag_rows(_item), do: []
+
+  defp tag_label("book_title"), do: "title"
+  defp tag_label("series_number"), do: "series no."
+  defp tag_label(key), do: String.replace(key, "_", " ")
+
+  defp format_tag(value) when is_list(value), do: Enum.join(value, ", ")
+  defp format_tag(value), do: to_string(value)
+
+  @doc """
+  The search terms auto-match derived, and where each came from.
+
+  Tags win over the release name because they're measurably more reliable, but
+  that means a wrong tag beats a right folder name — worth being able to see.
+  """
+  def hint_rows(%InboxItem{matches: %{"hints" => hints}}) when is_map(hints) do
+    for key <- ~w(title author narrator series asin),
+        value = hints[key],
+        value not in [nil, ""],
+        do: {key, value}
+  end
+
+  def hint_rows(_item), do: []
+
+  @doc """
+  Why nothing was filled in from a recording match.
+
+  "No provider listed this" and "a provider listed a different reader's
+  edition" want completely different things from the operator, and an empty
+  set of fields says neither.
+  """
+  def doubt_message(%Recording{doubt: :narrator_conflict, doubt_detail: detail}), do: detail
+
+  def doubt_message(%Recording{doubt: :low_confidence, doubt_detail: detail}), do: detail
+
+  def doubt_message(%Recording{doubt: :nothing_found, candidates: []}),
+    do:
+      "No provider had a recording matching this. That is common and not a problem — " <>
+        "a delisted edition vanishes from Audible's search and from ASIN lookup alike. " <>
+        "The fields below come from the file's own tags."
+
+  def doubt_message(_recording), do: nil
 
   @doc """
   Which providers were asked at this level, and what each said.
@@ -291,24 +382,23 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def provider_outcomes(_item, _level), do: []
 
-  def outcome_label(%{"status" => "failed"} = outcome),
-    do: {"#{outcome["name"]} couldn't be reached", :red}
-
-  def outcome_label(%{"count" => 0} = outcome), do: {"#{outcome["name"]}: nothing", :gray}
-
-  def outcome_label(outcome), do: {"#{outcome["name"]}: #{outcome["count"]}", :gray}
-
-  @doc "A work candidate as one readable line."
-  def candidate_line(candidate) do
-    [candidate["title"], candidate["authors"] && Enum.join(candidate["authors"], ", ")]
-    |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.join(" — ")
+  @doc "The candidate a decision's fields were filled from, if any."
+  def selected_candidate(%{candidates: candidates, selected_source: source, selected_id: id})
+      when is_binary(source) do
+    Enum.find(candidates, &(&1["source"] == source and to_string(&1["id"]) == id))
   end
 
-  def candidate_origin(%{"source" => "local"}), do: "already in the library"
-  def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
-  def candidate_origin(%{"source" => "provider:" <> id}), do: id
-  def candidate_origin(_candidate), do: nil
+  def selected_candidate(_decision), do: nil
+
+  @doc """
+  How many decisions the bulk button would settle, so its label can say.
+
+  A button that might do fourteen things or nothing should not look the same
+  in both cases.
+  """
+  def settleable(unresolved) do
+    Enum.count(unresolved, &(&1.state != :missing))
+  end
 
   def confidence_label(nil), do: {"no match", :gray}
   def confidence_label(confidence) when confidence >= 0.85, do: {"near-certain", :brand}

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -13,13 +13,53 @@
           <p class="text-sm">
             <span class="font-bold">{@progress.resolved}</span> of {@progress.total} settled
           </p>
-          <.button type="button" color={:zinc} class="mt-2" phx-click="rebuild">
+          <.button
+            type="button"
+            color={:zinc}
+            class="mt-2"
+            phx-click="rebuild"
+            data-confirm="Throw away every choice made here and rebuild from the files and providers?"
+          >
             Start over
           </.button>
         </div>
       </div>
 
+      <%!-- Tags are the primary source (98% of real releases carry a usable
+            one) and the form used to show none of them, so a match that went
+            somewhere strange had no visible cause. --%>
+      <details :if={tag_rows(@item) != [] or hint_rows(@item) != []} class="pt-2">
+        <summary class="cursor-pointer text-sm dark:text-zinc-400">What the files say</summary>
+
+        <div class="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
+          <div :if={tag_rows(@item) != []} data-role="tags">
+            <p class="text-xs font-bold dark:text-zinc-400">Embedded tags</p>
+            <p :for={{label, value} <- tag_rows(@item)} class="text-xs dark:text-zinc-500">
+              <span class="dark:text-zinc-600">{label}:</span> {value}
+            </p>
+          </div>
+
+          <div :if={hint_rows(@item) != []} data-role="hints">
+            <p class="text-xs font-bold dark:text-zinc-400">Used to search</p>
+            <p :for={{label, value} <- hint_rows(@item)} class="text-xs dark:text-zinc-500">
+              <span class="dark:text-zinc-600">{label}:</span> {value}
+            </p>
+            <p class="pt-1 text-xs italic dark:text-zinc-600">
+              Taken from the tags first and the release name second.
+            </p>
+          </div>
+        </div>
+      </details>
+
       <p :if={@item.issue} class="pt-2 text-sm text-red-600">{@item.issue}</p>
+    </section>
+
+    <%!-- The one fact this whole form is deciding, said as a sentence. Two
+          questions, but a file is a recording of exactly one work — so there
+          is one answer to check at a glance. --%>
+    <section :if={identity_summary(@item.draft)} class="space-y-1" data-role="identity-summary">
+      <p class="text-xs uppercase tracking-wide dark:text-zinc-500">This release is</p>
+      <p class="text-lg font-bold">{identity_summary(@item.draft)}</p>
     </section>
 
     <%!-- The invariant, rendered. Nothing here is a surprise at import time. --%>
@@ -34,20 +74,34 @@
           <.badge color={elem(state_words(decision.state), 1)} class="text-xs">
             {elem(state_words(decision.state), 0)}
           </.badge>
-          <span>{decision.label}</span>
+          <.link href={"##{decision.section}"} class="hover:underline">{decision.label}</.link>
         </li>
       </ul>
-      <.button type="button" color={:zinc} class="mt-3" phx-click="approve-all">
-        Accept everything that's only waiting on a nod
+
+      <%!-- Named for what it does, not for how it feels. It takes the leading
+            proposal wherever there is one; it does not invent a value, a
+            series number, or a recording we already said we doubt. --%>
+      <.button
+        :if={settleable(@unresolved) > 0}
+        type="button"
+        color={:zinc}
+        class="mt-3"
+        phx-click="approve-all"
+      >
+        Take the top suggestion for {settleable(@unresolved)} of these
       </.button>
+
+      <p class="pt-2 text-xs italic dark:text-zinc-500">
+        Anything nothing proposed, any series without a number, and any recording match we doubt is
+        left alone — those need a real answer, not a shortcut.
+      </p>
     </section>
 
     <%!-- ==================== THE WORK ==================== --%>
-    <section class="space-y-4">
+    <section id="work" class="space-y-4">
       <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
-        The work
+        The work — which book this is a recording of
       </h2>
-      <.provider_outcomes_row outcomes={provider_outcomes(@item, "work")} />
 
       <div class="space-y-2">
         <div class="flex items-center gap-2">
@@ -63,57 +117,77 @@
             :if={@item.draft.work.confidence}
             color={elem(confidence_label(@item.draft.work.confidence), 1)}
             class="text-xs"
+            title={"score #{@item.draft.work.confidence}"}
           >
             {elem(confidence_label(@item.draft.work.confidence), 0)}
           </.badge>
         </div>
 
+        <.query_row query={@item.draft.work.query} fields={@item.draft.work.query_fields} />
+        <.provider_outcomes_row outcomes={provider_outcomes(@item, "work")} />
+
+        <p :if={@item.draft.work.candidates != []} class="text-sm dark:text-zinc-400">
+          Exactly one of these is the book. Picking one fills the fields below from it.
+        </p>
+
         <p :if={@item.draft.work.candidates == []} class="text-sm italic dark:text-zinc-500">
           Nothing matched. A new book will be created from the fields below.
         </p>
 
-        <div
+        <.candidate_option
           :for={candidate <- @item.draft.work.candidates}
-          class={[
-            "flex cursor-pointer items-center gap-3 rounded-sm border p-2",
-            chosen_work?(@item.draft.work, candidate) && "border-brand dark:border-brand-dark",
-            !chosen_work?(@item.draft.work, candidate) && "border-zinc-300 dark:border-zinc-700"
-          ]}
-          phx-click="choose-work"
-          phx-value-source={candidate["source"]}
-          phx-value-id={candidate["id"]}
-        >
-          <.icon
-            :if={chosen_work?(@item.draft.work, candidate)}
-            name="fa-circle-check"
-            class="text-brand h-4 w-4 flex-none dark:text-brand-dark"
-          />
-          <div class="min-w-0">
-            <p class="truncate text-sm">{candidate_line(candidate)}</p>
-            <p class="text-xs dark:text-zinc-500">{candidate_origin(candidate)}</p>
-          </div>
-        </div>
+          candidate={candidate}
+          selected={Work.selected?(@item.draft.work, candidate)}
+          event="choose-work"
+        />
 
-        <button
-          :if={!@item.draft.work.approved}
-          type="button"
-          phx-click="approve-work"
-          phx-value-approved="true"
-          class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
-        >
-          {if @item.draft.work.candidates == [], do: "Create a new book", else: "That's the one"}
-        </button>
+        <div class="flex flex-wrap items-center gap-2 pt-1">
+          <%!-- "None of these" is a real answer and has to be reachable, or an
+                unlisted book can never be settled. --%>
+          <button
+            :if={@item.draft.work.candidates != []}
+            type="button"
+            phx-click="new-work"
+            class={[
+              "rounded-sm border px-2 py-1 text-xs",
+              is_nil(@item.draft.work.selected_source) && "border-brand dark:border-brand-dark",
+              @item.draft.work.selected_source && "border-zinc-300 dark:border-zinc-700"
+            ]}
+          >
+            None of these — create a new book
+          </button>
+
+          <button
+            :if={!@item.draft.work.approved}
+            type="button"
+            phx-click="approve-work"
+            phx-value-approved="true"
+            class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+          >
+            {if @item.draft.work.candidates == [],
+              do: "Confirm — create a new book",
+              else: "Confirm the highlighted one"}
+          </button>
+        </div>
       </div>
 
       <%!-- Linking inherits the book's own fields; only additive series
-            memberships remain to decide. --%>
-      <p
+            memberships remain to decide. The book's own facts are still shown,
+            because "is this the right book?" can't be answered against a
+            title alone. --%>
+      <div
         :if={@item.draft.work.mode == :link}
-        class="rounded-sm bg-zinc-100 p-3 text-sm dark:bg-zinc-800"
+        class="space-y-1 rounded-sm bg-zinc-100 p-3 text-sm dark:bg-zinc-800"
       >
-        Using the book already in the library. Its title, date and authors are left exactly as they
-        are — an import fills blanks, it never overwrites curation.
-      </p>
+        <p class="font-bold">{candidate_title(selected_candidate(@item.draft.work) || %{})}</p>
+        <p class="text-xs dark:text-zinc-400">
+          {candidate_facts(selected_candidate(@item.draft.work) || %{})}
+        </p>
+        <p class="pt-1">
+          Using the book already in the library. Its title, date and authors are left exactly as they
+          are — an import fills blanks, it never overwrites curation.
+        </p>
+      </div>
 
       <%!-- Typing lives in a form; choosing does not. They are kept apart
             because a <form> inside a <form> is invalid HTML and the parser
@@ -142,6 +216,7 @@
               name={:published}
               form={work}
               type="date"
+              hint="The work's original publication date, not this recording's release date."
               field={@item.draft.work.published}
             />
 
@@ -204,16 +279,80 @@
     </section>
 
     <%!-- ==================== THE RECORDING ==================== --%>
-    <section class="space-y-4">
+    <section id="recording" class="space-y-4">
       <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
-        The recording
+        The recording — which reading of it these files are
       </h2>
-      <.provider_outcomes_row outcomes={provider_outcomes(@item, "recording")} />
 
-      <p class="text-sm italic dark:text-zinc-500">
-        A new recording of that work. (Replacing an existing recording's files is a later addition —
-        for now every import creates one.)
-      </p>
+      <div class="space-y-2">
+        <div class="flex items-center gap-2">
+          <.label>Which recording</.label>
+          <.badge
+            :if={!@item.draft.recording.approved}
+            color={elem(state_words(:unconfirmed), 1)}
+            class="text-xs"
+          >
+            {elem(state_words(:unconfirmed), 0)}
+          </.badge>
+          <.badge
+            :if={@item.draft.recording.confidence}
+            color={elem(confidence_label(@item.draft.recording.confidence), 1)}
+            class="text-xs"
+            title={"score #{@item.draft.recording.confidence}"}
+          >
+            {elem(confidence_label(@item.draft.recording.confidence), 0)}
+          </.badge>
+        </div>
+
+        <.query_row
+          query={@item.draft.recording.query}
+          fields={@item.draft.recording.query_fields}
+        />
+        <.provider_outcomes_row outcomes={provider_outcomes(@item, "recording")} />
+
+        <%!-- A doubted match used to be indistinguishable from no match at
+              all: both left every field empty and said nothing. The reason is
+              the whole difference between "pick one" and "type it in". --%>
+        <p
+          :if={doubt_message(@item.draft.recording)}
+          class="rounded-sm border border-amber-500 p-3 text-sm"
+          data-role="doubt"
+        >
+          {doubt_message(@item.draft.recording)}
+        </p>
+
+        <p :if={@item.draft.recording.candidates != []} class="text-sm dark:text-zinc-400">
+          These files are one recording. Picking it fills publisher, release date and cover from
+          that catalogue entry — and settles the book above when the two are known to go together.
+        </p>
+
+        <.candidate_option
+          :for={candidate <- @item.draft.recording.candidates}
+          candidate={candidate}
+          selected={Recording.selected?(@item.draft.recording, candidate)}
+          event="choose-recording"
+        />
+
+        <div class="flex flex-wrap items-center gap-2 pt-1">
+          <button
+            :if={@item.draft.recording.candidates != []}
+            type="button"
+            phx-click="uncatalogued"
+            class={[
+              "rounded-sm border px-2 py-1 text-xs",
+              Recording.uncatalogued?(@item.draft.recording) && "border-brand dark:border-brand-dark",
+              !Recording.uncatalogued?(@item.draft.recording) && "border-zinc-300 dark:border-zinc-700"
+            ]}
+          >
+            None of these — it's in no catalogue
+          </button>
+        </div>
+
+        <p class="text-xs italic dark:text-zinc-500">
+          Every import creates a new recording. Pointing one at an existing recording's files —
+          the upgrade/replace case — is a later addition.
+        </p>
+      </div>
 
       <.simple_form id="recording-form" for={@form} phx-change="validate" autocomplete="off">
         <.inputs_for :let={draft} field={@form[:draft]}>
@@ -224,6 +363,8 @@
               name={:title}
               form={recording}
               placeholder="only if it differs from the book's title"
+              hint={"Leave empty unless this reading is titled differently — " <>
+                "\"The Way of Kings (1 of 3)\", say."}
               field={@item.draft.recording.title}
             />
 
@@ -233,6 +374,7 @@
               name={:published}
               form={recording}
               type="date"
+              hint="When this reading was published, which is rarely the work's own date."
               field={@item.draft.recording.published}
             />
 
@@ -250,6 +392,7 @@
               name={:cover}
               form={recording}
               placeholder="image URL"
+              preview={true}
               field={@item.draft.recording.cover}
             />
 
@@ -294,7 +437,7 @@
     </section>
 
     <%!-- ==================== FILES & DESTINATION ==================== --%>
-    <section class="space-y-2">
+    <section id="destination" class="space-y-2">
       <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
         Files &amp; destination
       </h2>
@@ -310,10 +453,10 @@
           <.label>Library root</.label>
           <.badge
             :if={!@item.draft.destination.approved}
-            color={:yellow}
+            color={elem(state_words(:unconfirmed), 1)}
             class="text-xs"
           >
-            needs a look
+            {elem(state_words(:unconfirmed), 0)}
           </.badge>
         </div>
 
@@ -358,8 +501,15 @@
 
         <.brand_link navigate={~p"/admin/inbox"}>Back to the inbox</.brand_link>
 
+        <%!-- Why the button is off, always. A blocker that only showed up as a
+              red line further up the page could leave this disabled while the
+              outstanding count read zero. --%>
         <p :if={@unresolved != []} class="text-sm dark:text-zinc-500">
           {length(@unresolved)} decision{if length(@unresolved) > 1, do: "s"} still to settle.
+        </p>
+
+        <p :if={@unresolved == [] and @destination.blocker} class="text-sm text-red-600">
+          Everything is settled, but the files can't be placed yet — see Files &amp; destination.
         </p>
       </div>
     </section>

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -90,6 +90,45 @@ defmodule Ambry.Inbox.AutoMatchTest do
       assert matches["recording"]["query"] == "B003ZWFO7E"
     end
 
+    # Every provider we use reports a book's position in its series
+    # (Hardcover's `position`, rreading-glasses' `PositionInSeries`, Audible's
+    # `sequence`), and it was being dropped on the floor here — so the inbox
+    # asked the operator for a number nobody had to look up.
+    test "carries each series' number, not just its name" do
+      patch_work_results([
+        book("Leviathan Wakes", ["James S.A. Corey"],
+          series: [
+            %Provider.Series{id: "s1", name: "The Expanse", number: "1"},
+            %Provider.Series{id: "s2", name: "The Expanse (Chronological)", number: "2"}
+          ]
+        )
+      ])
+
+      %{matches: matches} = AutoMatch.match(item(title: "Leviathan Wakes"))
+
+      assert [best | _rest] = matches["work"]["candidates"]
+
+      assert best["series"] == [
+               %{"name" => "The Expanse", "number" => "1"},
+               %{"name" => "The Expanse (Chronological)", "number" => "2"}
+             ]
+    end
+
+    test "records the search's fields, not only its flattened string" do
+      patch_work_results([book("Neuromancer", ["William Gibson"])])
+
+      %{matches: matches} =
+        AutoMatch.match(item(title: "Neuromancer", author: "William Gibson"))
+
+      # "what did you even search for?" is the first question a bad match
+      # raises, and the flattened string doesn't answer it — Audible matches
+      # `title` against the title alone
+      assert matches["work"]["query_fields"] == %{
+               "title" => "Neuromancer",
+               "author" => "William Gibson"
+             }
+    end
+
     test "ranks a book already in the library first" do
       insert(:book, title: "The Way of Kings")
       patch_work_results([book("The Way of Kings", ["Brandon Sanderson"])])
@@ -267,7 +306,8 @@ defmodule Ambry.Inbox.AutoMatchTest do
       asin: opts[:asin],
       authors: Enum.map(authors, &%Provider.Contributor{name: &1, role: "author"}),
       narrators:
-        Enum.map(opts[:narrators] || [], &%Provider.Contributor{name: &1, role: "narrator"})
+        Enum.map(opts[:narrators] || [], &%Provider.Contributor{name: &1, role: "narrator"}),
+      series: opts[:series] || []
     }
   end
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -375,6 +375,281 @@ defmodule Ambry.Inbox.DraftTest do
       assert draft.recording.publisher.value == nil
       assert draft.recording.published.value == nil
       assert draft.recording.cover.value == nil
+
+      # and the reason is recorded rather than left as an unexplained set of
+      # empty fields, which is indistinguishable from having found nothing
+      assert draft.recording.doubt == :narrator_conflict
+      assert draft.recording.doubt_detail =~ "Jeff Harding"
+      assert draft.recording.doubt_detail =~ "Robertson Dean"
+
+      # a doubted identity is a real question, so it stays open
+      refute draft.recording.approved
+
+      assert Enum.any?(
+               Draft.unresolved(draft),
+               &(&1.label == "Which recording this is" and &1.state == :unconfirmed)
+             )
+    end
+
+    test "finding nothing at all is settled, and says so" do
+      draft = Seed.build(item(%{matches: matches([provider_candidate(%{})]), tags: %{}}))
+
+      # plenty of perfectly good rips are in no catalogue — that's an answer,
+      # not an outstanding question
+      assert draft.recording.doubt == :nothing_found
+      assert draft.recording.approved
+    end
+  end
+
+  describe "choosing a candidate" do
+    test "picking a different book refills the work's fields from it" do
+      candidates = [
+        provider_candidate(%{"id" => "hc-1", "title" => "Leviathan Wakes"}),
+        provider_candidate(%{
+          "id" => "hc-2",
+          "title" => "Caliban's War",
+          "published" => "2012-06-26",
+          "score" => 0.6
+        })
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert item.draft.work.title.value == "Leviathan Wakes"
+      assert item.draft.work.selected_id == "hc-1"
+
+      draft = Draft.Edit.choose_work(item.draft, item, "provider:hardcover", "hc-2")
+
+      # the list is a question with one right answer, so choosing has to move
+      # the fields — it used to only flip `mode`, which is why every row
+      # rendered as chosen and clicking one did nothing visible
+      assert draft.work.title.value == "Caliban's War"
+      assert draft.work.published.value == "2012-06-26"
+      assert draft.work.selected_id == "hc-2"
+      assert draft.work.approved
+    end
+
+    test "a typed value survives choosing a different book" do
+      candidates = [
+        provider_candidate(%{"id" => "hc-1"}),
+        provider_candidate(%{"id" => "hc-2", "title" => "Caliban's War", "score" => 0.6})
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      {:ok, item} =
+        Inbox.update_draft(item, %{
+          "work" => %{"title" => %{"value" => "What I Actually Want"}}
+        })
+
+      draft = Draft.Edit.choose_work(item.draft, item, "provider:hardcover", "hc-2")
+
+      # 1d again: curation outranks any source, including a source the
+      # operator just picked
+      assert draft.work.title.value == "What I Actually Want"
+      assert draft.work.title.source == "manual"
+    end
+
+    test "clicking the already-chosen book confirms rather than resetting" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      touched = Draft.Edit.approve_credit(item.draft, :work, 0, true)
+      assert Enum.at(touched.work.authors, 0).approved
+
+      draft = Draft.Edit.choose_work(touched, item, "provider:hardcover", "hc-1")
+
+      assert Enum.at(draft.work.authors, 0).approved
+    end
+
+    test "choosing a recording settles the book it is known to be of" do
+      work = [
+        provider_candidate(%{"id" => "hc-1"}),
+        provider_candidate(%{"id" => "hc-2", "title" => "Caliban's War", "score" => 0.6})
+      ]
+
+      recording = [
+        %{
+          "source" => "provider:hardcover",
+          "provider_name" => "Hardcover editions",
+          "id" => "ed-9",
+          "title" => "Caliban's War",
+          "narrators" => ["Jefferson Mays"],
+          "publisher" => "Orbit",
+          "published" => "2012-06-26",
+          "score" => 0.4,
+          # editions come out of a work's own list, so which work is not a
+          # second question
+          "of_work" => %{"source" => "provider:hardcover", "id" => "hc-2"}
+        }
+      ]
+
+      item =
+        item(%{
+          matches: matches(work, recording: recording, recording_confidence: 0.4),
+          tags: %{}
+        })
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      assert item.draft.work.selected_id == "hc-1"
+
+      draft = Draft.Edit.choose_recording(item.draft, item, "provider:hardcover", "ed-9")
+
+      assert draft.recording.selected_id == "ed-9"
+      assert draft.recording.publisher.value == "Orbit"
+      # a file is a recording of exactly one work, so identifying the
+      # recording answers the book question too
+      assert draft.work.selected_id == "hc-2"
+      assert draft.work.title.value == "Caliban's War"
+    end
+
+    test "a recording in no catalogue is a real answer" do
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "id" => "B01",
+          "title" => "Neuromancer",
+          "narrators" => ["Robertson Dean"],
+          "score" => 0.5
+        }
+      ]
+
+      item =
+        item(%{
+          matches:
+            matches([provider_candidate(%{})], recording: recording, recording_confidence: 0.5),
+          tags: %{"narrators" => ["Jeff Harding"]}
+        })
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      refute item.draft.recording.approved
+
+      draft = Draft.Edit.choose_uncatalogued(item.draft, item)
+
+      assert draft.recording.approved
+      assert draft.recording.selected_source == nil
+      assert Draft.Recording.uncatalogued?(draft.recording)
+    end
+
+    test "taking the top suggestion never adopts a doubted recording" do
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "id" => "B01",
+          "title" => "Neuromancer",
+          "narrators" => ["Robertson Dean"],
+          "publisher" => "Penguin Audio",
+          "score" => 0.5
+        }
+      ]
+
+      item =
+        item(%{
+          matches:
+            matches([provider_candidate(%{})], recording: recording, recording_confidence: 0.5),
+          tags: %{"narrators" => ["Jeff Harding"]}
+        })
+
+      draft = item |> Seed.build() |> Draft.Edit.approve_all()
+
+      # the leading candidate here is, by construction, the wrong recording of
+      # the right book — the one thing this button must not paper over
+      refute draft.recording.approved
+      assert draft.recording.publisher.value == nil
+    end
+  end
+
+  describe "sources that agree" do
+    test "a format label is not a disagreement" do
+      # Audible titles carry "(Unabridged)" and work-level providers don't, so
+      # treating the two as rival answers made the operator arbitrate a
+      # non-question on a large share of imports
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches([provider_candidate(%{"title" => "Neuromancer (Unabridged)"})]),
+            tags: %{"book_title" => "Neuromancer"}
+          })
+        )
+
+      assert draft.work.title.approved
+      # and the clean spelling wins the field
+      assert draft.work.title.value == "Neuromancer"
+      # both are still offered, because the operator may want the other
+      assert length(draft.work.title.candidates) == 2
+    end
+
+    test "genuinely different titles still disagree" do
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches([provider_candidate(%{"title" => "Neuromancer"})]),
+            tags: %{"book_title" => "Count Zero"}
+          })
+        )
+
+      refute draft.work.title.approved
+      assert Draft.Field.state(draft.work.title) == :ambiguous
+    end
+  end
+
+  describe "series numbers" do
+    test "a number the provider supplied settles the membership" do
+      candidates = [
+        provider_candidate(%{
+          "series" => [%{"name" => "The Expanse", "number" => "1"}]
+        })
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      # every provider we use reports the position; it was being thrown away
+      # between the search result and the draft, so the inbox asked the
+      # operator for a number nobody had to look up
+      assert [link] = draft.work.series
+      assert link.number == "1"
+      assert SeriesLink.resolved?(link)
+    end
+
+    test "each series keeps its own number" do
+      candidates = [
+        provider_candidate(%{
+          "series" => [
+            %{"name" => "The Expanse", "number" => "1"},
+            %{"name" => "The Expanse (Chronological)", "number" => "2"}
+          ]
+        })
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert [first, second] = draft.work.series
+      assert first.number == "1"
+      assert second.number == "2"
+    end
+
+    test "a tag's number is not applied to a series the tag didn't name" do
+      candidates = [
+        provider_candidate(%{
+          "series" => [%{"name" => "The Expanse"}, %{"name" => "Some Other Series"}]
+        })
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches(candidates),
+            tags: %{"series" => "The Expanse", "series_number" => "1"}
+          })
+        )
+
+      assert [expanse, other] = draft.work.series
+      assert expanse.number == "1"
+      # the file said where this book sits in The Expanse and nothing at all
+      # about the other one; borrowing the number would be inventing a fact
+      assert other.number == nil
     end
   end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -5,6 +5,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.InboxItem
   alias Ambry.Repo
 
   setup :register_and_log_in_admin_user
@@ -47,29 +48,29 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       # tag-derived credits are never auto-settled, so the narrators from the
       # fixture's `composer` tag are listed by name
       assert html =~ "Michael Kramer"
-      assert html =~ "needs a look"
+      assert html =~ "needs confirming"
     end
   end
 
   describe "settling decisions" do
-    test "accept-everything settles what's only waiting on a nod", %{conn: conn} do
+    test "take-the-top-suggestion settles everything that has one", %{conn: conn} do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      html = view |> element("button", "Accept everything") |> render_click()
+      html = view |> element("button[phx-click='approve-all']") |> render_click()
 
       refute html =~ "Still to settle"
       assert Inbox.get_item!(item.id).ready
     end
 
-    test "accept-everything never invents a missing required value", %{conn: conn} do
+    test "take-the-top-suggestion never invents a missing required value", %{conn: conn} do
       item = probed_item(dated: false)
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
       assert html =~ "First published"
 
-      html = view |> element("button", "Accept everything") |> render_click()
+      html = view |> element("button[phx-click='approve-all']") |> render_click()
 
       # the date nobody supplied is still outstanding — this button settles
       # choices, it does not fabricate facts
@@ -209,6 +210,59 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "identity — one answer, not a shortlist" do
+    test "exactly one work candidate is marked as chosen", %{conn: conn} do
+      # Every provider row used to wear a checkmark the moment the work was
+      # approved, which said the release was all of them at once.
+      item = probed_item() |> with_work_candidates()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert view |> element("[data-role='candidate'][data-selected='true']") |> has_element?()
+      assert view |> render() |> selected_candidates() |> length() == 1
+    end
+
+    test "choosing another candidate moves the fields", %{conn: conn} do
+      item = probed_item() |> with_work_candidates()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert Inbox.get_item!(item.id).draft.work.title.value == "The Way of Kings"
+
+      view
+      |> element("[phx-click='choose-work'][phx-value-id='hc-2']")
+      |> render_click()
+
+      work = Inbox.get_item!(item.id).draft.work
+
+      assert work.selected_id == "hc-2"
+      assert "Words of Radiance" in Enum.map(work.title.candidates, & &1.value)
+
+      # and the new candidate genuinely contradicts the file's tags, so the
+      # title stops being settled rather than silently taking one side
+      refute work.title.approved
+      assert "2014-03-04" in Enum.map(work.published.candidates, & &1.value)
+    end
+
+    test "the search that produced the candidates is visible", %{conn: conn} do
+      item = probed_item() |> with_work_candidates()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Searched for"
+      assert html =~ "The Way of Kings"
+    end
+
+    test "the file's own tags are visible", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "What the files say"
+      assert html =~ "Michael Kramer"
+    end
+  end
+
   describe "destination" do
     test "says where the file is going before anything is committed", %{conn: conn} do
       item = probed_item() |> settle()
@@ -218,6 +272,53 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert html =~ "Referenced where it lies"
       assert html =~ "never move, rename or delete"
     end
+  end
+
+  # Two plausible works from one provider, so the candidate list is a real
+  # question rather than a formality.
+  defp with_work_candidates(item) do
+    candidate = fn id, title, published ->
+      %{
+        "source" => "provider:hardcover",
+        "provider_name" => "Hardcover",
+        "id" => id,
+        "title" => title,
+        "authors" => ["Brandon Sanderson"],
+        "published" => published,
+        "published_format" => "full",
+        "score" => if(id == "hc-1", do: 0.95, else: 0.6)
+      }
+    end
+
+    {:ok, item} =
+      item
+      |> InboxItem.changeset(%{
+        matches: %{
+          "work" => %{
+            "candidates" => [
+              candidate.("hc-1", "The Way of Kings", "2010-08-31"),
+              candidate.("hc-2", "Words of Radiance", "2014-03-04")
+            ],
+            "confidence" => 0.95,
+            "query" => "The Way of Kings Brandon Sanderson",
+            "query_fields" => %{
+              "title" => "The Way of Kings",
+              "author" => "Brandon Sanderson"
+            }
+          },
+          "recording" => %{"candidates" => [], "confidence" => 0.0}
+        }
+      })
+      |> Repo.update()
+
+    {:ok, item} = Inbox.rebuild_draft(item)
+    item
+  end
+
+  defp selected_candidates(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("[data-role='candidate'][data-selected='true']")
   end
 
   defp probed_item(opts \\ []) do


### PR DESCRIPTION
Operator review of the built staged import form, and the ontology it should
have been built on:

> **There is only one correct answer to "what recording is this?"** A file is a
> file of *one* recording, and that recording is a recording of exactly one
> work. Once we've identified *which* recording it is — a fact — *then* there
> can be variations in the quality of metadata about that specific recording
> and work.

Two structural consequences the form was violating:

1. **Identity and metadata quality are different kinds of question.** Identity
   has one right answer; metadata quality is a per-field preference among
   sources. 1g's "two matches, not one" is right as a *matching strategy* but
   was carried into the *presentation* as two co-equal, unrelated decisions.
2. **The dependency runs recording → work**, not the reverse. The code only
   ever pointed the arrow the other way (match the work, then fetch its
   editions).

## The six defects

Each had a different root cause.

**The work candidate list was decoration.** `chosen_work?/2` returned the
work's `approved` flag for *every* non-local candidate, so once the work was
confirmed the whole list wore green checkmarks. Clicking a row called
`choose_work/3`, which only flipped `mode` — fields were seeded from the top
hit at build time and no later choice could move them. Fixed by storing
`selected_source`/`selected_id` on `Work` and `Recording`, and by making
choosing *re-seed* (`Seed.reseed_work/4`), preserving anything typed. Exactly
one row can be checked, because exactly one is the answer. Adds the previously
unreachable "None of these — create a new book".

**The Recording section had no candidate list** — the asymmetry the operator
called "fishy". It has one now: narrator, year, publisher, ASIN, since
narrator is what tells two recordings of one work apart. Edition candidates
carry `of_work`, so choosing one **also settles the book** — one click
answering both questions.

**"Audible: 1, Hardcover editions: 1" and yet every field came from tags.**
`Seed.trusted?/3` was refusing a doubted candidate the right to describe the
file — correct, invisibly applied. A refusal indistinguishable from "nothing
found" is not actionable. `Recording.doubt` now records `:narrator_conflict` /
`:low_confidence` / `:nothing_found` with a written reason, and a doubted
recording is an **open decision**. Take-the-top-suggestion refuses to settle
it: its leading candidate is by construction the wrong recording of the right
book.

**The series number was never filled in, though every provider reports one.**
`AutoMatch.provider_candidate/3` mapped `Provider.Series` with
`Enum.map(& &1.name)` — Hardcover (`position`/`details`), rreading-glasses
(`PositionInSeries`) and Audible (`sequence`) all extracted it correctly and
it was dropped between the search result and the draft. `Seed` compounded it
by reading the number only from tags (36% coverage) and applying that single
number to every proposed series. This is why the old import form "figured it
out easily" — it read the provider struct directly; only the inbox path lost
it.

**"Sources disagree" on "Neuromancer" vs "Neuromancer (Unabridged)".**
`Seed.normalize/1` only downcased and collapsed whitespace, while
`AutoMatch.normalize/1` — used for *scoring* — already stripped format labels.
The two halves of the system disagreed about what "the same" means. Scalar
decisions take an equivalence function now; both spellings stay in the
candidate list and the cleaner spelling wins the field. Deliberately NOT
stripped: "Dramatized Adaptation", "(1 of 3)" — those name a genuinely
different recording.

**The query was stored and never shown.** `matches[level]["query"]` held only
the flattened string, which is what the cache keys on and what text-only
providers see — not what was asked (Audible matches `title` against the title
alone). `query_fields` is stored and rendered per level, alongside the raw
tags and derived hints in a "What the files say" panel.

*Known limit:* Audible **widens** a query that returns nothing
(title+author+narrator → title+author → title → keywords) and the provider
behaviour has no way to report which attempt succeeded, so the form shows the
requested query and says so. Reporting the effective query needs
`{:ok, books, meta}` through the behaviour and the cache — deferred.

## Vocabulary and consistency

- **"Accept everything that's only waiting on a nod"** read vaguely and was
  also wrong about itself — it silently took the top of a genuine
  disagreement. Now "Take the top suggestion for N of these", with its three
  refusals spelled out (nothing proposed it · no series number · a doubted
  recording). One approve verb throughout: "Confirm".
- **`Field.state/1` was lying** — it reported `:ambiguous` ("sources disagree")
  for a field with one candidate *and* for one with none. It counts distinct
  proposals now. `:unconfirmed` reads "needs confirming".
- Added: a "This release is …" identity summary; the linked book's own facts
  when linking to an existing record (a match can't be checked against a bare
  title); a cover **preview**; anchors from the outstanding list to the
  section; a confirm on "Start over"; hints on the two date fields (they mean
  different things and read identically); and a disabled Import button that
  explains a destination blocker instead of showing "0 decisions still to
  settle" beside a button that won't press.

## Not done, deliberately

Reordering the form to lead with the recording. The ontology argues for it,
but "which book, then which reading of it" reads naturally and the
recording → work link now delivers the one-click benefit without the churn.
Revisit if the order still fights the operator.

## Verification

`mix check` clean; 1073 tests pass under `--warnings-as-errors`. New coverage
for candidate re-seeding, manual-edit survival, recording → work follow-through,
uncatalogued recordings, doubt reasons, format-label equivalence and per-series
numbers.

The series-number plumbing is unit-tested but **not confirmed against a live
provider round trip** — worth watching on the next staging pass.

ROADMAP.md is updated (3e "The identity pass — one recording, one work", and
the 1g series bullet). It lives outside this repo, so it isn't in this diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
