### PR TITLE
Let each field pick its own source, and let names be typed

### DIFF
--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -313,12 +313,15 @@ defmodule Ambry.Inbox.AutoMatch do
         _corroborated ->
           first
           |> Map.put("also_from", Enum.map(rest, &(&1["provider_name"] || &1["source"])))
-          # The merged candidates' own ids are kept, not just their names:
-          # they are how the *other* providers refer to this work, and losing
-          # them means losing the ability to ask them anything else about it —
-          # which is exactly how the edition lookup came up empty when the
-          # corroborating provider happened to lose the merge.
-          |> Map.put("merged", Enum.map(rest, &%{"source" => &1["source"], "id" => &1["id"]}))
+          # The corroborating candidates are kept WHOLE, not reduced to a
+          # reference. Two providers agreeing on which work this is do not
+          # agree on everything about it — one has the better description, the
+          # other the better cover — and the loser's payload was being thrown
+          # away, so the operator could only ever see the winner's values.
+          # (Their ids matter too: they are how the other providers refer to
+          # this work, which is how the edition lookup finds an edition the
+          # merge winner doesn't keep.)
+          |> Map.put("merged", rest)
           |> Map.put("score", min(first["score"] + @agreement_bonus, 1.0))
       end
     end)

--- a/lib/ambry/inbox/draft/credit.ex
+++ b/lib/ambry/inbox/draft/credit.ex
@@ -88,7 +88,7 @@ defmodule Ambry.Inbox.Draft.Credit do
   def changeset(credit, attrs) do
     credit
     |> cast(attrs, [:name, :kind, :mode, :identity_id, :source, :approved])
-    |> validate_required([:name, :kind])
+    |> validate_required([:kind])
     |> cast_embed(:candidates)
     |> cast_embed(:people)
     |> validate_resolution()
@@ -96,8 +96,9 @@ defmodule Ambry.Inbox.Draft.Credit do
 
   # Only what can never be legitimate is rejected: an *approved* credit with
   # nothing behind it. An unapproved one is allowed to be half-made, because
-  # that's what the operator is doing while they make it — `resolved?/1`
-  # reports it instead, and the import button reads that.
+  # that's what the operator is doing while they make it — including a blank
+  # name, since clearing the box to retype is the first half of renaming.
+  # `resolved?/1` reports it instead, and the import button reads that.
   defp validate_resolution(changeset) do
     approved? = get_field(changeset, :approved)
 
@@ -108,6 +109,9 @@ defmodule Ambry.Inbox.Draft.Credit do
       get_field(changeset, :mode) == :link ->
         validate_required(changeset, [:identity_id])
 
+      blank?(get_field(changeset, :name)) ->
+        add_error(changeset, :name, "is needed before this can be imported")
+
       get_field(changeset, :people) == [] ->
         add_error(changeset, :people, "needs at least one person behind it")
 
@@ -116,20 +120,42 @@ defmodule Ambry.Inbox.Draft.Credit do
     end
   end
 
+  defp blank?(nil), do: true
+  defp blank?(name) when is_binary(name), do: String.trim(name) == ""
+
   @doc """
   Whether this credit still needs a human.
   """
   def resolved?(%__MODULE__{approved: true, mode: :link, identity_id: id}), do: not is_nil(id)
+
+  def resolved?(%__MODULE__{approved: true, mode: :create, name: name}) when not is_binary(name),
+    do: false
+
   def resolved?(%__MODULE__{approved: true, mode: :create, people: []}), do: false
 
   # Every person behind the credit has to actually say who they are. A blank
   # row the operator added and hasn't filled in yet is stored happily and
   # reported here — which is what lets them add two people and name them one
   # at a time.
-  def resolved?(%__MODULE__{approved: true, mode: :create, people: people}),
-    do: Enum.all?(people, &PersonRef.complete?/1)
+  def resolved?(%__MODULE__{approved: true, mode: :create, name: name, people: people}),
+    do: String.trim(name) != "" and Enum.all?(people, &PersonRef.complete?/1)
 
   def resolved?(%__MODULE__{}), do: false
+
+  @doc """
+  Whether this credit is the ordinary case: one new person of the same name.
+
+  The form collapses to a single control when it is, because "who is behind
+  this name" is a question about the *person* that almost never has an
+  interesting answer — and asking it on every import buried the two cases
+  where it does.
+  """
+  def simple?(%__MODULE__{mode: :link}), do: true
+
+  def simple?(%__MODULE__{mode: :create, name: name, people: [%PersonRef{} = person]}),
+    do: is_nil(person.person_id) and person.name == name
+
+  def simple?(%__MODULE__{}), do: false
 
   @doc """
   Why it isn't resolved.

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -88,7 +88,7 @@ defmodule Ambry.Inbox.Draft.Edit do
         |> update_in([Access.key(:recording)], fn recording ->
           if Recording.selected?(recording, candidate),
             do: %{recording | approved: true, doubt: :none, doubt_detail: nil},
-            else: Seed.reseed_recording(recording, candidate, tags(item), item)
+            else: Seed.reseed_recording(recording, candidate, work_chain(draft), tags(item), item)
         end)
         |> follow_work(item, candidate)
     end
@@ -102,8 +102,12 @@ defmodule Ambry.Inbox.Draft.Edit do
   in no storefront at all.
   """
   def choose_uncatalogued(draft, %InboxItem{} = item) do
-    update_in(draft.recording, &Seed.reseed_uncatalogued(&1, tags(item), item))
+    update_in(draft.recording, &Seed.reseed_uncatalogued(&1, work_chain(draft), tags(item), item))
   end
+
+  # The chosen book's sources, which get a say in the recording's descriptive
+  # fields.
+  defp work_chain(draft), do: draft.work |> Seed.selected_candidate() |> Seed.chain()
 
   defp follow_work(draft, item, %{"of_work" => %{"source" => source, "id" => id}})
        when is_binary(source) do
@@ -145,6 +149,43 @@ defmodule Ambry.Inbox.Draft.Edit do
 
       %{credit | mode: :create, identity_id: nil, people: people}
     end)
+  end
+
+  @doc """
+  Renames the identity a credit will create.
+
+  A provider's spelling is a proposal like any other, and there was no way to
+  overrule it — so "David Wong" could only ever be imported as a person called
+  David Wong, when the human is Jason Pargin.
+
+  The default person's name follows along while it is still tracking the
+  credit, which is what makes that case two edits instead of a special mode:
+  rename the credit, reveal the pen name, rename the person.
+  """
+  def rename_credit(draft, section, index, name) do
+    update_credit(draft, section, index, fn credit ->
+      people =
+        Enum.map(credit.people, fn person ->
+          if is_nil(person.person_id) and person.name == credit.name,
+            do: %{person | name: name},
+            else: person
+        end)
+
+      # Clearing the box un-confirms: a credit cannot stay settled with
+      # nothing to create. Any other rename keeps the confirmation, so fixing
+      # a typo doesn't cost a second click.
+      %{credit | name: name, people: people, approved: credit.approved and blank?(name) == false}
+    end)
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(name) when is_binary(name), do: String.trim(name) == ""
+
+  @doc """
+  Renames the series a link will create.
+  """
+  def rename_series(draft, index, name) do
+    update_series(draft, index, &%{&1 | name: name, approved: &1.approved and not blank?(name)})
   end
 
   @doc """

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -90,7 +90,7 @@ defmodule Ambry.Inbox.Draft.Seed do
       evidence: evidence(item),
       stale: false,
       work: work(work_level, hints, tags),
-      recording: recording(recording_level, hints, tags, item),
+      recording: recording(recording_level, work_level, hints, tags, item),
       destination: destination(item)
     }
   end
@@ -213,16 +213,45 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp put_work_fields(%Work{} = work, best, hints, tags) do
     book_id = if best && best["source"] == "local", do: best["id"]
+    sources = chain(best)
+
+    published = keep_manual(work.published, published_field(sources, tags))
 
     %{
       work
-      | title: keep_manual(work.title, title_field(best, hints, tags)),
-        published: keep_manual(work.published, published_field(best, tags)),
-        published_format: keep_manual(work.published_format, published_format_field(best, tags)),
+      | title: keep_manual(work.title, title_field(sources, hints, tags)),
+        published: published,
+        published_format:
+          keep_manual(
+            work.published_format,
+            published_format_field(sources, tags, published)
+          ),
         authors: author_credits(best, tags),
         series: series_links(best, tags, book_id)
     }
   end
+
+  # A candidate and everybody who corroborated it.
+  #
+  # Two providers agreeing on which work this is do NOT agree on everything
+  # about it — one has the better description, another the better cover — and
+  # collapsing them into a winner left the operator choosing between one
+  # provider and the file's tags. Identity is still one answer; *where each
+  # field's value comes from* is a separate question per field.
+  def chain(nil), do: []
+  def chain(candidate), do: [candidate | List.wrap(candidate["merged"])]
+
+  @doc """
+  The candidate a decision's fields were filled from, if any.
+  """
+  def selected_candidate(%{candidates: candidates, selected_source: source, selected_id: id})
+      when is_binary(source) do
+    Enum.find(candidates, &(&1["source"] == source and to_string(&1["id"]) == id))
+  end
+
+  def selected_candidate(_decision), do: nil
+
+  defp from_chain(sources, key), do: Enum.map(sources, &candidate(&1, key))
 
   # A field the operator typed is theirs; re-seeding from another candidate
   # must not quietly undo a correction. Everything else is provider data being
@@ -258,11 +287,12 @@ defmodule Ambry.Inbox.Draft.Seed do
   # library, 96% of releases carry a title in tags and the parser is what the
   # other ~2% rely on — so letting the folder name argue with a provider would
   # make nearly every import ambiguous on its title for no gain.
-  defp title_field(best, hints, tags) do
-    [candidate(best, "title"), tag_candidate(tags, "book_title")]
+  defp title_field(sources, hints, tags) do
+    (from_chain(sources, "title") ++ [tag_candidate(tags, "book_title")])
     |> scalar(
       required: true,
-      equivalence: &title_key/1,
+      equivalence: &(title_key(&1) == title_key(&2)),
+      prefer: &shorter/2,
       fallback: release_candidate(hints.title)
     )
   end
@@ -290,17 +320,73 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp title_key(other), do: normalize(other)
 
-  defp published_field(best, tags) do
-    [candidate(best, "published"), tag_candidate(tags, "published")]
-    |> scalar(required: true)
+  # **Year-only knowledge arrives as a literal January 1st.** Every source
+  # does it — the ROADMAP records it for Goodreads-shaped data, and the
+  # operator's own files carry it too, which is why the tag date and the
+  # provider date were being reported as rival opinions on a large share of
+  # imports. "2017-01-01" and "2017-10-03" are not two answers; they are one
+  # fact at two precisions, and the precise one is the answer.
+  #
+  # Two *precise* dates in one year genuinely do disagree, and so do two
+  # different years. Both stay the operator's.
+  defp same_date?(one, other) do
+    case {parse_date(one), parse_date(other)} do
+      {%Date{} = a, %Date{} = b} ->
+        a == b or (a.year == b.year and (year_only?(a) or year_only?(b)))
+
+      _unparseable ->
+        normalize(one) == normalize(other)
+    end
+  end
+
+  defp more_precise(held, incoming) do
+    case {parse_date(held), parse_date(incoming)} do
+      {%Date{} = a, %Date{} = b} ->
+        if year_only?(a) and not year_only?(b), do: incoming, else: held
+
+      _unparseable ->
+        held
+    end
+  end
+
+  defp year_only?(%Date{month: 1, day: 1}), do: true
+  defp year_only?(%Date{}), do: false
+
+  defp parse_date(value) when is_binary(value) do
+    case Date.from_iso8601(value) do
+      {:ok, date} -> date
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp parse_date(_other), do: nil
+
+  # The display format is not an opinion of its own — it says how much of the
+  # date is real, so it belongs to whichever source won the date. Left to
+  # decide itself it would report "sources disagree" on exactly the imports
+  # the rule above just settled: the tag says year, the provider says full.
+  defp follow_date_source(%Field{} = format, %Field{approved: true, source: source})
+       when is_binary(source) do
+    case Enum.find(format.candidates, &(&1.source == source)) do
+      nil -> format
+      winner -> %{format | value: winner.value, source: winner.source, approved: true}
+    end
+  end
+
+  defp follow_date_source(format, _published), do: format
+
+  defp published_field(sources, tags) do
+    (from_chain(sources, "published") ++ [tag_candidate(tags, "published")])
+    |> scalar(required: true, equivalence: &same_date?/2, prefer: &more_precise/2)
   end
 
   # Not derivable from the date: year-only knowledge arrives as a literal
   # Jan 1st, and rendering that as a real release day is the exact bug the
   # v1.9.0 punch list fixed for the import forms.
-  defp published_format_field(best, tags) do
-    [candidate(best, "published_format"), tag_candidate(tags, "published_format")]
+  defp published_format_field(sources, tags, published) do
+    (from_chain(sources, "published_format") ++ [tag_candidate(tags, "published_format")])
     |> scalar(required: false)
+    |> follow_date_source(published)
     |> default_to("full")
   end
 
@@ -312,8 +398,9 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## recording
 
-  defp recording(level, hints, tags, item) do
+  defp recording(level, work_level, hints, tags, item) do
     candidates = Map.get(level, "candidates", []) || []
+    work_chain = work_level |> Map.get("candidates", []) |> List.first() |> chain()
 
     # **Only a recording we actually believe in gets to fill anything in.**
     # Audible's search widens when a narrow query finds nothing, so a book
@@ -340,13 +427,13 @@ defmodule Ambry.Inbox.Draft.Seed do
       # showing up only as fields that mysteriously stayed empty.
       approved: doubt in [:none, :nothing_found]
     }
-    |> put_recording_fields(best, tags, item)
+    |> put_recording_fields(best, work_chain, tags, item)
   end
 
   @doc """
   Fills a recording's fields from one catalogue entry, keeping typed values.
   """
-  def reseed_recording(%Recording{} = recording, candidate, tags, item) do
+  def reseed_recording(%Recording{} = recording, candidate, work_chain, tags, item) do
     %{
       recording
       | approved: true,
@@ -355,33 +442,44 @@ defmodule Ambry.Inbox.Draft.Seed do
         doubt: :none,
         doubt_detail: nil
     }
-    |> put_recording_fields(candidate, tags, item)
+    |> put_recording_fields(candidate, work_chain, tags, item)
   end
 
   @doc """
   Settles a recording as one no catalogue lists, described by the file alone.
   """
-  def reseed_uncatalogued(%Recording{} = recording, tags, item) do
+  def reseed_uncatalogued(%Recording{} = recording, work_chain, tags, item) do
     %{recording | approved: true, selected_source: nil, selected_id: nil}
-    |> put_recording_fields(nil, tags, item)
+    |> put_recording_fields(nil, work_chain, tags, item)
   end
 
-  defp put_recording_fields(%Recording{} = recording, best, tags, item) do
+  # The work's sources get a say in the recording's *descriptive* fields —
+  # description, cover, publisher are facts about the book that a work-level
+  # provider often has better than a storefront does, and the operator has to
+  # be able to take the description from one and the cover from another.
+  #
+  # The release date deliberately does NOT draw from them: a work-level
+  # provider's date is the work's original publication date, which is a
+  # different fact wearing the same name.
+  defp put_recording_fields(%Recording{} = recording, best, work_chain, tags, item) do
+    chain = chain(best)
+    describing = chain ++ work_chain
+
     %{
       recording
       | title: keep_manual(recording.title, scalar([], required: false)),
-        published: keep_manual(recording.published, scalar([candidate(best, "published")])),
+        published: keep_manual(recording.published, scalar(from_chain(chain, "published"))),
         publisher:
           keep_manual(
             recording.publisher,
-            scalar([candidate(best, "publisher"), tag_candidate(tags, "publisher")])
+            scalar(from_chain(describing, "publisher") ++ [tag_candidate(tags, "publisher")])
           ),
         description:
           keep_manual(
             recording.description,
-            scalar([candidate(best, "description"), tag_candidate(tags, "description")])
+            scalar(from_chain(describing, "description") ++ [tag_candidate(tags, "description")])
           ),
-        cover: keep_manual(recording.cover, cover_field(best, tags, item)),
+        cover: keep_manual(recording.cover, cover_field(describing, tags, item)),
         narrators: narrator_credits(best, tags)
     }
   end
@@ -449,7 +547,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   # Embedded art and a provider cover are both real answers, so two of them is
   # a choice rather than a winner. The embedded candidate carries the audio
   # file to extract from; approval does the extracting.
-  defp cover_field(best, tags, item) do
+  defp cover_field(sources, tags, item) do
     embedded =
       if tags["has_cover_art"] && item.files != [] do
         %Candidate{
@@ -459,7 +557,7 @@ defmodule Ambry.Inbox.Draft.Seed do
         }
       end
 
-    [candidate(best, "cover_url"), embedded] |> scalar(required: false)
+    (from_chain(sources, "cover_url") ++ [embedded]) |> scalar(required: false)
   end
 
   ## credits
@@ -667,52 +765,70 @@ defmodule Ambry.Inbox.Draft.Seed do
   # into a choice.
   defp scalar(candidates, opts \\ []) do
     required = Keyword.get(opts, :required, false)
-    same? = Keyword.get(opts, :equivalence, &normalize/1)
-    candidates = Enum.reject(candidates, &is_nil/1)
+    same? = Keyword.get(opts, :equivalence, &(normalize(&1) == normalize(&2)))
+    prefer = Keyword.get(opts, :prefer, fn held, _incoming -> held end)
 
     candidates =
-      case {groups(candidates, same?), Keyword.get(opts, :fallback)} do
+      candidates
+      |> Enum.reject(&(is_nil(&1) or &1.value in [nil, ""]))
+      |> collapse(same?, prefer)
+
+    candidates =
+      case {candidates, Keyword.get(opts, :fallback)} do
         {[], fallback} when not is_nil(fallback) -> [fallback]
         _primary_had_something -> candidates
       end
 
     field = %Field{required: required, candidates: candidates}
 
-    case groups(candidates, same?) do
+    case candidates do
       # nothing proposed it. Optional means waived — an explicit "none", which
       # is what makes "every piece resolved" reachable at all.
       [] ->
         %{field | approved: not required}
 
-      # one answer, whether from one source, several that agree exactly, or
-      # several that agree once format labels are set aside
-      [group] ->
-        value = preferred(group)
-        %{field | value: value, source: source_for(candidates, value), approved: true}
+      # one answer, whether from one source or several that turned out to mean
+      # the same thing
+      [only] ->
+        %{field | value: only.value, source: only.source, approved: true}
 
       _several ->
         %{field | approved: false}
     end
   end
 
-  # Proposals that mean the same thing, gathered. Every group is one answer;
-  # more than one group is a genuine disagreement for the operator to settle.
-  defp groups(candidates, same?) do
-    candidates
-    |> Enum.map(& &1.value)
-    |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.group_by(same?)
-    |> Map.values()
+  # Proposals that mean the same thing become one chip, crediting everybody
+  # who said it.
+  #
+  # `same?` is a binary predicate rather than a key function because the
+  # interesting equivalences aren't groupable: a year-only date matches any
+  # date in that year, but two full dates in that year don't match each other.
+  # `prefer` then decides which spelling survives — the cleaner title, the
+  # more precise date.
+  defp collapse(candidates, same?, prefer) do
+    Enum.reduce(candidates, [], fn candidate, kept ->
+      case Enum.find_index(kept, &same?.(&1.value, candidate.value)) do
+        nil -> kept ++ [candidate]
+        index -> List.update_at(kept, index, &combine(&1, candidate, prefer))
+      end
+    end)
   end
 
-  # Given two spellings of one answer, the shorter is the title and the longer
-  # is the title with a format label bolted on.
-  defp preferred(values), do: values |> Enum.uniq() |> Enum.min_by(&String.length/1)
+  defp combine(held, incoming, prefer) do
+    winner = if prefer.(held.value, incoming.value) == incoming.value, do: incoming, else: held
 
-  defp source_for(candidates, value) do
-    Enum.find_value(candidates, fn candidate ->
-      candidate.value == value && candidate.source
-    end)
+    %{winner | label: join_labels(held.label, incoming.label)}
+  end
+
+  defp join_labels(one, one), do: one
+  defp join_labels(nil, other), do: other
+  defp join_labels(one, nil), do: one
+  defp join_labels(one, other), do: "#{one}, #{other}"
+
+  # Two spellings of one title: the shorter is the title, the longer is the
+  # title with a format label bolted on.
+  defp shorter(held, incoming) do
+    if String.length(incoming) < String.length(held), do: incoming, else: held
   end
 
   defp normalize(string) when is_binary(string) do

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -56,7 +56,6 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
   def changeset(series_link, attrs) do
     series_link
     |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved])
-    |> validate_required([:name])
     |> cast_embed(:candidates)
     |> validate_number()
     |> validate_link()
@@ -90,7 +89,12 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
   number in this series" is a real answer, and waiving it is an approval.
   """
   def resolved?(%__MODULE__{approved: true, mode: :link, series_id: id}), do: not is_nil(id)
-  def resolved?(%__MODULE__{approved: true, mode: :create, name: name}), do: not is_nil(name)
+
+  # A blank name is storable — clearing the box to retype is the first half of
+  # renaming — but it is never resolved.
+  def resolved?(%__MODULE__{approved: true, mode: :create, name: name}) when is_binary(name),
+    do: String.trim(name) != ""
+
   def resolved?(%__MODULE__{}), do: false
 
   def state(%__MODULE__{} = link) do

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -312,16 +312,29 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :section, :string, required: true
   attr :identities, :list, required: true
   attr :people, :list, required: true
-  attr :verb, :string, required: true
+  attr :verb, :string, required: true, doc: ~s(the visible label — "Written by")
+  attr :reveal, :string, required: true, doc: ~s(the unfold link — "This is a pen name")
+  attr :backing, :string, required: true, doc: ~s(the unfolded label — "Pen name of")
+  attr :expanded, :boolean, required: true
 
   @doc """
   One credit, resolved to an identity.
 
-  The vocabulary is doing the teaching: **Credited as** is the name on the
-  book, **Written by** / **Performed by** are the humans behind it. Two or more
-  people is a shared pen name — the whole of the composite-author case,
-  expressed as a longer list rather than a separate mode, which is what stops
-  the case space exploding.
+  ## One control by default
+
+  A credited name IS an identity. How many humans stand behind it is a fact
+  about the *person* — not about this book — and no provider reports it, so
+  asking on every import buried the two cases where the answer is interesting
+  under dozens where it isn't. The person layer is therefore folded away
+  behind "This is a pen name" / "This is a stage name", and unfolds itself
+  whenever the credit is anything but the 1:1 default (`Credit.simple?/1`).
+
+  ## The name is editable
+
+  A provider's spelling is a proposal like any other. Without a box to
+  overrule it, "David Wong" could only be imported as a person called David
+  Wong — the human is Jason Pargin, and that import is one author plus one
+  differently-named person, which is now two edits rather than impossible.
 
   A link decision always targets an identity, never a Person. That is the
   generalized fix for the pen-name bug where matching found a Person and
@@ -337,7 +350,7 @@ defmodule AmbryWeb.Admin.Decisions do
             name="fa-circle-check"
             class="text-brand h-4 w-4 flex-none dark:text-brand-dark"
           />
-          <span class="truncate font-semibold">{@credit.name}</span>
+          <.label class="text-xs">{@verb}</.label>
 
           <.badge
             :if={!Credit.resolved?(@credit)}
@@ -377,85 +390,115 @@ defmodule AmbryWeb.Admin.Decisions do
         </div>
       </div>
 
-      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <div>
-          <.label class="text-xs">Credited as</.label>
-          <form id={"credit-#{@section}-#{@index}-identity"} phx-change="link-credit">
-            <input type="hidden" name="section" value={@section} />
-            <input type="hidden" name="index" value={@index} />
-            <select
-              name="identity_id"
-              class="mt-1 w-full rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
-            >
-              <option value="">Create "{@credit.name}"</option>
-              <option
-                :for={{name, id} <- @identities}
-                value={id}
-                selected={@credit.mode == :link and @credit.identity_id == id}
-              >
-                {name}
-              </option>
-            </select>
-          </form>
-        </div>
+      <form
+        id={"credit-#{@section}-#{@index}-identity"}
+        phx-change="credit-change"
+        class="flex flex-wrap items-center gap-2"
+      >
+        <input type="hidden" name="section" value={@section} />
+        <input type="hidden" name="index" value={@index} />
 
-        <div :if={@credit.mode == :create}>
-          <.label class="text-xs">{@verb}</.label>
+        <select
+          name="identity_id"
+          class="rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        >
+          <option value="">Create new…</option>
+          <option
+            :for={{name, id} <- @identities}
+            value={id}
+            selected={@credit.mode == :link and @credit.identity_id == id}
+          >
+            {name}
+          </option>
+        </select>
 
-          <div class="mt-1 space-y-1">
-            <form
-              :for={{person, person_index} <- Enum.with_index(@credit.people)}
-              id={"credit-#{@section}-#{@index}-person-#{person_index}"}
-              phx-change="set-person"
-              class="flex items-center gap-1"
-            >
-              <input type="hidden" name="section" value={@section} />
-              <input type="hidden" name="index" value={@index} />
-              <input type="hidden" name="person" value={person_index} />
+        <input
+          :if={@credit.mode == :create}
+          type="text"
+          name="name"
+          value={@credit.name}
+          placeholder="name"
+          class="min-w-0 flex-grow rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        />
 
-              <select
-                name="person_id"
-                class="w-full rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
-              >
-                <option value="">New person: {person.name || @credit.name}</option>
-                <option :for={{name, id} <- @people} value={id} selected={person.person_id == id}>
-                  {name}
-                </option>
-              </select>
-
-              <button
-                :if={length(@credit.people) > 1}
-                type="button"
-                phx-click="remove-person"
-                phx-value-section={@section}
-                phx-value-index={@index}
-                phx-value-person={person_index}
-              >
-                <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
-              </button>
-            </form>
-
-            <%!-- Narrators stay one-to-one with a Person by design; only the
-                  author control grows a second entry. --%>
-            <button
-              :if={@section == "work"}
-              type="button"
-              phx-click="add-person"
-              phx-value-section={@section}
-              phx-value-index={@index}
-              class="text-xs underline dark:text-zinc-400"
-            >
-              Add another person
-            </button>
-
-            <p :if={length(@credit.people) > 1} class="text-xs italic dark:text-zinc-500">
-              A shared pen name — {@credit.name} will be one author credited to {Enum.count(@credit.people)} people.
-            </p>
-          </div>
-        </div>
-
-        <p :if={@credit.mode == :link} class="self-end text-xs italic dark:text-zinc-500">
+        <span :if={@credit.mode == :link} class="text-xs italic dark:text-zinc-500">
           {linked_people(@credit) || "Already in the library."}
+        </span>
+      </form>
+
+      <%!-- Folded away until it matters, and unfolded automatically the moment
+            it does — a credit backed by somebody else, or by two people, can
+            never be hiding behind a collapsed control. --%>
+      <button
+        :if={@credit.mode == :create and !@expanded}
+        type="button"
+        phx-click="toggle-people"
+        phx-value-section={@section}
+        phx-value-index={@index}
+        class="text-xs underline dark:text-zinc-400"
+      >
+        {@reveal}
+      </button>
+
+      <div :if={@credit.mode == :create and @expanded} class="space-y-1">
+        <.label class="text-xs">{@backing}</.label>
+
+        <form
+          :for={{person, person_index} <- Enum.with_index(@credit.people)}
+          id={"credit-#{@section}-#{@index}-person-#{person_index}"}
+          phx-change="person-change"
+          class="flex flex-wrap items-center gap-2"
+        >
+          <input type="hidden" name="section" value={@section} />
+          <input type="hidden" name="index" value={@index} />
+          <input type="hidden" name="person" value={person_index} />
+
+          <select
+            name="person_id"
+            class="rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+          >
+            <option value="">Create new…</option>
+            <option :for={{name, id} <- @people} value={id} selected={person.person_id == id}>
+              {name}
+            </option>
+          </select>
+
+          <input
+            :if={is_nil(person.person_id)}
+            type="text"
+            name="name"
+            value={person.name}
+            placeholder="the person's real name"
+            class="min-w-0 flex-grow rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+          />
+
+          <button
+            :if={length(@credit.people) > 1}
+            type="button"
+            phx-click="remove-person"
+            phx-value-section={@section}
+            phx-value-index={@index}
+            phx-value-person={person_index}
+          >
+            <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
+          </button>
+        </form>
+
+        <%!-- Narrators stay one-to-one with a Person by design; only the
+              author control grows a second entry. --%>
+        <button
+          :if={@section == "work"}
+          type="button"
+          phx-click="add-person"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          class="text-xs underline dark:text-zinc-400"
+        >
+          Add another person
+        </button>
+
+        <p :if={length(@credit.people) > 1} class="text-xs italic dark:text-zinc-500">
+          A shared pen name — {@credit.name} will be one author credited to {Enum.count(@credit.people)} people.
         </p>
       </div>
     </div>
@@ -483,7 +526,7 @@ defmodule AmbryWeb.Admin.Decisions do
         class="text-brand h-4 w-4 flex-none dark:text-brand-dark"
       />
 
-      <span class="font-semibold">{@link.name}</span>
+      <span :if={@link.mode == :link} class="font-semibold">{@link.name}</span>
 
       <.badge
         :if={!SeriesLink.resolved?(@link)}
@@ -505,13 +548,13 @@ defmodule AmbryWeb.Admin.Decisions do
         />
       </form>
 
-      <form id={"series-#{@index}-link"} phx-change="link-series">
+      <form id={"series-#{@index}-link"} phx-change="link-series" class="flex items-center gap-2">
         <input type="hidden" name="index" value={@index} />
         <select
           name="series_id"
           class="rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
         >
-          <option value="">Create "{@link.name}"</option>
+          <option value="">Create new…</option>
           <option
             :for={{name, id} <- @options}
             value={id}
@@ -520,6 +563,17 @@ defmodule AmbryWeb.Admin.Decisions do
             {name}
           </option>
         </select>
+
+        <%!-- A provider's spelling of a series name is a proposal, not a
+              decree. "The Expanse" vs "Expanse" is the operator's call. --%>
+        <input
+          :if={@link.mode == :create}
+          type="text"
+          name="name"
+          value={@link.name}
+          placeholder="series name"
+          class="rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        />
       </form>
 
       <button

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -19,11 +19,14 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   ## Vocabulary
 
-  Credits read "Credited as" / "Written by" (or "Performed by"), which is what
-  makes the two-level identity model legible without explaining it: the
-  identity is what the book credits, the people are the humans behind it, and
-  two or more of them is a shared pen name. That is the entire composite-author
-  case — a longer list, not a different mode.
+  A credit reads as one line — "Written by" / "Narrated by" — and the person
+  layer is folded away behind "This is a pen name" / "This is a stage name".
+  An earlier version showed both levels always, on the theory that "Credited
+  as / Written by" teaches the model for free; in practice it charged every
+  ordinary import for a question about personhood that only two imports in a
+  hundred have an interesting answer to. The fold unfolds itself whenever the
+  credit is anything but one new person of the same name, so nothing
+  interesting can hide inside it.
   """
 
   use AmbryWeb, :admin_live_view
@@ -34,6 +37,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Books
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Work
@@ -51,7 +55,19 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(series: Books.series_for_select())
      |> assign(authors: People.authors_for_select(), narrators: People.narrators_for_select())
      |> assign(people: People.people_for_select())
+     |> assign(expanded: MapSet.new())
      |> load(item)}
+  end
+
+  @doc """
+  Whether a credit's person layer should be showing.
+
+  Folded away for the ordinary case — one new person of the same name — and
+  unfolded whenever the credit is anything else, so a pen name can never be
+  hiding behind a collapsed control.
+  """
+  def expanded?(expanded, section, index, credit) do
+    MapSet.member?(expanded, {section, index}) or not Credit.simple?(credit)
   end
 
   @impl Phoenix.LiveView
@@ -93,14 +109,33 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.choose_uncatalogued(&1, item))}
   end
 
-  def handle_event("link-credit", %{"section" => section, "index" => i} = params, socket) do
+  def handle_event("credit-change", %{"section" => section, "index" => i} = params, socket) do
+    section = atom(section)
+    index = to_int(i)
     id = to_int(params["identity_id"])
 
     {:noreply,
      edit(socket, fn draft ->
-       if id,
-         do: Draft.Edit.link_credit(draft, atom(section), to_int(i), id),
-         else: Draft.Edit.create_credit(draft, atom(section), to_int(i))
+       if id do
+         Draft.Edit.link_credit(draft, section, index, id)
+       else
+         draft
+         |> Draft.Edit.create_credit(section, index)
+         |> Draft.Edit.rename_credit(section, index, params["name"] || "")
+       end
+     end)}
+  end
+
+  # Whether the person layer is unfolded is view state, not a decision — it
+  # has no business in the stored draft.
+  def handle_event("toggle-people", %{"section" => section, "index" => index}, socket) do
+    {:noreply,
+     update(socket, :expanded, fn expanded ->
+       key = {section, to_int(index)}
+
+       if MapSet.member?(expanded, key),
+         do: MapSet.delete(expanded, key),
+         else: MapSet.put(expanded, key)
      end)}
   end
 
@@ -112,11 +147,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.remove_person(&1, atom(s), to_int(i), to_int(p)))}
   end
 
-  def handle_event("set-person", %{"section" => s, "index" => i, "person" => p} = params, socket) do
+  def handle_event(
+        "person-change",
+        %{"section" => s, "index" => i, "person" => p} = params,
+        socket
+      ) do
     # An existing person is chosen by id; anything else is a name to create.
     attrs =
       case to_int(params["person_id"]) do
-        nil -> %{name: params["name"], person_id: nil}
+        nil -> %{name: params["name"] || "", person_id: nil}
         id -> %{person_id: id, name: nil}
       end
 
@@ -145,13 +184,18 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def handle_event("link-series", %{"index" => i} = params, socket) do
+    index = to_int(i)
     id = to_int(params["series_id"])
 
     {:noreply,
      edit(socket, fn draft ->
-       if id,
-         do: Draft.Edit.link_series(draft, to_int(i), id),
-         else: Draft.Edit.create_series(draft, to_int(i))
+       if id do
+         Draft.Edit.link_series(draft, index, id)
+       else
+         draft
+         |> Draft.Edit.create_series(index)
+         |> Draft.Edit.rename_series(index, params["name"] || "")
+       end
      end)}
   end
 
@@ -383,12 +427,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def provider_outcomes(_item, _level), do: []
 
   @doc "The candidate a decision's fields were filled from, if any."
-  def selected_candidate(%{candidates: candidates, selected_source: source, selected_id: id})
-      when is_binary(source) do
-    Enum.find(candidates, &(&1["source"] == source and to_string(&1["id"]) == id))
-  end
-
-  def selected_candidate(_decision), do: nil
+  defdelegate selected_candidate(decision), to: Ambry.Inbox.Draft.Seed
 
   @doc """
   How many decisions the bulk button would settle, so its label can say.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -248,6 +248,9 @@
           identities={@authors}
           people={@people}
           verb="Written by"
+          reveal="This is a pen name"
+          backing="Pen name of"
+          expanded={expanded?(@expanded, "work", index, credit)}
         />
       </div>
 
@@ -421,7 +424,10 @@
           section="recording"
           identities={@narrators}
           people={@people}
-          verb="Performed by"
+          verb="Narrated by"
+          reveal="This is a stage name"
+          backing="Stage name of"
+          expanded={expanded?(@expanded, "recording", index, credit)}
         />
       </div>
     </section>

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -577,8 +577,12 @@ defmodule Ambry.Inbox.DraftTest do
       assert draft.work.title.approved
       # and the clean spelling wins the field
       assert draft.work.title.value == "Neuromancer"
-      # both are still offered, because the operator may want the other
-      assert length(draft.work.title.candidates) == 2
+
+      # one chip, crediting everybody who said it — two chips reading
+      # "Hardcover: Neuromancer" and "the file's tags: Neuromancer
+      # (Unabridged)" is a choice nobody wants to make
+      assert [only] = draft.work.title.candidates
+      assert only.label == "Hardcover, The file's tags"
     end
 
     test "genuinely different titles still disagree" do
@@ -592,6 +596,235 @@ defmodule Ambry.Inbox.DraftTest do
 
       refute draft.work.title.approved
       assert Draft.Field.state(draft.work.title) == :ambiguous
+    end
+  end
+
+  describe "mixing sources" do
+    # Two providers agreeing on WHICH work this is do not agree on everything
+    # about it. Collapsing them to a winner left the operator choosing between
+    # one provider and the file's tags.
+    test "a corroborating provider still gets to propose its own values" do
+      candidate =
+        provider_candidate(%{
+          "description" => "Hardcover's description",
+          "cover_url" => "https://example.test/hardcover.jpg",
+          "merged" => [
+            %{
+              "source" => "provider:rreading_glasses",
+              "provider_name" => "rreading-glasses",
+              "id" => "rg-1",
+              "title" => "Leviathan Wakes",
+              "description" => "rreading-glasses' description",
+              "cover_url" => "https://example.test/rg.jpg"
+            }
+          ]
+        })
+
+      draft = Seed.build(item(%{matches: matches([candidate]), tags: %{}}))
+
+      values = Enum.map(draft.recording.description.candidates, & &1.value)
+      assert "Hardcover's description" in values
+      assert "rreading-glasses' description" in values
+
+      covers = Enum.map(draft.recording.cover.candidates, & &1.value)
+      assert "https://example.test/hardcover.jpg" in covers
+      assert "https://example.test/rg.jpg" in covers
+    end
+
+    # The operator's example: description from a work-level provider, cover
+    # from the recording-level one.
+    test "the work's sources describe the recording too" do
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "provider_name" => "Audible",
+          "id" => "B01",
+          "title" => "Leviathan Wakes",
+          "narrators" => ["Jefferson Mays"],
+          "cover_url" => "https://example.test/audible.jpg",
+          "score" => 1.0
+        }
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches:
+              matches([provider_candidate(%{"description" => "The work-level description"})],
+                recording: recording,
+                recording_confidence: 1.0
+              ),
+            tags: %{}
+          })
+        )
+
+      assert "The work-level description" in Enum.map(
+               draft.recording.description.candidates,
+               & &1.value
+             )
+
+      assert "https://example.test/audible.jpg" in Enum.map(
+               draft.recording.cover.candidates,
+               & &1.value
+             )
+    end
+
+    # A work-level provider's date is the work's ORIGINAL publication date,
+    # which is a different fact wearing the same name.
+    test "the work's date is never offered as the recording's release date" do
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "id" => "B01",
+          "title" => "Leviathan Wakes",
+          "narrators" => ["Jefferson Mays"],
+          "published" => "2011-06-15",
+          "score" => 1.0
+        }
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches:
+              matches([provider_candidate(%{"published" => "1999-01-02"})],
+                recording: recording,
+                recording_confidence: 1.0
+              ),
+            tags: %{}
+          })
+        )
+
+      refute "1999-01-02" in Enum.map(draft.recording.published.candidates, & &1.value)
+    end
+  end
+
+  describe "date precision" do
+    # Year-only knowledge arrives as a literal January 1st from every source
+    # that has it, so the tag date and the provider date were being reported
+    # as rival opinions on a large share of imports.
+    test "a January 1st date defers to a precise one in the same year" do
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches([provider_candidate(%{"published" => "2017-10-03"})]),
+            tags: %{"published" => "2017-01-01"}
+          })
+        )
+
+      assert draft.work.published.approved
+      assert draft.work.published.value == "2017-10-03"
+    end
+
+    test "the display format follows whichever source won the date" do
+      draft =
+        Seed.build(
+          item(%{
+            matches:
+              matches([
+                provider_candidate(%{
+                  "published" => "2017-10-03",
+                  "published_format" => "full"
+                })
+              ]),
+            tags: %{"published" => "2017-01-01", "published_format" => "year"}
+          })
+        )
+
+      # otherwise the two columns describing one fact disagree with each other
+      assert draft.work.published_format.approved
+      assert draft.work.published_format.value == "full"
+    end
+
+    test "two precise dates in one year genuinely disagree" do
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches([provider_candidate(%{"published" => "2017-10-03"})]),
+            tags: %{"published" => "2017-03-08"}
+          })
+        )
+
+      refute draft.work.published.approved
+    end
+
+    test "different years disagree" do
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches([provider_candidate(%{"published" => "2017-10-03"})]),
+            tags: %{"published" => "2011-01-01"}
+          })
+        )
+
+      refute draft.work.published.approved
+    end
+  end
+
+  describe "naming what gets created" do
+    # The motivating case: "David Wong" is a pen name of Jason Pargin, and
+    # importing it as a new author needed a new person under a DIFFERENT name.
+    test "a credit's identity and its person can be named separately" do
+      item = item(%{matches: matches([provider_candidate(%{"authors" => ["David Wong"]})])})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        item.draft
+        |> Draft.Edit.rename_credit(:work, 0, "David Wong")
+        |> Draft.Edit.set_person(:work, 0, 0, %{name: "Jason Pargin", person_id: nil})
+
+      credit = hd(draft.work.authors)
+      assert credit.name == "David Wong"
+      assert [%{name: "Jason Pargin", person_id: nil}] = credit.people
+      refute Credit.simple?(credit)
+    end
+
+    test "the default person follows the credit's name until it is customised" do
+      item = item(%{matches: matches([provider_candidate(%{"authors" => ["Jmes S.A. Corey"]})])})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.rename_credit(item.draft, :work, 0, "James S.A. Corey")
+
+      # fixing a typo in the credited name shouldn't leave a person behind
+      # still carrying it
+      credit = hd(draft.work.authors)
+      assert credit.name == "James S.A. Corey"
+      assert [%{name: "James S.A. Corey"}] = credit.people
+      assert Credit.simple?(credit)
+
+      # but once the person is somebody else, renaming the credit leaves them
+      # alone
+      draft = Draft.Edit.set_person(draft, :work, 0, 0, %{name: "Ty Franck", person_id: nil})
+      draft = Draft.Edit.rename_credit(draft, :work, 0, "J.S.A. Corey")
+
+      assert [%{name: "Ty Franck"}] = hd(draft.work.authors).people
+    end
+
+    test "a half-typed name is storable but never resolved" do
+      item = item(%{matches: matches([provider_candidate(%{})])})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.rename_credit(item.draft, :work, 0, "")
+
+      # clearing the box to retype must not fail the changeset — validation
+      # gates saving, the invariant gates importing
+      assert {:ok, saved} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+      assert hd(saved.draft.work.authors).name in [nil, ""]
+      refute Credit.resolved?(hd(saved.draft.work.authors))
+      refute hd(saved.draft.work.authors).approved
+    end
+
+    test "a created series can be renamed" do
+      candidates = [
+        provider_candidate(%{"series" => [%{"name" => "Expanse", "number" => "1"}]})
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.rename_series(item.draft, 0, "The Expanse")
+
+      assert hd(draft.work.series).name == "The Expanse"
     end
   end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -140,6 +140,14 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
+      # the person layer is folded away for the ordinary case, so the pen-name
+      # path starts by saying that this isn't one
+      view
+      |> element(
+        "button[phx-click='toggle-people'][phx-value-section='work'][phx-value-index='0']"
+      )
+      |> render_click()
+
       html =
         view
         |> element(
@@ -157,6 +165,12 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element(
+        "button[phx-click='toggle-people'][phx-value-section='work'][phx-value-index='0']"
+      )
+      |> render_click()
 
       view
       |> element("button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']")


### PR DESCRIPTION
Second operator review of the staged import form. Four findings, all
confirming the same split as #1188: **identity is one answer; where each
field's value comes from is a separate question per field.** That PR got the
identity half right and left the field half as it was.

## 1. Field values couldn't be mixed across sources

> "When I have a 100% match from rreading-glasses and a 100% match from
> Hardcover, I can't mix and match metadata. What if I wanted the description
> from Hardcover but the cover image from Audible?"

Root cause was in the matcher, not the form. `merge_agreeing/1` collapsed two
providers returning the same work into the winner and reduced the losers to
`%{"source", "id"}` — their descriptions, covers and publishers were
**deleted**. Two providers agreeing on *which* work this is do not agree on
everything *about* it.

Corroborating candidates are now kept whole, and the seeder draws each scalar
from the chosen candidate **plus everybody who corroborated it**
(`Seed.chain/1`). The recording's descriptive fields — description, cover,
publisher — also draw from the *work's* chain, since a work-level provider
often has a better description than a storefront does.

**The release date deliberately does not.** A work-level provider's date is the
work's original publication date, a different fact wearing the same name.

*Rejected: making the identity lists multi-select* (the operator's suggested
shape). Identity has one right answer — the invariant #1188 established — and a
multi-select would mean "this file is two recordings". The actual need was
per-field source choice.

Also: proposals that mean the same thing now collapse into **one chip crediting
everybody who said it** ("Hardcover, rreading-glasses: …") instead of N
identical chips.

## 2. A January 1st date is not a rival opinion

> "If sources disagree on publication date because the tag is 2017-01-01 but
> Hardcover says 2017-10-03, then clearly it's the latter."

Tag dates are year-only for most of the operator's files and arrive as a
literal January 1st; so does Goodreads-shaped year-only knowledge (already
recorded in the v1.9.0 punch list). So this was being reported as "sources
disagree" on a large share of imports when it is **one fact at two
precisions**.

Now: same year and either side is Jan 1 → one answer, and the precise one wins.
Two precise dates in one year, or two different years, still disagree.

Handled with it: `published_format` now **follows whichever source won the
date** rather than deciding separately — otherwise the two columns describing
one fact contradicted each other ("year" from tags, "full" from the provider).

Mechanically this needed `scalar/2`'s equivalence to become a **binary
predicate** rather than a key function: a year-only date matches any date in
that year, but two full dates in that year don't match each other, which isn't
groupable.

## 3. The credit widget asked about personhood on every import

One line now — **"Written by" / "Narrated by"** — with the person layer folded
behind **"This is a pen name" / "This is a stage name"**. It unfolds itself
whenever `Credit.simple?/1` is false (a different person behind the name, or
two of them), so nothing interesting can hide inside a collapsed control. Fold
state is a LiveView assign, not draft — it isn't a decision.

This reverses the original 3e design's "Credited as / Written by teaches the
two-level model for free". It does teach it, and it charges every ordinary
import for a question that two in a hundred have an interesting answer to.

## 4. Nothing created could be renamed

> "Right now I can't import 'David Wong' as a completely new author and person
> in one go — because David Wong is a pen name of Jason Pargin."

Every "Create X" took the provider's spelling verbatim. Identity, person and
series names all have text boxes now. The default person's name follows the
credit's until the operator customises it, which makes the motivating case two
edits (rename the credit, unfold, name the person) rather than impossible.

Blank names are **storable but never resolved** — clearing the box to retype is
the first half of renaming — so `validate_required` moved out of the changeset
and into `resolved?/1`, exactly the "validation gates saving, the invariant
gates importing" rule. Clearing a name un-confirms the credit; any other rename
keeps the confirmation, so fixing a typo costs no extra click.

## Verification

`mix check` clean; 1084 tests pass under `--warnings-as-errors`. New coverage
for corroborating-source values, work-sources-describe-the-recording, the
release-date exclusion, all four date-precision cases, format-follows-date, and
separate identity/person naming including the David Wong case.

ROADMAP.md updated (3e, "Second review — mixing sources, date precision,
naming"). It lives outside this repo, so it isn't in this diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
