### PR TITLE
Provider records are evidence, not identities

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -39,6 +39,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.Lookup
   alias Ambry.Inbox.Progress
   alias Ambry.Inbox.RunDiscovery
   alias Ambry.Inbox.RunMatch
@@ -266,6 +267,31 @@ defmodule Ambry.Inbox do
     |> InboxItem.put_draft(attrs)
     |> Repo.update()
   end
+
+  @doc """
+  How a provider record is referred to: its provider and that provider's id.
+  """
+  defdelegate record_ref(record), to: AutoMatch, as: :ref
+
+  @doc """
+  Fetches the full record behind a thin search hit.
+  """
+  defdelegate hydrate_record(item, level, ref), to: Lookup, as: :hydrate
+
+  @doc """
+  Asks every editions-capable database what recordings a work is known to have.
+  """
+  defdelegate fetch_editions(item, work_refs), to: Lookup, as: :editions
+
+  @doc """
+  Runs an operator-written search and adds whatever it returns.
+  """
+  defdelegate research(item, level, fields), to: Lookup
+
+  @doc """
+  Asks one provider again — the one that was unreachable during matching.
+  """
+  defdelegate retry_provider(item, level, provider_id), to: Lookup
 
   @doc """
   A changeset for the staged import, for the form to render.

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -23,11 +23,15 @@ defmodule Ambry.Inbox.AutoMatch do
   alternatives instant — and leaves re-searching for the case it's actually
   for, where the right answer isn't in the list at all.
 
-  ## Local records outrank providers
+  ## Provider records are evidence, local Books are an outcome
 
-  A work already in the library is the best possible match: it's what stops a
-  second recording of a book from creating a duplicate Book. So local hits
-  are ranked ahead of provider results at equal confidence.
+  A record from Hardcover and a record from rreading-glasses for one book are
+  two databases describing the same thing, not two rival identities — they are
+  kept as separate records and both may feed the import. A Book already in the
+  library is categorically different: linking to it creates nothing, inherits
+  its curation, and is what stops a second recording splitting the library. So
+  local hits live in their own list (`"local"`), never ranked among the
+  provider records.
   """
 
   alias Ambry.Books
@@ -40,6 +44,12 @@ defmodule Ambry.Inbox.AutoMatch do
   require Logger
 
   @candidate_limit 8
+
+  # How many records about the *same* thing are worth a follow-up call each
+  # (details, editions). Two databases holding a record of one book is normal;
+  # eight of them saying it is not, and past a few the extra requests buy
+  # nothing.
+  @group_limit 4
 
   # Corroboration bonus when two providers independently return the same work.
   @agreement_bonus 0.05
@@ -82,6 +92,24 @@ defmodule Ambry.Inbox.AutoMatch do
   end
 
   @doc """
+  The records that look like they're about the same thing as the best one.
+
+  Used for three things, none of which is merging: scoring (corroboration is
+  not a rival), deciding what to pre-tick, and deciding which records are
+  worth a details or editions call. The records themselves stay separate rows
+  — two databases holding a record of one book is the normal case.
+  """
+  def top_group([]), do: []
+
+  def top_group([best | _rest] = candidates) do
+    key = agreement_key(best)
+
+    candidates
+    |> Enum.filter(&(agreement_key(&1) == key))
+    |> Enum.take(@group_limit)
+  end
+
+  @doc """
   What we think the item is, from its tags first and its release name second.
 
   Tags win because they're vastly more reliable — measured across a real
@@ -101,14 +129,21 @@ defmodule Ambry.Inbox.AutoMatch do
     }
   end
 
+  # Local Books are kept in their own list, not ranked among the provider
+  # records. Reusing a Book you already have and importing one you don't are
+  # different *outcomes* — one creates nothing, inherits the book's curation
+  # and adds an alternate edition — while a provider record is *evidence*
+  # about a book. Ranking them together made the form ask one question that
+  # was really two.
   defp match_work(hints) do
     query = work_query(hints)
 
     {candidates, outcomes} = provider_books(:work, query, hints)
 
     query
-    |> level_result(local_books(hints) ++ candidates, outcomes)
-    |> hydrate_best()
+    |> level_result(candidates, outcomes)
+    |> Map.put("local", local_books(hints))
+    |> hydrate_top()
   end
 
   # A search hit is a summary, not the record. Measured against
@@ -118,17 +153,51 @@ defmodule Ambry.Inbox.AutoMatch do
   # draft from the summary meant importing a thinner book than the provider
   # actually knew about.
   #
-  # Only the top candidate is fetched, and only when it's a provider hit: one
-  # extra request per item on a serial queue is affordable, one per candidate
-  # is not, and a local record is already the real thing.
-  defp hydrate_best(%{"candidates" => [best | rest]} = result) do
-    case details_for(best) do
-      nil -> result
-      fuller -> %{result | "candidates" => [Map.merge(best, fuller) | rest]}
-    end
+  # Every record about the top work is hydrated, not just the single best one:
+  # they all feed the field candidates, so a thin one means the operator can't
+  # take rreading-glasses' description after all. Records about *other* works
+  # stay thin until ticked — nobody has said they're relevant yet.
+  defp hydrate_top(%{"candidates" => candidates} = result) do
+    wanted = candidates |> top_group() |> MapSet.new(&ref/1)
+
+    %{
+      result
+      | "candidates" =>
+          Enum.map(candidates, fn record ->
+            if MapSet.member?(wanted, ref(record)), do: details(record), else: record
+          end)
+    }
   end
 
-  defp hydrate_best(result), do: result
+  defp hydrate_top(result), do: result
+
+  @doc "How a record is referred to: its provider and that provider's id."
+  def ref(record), do: {record["source"], to_string(record["id"])}
+
+  @doc """
+  Marks a record as having had its full details fetched.
+
+  Records about the top work are hydrated while matching; the rest stay thin
+  until the operator ticks one, since nothing has suggested they're relevant
+  and their description and cover aren't wanted until they are.
+  """
+  def hydrated(record), do: Map.put(record, "hydrated", true)
+
+  @doc """
+  Everything a provider knows about one record, for filling in a thin search
+  hit.
+
+  A search result is a summary: measured against rreading-glasses, `search`
+  returns a work carrying **one** edition while `book_details` returns the same
+  work with **seventeen**, plus the fuller description and a cover the summary
+  may lack.
+  """
+  def details(record) do
+    case details_for(record) do
+      nil -> record
+      fuller -> record |> Map.merge(fuller) |> hydrated()
+    end
+  end
 
   defp details_for(%{"source" => "provider:" <> provider_id, "id" => id}) when is_binary(id) do
     case Providers.book_details(provider_id, id, []) do
@@ -163,9 +232,9 @@ defmodule Ambry.Inbox.AutoMatch do
   defp match_recording(%{asin: asin} = hints, work) when is_binary(asin) do
     query = %Provider.Query{keywords: asin}
     {candidates, outcomes} = provider_books(:recording, query, hints)
-    {edition_candidates, edition_outcomes} = work_editions(work, hints)
+    {editions, edition_outcomes} = editions_for(top_group(work["candidates"]), hints)
 
-    level_result(query, candidates ++ edition_candidates, outcomes ++ edition_outcomes)
+    level_result(query, candidates ++ editions, outcomes ++ edition_outcomes)
   end
 
   # Structured, not concatenated. Audible's catalog matches `title` against
@@ -181,39 +250,56 @@ defmodule Ambry.Inbox.AutoMatch do
     }
 
     {candidates, outcomes} = provider_books(:recording, query, hints)
-    {edition_candidates, edition_outcomes} = work_editions(work, hints)
+    {editions, edition_outcomes} = editions_for(top_group(work["candidates"]), hints)
 
-    level_result(query, candidates ++ edition_candidates, outcomes ++ edition_outcomes)
+    level_result(query, candidates ++ editions, outcomes ++ edition_outcomes)
   end
 
-  # The recordings a matched work is known to have. This is what finds an
-  # edition a storefront has erased: Audible's catalog API is a storefront,
-  # not a bibliography — when rights lapse and a title is pulled, it vanishes
-  # from search *and* from direct ASIN lookup, with no record that it ever
-  # existed. A work-level provider that keeps editions still has it.
-  defp work_editions(%{"candidates" => [best | _rest]}, hints) do
-    # Any provider that recognised this work will do — including one that
-    # lost the merge. The winner isn't necessarily the one that keeps
-    # editions.
-    [%{"source" => best["source"], "id" => best["id"]} | List.wrap(best["merged"])]
-    |> Enum.find_value({[], []}, fn ref ->
-      with "provider:" <> provider_id <- ref["source"],
-           true <- is_binary(ref["id"]),
-           {:ok, %{capabilities: capabilities}} <- Registry.fetch(provider_id),
-           true <- :editions in capabilities do
-        fetch_editions(provider_id, ref["id"], hints, work_ref(best))
-      else
-        _not_this_one -> nil
-      end
+  @doc """
+  The recordings the given work records are known to have.
+
+  This is what finds an edition a storefront has erased: Audible's catalog API
+  is a storefront, not a bibliography — when rights lapse and a title is
+  pulled, it vanishes from search *and* from direct ASIN lookup, with no record
+  that it ever existed. Hardcover and rreading-glasses are databases of
+  editions rather than shops, so they still have it. Measured for Neuromancer:
+  Audible 1 audio edition, Hardcover 7 — including a narrator Audible doesn't
+  list at all.
+
+  **Every capable record is asked**, not the first one. This used to be an
+  `Enum.find_value` that stopped at the first editions-capable provider even
+  when it returned nothing or errored, which is precisely backwards: the whole
+  value here is coverage across databases.
+
+  Run during matching over the records about the top work, and again from the
+  form whenever the operator ticks a work record that hasn't been asked yet.
+  The `metadata` queue is serial and retries, so a thorough match is allowed
+  to take as long as it takes.
+  """
+  def editions_for(records, hints) do
+    records
+    |> Enum.filter(&editions_capable?/1)
+    |> Enum.reduce({[], []}, fn record, {candidates, outcomes} ->
+      "provider:" <> provider_id = record["source"]
+      {found, outcome} = fetch_editions(provider_id, record["id"], hints, work_ref(record))
+      {candidates ++ found, outcomes ++ outcome}
     end)
   end
 
-  defp work_editions(_work, _hints), do: {[], []}
+  defp editions_capable?(%{"source" => "provider:" <> provider_id, "id" => id})
+       when is_binary(id) do
+    case Registry.fetch(provider_id) do
+      {:ok, entry} -> :editions in entry.capabilities
+      _unknown -> false
+    end
+  end
+
+  defp editions_capable?(_record), do: false
 
   # A recording is a recording of exactly one work, so an edition that came
-  # out of a work's own list carries that work with it. Choosing such a
-  # recording in the form settles the book too, instead of asking the operator
-  # the same question twice.
+  # out of a work's own list carries that work with it. Ticking such a
+  # recording settles the book too, instead of asking the operator the same
+  # question twice.
   defp work_ref(%{"source" => source, "id" => id}), do: %{"source" => source, "id" => id}
 
   defp fetch_editions(provider_id, work_id, hints, of_work) do
@@ -244,7 +330,7 @@ defmodule Ambry.Inbox.AutoMatch do
          [
            %{
              "id" => "#{provider_id}:editions",
-             "name" => "editions",
+             "name" => "#{provider_name(provider_id)} editions",
              "status" => "failed",
              "count" => 0,
              "reason" => describe(reason)
@@ -253,26 +339,25 @@ defmodule Ambry.Inbox.AutoMatch do
     end
   end
 
+  defp provider_name(provider_id) do
+    case Registry.fetch(provider_id) do
+      {:ok, entry} -> entry.display_name
+      _unknown -> provider_id
+    end
+  end
+
   defp work_query(%{title: nil}), do: nil
 
   defp work_query(hints), do: %Provider.Query{title: hints.title, author: hints.author}
 
   defp level_result(query, candidates, outcomes) do
-    candidates =
-      candidates
-      |> merge_agreeing()
-      |> Enum.sort_by(& &1["score"], :desc)
-      |> Enum.take(@candidate_limit)
-
     %{
       "query" => query && to_string(query),
       # The flattened string is what the cache keys on and what text-only
       # providers see, but it isn't what was *asked* — the fields are, and
       # they're what the operator needs to read when a match looks wrong.
       "query_fields" => query_fields(query),
-      "candidates" => candidates,
-      # the operator confirms; this is only the suggestion
-      "selected" => candidates |> List.first() |> selected_ref(),
+      "candidates" => rank(candidates),
       "confidence" => confidence(candidates),
       # which providers were asked, and what each said. A provider that fails
       # used to vanish silently, leaving the operator to wonder why a source
@@ -281,8 +366,20 @@ defmodule Ambry.Inbox.AutoMatch do
     }
   end
 
-  defp selected_ref(nil), do: nil
-  defp selected_ref(candidate), do: %{"source" => candidate["source"], "id" => candidate["id"]}
+  @doc """
+  Orders records best-first and caps the list.
+
+  Records are **not** fused when two providers return the same thing. That is
+  the normal case, not a duplicate to clean up: they are two databases holding
+  a record of one book, and each knows things the other doesn't — one has the
+  better description, the other the better cover. Collapsing them deleted the
+  loser's payload and made the list look like a set of rival identities.
+  """
+  def rank(candidates) do
+    candidates
+    |> Enum.sort_by(& &1["score"], :desc)
+    |> Enum.take(@candidate_limit)
+  end
 
   defp query_fields(nil), do: %{}
 
@@ -296,42 +393,6 @@ defmodule Ambry.Inbox.AutoMatch do
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)
     |> Map.new()
   end
-
-  # Two providers returning the same work is the strongest signal available,
-  # not a disagreement — but the runner-up penalty below read it as one and
-  # dropped a perfect double hit to 0.5 confidence, which is why so many
-  # obviously-right matches asked to be looked at. Duplicates collapse into
-  # one candidate that remembers it was corroborated.
-  defp merge_agreeing(candidates) do
-    candidates
-    |> Enum.group_by(&agreement_key/1)
-    |> Enum.map(fn {_key, [first | rest]} ->
-      case rest do
-        [] ->
-          first
-
-        _corroborated ->
-          first
-          |> Map.put("also_from", Enum.map(rest, &(&1["provider_name"] || &1["source"])))
-          # The corroborating candidates are kept WHOLE, not reduced to a
-          # reference. Two providers agreeing on which work this is do not
-          # agree on everything about it — one has the better description, the
-          # other the better cover — and the loser's payload was being thrown
-          # away, so the operator could only ever see the winner's values.
-          # (Their ids matter too: they are how the other providers refer to
-          # this work, which is how the edition lookup finds an edition the
-          # merge winner doesn't keep.)
-          |> Map.put("merged", rest)
-          |> Map.put("score", min(first["score"] + @agreement_bonus, 1.0))
-      end
-    end)
-  end
-
-  # A local record and a provider hit for the same work are deliberately NOT
-  # merged: "reuse the book you already have" and "create it from this
-  # provider" are different outcomes, and the operator has to be able to see
-  # both. Only provider-to-provider duplicates collapse.
-  defp agreement_key(%{"source" => "local", "id" => id}), do: {:local, id}
 
   # Recordings are keyed by what makes them *different recordings*. Title and
   # author identify a work; two audiobooks of one work share both and are not
@@ -351,16 +412,37 @@ defmodule Ambry.Inbox.AutoMatch do
   # Confidence is about the *decision*, not just the top hit: a strong match
   # with a genuinely different runner-up is exactly the case a human should
   # look at, so a close second pulls it down.
-  defp confidence([]), do: 0.0
+  #
+  # Corroboration is not a rival. Records are no longer fused, so two providers
+  # returning the same work are two rows — and scoring them as rivals would
+  # read the best-corroborated match in the library as the most doubtful one,
+  # which is the bug #1186 fixed by merging. Grouping for the score keeps that
+  # fix without the merge.
+  defp confidence(candidates) do
+    candidates
+    |> Enum.group_by(&agreement_key/1)
+    |> Map.values()
+    |> Enum.map(&group_score/1)
+    |> Enum.sort(:desc)
+    |> decide()
+  end
 
-  defp confidence([best]), do: best["score"]
+  defp group_score(group) do
+    best = group |> Enum.map(&(&1["score"] || 0.0)) |> Enum.max()
+    bonus = if length(group) > 1, do: @agreement_bonus, else: 0.0
 
-  defp confidence([best, second | _rest]) do
-    penalty = 0.5 * second["score"] / max(best["score"], 0.001)
+    min(best + bonus, 1.0)
+  end
 
-    (best["score"] * (1.0 - penalty))
+  defp decide([]), do: 0.0
+  defp decide([only]), do: only
+
+  defp decide([best, second | _rest]) do
+    penalty = 0.5 * second / max(best, 0.001)
+
+    (best * (1.0 - penalty))
     |> max(0.0)
-    |> min(best["score"])
+    |> min(best)
     |> Float.round(3)
   end
 
@@ -379,10 +461,10 @@ defmodule Ambry.Inbox.AutoMatch do
         "authors" => Enum.map(book.authors || [], & &1.name),
         "series" => series_refs(book.series),
         "published" => book.published && Date.to_iso8601(book.published),
-        # a work already in the library beats an equally-good provider hit:
-        # reusing it is what prevents duplicate Books
-        "score" =>
-          score(book.title, Enum.map(book.authors || [], & &1.name), nil, nil, hints) + 0.05
+        # No thumb on the scale any more: local Books are their own list, so
+        # the score is plain similarity and is used only to decide whether the
+        # match is strong enough to offer as "this is an edition of that".
+        "score" => score(book.title, Enum.map(book.authors || [], & &1.name), nil, nil, hints)
       }
     end)
   end
@@ -436,6 +518,13 @@ defmodule Ambry.Inbox.AutoMatch do
   # instance being down, without leaking a whole HTTP response into jsonb.
   defp describe(reason) do
     reason |> inspect() |> String.slice(0, 200)
+  end
+
+  @doc """
+  Turns provider books into records, for a search run outside matching.
+  """
+  def records_from(books, entry, hints) do
+    books |> Enum.take(@candidate_limit) |> Enum.map(&provider_candidate(&1, entry, hints))
   end
 
   defp provider_candidate(book, entry, hints) do

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -21,6 +21,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.SourceRef
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
 
@@ -39,93 +40,118 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   @doc """
-  Settles which Book this is, and fills the work's fields from that answer.
+  Settles that this release is an edition of a Book already in the library.
 
-  Choosing used to only flip `mode`, which is why every provider row rendered
-  as chosen and clicking one appeared to do nothing: the fields had been
-  seeded from the top hit at build time and no later choice could move them.
-  A release is a recording of exactly one work, so picking a different
-  candidate has to change what the book will say.
+  Nothing is created: the book's title, date and authors stay exactly as they
+  are, and only the *additive* proposals — a series it isn't in yet — remain
+  to decide. This is what stops a second recording of a work splitting the
+  library in two, which is why it's the first question the form asks.
   """
-  def choose_work(draft, %InboxItem{} = item, source, id) do
-    case find_candidate(draft.work.candidates, source, id) do
-      nil ->
-        draft
+  def link_book(draft, %InboxItem{} = item, book_id) do
+    draft
+    |> update_in([Access.key(:work)], &%{&1 | mode: :link, book_id: book_id, approved: true})
+    |> reseed(item)
+  end
 
-      candidate ->
-        # Clicking the row that's already chosen is a confirmation, not a
-        # change — re-seeding there would silently discard every credit and
-        # series the operator has settled since.
-        if Work.selected?(draft.work, candidate) do
-          update_in(draft.work, &%{&1 | approved: true})
+  @doc """
+  Settles that this is a book the library doesn't have yet.
+
+  Not a separate answer from "import this provider record" — importing a
+  record IS creating a book. This is the answer to "is it one you already
+  have", and it's no.
+  """
+  def new_book(draft, %InboxItem{} = item) do
+    draft
+    |> update_in([Access.key(:work)], &%{&1 | mode: :create, book_id: nil, approved: true})
+    |> reseed(item)
+  end
+
+  @doc """
+  Adds or removes a provider record from those describing this import.
+
+  Records are evidence, not identities: Hardcover and rreading-glasses both
+  having a record of one book is the normal case, and each knows things the
+  other doesn't. Ticking both is how the description comes from one and the
+  cover from the other.
+  """
+  def toggle_source(draft, %InboxItem{} = item, level, record) do
+    draft
+    |> update_in([Access.key(level)], fn decision ->
+      sources =
+        if Enum.any?(decision.sources, &SourceRef.points_at?(&1, record)) do
+          Enum.reject(decision.sources, &SourceRef.points_at?(&1, record))
         else
-          update_in(draft.work, &Seed.reseed_work(&1, candidate, hints(item), tags(item)))
+          decision.sources ++ [SourceRef.of(record)]
         end
-    end
-  end
 
-  @doc """
-  Settles the work as a book nothing matched, described by the file alone.
-  """
-  def choose_new_work(draft, %InboxItem{} = item) do
-    update_in(draft.work, &Seed.reseed_new_work(&1, hints(item), tags(item)))
-  end
-
-  @doc """
-  Settles which catalogued recording this release is.
-
-  Because a recording is a recording of exactly one work, a candidate that
-  came out of a work's own edition list answers the book question too — so
-  choosing it settles the work rather than asking again.
-  """
-  def choose_recording(draft, %InboxItem{} = item, source, id) do
-    case find_candidate(draft.recording.candidates, source, id) do
-      nil ->
-        draft
-
-      candidate ->
-        draft
-        |> update_in([Access.key(:recording)], fn recording ->
-          if Recording.selected?(recording, candidate),
-            do: %{recording | approved: true, doubt: :none, doubt_detail: nil},
-            else: Seed.reseed_recording(recording, candidate, work_chain(draft), tags(item), item)
-        end)
-        |> follow_work(item, candidate)
-    end
-  end
-
-  @doc """
-  Settles the recording as one no catalogue lists.
-
-  A real answer, not a failure: a delisted edition disappears from Audible's
-  search *and* from direct ASIN lookup, so plenty of perfectly good rips are
-  in no storefront at all.
-  """
-  def choose_uncatalogued(draft, %InboxItem{} = item) do
-    update_in(draft.recording, &Seed.reseed_uncatalogued(&1, work_chain(draft), tags(item), item))
-  end
-
-  # The chosen book's sources, which get a say in the recording's descriptive
-  # fields.
-  defp work_chain(draft), do: draft.work |> Seed.selected_candidate() |> Seed.chain()
-
-  defp follow_work(draft, item, %{"of_work" => %{"source" => source, "id" => id}})
-       when is_binary(source) do
-    if Work.selected?(draft.work, %{"source" => source, "id" => id}),
-      do: draft,
-      else: choose_work(draft, item, source, id)
-  end
-
-  defp follow_work(draft, _item, _candidate), do: draft
-
-  defp find_candidate(candidates, source, id) do
-    Enum.find(candidates, fn candidate ->
-      candidate["source"] == source and to_string(candidate["id"]) == to_string(id)
+      settle(%{decision | sources: sources}, level)
     end)
+    |> follow_work(item, level, record)
+    |> reseed(item)
   end
 
-  defp hints(%InboxItem{} = item), do: AutoMatch.hints(item)
-  defp tags(%InboxItem{tags: tags}), do: tags || %{}
+  @doc """
+  Settles the recording as one no catalogue lists, described by the file alone.
+
+  A real answer rather than a failure: a delisted edition disappears from
+  Audible's search *and* from direct ASIN lookup, so plenty of perfectly good
+  rips are in no storefront at all.
+  """
+  def uncatalogued(draft, %InboxItem{} = item) do
+    draft
+    |> update_in([Access.key(:recording)], fn recording ->
+      %{recording | sources: [], approved: true, doubt: :none, doubt_detail: nil}
+    end)
+    |> reseed(item)
+  end
+
+  # Ticking a record answers the question the level was asking, and a doubt
+  # the operator has now overruled stops being a doubt.
+  defp settle(decision, :recording),
+    do: %{decision | approved: true, doubt: :none, doubt_detail: nil}
+
+  defp settle(decision, :work), do: decision
+
+  # A recording is a recording of exactly one work, so an edition record that
+  # came out of a work's own list carries that work with it — ticking the
+  # edition ticks the work rather than asking the same question twice.
+  defp follow_work(draft, item, :recording, %{"of_work" => %{"source" => source, "id" => id}})
+       when is_binary(source) do
+    record = Enum.find(records(item, "work"), &(AutoMatch.ref(&1) == {source, to_string(id)}))
+
+    cond do
+      is_nil(record) -> draft
+      Work.uses?(draft.work, record) -> draft
+      true -> update_in(draft.work.sources, &(&1 ++ [SourceRef.of(record)]))
+    end
+  end
+
+  defp follow_work(draft, _item, _level, _record), do: draft
+
+  @doc """
+  Re-derives every field from the currently ticked records.
+
+  Called after new evidence arrives — a hydrated record, fresh search results
+  — because a record that was a summary when it was ticked may now have a
+  description and a cover to offer.
+  """
+  def resettle(draft, item), do: reseed(draft, item)
+
+  @doc """
+  Whether a level currently counts this record.
+  """
+  def uses?(draft, :work, record), do: Work.uses?(draft.work, record)
+  def uses?(draft, :recording, record), do: Recording.uses?(draft.recording, record)
+
+  # Fields are derived from whichever records are ticked, so every change to
+  # the ticked set re-derives them. Typed values survive.
+  defp reseed(draft, item) do
+    work = Seed.reseed_work(draft.work, item)
+
+    %{draft | work: work, recording: Seed.reseed_recording(draft.recording, work, item)}
+  end
+
+  defp records(item, level), do: Seed.records(item, level)
 
   @doc """
   Points a credit at an identity that already exists.

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -14,22 +14,21 @@ defmodule Ambry.Inbox.Draft.Recording do
 
   alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.SourceRef
 
   @primary_key false
 
   embedded_schema do
-    field :candidates, {:array, :map}, default: []
     field :confidence, :float
     field :query, :string
     field :query_fields, :map, default: %{}
     field :approved, :boolean, default: false
 
-    # Which catalogue entry describes this recording — the sharpest fact
-    # available about an import, because a file is a recording of exactly one
-    # thing. `nil` with candidates present means the operator has said none of
-    # them is it; the fields below then come from the file alone.
-    field :selected_source, :string
-    field :selected_id, :string
+    # Which records describe this recording. Hardcover, rreading-glasses and
+    # Audible will all have a record of a popular reading — and the databases
+    # keep out-of-print editions the storefront has scrubbed — so more than
+    # one is normal and each may contribute a different field.
+    embeds_many :sources, SourceRef, on_replace: :delete
 
     # Why nothing was filled in from a match. A doubted candidate stays in the
     # list to be chosen but is not allowed to describe the file, and the
@@ -51,17 +50,8 @@ defmodule Ambry.Inbox.Draft.Recording do
   @doc false
   def changeset(recording, attrs) do
     recording
-    |> cast(attrs, [
-      :candidates,
-      :confidence,
-      :query,
-      :query_fields,
-      :approved,
-      :selected_source,
-      :selected_id,
-      :doubt,
-      :doubt_detail
-    ])
+    |> cast(attrs, [:confidence, :query, :query_fields, :approved, :doubt, :doubt_detail])
+    |> cast_embed(:sources)
     |> cast_embed(:title)
     |> cast_embed(:published)
     |> cast_embed(:publisher)
@@ -86,29 +76,25 @@ defmodule Ambry.Inbox.Draft.Recording do
   defp identity(%__MODULE__{approved: true}), do: []
 
   defp identity(%__MODULE__{}),
-    do: [%{section: :recording, label: "Which recording this is", state: :unconfirmed}]
+    do: [
+      %{section: :recording, label: "Which records describe this recording", state: :unconfirmed}
+    ]
 
   @doc """
-  Whether a candidate is the one this recording was identified as.
+  Whether the operator has said this provider record describes the recording.
   """
-  def selected?(%__MODULE__{selected_source: nil}, _candidate), do: false
-
-  def selected?(%__MODULE__{} = recording, candidate) do
-    recording.selected_source == candidate["source"] and
-      recording.selected_id == to_string(candidate["id"])
-  end
+  def uses?(%__MODULE__{sources: sources}, record),
+    do: Enum.any?(sources, &SourceRef.points_at?(&1, record))
 
   @doc """
-  Whether the operator has said this release is in no catalogue.
+  Whether the operator has settled this as a recording no catalogue lists.
 
-  A real answer, and the one that settles the identity for the many recordings
-  that genuinely aren't listed anywhere — a delisted edition disappears from
-  Audible's search *and* from direct ASIN lookup, so "not found" is a fact
-  about the catalogue, not a failure of the import.
+  A real answer, and the one that settles the many recordings that genuinely
+  aren't listed anywhere — a delisted edition disappears from Audible's search
+  *and* from direct ASIN lookup, so "not found" is a fact about the catalogue,
+  not a failure of the import.
   """
-  def uncatalogued?(%__MODULE__{selected_source: nil, approved: true, candidates: [_ | _]}),
-    do: true
-
+  def uncatalogued?(%__MODULE__{sources: [], approved: true}), do: true
   def uncatalogued?(%__MODULE__{}), do: false
 
   defp field(nil, _label), do: []

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -59,6 +59,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.SourceRef
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
   alias Ambry.Library
@@ -69,7 +70,12 @@ defmodule Ambry.Inbox.Draft.Seed do
   alias Ambry.Repo
 
   @strong_match 0.90
-  @weak_runner_up 0.70
+
+  # How closely an existing Book has to match before the import proposes
+  # linking to it rather than creating one. Deliberately high: attaching a
+  # recording to the wrong book is a worse outcome than one duplicate Book,
+  # and it's much harder to notice.
+  @strong_local 0.95
 
   # How sure a recording match must be before its metadata is allowed to
   # describe this file.
@@ -86,11 +92,13 @@ defmodule Ambry.Inbox.Draft.Seed do
     work_level = Map.get(matches, "work", %{})
     recording_level = Map.get(matches, "recording", %{})
 
+    work = work(work_level, hints, tags)
+
     %Draft{
       evidence: evidence(item),
       stale: false,
-      work: work(work_level, hints, tags),
-      recording: recording(recording_level, work_level, hints, tags, item),
+      work: work,
+      recording: recording(recording_level, work, hints, tags, item),
       destination: destination(item)
     }
   end
@@ -153,67 +161,44 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## work
 
+  # The first decision is not "which of these records", it is **is this a book
+  # you already have, or a new one**. Those are different outcomes — linking
+  # creates nothing and inherits the book's curation — and mixing them into
+  # one ranked list made the form ask one question that was really two.
   defp work(level, hints, tags) do
-    candidates = Map.get(level, "candidates", []) || []
-    best = List.first(candidates)
+    records = records(level)
+    local = Map.get(level, "local", []) || []
     confidence = Map.get(level, "confidence")
 
-    {mode, book_id, approved} = work_identity(candidates, confidence)
+    {mode, book_id, approved} = work_identity(local, records, confidence)
 
     %Work{
       mode: mode,
       book_id: book_id,
       approved: approved,
-      candidates: candidates,
       confidence: confidence,
       query: Map.get(level, "query"),
       query_fields: Map.get(level, "query_fields") || %{},
-      selected_source: best && best["source"],
-      selected_id: best && to_string(best["id"])
+      sources: Enum.map(AutoMatch.top_group(records), &SourceRef.of/1)
     }
-    |> put_work_fields(best, hints, tags)
+    |> put_work_fields(records, hints, tags)
   end
 
   @doc """
-  Fills a work's fields from one candidate, keeping anything the operator
-  typed.
+  Re-derives a work's fields from whichever records are currently ticked.
 
-  This is what makes the candidate list a question rather than a display: a
-  release is a recording of exactly one work, so picking a different candidate
-  has to change what the book will say. Manual edits survive, because 1d's
-  whole point is that curation outranks any source.
+  Ticking a record is what makes it speak: every scalar draws its candidates
+  from the ticked set plus the file's tags, which is how the description can
+  come from one database and the cover from another. Anything the operator
+  typed survives — 1d's whole point is that curation outranks any source.
   """
-  def reseed_work(%Work{} = work, candidate, hints, tags) do
-    %{
-      work
-      | mode: if(candidate["source"] == "local", do: :link, else: :create),
-        book_id: if(candidate["source"] == "local", do: candidate["id"]),
-        approved: true,
-        selected_source: candidate["source"],
-        selected_id: to_string(candidate["id"])
-    }
-    |> put_work_fields(candidate, hints, tags)
+  def reseed_work(%Work{} = work, %InboxItem{} = item) do
+    put_work_fields(work, records(item, "work"), AutoMatch.hints(item), item.tags || %{})
   end
 
-  @doc """
-  Detaches a work from every candidate — a book nothing matched, described by
-  the file alone.
-  """
-  def reseed_new_work(%Work{} = work, hints, tags) do
-    %{
-      work
-      | mode: :create,
-        book_id: nil,
-        approved: true,
-        selected_source: nil,
-        selected_id: nil
-    }
-    |> put_work_fields(nil, hints, tags)
-  end
-
-  defp put_work_fields(%Work{} = work, best, hints, tags) do
-    book_id = if best && best["source"] == "local", do: best["id"]
-    sources = chain(best)
+  defp put_work_fields(%Work{} = work, records, hints, tags) do
+    sources = used(records, work.sources)
+    book_id = if work.mode == :link, do: work.book_id
 
     published = keep_manual(work.published, published_field(sources, tags))
 
@@ -222,36 +207,37 @@ defmodule Ambry.Inbox.Draft.Seed do
       | title: keep_manual(work.title, title_field(sources, hints, tags)),
         published: published,
         published_format:
-          keep_manual(
-            work.published_format,
-            published_format_field(sources, tags, published)
-          ),
-        authors: author_credits(best, tags),
-        series: series_links(best, tags, book_id)
+          keep_manual(work.published_format, published_format_field(sources, tags, published)),
+        authors: author_credits(sources, tags),
+        series: series_links(sources, tags, book_id)
     }
   end
 
-  # A candidate and everybody who corroborated it.
-  #
-  # Two providers agreeing on which work this is do NOT agree on everything
-  # about it — one has the better description, another the better cover — and
-  # collapsing them into a winner left the operator choosing between one
-  # provider and the file's tags. Identity is still one answer; *where each
-  # field's value comes from* is a separate question per field.
-  def chain(nil), do: []
-  def chain(candidate), do: [candidate | List.wrap(candidate["merged"])]
+  @doc """
+  The provider records stored for a level.
+  """
+  def records(%InboxItem{matches: matches}, level) when is_map(matches),
+    do: matches |> Map.get(level, %{}) |> records()
+
+  def records(%InboxItem{}, _level), do: []
+  def records(level) when is_map(level), do: Map.get(level, "candidates", []) || []
+  def records(_level), do: []
 
   @doc """
-  The candidate a decision's fields were filled from, if any.
+  The existing Books that might be this work.
   """
-  def selected_candidate(%{candidates: candidates, selected_source: source, selected_id: id})
-      when is_binary(source) do
-    Enum.find(candidates, &(&1["source"] == source and to_string(&1["id"]) == id))
+  def local_records(%InboxItem{matches: matches}, level) when is_map(matches),
+    do: matches |> Map.get(level, %{}) |> Map.get("local", []) |> List.wrap()
+
+  def local_records(%InboxItem{}, _level), do: []
+
+  # The ticked records, in the order they're listed rather than the order they
+  # were ticked, so the chip order in the form is stable.
+  defp used(records, refs) do
+    Enum.filter(records, fn record -> Enum.any?(refs, &SourceRef.points_at?(&1, record)) end)
   end
 
-  def selected_candidate(_decision), do: nil
-
-  defp from_chain(sources, key), do: Enum.map(sources, &candidate(&1, key))
+  defp from_records(records, key), do: Enum.map(records, &candidate(&1, key))
 
   # A field the operator typed is theirs; re-seeding from another candidate
   # must not quietly undo a correction. Everything else is provider data being
@@ -259,28 +245,34 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp keep_manual(%Field{source: "manual"} = existing, _fresh), do: existing
   defp keep_manual(_existing, fresh), do: fresh
 
-  # An existing Book is the best outcome there is — it's what stops a second
-  # recording of a work splitting the library — so a confident local hit links
-  # rather than creating a near-duplicate.
-  defp work_identity([], _confidence), do: {:create, nil, false}
+  # Reusing a Book already in the library is the best outcome there is — it's
+  # what stops a second recording of a work splitting the library — so a
+  # convincing local hit is proposed as a link. Anything else is a new book,
+  # which is also what an item with no matches at all is: "create a new book"
+  # was never a separate answer, just the absence of an existing one.
+  defp work_identity(local, records, confidence) do
+    case Enum.max_by(local, &(&1["score"] || 0.0), fn -> nil end) do
+      %{"id" => id, "score" => score} when score >= @strong_local ->
+        {:link, id, true}
 
-  defp work_identity([best | rest], confidence) do
-    strong? = strong?(best, rest, confidence)
+      %{} ->
+        # A local book close enough to show but not to assume: the operator
+        # has to say, because attaching a recording to the wrong existing book
+        # is worse than creating one book too many.
+        {:create, nil, false}
 
-    case best do
-      %{"source" => "local", "id" => id} when is_integer(id) -> {:link, id, strong?}
-      _provider -> {:create, nil, strong?}
+      nil ->
+        {:create, nil, settled_new_book?(records, confidence)}
     end
   end
 
-  defp strong?(best, rest, confidence) do
-    runner_up = rest |> List.first() |> then(&(&1 && &1["score"])) || 0.0
+  # With no local book in the running, "new book" is the only answer there is;
+  # it still needs a nod when the records are too weak to have filled the
+  # fields convincingly.
+  defp settled_new_book?([], _confidence), do: true
 
-    cond do
-      best["score"] == 1.0 -> true
-      (confidence || 0.0) >= @strong_match and runner_up <= @weak_runner_up -> true
-      true -> false
-    end
+  defp settled_new_book?([best | _rest], confidence) do
+    best["score"] == 1.0 or (confidence || 0.0) >= @strong_match
   end
 
   # The release name is a fallback, not a peer. Measured across the real
@@ -288,7 +280,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   # other ~2% rely on — so letting the folder name argue with a provider would
   # make nearly every import ambiguous on its title for no gain.
   defp title_field(sources, hints, tags) do
-    (from_chain(sources, "title") ++ [tag_candidate(tags, "book_title")])
+    (from_records(sources, "title") ++ [tag_candidate(tags, "book_title")])
     |> scalar(
       required: true,
       equivalence: &(title_key(&1) == title_key(&2)),
@@ -376,7 +368,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp follow_date_source(format, _published), do: format
 
   defp published_field(sources, tags) do
-    (from_chain(sources, "published") ++ [tag_candidate(tags, "published")])
+    (from_records(sources, "published") ++ [tag_candidate(tags, "published")])
     |> scalar(required: true, equivalence: &same_date?/2, prefer: &more_precise/2)
   end
 
@@ -384,7 +376,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   # Jan 1st, and rendering that as a real release day is the exact bug the
   # v1.9.0 punch list fixed for the import forms.
   defp published_format_field(sources, tags, published) do
-    (from_chain(sources, "published_format") ++ [tag_candidate(tags, "published_format")])
+    (from_records(sources, "published_format") ++ [tag_candidate(tags, "published_format")])
     |> scalar(required: false)
     |> follow_date_source(published)
     |> default_to("full")
@@ -398,91 +390,76 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## recording
 
-  defp recording(level, work_level, hints, tags, item) do
-    candidates = Map.get(level, "candidates", []) || []
-    work_chain = work_level |> Map.get("candidates", []) |> List.first() |> chain()
+  defp recording(level, work, hints, tags, item) do
+    records = records(level)
 
     # **Only a recording we actually believe in gets to fill anything in.**
     # Audible's search widens when a narrow query finds nothing, so a book
     # whose only catalogued edition has a different reader still returns that
     # edition — and taking its publisher, release date and cover would quietly
-    # describe this file as a recording it is not. A doubted candidate stays
-    # in the list for the operator to pick; it just doesn't get to speak
-    # first.
-    {doubt, detail, best} = trust(candidates, level, hints)
+    # describe this file as a recording it is not. A doubted record stays in
+    # the list to be ticked; it just isn't ticked for you.
+    {doubt, detail, best} = trust(records, level, hints)
 
     %Recording{
-      candidates: candidates,
       confidence: Map.get(level, "confidence"),
       query: Map.get(level, "query"),
       query_fields: Map.get(level, "query_fields") || %{},
       doubt: doubt,
       doubt_detail: detail,
-      selected_source: best && best["source"],
-      selected_id: best && to_string(best["id"]),
-      # Which recording this is is a fact with one right answer, so it settles
-      # only when we actually know it: a trusted match, or nothing to choose
-      # between. A doubted candidate leaves the question open rather than
-      # being adopted quietly — that ambiguity was previously invisible,
-      # showing up only as fields that mysteriously stayed empty.
+      sources: if(best, do: Enum.map(AutoMatch.top_group(records), &SourceRef.of/1), else: []),
+      # Settled when we actually know which recording this is — a trusted
+      # match — or when there was nothing to choose between. A doubted record
+      # leaves the question open rather than being adopted quietly; that
+      # ambiguity used to be invisible, showing up only as fields that
+      # mysteriously stayed empty.
       approved: doubt in [:none, :nothing_found]
     }
-    |> put_recording_fields(best, work_chain, tags, item)
+    |> put_recording_fields(records, work, tags, item)
   end
 
   @doc """
-  Fills a recording's fields from one catalogue entry, keeping typed values.
+  Re-derives a recording's fields from whichever records are currently ticked.
   """
-  def reseed_recording(%Recording{} = recording, candidate, work_chain, tags, item) do
-    %{
-      recording
-      | approved: true,
-        selected_source: candidate["source"],
-        selected_id: to_string(candidate["id"]),
-        doubt: :none,
-        doubt_detail: nil
-    }
-    |> put_recording_fields(candidate, work_chain, tags, item)
+  def reseed_recording(%Recording{} = recording, %Work{} = work, %InboxItem{} = item) do
+    put_recording_fields(recording, records(item, "recording"), work, item.tags || %{}, item)
   end
 
-  @doc """
-  Settles a recording as one no catalogue lists, described by the file alone.
-  """
-  def reseed_uncatalogued(%Recording{} = recording, work_chain, tags, item) do
-    %{recording | approved: true, selected_source: nil, selected_id: nil}
-    |> put_recording_fields(nil, work_chain, tags, item)
-  end
-
-  # The work's sources get a say in the recording's *descriptive* fields —
-  # description, cover, publisher are facts about the book that a work-level
-  # provider often has better than a storefront does, and the operator has to
-  # be able to take the description from one and the cover from another.
+  # The work's records get a say in the recording's *descriptive* fields —
+  # description, cover and publisher are facts about the book that a database
+  # often has better than a storefront does, and the operator has to be able to
+  # take the description from one and the cover from another.
   #
   # The release date deliberately does NOT draw from them: a work-level
-  # provider's date is the work's original publication date, which is a
+  # record's date is the work's original publication date, which is a
   # different fact wearing the same name.
-  defp put_recording_fields(%Recording{} = recording, best, work_chain, tags, item) do
-    chain = chain(best)
-    describing = chain ++ work_chain
+  defp put_recording_fields(%Recording{} = recording, records, work, tags, item) do
+    mine = used(records, recording.sources)
+    describing = mine ++ work_records(work, item)
 
     %{
       recording
       | title: keep_manual(recording.title, scalar([], required: false)),
-        published: keep_manual(recording.published, scalar(from_chain(chain, "published"))),
+        published: keep_manual(recording.published, scalar(from_records(mine, "published"))),
         publisher:
           keep_manual(
             recording.publisher,
-            scalar(from_chain(describing, "publisher") ++ [tag_candidate(tags, "publisher")])
+            scalar(from_records(describing, "publisher") ++ [tag_candidate(tags, "publisher")])
           ),
         description:
           keep_manual(
             recording.description,
-            scalar(from_chain(describing, "description") ++ [tag_candidate(tags, "description")])
+            scalar(
+              from_records(describing, "description") ++ [tag_candidate(tags, "description")]
+            )
           ),
         cover: keep_manual(recording.cover, cover_field(describing, tags, item)),
-        narrators: narrator_credits(best, tags)
+        narrators: narrator_credits(mine, tags)
     }
   end
+
+  defp work_records(%Work{} = work, %InboxItem{} = item),
+    do: item |> records("work") |> used(work.sources)
 
   # An ASIN hit is identity, so it needs no corroboration. Otherwise the
   # narrator decides: when the file names a reader and the candidate names a
@@ -557,24 +534,44 @@ defmodule Ambry.Inbox.Draft.Seed do
         }
       end
 
-    (from_chain(sources, "cover_url") ++ [embedded]) |> scalar(required: false)
+    (from_records(sources, "cover_url") ++ [embedded]) |> scalar(required: false)
   end
 
   ## credits
 
-  defp author_credits(best, tags) do
-    names = names(best && best["authors"]) || names(tags["authors"]) || []
-    source = if names == names(best && best["authors"]), do: source_of(best), else: "tags"
-
-    Enum.map(names, &credit(&1, :author, source))
+  defp author_credits(records, tags) do
+    records
+    |> proposed_names("authors")
+    |> or_from_tags(tags, "authors")
+    |> Enum.map(fn {name, source} -> credit(name, :author, source) end)
   end
 
-  defp narrator_credits(best, tags) do
-    names = names(best && best["narrators"]) || names(tags["narrators"]) || []
-    source = if names == names(best && best["narrators"]), do: source_of(best), else: "tags"
-
-    Enum.map(names, &credit(&1, :narrator, source))
+  defp narrator_credits(records, tags) do
+    records
+    |> proposed_names("narrators")
+    |> or_from_tags(tags, "narrators")
+    |> Enum.map(fn {name, source} -> credit(name, :narrator, source) end)
   end
+
+  # Names across every ticked record, in first-mentioned order and deduped
+  # case-insensitively: two databases listing the same author is one credit,
+  # not two.
+  defp proposed_names(records, key) do
+    records
+    |> Enum.flat_map(fn record ->
+      record |> Map.get(key) |> names() |> List.wrap() |> Enum.map(&{&1, source_of(record)})
+    end)
+    |> Enum.uniq_by(fn {name, _source} -> down(name) end)
+  end
+
+  # The file only gets a say when no record proposed anybody. A tag name is a
+  # weaker proposal — 1b's multi-value splitting is knowingly imperfect — so it
+  # never argues with a record, it just fills a silence.
+  defp or_from_tags([], tags, key) do
+    tags |> Map.get(key) |> names() |> List.wrap() |> Enum.map(&{&1, "tags"})
+  end
+
+  defp or_from_tags(proposed, _tags, _key), do: proposed
 
   defp credit(name, kind, source) do
     matches = identity_matches(name, kind)
@@ -650,17 +647,38 @@ defmodule Ambry.Inbox.Draft.Seed do
   # When linking to an existing book, a proposed series is only offered if the
   # book doesn't already have it: an import may fill a blank, never overwrite
   # curation.
-  defp series_links(best, tags, book_id) do
-    {proposals, source} =
-      case series_proposals(best && best["series"]) do
-        [] -> {series_proposals_from_tags(tags), "tags"}
-        from_provider -> {from_provider, source_of(best)}
-      end
-
-    proposals
+  defp series_links(records, tags, book_id) do
+    records
+    |> Enum.flat_map(fn record ->
+      record
+      |> Map.get("series")
+      |> series_proposals()
+      |> Enum.map(&Map.put(&1, :source, source_of(record)))
+    end)
+    |> merge_by_name()
+    |> case do
+      [] -> series_proposals_from_tags(tags)
+      proposed -> proposed
+    end
     |> Enum.reject(&already_on_book?(&1.name, book_id))
     |> then(fn kept ->
-      Enum.map(kept, &series_link(&1.name, &1.number || tag_number(&1.name, tags, kept), source))
+      Enum.map(
+        kept,
+        &series_link(&1.name, &1.number || tag_number(&1.name, tags, kept), &1.source)
+      )
+    end)
+  end
+
+  # One series named by two databases is one membership. Whichever of them
+  # supplied a number wins, because a number nobody supplied is a question the
+  # operator has to answer and this is the cheapest way not to ask it.
+  defp merge_by_name(proposals) do
+    proposals
+    |> Enum.group_by(&down(&1.name))
+    |> Map.values()
+    |> Enum.map(fn group -> Enum.find(group, List.first(group), & &1.number) end)
+    |> Enum.sort_by(fn proposal ->
+      Enum.find_index(proposals, &(down(&1.name) == down(proposal.name)))
     end)
   end
 
@@ -695,14 +713,14 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp series_proposal(%{"name" => name} = entry) when is_binary(name) do
     case presence(name) do
       nil -> nil
-      name -> %{name: name, number: presence(entry["number"])}
+      name -> %{name: name, number: presence(entry["number"]), source: nil}
     end
   end
 
   defp series_proposal(name) when is_binary(name) do
     case presence(name) do
       nil -> nil
-      name -> %{name: name, number: nil}
+      name -> %{name: name, number: nil, source: nil}
     end
   end
 
@@ -711,7 +729,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp series_proposals_from_tags(tags) do
     case presence(tags["series"]) do
       nil -> []
-      name -> [%{name: name, number: presence(tags["series_number"])}]
+      name -> [%{name: name, number: presence(tags["series_number"]), source: "tags"}]
     end
   end
 
@@ -860,7 +878,6 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp release_candidate(value),
     do: %Candidate{value: value, source: "release_name", label: "The release name"}
 
-  defp source_of(nil), do: nil
   defp source_of(%{"source" => source}), do: source
   defp source_of(_other), do: nil
 

--- a/lib/ambry/inbox/draft/source_ref.ex
+++ b/lib/ambry/inbox/draft/source_ref.ex
@@ -1,0 +1,40 @@
+defmodule Ambry.Inbox.Draft.SourceRef do
+  @moduledoc """
+  A pointer at one provider record the operator has said describes this import.
+
+  The records themselves are *evidence* and live on `inbox_items.matches`,
+  where discovery and re-searching write them. Which ones count is a
+  *decision*, so it lives in the draft — that's the same boundary the whole
+  draft/matches split is built on, and it's what lets a re-search add records
+  without touching a curated choice.
+
+  More than one is the normal case. Hardcover and rreading-glasses both having
+  a record of Leviathan Wakes doesn't make it two books; it makes it one book
+  two databases know about, and each knows things the other doesn't.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+
+  embedded_schema do
+    field :source, :string
+    field :id, :string
+  end
+
+  @doc false
+  def changeset(source_ref, attrs) do
+    source_ref
+    |> cast(attrs, [:source, :id])
+    |> validate_required([:source, :id])
+  end
+
+  @doc "The ref for a record, as stored."
+  def of(record), do: %__MODULE__{source: record["source"], id: to_string(record["id"])}
+
+  @doc "Whether this ref points at the given record."
+  def points_at?(%__MODULE__{} = ref, record),
+    do: ref.source == record["source"] and ref.id == to_string(record["id"])
+end

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -16,6 +16,7 @@ defmodule Ambry.Inbox.Draft.Work do
   alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.SourceRef
 
   @primary_key false
 
@@ -24,19 +25,14 @@ defmodule Ambry.Inbox.Draft.Work do
     field :book_id, :id
     field :approved, :boolean, default: false
 
-    # the ranked work-level candidate list from auto-match, kept whole
-    field :candidates, {:array, :map}, default: []
     field :confidence, :float
     field :query, :string
     field :query_fields, :map, default: %{}
 
-    # WHICH candidate the fields below were filled from. Without it the form
-    # could only ask "is this a new book or an existing one?", so every
-    # provider row rendered as chosen and clicking one changed nothing
-    # visible. Ids are held as strings because a local candidate's is an
-    # integer and a provider's is not.
-    field :selected_source, :string
-    field :selected_id, :string
+    # Which provider records describe this book. The records live on the
+    # item's `matches` because they're evidence; which of them count is a
+    # decision, so it lives here.
+    embeds_many :sources, SourceRef, on_replace: :delete
 
     embeds_one :title, Field, on_replace: :update
     embeds_one :published, Field, on_replace: :update
@@ -49,17 +45,8 @@ defmodule Ambry.Inbox.Draft.Work do
   @doc false
   def changeset(work, attrs) do
     work
-    |> cast(attrs, [
-      :mode,
-      :book_id,
-      :approved,
-      :candidates,
-      :confidence,
-      :query,
-      :query_fields,
-      :selected_source,
-      :selected_id
-    ])
+    |> cast(attrs, [:mode, :book_id, :approved, :confidence, :query, :query_fields])
+    |> cast_embed(:sources)
     |> cast_embed(:title)
     |> cast_embed(:published)
     |> cast_embed(:published_format)
@@ -99,7 +86,9 @@ defmodule Ambry.Inbox.Draft.Work do
   end
 
   defp identity(%__MODULE__{approved: true}), do: []
-  defp identity(%__MODULE__{}), do: [%{section: :work, label: "Which book", state: :unconfirmed}]
+
+  defp identity(%__MODULE__{}),
+    do: [%{section: :work, label: "Whether this is a book you already have", state: :unconfirmed}]
 
   defp unresolved_field(nil, _label), do: []
 
@@ -119,15 +108,8 @@ defmodule Ambry.Inbox.Draft.Work do
   defp state_of(%SeriesLink{} = link), do: SeriesLink.state(link)
 
   @doc """
-  Whether a candidate is the one this work's fields were filled from.
-
-  Exactly one can be, which is the whole point: the candidate list is a
-  question with one right answer, not a set of things that all matched.
+  Whether the operator has said this provider record describes the book.
   """
-  def selected?(%__MODULE__{selected_source: nil}, _candidate), do: false
-
-  def selected?(%__MODULE__{} = work, candidate) do
-    work.selected_source == candidate["source"] and
-      work.selected_id == to_string(candidate["id"])
-  end
+  def uses?(%__MODULE__{sources: sources}, record),
+    do: Enum.any?(sources, &SourceRef.points_at?(&1, record))
 end

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -1,0 +1,252 @@
+defmodule Ambry.Inbox.Lookup do
+  @moduledoc """
+  Asking providers things *after* an item has been matched.
+
+  Matching is thorough and runs on a serial, retrying queue, so most items
+  never need any of this. It exists for the case the operator's own words
+  describe: **"you got this wrong"** — where the right answer wasn't in the
+  list at all, or a provider was rate-limited during the scan, or a record
+  nobody expected to matter turns out to be the one.
+
+  Everything here writes to `inbox_items.matches`, which is *evidence*, and
+  never to the draft, which is *decisions*. That's the same boundary
+  discovery respects, and it's what lets a re-search add records without
+  disturbing a curated choice: new records simply appear un-ticked.
+
+  Records are added, never replaced. A record the draft already points at
+  keeps its identity across a re-search — otherwise re-searching would
+  silently un-tick whatever the operator had chosen.
+  """
+
+  alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Registry
+  alias Ambry.Repo
+
+  require Logger
+
+  @doc """
+  Fetches the full record behind a thin search hit.
+
+  Matching hydrates the records about the top work; anything further down the
+  list stays a summary until somebody says it matters. A summary can be
+  missing the description and the cover entirely — measured against
+  rreading-glasses, search returns a work with one edition and details returns
+  the same work with seventeen.
+  """
+  def hydrate(%InboxItem{} = item, level, record_ref) do
+    update_records(item, level, fn records ->
+      Enum.map(records, fn record ->
+        if AutoMatch.ref(record) == record_ref and !record["hydrated"],
+          do: AutoMatch.details(record),
+          else: record
+      end)
+    end)
+  end
+
+  @doc """
+  Asks every editions-capable database what recordings the given work records
+  have.
+
+  This is the route to an edition no storefront will admit exists. Audible's
+  catalog is a shop: when rights lapse the title vanishes from search and from
+  ASIN lookup alike. Hardcover and rreading-glasses are databases of editions
+  and keep it.
+  """
+  def editions(%InboxItem{} = item, work_refs) do
+    records =
+      item
+      |> records("work")
+      |> Enum.filter(&(AutoMatch.ref(&1) in work_refs))
+
+    {found, outcomes} = AutoMatch.editions_for(records, AutoMatch.hints(item))
+
+    item
+    |> update_records("recording", &add(&1, found))
+    |> update_outcomes("recording", outcomes)
+  end
+
+  @doc """
+  Runs a search the operator wrote, and adds whatever it returns.
+
+  The last resort in the ranked-candidates design: the stored list makes
+  "show me the alternatives" free, and this is for the case it's actually
+  for — the right answer isn't in the list at all, usually because the tags
+  sent the search somewhere strange.
+  """
+  def research(%InboxItem{} = item, level, fields) do
+    query = query_from(fields)
+
+    if Provider.Query.blank?(query) do
+      {:ok, item}
+    else
+      {found, outcomes} = search(level, query, AutoMatch.hints(item))
+
+      item
+      |> update_records(level, &add(&1, found))
+      |> update_outcomes(level, outcomes)
+      |> remember_query(level, query)
+    end
+  end
+
+  @doc """
+  Asks one provider again — the one that was rate-limited or down when this
+  item was matched.
+
+  Without this, a 429 during a scan costs an item that provider's records
+  until somebody re-runs the whole match. The "couldn't be reached" chip is
+  the retry button.
+  """
+  def retry_provider(%InboxItem{} = item, level, provider_id) do
+    hints = AutoMatch.hints(item)
+    query = stored_query(item, level) || query_from(%{})
+
+    case Registry.fetch(provider_id) do
+      {:ok, entry} ->
+        {found, outcome} = search_one(entry, query, hints)
+
+        item
+        |> update_records(level, &add(&1, found))
+        |> update_outcomes(level, [outcome])
+
+      {:error, _reason} ->
+        {:ok, item}
+    end
+  end
+
+  ## plumbing
+
+  defp search(level, query, hints) do
+    [level: level_atom(level), capability: :book_search]
+    |> Registry.enabled()
+    |> Enum.reduce({[], []}, fn entry, {records, outcomes} ->
+      {found, outcome} = search_one(entry, query, hints)
+      {records ++ found, outcomes ++ [outcome]}
+    end)
+  end
+
+  defp search_one(entry, query, hints) do
+    case Providers.search_books(entry.id, query, refresh: true) do
+      {:ok, books} ->
+        {AutoMatch.records_from(books, entry, hints),
+         %{
+           "id" => entry.id,
+           "name" => entry.display_name,
+           "status" => "ok",
+           "count" => length(books)
+         }}
+
+      {:error, reason} ->
+        Logger.warning(fn -> "Inbox lookup: #{entry.id} failed: #{inspect(reason)}" end)
+
+        {[],
+         %{
+           "id" => entry.id,
+           "name" => entry.display_name,
+           "status" => "failed",
+           "count" => 0,
+           "reason" => reason |> inspect() |> String.slice(0, 200)
+         }}
+    end
+  end
+
+  # New records join the list; ones already there keep their place and their
+  # payload. Replacing them would un-tick the operator's choices, which is the
+  # one thing evidence-writing must never do.
+  defp add(existing, found) do
+    known = MapSet.new(existing, &AutoMatch.ref/1)
+
+    existing
+    |> Kernel.++(Enum.reject(found, &MapSet.member?(known, AutoMatch.ref(&1))))
+    |> Enum.sort_by(&(&1["score"] || 0.0), :desc)
+  end
+
+  defp update_records(item, level, fun) do
+    matches = item.matches || %{}
+    level_map = Map.get(matches, level, %{})
+    updated = Map.put(level_map, "candidates", fun.(Map.get(level_map, "candidates", []) || []))
+
+    item
+    |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
+    |> Repo.update()
+  end
+
+  defp update_outcomes({:ok, item}, level, outcomes), do: update_outcomes(item, level, outcomes)
+  defp update_outcomes({:error, _reason} = error, _level, _outcomes), do: error
+
+  defp update_outcomes(%InboxItem{} = item, level, outcomes) do
+    matches = item.matches || %{}
+    level_map = Map.get(matches, level, %{})
+    existing = Map.get(level_map, "providers", []) || []
+
+    # An outcome replaces the earlier one for the same provider: "couldn't be
+    # reached" must stop saying that once it has been reached.
+    fresh = MapSet.new(outcomes, & &1["id"])
+    kept = Enum.reject(existing, &MapSet.member?(fresh, &1["id"]))
+
+    updated = Map.put(level_map, "providers", kept ++ outcomes)
+
+    item
+    |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
+    |> Repo.update()
+  end
+
+  defp remember_query({:ok, item}, level, query), do: remember_query(item, level, query)
+  defp remember_query({:error, _reason} = error, _level, _query), do: error
+
+  defp remember_query(%InboxItem{} = item, level, query) do
+    matches = item.matches || %{}
+
+    updated =
+      matches
+      |> Map.get(level, %{})
+      |> Map.put("query", to_string(query))
+      |> Map.put("query_fields", non_blank(query))
+
+    item
+    |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
+    |> Repo.update()
+  end
+
+  defp non_blank(%Provider.Query{} = query) do
+    %{
+      "title" => query.title,
+      "author" => query.author,
+      "narrator" => query.narrator,
+      "keywords" => query.keywords
+    }
+    |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+    |> Map.new()
+  end
+
+  defp query_from(fields) do
+    %Provider.Query{
+      title: blank_to_nil(fields["title"]),
+      author: blank_to_nil(fields["author"]),
+      narrator: blank_to_nil(fields["narrator"]),
+      keywords: blank_to_nil(fields["keywords"])
+    }
+  end
+
+  defp stored_query(%InboxItem{matches: matches}, level) when is_map(matches) do
+    case get_in(matches, [level, "query_fields"]) do
+      fields when is_map(fields) and map_size(fields) > 0 -> query_from(fields)
+      _none -> nil
+    end
+  end
+
+  defp stored_query(_item, _level), do: nil
+
+  defp blank_to_nil(nil), do: nil
+  defp blank_to_nil(value) when is_binary(value), do: with("" <- String.trim(value), do: nil)
+
+  defp records(%InboxItem{matches: matches}, level) when is_map(matches),
+    do: get_in(matches, [level, "candidates"]) || []
+
+  defp records(_item, _level), do: []
+
+  defp level_atom("work"), do: :work
+  defp level_atom("recording"), do: :recording
+end

--- a/lib/ambry/inbox/run_match.ex
+++ b/lib/ambry/inbox/run_match.ex
@@ -2,15 +2,27 @@ defmodule Ambry.Inbox.RunMatch do
   @moduledoc """
   Proposes what one inbox item is.
 
-  Kept to one at a time on purpose. A first scan of a real library means
-  hundreds of lookups, and the public metadata instances are shared services
-  that rate-limit — so this trades wall-clock for being a well-behaved
-  client, and the queue drains in the background either way.
+  Kept to one at a time on purpose. Cold-starting a server from an existing
+  collection means hundreds of lookups against shared metadata instances that
+  rate-limit — so this trades wall-clock for being a well-behaved client, and
+  the queue drains in the background either way. Day to day it's a handful of
+  books, where the serialisation costs nothing.
+
+  Because nothing waits on it, matching is allowed to be **thorough**: search
+  every enabled provider, fetch full details for the records about the top
+  work, and ask every editions-capable database what recordings that work has.
+
+  ## Retries
+
+  A rate-limited provider used to cost an item its records permanently — one
+  attempt, and the failure survived only as a discarded job that the Oban
+  pruner deletes within a day. Now it backs off and tries again, and the
+  operator can retry a single provider from the form besides.
   """
 
   use Oban.Worker,
     queue: :metadata,
-    max_attempts: 1,
+    max_attempts: 5,
     unique: [period: 60, fields: [:worker, :args]]
 
   alias Ambry.Inbox
@@ -23,4 +35,10 @@ defmodule Ambry.Inbox.RunMatch do
       {:error, :not_found} -> :ok
     end
   end
+
+  # Shared instances rate-limit with a ~30s Retry-After, so the first retry
+  # waits past that rather than immediately spending another request on being
+  # told no.
+  @impl Oban.Worker
+  def backoff(%Oban.Job{attempt: attempt}), do: trunc(:math.pow(2, attempt) * 30)
 end

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -23,6 +23,8 @@ defmodule AmbryWeb.Admin.Decisions do
   alias Ambry.Inbox.Draft.SeriesLink
 
   attr :outcomes, :list, required: true
+  attr :level, :string, default: nil
+  attr :retrying, :any, default: nil
 
   @doc """
   What each provider said when asked — including the ones that couldn't
@@ -37,19 +39,33 @@ defmodule AmbryWeb.Admin.Decisions do
     ~H"""
     <div :if={@outcomes != []} class="flex flex-wrap items-center gap-2" data-role="provider-outcomes">
       <span class="text-xs dark:text-zinc-500">Asked:</span>
+
       <span
         :for={outcome <- @outcomes}
-        class={[
-          "rounded-sm border px-2 py-0.5 text-xs",
-          outcome["status"] == "failed" && "border-red-500 text-red-600",
-          outcome["status"] != "failed" && "border-zinc-300 dark:border-zinc-700"
-        ]}
-        title={outcome["reason"]}
+        :if={outcome["status"] != "failed"}
+        class="rounded-sm border border-zinc-300 px-2 py-0.5 text-xs dark:border-zinc-700"
       >
-        {outcome["name"]}: {if outcome["status"] == "failed",
-          do: "couldn't be reached",
-          else: outcome["count"]}
+        {outcome["name"]}: {outcome["count"]}
       </span>
+
+      <%!-- A provider that was rate-limited during matching used to cost this
+            item its records until somebody re-ran the whole match. The chip is
+            the retry. --%>
+      <button
+        :for={outcome <- @outcomes}
+        :if={outcome["status"] == "failed"}
+        type="button"
+        phx-click="retry-provider"
+        phx-value-level={@level}
+        phx-value-provider={outcome["id"]}
+        disabled={@retrying == outcome["id"]}
+        title={outcome["reason"]}
+        class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600 disabled:opacity-50"
+      >
+        {outcome["name"]}: {if @retrying == outcome["id"],
+          do: "asking again…",
+          else: "couldn't be reached — retry"}
+      </button>
     </div>
     """
   end
@@ -90,48 +106,149 @@ defmodule AmbryWeb.Admin.Decisions do
         do: {key, value}
   end
 
-  attr :candidate, :map, required: true
-  attr :selected, :boolean, required: true
-  attr :event, :string, required: true
-  attr :subtitle, :string, default: nil
+  attr :record, :map, required: true
+  attr :used, :boolean, required: true
+  attr :level, :string, required: true
 
   @doc """
-  One candidate for an identity decision — a book, or a catalogued recording.
+  One provider record, and whether it counts.
 
-  A list where every row wore a checkmark was the clearest symptom of the
-  decision model not reaching the UI: the item is a recording of exactly ONE
-  work, so exactly one row can be the answer and the rest are what it isn't.
+  Not an identity — evidence. Hardcover and rreading-glasses both holding a
+  record of one book is the normal case, not a duplicate to clean up, and each
+  knows things the other doesn't. Ticking both is how the description comes
+  from one and the cover from the other.
   """
-  def candidate_option(assigns) do
+  def record_row(assigns) do
+    ~H"""
+    <label
+      class={[
+        "flex cursor-pointer items-start gap-3 rounded-sm border p-2",
+        @used && "border-brand bg-brand/5 dark:border-brand-dark dark:bg-brand-dark/10",
+        !@used && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+      ]}
+      data-role="record"
+      data-used={@used && "true"}
+    >
+      <input
+        type="checkbox"
+        checked={@used}
+        phx-click="toggle-source"
+        phx-value-level={@level}
+        phx-value-source={@record["source"]}
+        phx-value-id={@record["id"]}
+        class="mt-1 h-4 w-4 flex-none rounded-sm"
+      />
+      <div class="min-w-0 flex-grow">
+        <p class="truncate text-sm">{candidate_title(@record)}</p>
+        <p class="truncate text-xs dark:text-zinc-500">{candidate_facts(@record)}</p>
+      </div>
+      <span :if={@record["score"]} class="flex-none pt-0.5 text-xs dark:text-zinc-600">
+        {round(@record["score"] * 100)}%
+      </span>
+    </label>
+    """
+  end
+
+  attr :book, :map, required: true
+  attr :linked, :boolean, required: true
+
+  @doc """
+  An existing Book this release might be another edition of.
+
+  Kept well away from the provider records, because it answers a different
+  question. Linking creates nothing, inherits the book's curation and adds an
+  alternate edition; importing a provider record creates a Book. Ranking the
+  two together made the form ask one question that was really two.
+  """
+  def local_book_row(assigns) do
     ~H"""
     <div
       class={[
-        "flex cursor-pointer items-start gap-3 rounded-sm border p-2",
-        @selected && "border-brand bg-brand/5 dark:border-brand-dark dark:bg-brand-dark/10",
-        !@selected && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+        "flex items-start gap-3 rounded-sm border p-3",
+        @linked && "border-brand bg-brand/5 dark:border-brand-dark dark:bg-brand-dark/10",
+        !@linked && "border-zinc-300 dark:border-zinc-700"
       ]}
-      phx-click={@event}
-      phx-value-source={@candidate["source"]}
-      phx-value-id={@candidate["id"]}
-      data-role="candidate"
-      data-selected={@selected && "true"}
+      data-role="local-book"
+      data-linked={@linked && "true"}
     >
-      <.icon
-        name={if @selected, do: "fa-circle-check", else: "fa-circle"}
-        class={[
-          "mt-0.5 h-4 w-4 flex-none",
-          @selected && "text-brand dark:text-brand-dark",
-          !@selected && "text-zinc-300 dark:text-zinc-700"
-        ]}
-      />
       <div class="min-w-0 flex-grow">
-        <p class="truncate text-sm">{candidate_title(@candidate)}</p>
-        <p class="truncate text-xs dark:text-zinc-500">{@subtitle || candidate_facts(@candidate)}</p>
+        <p class="truncate text-sm font-semibold">{candidate_title(@book)}</p>
+        <p class="truncate text-xs dark:text-zinc-500">{candidate_facts(@book)}</p>
       </div>
-      <span :if={@candidate["score"]} class="flex-none pt-0.5 text-xs dark:text-zinc-600">
-        {round(@candidate["score"] * 100)}%
-      </span>
+
+      <button
+        :if={!@linked}
+        type="button"
+        phx-click="link-book"
+        phx-value-id={@book["id"]}
+        class="flex-none rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+      >
+        Yes — another edition of this
+      </button>
+
+      <span :if={@linked} class="flex-none text-xs dark:text-zinc-500">using this book</span>
     </div>
+    """
+  end
+
+  attr :level, :string, required: true
+  attr :fields, :map, required: true
+  attr :running, :boolean, default: false
+
+  @doc """
+  An editable version of the search that produced these records.
+
+  The stored candidate list makes "show me the alternatives" free; this is for
+  the case the list exists for — the right answer isn't in it at all, usually
+  because a wrong tag sent the search somewhere strange.
+  """
+  def research_form(assigns) do
+    ~H"""
+    <form
+      id={"research-#{@level}"}
+      phx-submit="research"
+      class="flex flex-wrap items-end gap-2"
+    >
+      <input type="hidden" name="level" value={@level} />
+
+      <label class="text-xs dark:text-zinc-500">
+        title
+        <input
+          type="text"
+          name="title"
+          value={@fields["title"]}
+          class="mt-1 block rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        />
+      </label>
+
+      <label class="text-xs dark:text-zinc-500">
+        author
+        <input
+          type="text"
+          name="author"
+          value={@fields["author"]}
+          class="mt-1 block rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        />
+      </label>
+
+      <label :if={@level == "recording"} class="text-xs dark:text-zinc-500">
+        narrator
+        <input
+          type="text"
+          name="narrator"
+          value={@fields["narrator"]}
+          class="mt-1 block rounded-sm border-zinc-300 text-sm dark:border-zinc-600 dark:bg-zinc-800"
+        />
+      </label>
+
+      <button
+        type="submit"
+        disabled={@running}
+        class="rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
+      >
+        {if @running, do: "Searching…", else: "Search again"}
+      </button>
+    </form>
     """
   end
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -40,9 +40,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
   alias Ambry.People
+
+  require Logger
 
   @impl Phoenix.LiveView
   def mount(%{"id" => id}, _session, socket) do
@@ -56,6 +59,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(authors: People.authors_for_select(), narrators: People.narrators_for_select())
      |> assign(people: People.people_for_select())
      |> assign(expanded: MapSet.new())
+     |> assign(researching: nil, retrying: nil, enriching: nil)
      |> load(item)}
   end
 
@@ -89,24 +93,56 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.waive_field(&1, atom(section), atom(field)))}
   end
 
-  def handle_event("choose-work", %{"source" => source} = params, socket) do
+  def handle_event("link-book", %{"id" => id}, socket) do
     item = socket.assigns.item
-    {:noreply, edit(socket, &Draft.Edit.choose_work(&1, item, source, params["id"]))}
+    {:noreply, edit(socket, &Draft.Edit.link_book(&1, item, to_int(id)))}
   end
 
-  def handle_event("new-work", _params, socket) do
+  def handle_event("new-book", _params, socket) do
     item = socket.assigns.item
-    {:noreply, edit(socket, &Draft.Edit.choose_new_work(&1, item))}
+    {:noreply, edit(socket, &Draft.Edit.new_book(&1, item))}
   end
 
-  def handle_event("choose-recording", %{"source" => source} = params, socket) do
+  def handle_event("toggle-source", %{"level" => level} = params, socket) do
     item = socket.assigns.item
-    {:noreply, edit(socket, &Draft.Edit.choose_recording(&1, item, source, params["id"]))}
+    ref = {params["source"], to_string(params["id"])}
+
+    case Enum.find(Seed.records(item, level), &(Inbox.record_ref(&1) == ref)) do
+      nil ->
+        {:noreply, socket}
+
+      record ->
+        socket = edit(socket, &Draft.Edit.toggle_source(&1, item, atom(level), record))
+
+        # A record nobody had asked about is a summary. Ticking it is the
+        # moment its description and cover start to matter, so that's when
+        # they're fetched — and when it's a work record, when its editions
+        # become worth asking for.
+        {:noreply, enrich(socket, level, record)}
+    end
   end
 
   def handle_event("uncatalogued", _params, socket) do
     item = socket.assigns.item
-    {:noreply, edit(socket, &Draft.Edit.choose_uncatalogued(&1, item))}
+    {:noreply, edit(socket, &Draft.Edit.uncatalogued(&1, item))}
+  end
+
+  def handle_event("research", %{"level" => level} = params, socket) do
+    item = socket.assigns.item
+
+    {:noreply,
+     socket
+     |> assign(researching: level)
+     |> start_async({:research, level}, fn -> Inbox.research(item, level, params) end)}
+  end
+
+  def handle_event("retry-provider", %{"level" => level, "provider" => provider}, socket) do
+    item = socket.assigns.item
+
+    {:noreply,
+     socket
+     |> assign(retrying: provider)
+     |> start_async({:retry, level}, fn -> Inbox.retry_provider(item, level, provider) end)}
   end
 
   def handle_event("credit-change", %{"section" => section, "index" => i} = params, socket) do
@@ -252,6 +288,69 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      socket
      |> put_flash(:info, "Dismissed. Files untouched.")
      |> push_navigate(to: ~p"/admin/inbox")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_async({:research, _level}, {:ok, {:ok, item}}, socket) do
+    {:noreply, socket |> assign(researching: nil) |> load(item) |> resettle()}
+  end
+
+  def handle_async({:retry, _level}, {:ok, {:ok, item}}, socket) do
+    {:noreply, socket |> assign(retrying: nil) |> load(item) |> resettle()}
+  end
+
+  def handle_async({:enrich, _ref}, {:ok, {:ok, item}}, socket) do
+    {:noreply, socket |> assign(enriching: nil) |> load(item) |> resettle()}
+  end
+
+  # A provider being unreachable at this moment is a thing to report, not a
+  # thing to crash on — the operator is mid-edit and the rest of the form is
+  # still perfectly usable.
+  def handle_async(_name, result, socket) do
+    Logger.warning(fn -> "Inbox form lookup failed: #{inspect(result)}" end)
+
+    {:noreply,
+     socket
+     |> assign(researching: nil, retrying: nil, enriching: nil)
+     |> put_flash(:error, "That provider couldn't be reached just now.")}
+  end
+
+  # New evidence has arrived; the ticked records may now say more than they
+  # did. Re-deriving is what turns a freshly hydrated record into chips.
+  defp resettle(socket) do
+    item = socket.assigns.item
+
+    case Inbox.update_draft(item, Inbox.dump_draft(Draft.Edit.resettle(item.draft, item))) do
+      {:ok, item} -> load(socket, item)
+      {:error, _changeset} -> socket
+    end
+  end
+
+  # Ticking a thin record is the moment its details start to matter; ticking a
+  # work record is the moment its editions do.
+  defp enrich(socket, level, record) do
+    item = socket.assigns.item
+    ref = Inbox.record_ref(record)
+
+    cond do
+      !record["hydrated"] and Draft.Edit.uses?(socket.assigns.item.draft, atom(level), record) ->
+        socket
+        |> assign(enriching: ref)
+        |> start_async({:enrich, ref}, fn ->
+          with {:ok, item} <- Inbox.hydrate_record(item, level, ref),
+               "work" <- level do
+            Inbox.fetch_editions(item, [ref])
+          end
+        end)
+
+      level == "work" and Draft.Edit.uses?(socket.assigns.item.draft, :work, record) ->
+        socket
+        |> assign(enriching: ref)
+        |> start_async({:enrich, ref}, fn -> Inbox.fetch_editions(item, [ref]) end)
+
+      true ->
+        socket
+    end
   end
 
   defp edit(socket, fun) do
@@ -404,7 +503,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def doubt_message(%Recording{doubt: :low_confidence, doubt_detail: detail}), do: detail
 
-  def doubt_message(%Recording{doubt: :nothing_found, candidates: []}),
+  def doubt_message(%Recording{doubt: :nothing_found}),
     do:
       "No provider had a recording matching this. That is common and not a problem — " <>
         "a delisted edition vanishes from Audible's search and from ASIN lookup alike. " <>
@@ -426,8 +525,11 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def provider_outcomes(_item, _level), do: []
 
-  @doc "The candidate a decision's fields were filled from, if any."
-  defdelegate selected_candidate(decision), to: Ambry.Inbox.Draft.Seed
+  @doc "The provider records found for a level."
+  defdelegate records(item, level), to: Seed
+
+  @doc "Existing Books this release might be another edition of."
+  defdelegate local_records(item, level), to: Seed
 
   @doc """
   How many decisions the bulk button would settle, so its label can say.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -103,9 +103,13 @@
         The work — which book this is a recording of
       </h2>
 
-      <div class="space-y-2">
+      <%!-- The first question, and a different KIND of question from the
+            records below: linking creates nothing and inherits the book's
+            curation, importing a record creates a Book. Ranking the two
+            together made the form ask one question that was really two. --%>
+      <div :if={local_records(@item, "work") != []} class="space-y-2" data-role="local-books">
         <div class="flex items-center gap-2">
-          <.label>Which book</.label>
+          <.label>Is this a book you already have?</.label>
           <.badge
             :if={!@item.draft.work.approved}
             color={elem(state_words(:unconfirmed), 1)}
@@ -113,6 +117,39 @@
           >
             {elem(state_words(:unconfirmed), 0)}
           </.badge>
+        </div>
+
+        <p class="text-sm dark:text-zinc-400">
+          If so this becomes another edition of it — no second book, and its existing details are
+          left alone.
+        </p>
+
+        <.local_book_row
+          :for={book <- local_records(@item, "work")}
+          book={book}
+          linked={@item.draft.work.mode == :link and @item.draft.work.book_id == book["id"]}
+        />
+
+        <button
+          type="button"
+          phx-click="new-book"
+          class={[
+            "rounded-sm border px-2 py-1 text-xs",
+            (@item.draft.work.mode == :create and @item.draft.work.approved) && "border-brand dark:border-brand-dark",
+            !(@item.draft.work.mode == :create and @item.draft.work.approved) && "border-zinc-300 dark:border-zinc-700"
+          ]}
+        >
+          No — this is a different book
+        </button>
+      </div>
+
+      <div class="space-y-2">
+        <div class="flex items-center gap-2">
+          <.label>
+            {if @item.draft.work.mode == :link,
+              do: "Records that could fill blanks",
+              else: "Records describing this book"}
+          </.label>
           <.badge
             :if={@item.draft.work.confidence}
             color={elem(confidence_label(@item.draft.work.confidence), 1)}
@@ -123,71 +160,52 @@
           </.badge>
         </div>
 
-        <.query_row query={@item.draft.work.query} fields={@item.draft.work.query_fields} />
-        <.provider_outcomes_row outcomes={provider_outcomes(@item, "work")} />
-
-        <p :if={@item.draft.work.candidates != []} class="text-sm dark:text-zinc-400">
-          Exactly one of these is the book. Picking one fills the fields below from it.
+        <p :if={records(@item, "work") != []} class="text-sm dark:text-zinc-400">
+          Tick every record that's about this book. Two databases having a record of it is normal —
+          and each knows things the other doesn't, so the description can come from one and the
+          cover from another.
         </p>
 
-        <p :if={@item.draft.work.candidates == []} class="text-sm italic dark:text-zinc-500">
-          Nothing matched. A new book will be created from the fields below.
+        <p :if={records(@item, "work") == []} class="text-sm italic dark:text-zinc-500">
+          No provider had a record of this. The fields below come from the file's own tags.
         </p>
 
-        <.candidate_option
-          :for={candidate <- @item.draft.work.candidates}
-          candidate={candidate}
-          selected={Work.selected?(@item.draft.work, candidate)}
-          event="choose-work"
+        <.record_row
+          :for={record <- records(@item, "work")}
+          record={record}
+          level="work"
+          used={Work.uses?(@item.draft.work, record)}
         />
 
-        <div class="flex flex-wrap items-center gap-2 pt-1">
-          <%!-- "None of these" is a real answer and has to be reachable, or an
-                unlisted book can never be settled. --%>
-          <button
-            :if={@item.draft.work.candidates != []}
-            type="button"
-            phx-click="new-work"
-            class={[
-              "rounded-sm border px-2 py-1 text-xs",
-              is_nil(@item.draft.work.selected_source) && "border-brand dark:border-brand-dark",
-              @item.draft.work.selected_source && "border-zinc-300 dark:border-zinc-700"
-            ]}
-          >
-            None of these — create a new book
-          </button>
+        <.provider_outcomes_row
+          outcomes={provider_outcomes(@item, "work")}
+          level="work"
+          retrying={@retrying}
+        />
 
-          <button
-            :if={!@item.draft.work.approved}
-            type="button"
-            phx-click="approve-work"
-            phx-value-approved="true"
-            class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
-          >
-            {if @item.draft.work.candidates == [],
-              do: "Confirm — create a new book",
-              else: "Confirm the highlighted one"}
-          </button>
-        </div>
+        <details>
+          <summary class="cursor-pointer text-xs dark:text-zinc-400">
+            Not what you're looking for? Search again
+          </summary>
+          <div class="pt-2">
+            <.research_form
+              level="work"
+              fields={@item.draft.work.query_fields}
+              running={@researching == "work"}
+            />
+          </div>
+        </details>
       </div>
 
       <%!-- Linking inherits the book's own fields; only additive series
-            memberships remain to decide. The book's own facts are still shown,
-            because "is this the right book?" can't be answered against a
-            title alone. --%>
-      <div
+            memberships remain to decide. --%>
+      <p
         :if={@item.draft.work.mode == :link}
-        class="space-y-1 rounded-sm bg-zinc-100 p-3 text-sm dark:bg-zinc-800"
+        class="rounded-sm bg-zinc-100 p-3 text-sm dark:bg-zinc-800"
       >
-        <p class="font-bold">{candidate_title(selected_candidate(@item.draft.work) || %{})}</p>
-        <p class="text-xs dark:text-zinc-400">
-          {candidate_facts(selected_candidate(@item.draft.work) || %{})}
-        </p>
-        <p class="pt-1">
-          Using the book already in the library. Its title, date and authors are left exactly as they
-          are — an import fills blanks, it never overwrites curation.
-        </p>
-      </div>
+        Using the book already in the library. Its title, date and authors are left exactly as they
+        are — an import fills blanks, it never overwrites curation.
+      </p>
 
       <%!-- Typing lives in a form; choosing does not. They are kept apart
             because a <form> inside a <form> is invalid HTML and the parser
@@ -289,7 +307,7 @@
 
       <div class="space-y-2">
         <div class="flex items-center gap-2">
-          <.label>Which recording</.label>
+          <.label>Records describing this recording</.label>
           <.badge
             :if={!@item.draft.recording.approved}
             color={elem(state_words(:unconfirmed), 1)}
@@ -307,15 +325,9 @@
           </.badge>
         </div>
 
-        <.query_row
-          query={@item.draft.recording.query}
-          fields={@item.draft.recording.query_fields}
-        />
-        <.provider_outcomes_row outcomes={provider_outcomes(@item, "recording")} />
-
         <%!-- A doubted match used to be indistinguishable from no match at
               all: both left every field empty and said nothing. The reason is
-              the whole difference between "pick one" and "type it in". --%>
+              the whole difference between "tick one" and "type it in". --%>
         <p
           :if={doubt_message(@item.draft.recording)}
           class="rounded-sm border border-amber-500 p-3 text-sm"
@@ -324,21 +336,27 @@
           {doubt_message(@item.draft.recording)}
         </p>
 
-        <p :if={@item.draft.recording.candidates != []} class="text-sm dark:text-zinc-400">
-          These files are one recording. Picking it fills publisher, release date and cover from
-          that catalogue entry — and settles the book above when the two are known to go together.
+        <p :if={records(@item, "recording") != []} class="text-sm dark:text-zinc-400">
+          Tick every record of <em>this reading</em> — the narrator is what tells two recordings of
+          one book apart, so check it before ticking. Databases keep editions the storefront has
+          delisted, which is often the only place an older reading still exists.
         </p>
 
-        <.candidate_option
-          :for={candidate <- @item.draft.recording.candidates}
-          candidate={candidate}
-          selected={Recording.selected?(@item.draft.recording, candidate)}
-          event="choose-recording"
+        <.record_row
+          :for={record <- records(@item, "recording")}
+          record={record}
+          level="recording"
+          used={Recording.uses?(@item.draft.recording, record)}
+        />
+
+        <.provider_outcomes_row
+          outcomes={provider_outcomes(@item, "recording")}
+          level="recording"
+          retrying={@retrying}
         />
 
         <div class="flex flex-wrap items-center gap-2 pt-1">
           <button
-            :if={@item.draft.recording.candidates != []}
             type="button"
             phx-click="uncatalogued"
             class={[
@@ -350,6 +368,19 @@
             None of these — it's in no catalogue
           </button>
         </div>
+
+        <details>
+          <summary class="cursor-pointer text-xs dark:text-zinc-400">
+            Not what you're looking for? Search again
+          </summary>
+          <div class="pt-2">
+            <.research_form
+              level="recording"
+              fields={@item.draft.recording.query_fields}
+              running={@researching == "recording"}
+            />
+          </div>
+        </details>
 
         <p class="text-xs italic dark:text-zinc-500">
           Every import creates a new recording. Pointing one at an existing recording's files —

--- a/test/ambry/inbox/approval_test.exs
+++ b/test/ambry/inbox/approval_test.exs
@@ -194,18 +194,24 @@ defmodule Ambry.Inbox.ApprovalTest do
           item
 
         match ->
-          candidate =
+          # A Book already in the library is a different kind of answer from a
+          # provider record, so it goes in its own list.
+          work =
             case match do
-              {"local", id} -> %{"source" => "local", "id" => id, "score" => 1.0}
-              %{} = provider -> provider
+              {"local", id} ->
+                %{
+                  "candidates" => [],
+                  "local" => [%{"id" => id, "score" => 1.0}],
+                  "confidence" => 1.0
+                }
+
+              %{} = provider ->
+                %{"candidates" => [provider], "local" => [], "confidence" => 1.0}
             end
 
           {:ok, item} =
             Inbox.update_item(item, %{
-              matches: %{
-                "work" => %{"candidates" => [candidate], "confidence" => 1.0},
-                "recording" => %{"candidates" => []}
-              }
+              matches: %{"work" => work, "recording" => %{"candidates" => []}}
             })
 
           item

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -60,7 +60,6 @@ defmodule Ambry.Inbox.AutoMatchTest do
       assert [best | _rest] = matches["work"]["candidates"]
       assert best["title"] == "The Way of Kings"
       assert best["score"] > 0.9
-      assert matches["work"]["selected"]["source"] =~ "provider:"
     end
 
     test "keeps every candidate, not just the winner" do
@@ -114,6 +113,27 @@ defmodule Ambry.Inbox.AutoMatchTest do
              ]
     end
 
+    # Nothing waits on matching, so it is allowed to be thorough: every record
+    # about the top work gets its full details fetched, not just the single
+    # best one. They all feed the field candidates, so a thin one means the
+    # operator can't take the other database's description after all.
+    test "fetches full details for every record about the top work" do
+      patch_work_results([
+        book("Leviathan Wakes", ["James S.A. Corey"]),
+        book("Leviathan Wakes", ["James S.A. Corey"])
+      ])
+
+      patch(Providers, :book_details, fn _id, _book_id, _opts ->
+        {:ok, %Provider.Book{provider: "test", id: "x", description: "fetched"}}
+      end)
+
+      %{matches: matches} = AutoMatch.match(item(title: "Leviathan Wakes"))
+
+      assert length(matches["work"]["candidates"]) == 2
+      assert Enum.all?(matches["work"]["candidates"], & &1["hydrated"])
+      assert Enum.all?(matches["work"]["candidates"], &(&1["description"] == "fetched"))
+    end
+
     test "records the search's fields, not only its flattened string" do
       patch_work_results([book("Neuromancer", ["William Gibson"])])
 
@@ -129,14 +149,19 @@ defmodule Ambry.Inbox.AutoMatchTest do
              }
     end
 
-    test "ranks a book already in the library first" do
+    # A Book already in the library is a different KIND of answer from a
+    # provider record: linking to it creates nothing and inherits its
+    # curation. Ranking the two in one list made the form ask one question
+    # that was really two.
+    test "keeps books already in the library out of the provider records" do
       insert(:book, title: "The Way of Kings")
       patch_work_results([book("The Way of Kings", ["Brandon Sanderson"])])
 
       %{matches: matches} = AutoMatch.match(item(title: "The Way of Kings"))
 
-      assert [best | _rest] = matches["work"]["candidates"]
-      assert best["source"] == "local"
+      assert [local] = matches["work"]["local"]
+      assert local["title"] == "The Way of Kings"
+      assert Enum.all?(matches["work"]["candidates"], &(&1["source"] != "local"))
     end
 
     test "reports low confidence when two different books are equally good" do
@@ -157,6 +182,10 @@ defmodule Ambry.Inbox.AutoMatchTest do
     # Two providers returning the SAME work is corroboration, not conflict.
     # Treating it as a tie dropped perfect double hits to 0.5 confidence and
     # sent obviously-correct matches back to the operator to adjudicate.
+    # Records are NOT fused when two databases return the same thing — that's
+    # the normal case, and each knows things the other doesn't. But for
+    # *scoring* they're one answer, or the runner-up penalty reads the
+    # best-corroborated match in the library as the most doubtful one.
     test "two providers agreeing is corroboration, not a tie" do
       patch_work_results([
         book("The Silent Patient", ["Alex Michaelides"]),
@@ -165,8 +194,8 @@ defmodule Ambry.Inbox.AutoMatchTest do
 
       %{matches: matches} = AutoMatch.match(item(title: "The Silent Patient"))
 
-      assert [only] = matches["work"]["candidates"]
-      assert only["also_from"] != []
+      # both records survive, so both can propose values
+      assert length(matches["work"]["candidates"]) == 2
       assert matches["work"]["confidence"] > 0.9
     end
 
@@ -217,7 +246,9 @@ defmodule Ambry.Inbox.AutoMatchTest do
 
       %{matches: matches} = AutoMatch.match(item(title: "The Way of Kings"))
 
-      assert [%{"source" => "local"} | _rest] = matches["work"]["candidates"]
+      assert [%{"title" => "The Way of Kings"}] = matches["work"]["local"]
+      assert [outcome | _rest] = matches["work"]["providers"]
+      assert outcome["status"] == "failed"
     end
 
     # Audible's catalog API is a storefront, not a bibliography: when rights

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -35,6 +35,7 @@ defmodule Ambry.Inbox.DraftTest do
     %{
       "work" => %{
         "candidates" => work_candidates,
+        "local" => Keyword.get(opts, :local, []),
         "confidence" => Keyword.get(opts, :confidence, 0.95),
         "query" => "q"
       },
@@ -53,7 +54,7 @@ defmodule Ambry.Inbox.DraftTest do
       draft = Seed.build(item)
 
       refute Draft.resolved?(draft)
-      assert Enum.any?(Draft.unresolved(draft), &(&1.label == "Which book"))
+      assert Enum.any?(Draft.unresolved(draft), &(&1.label == "First published"))
     end
 
     test "unresolved names the missing decision rather than just failing" do
@@ -86,38 +87,43 @@ defmodule Ambry.Inbox.DraftTest do
   describe "work identity" do
     test "a strong local hit links the existing book rather than creating one" do
       book = insert(:book, title: "Leviathan Wakes")
+      local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}]
 
-      candidates = [
-        %{"source" => "local", "id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}
-      ]
-
-      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+      draft = Seed.build(item(%{matches: matches([], local: local), tags: %{}}))
 
       assert draft.work.mode == :link
       assert draft.work.book_id == book.id
       assert draft.work.approved
     end
 
-    test "a close runner-up leaves the identity for the operator" do
+    # Attaching a recording to the wrong existing book is worse than one
+    # duplicate Book, and much harder to notice afterwards.
+    test "a local book that only nearly matches is offered, never assumed" do
+      book = insert(:book, title: "Leviathan Wakes")
+      local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 0.8}]
+
+      draft = Seed.build(item(%{matches: matches([provider_candidate(%{})], local: local)}))
+
+      assert draft.work.mode == :create
+      refute draft.work.approved
+    end
+
+    test "weak records leave the new-book answer for the operator" do
       candidates = [
-        provider_candidate(%{"id" => "a", "score" => 0.92}),
-        provider_candidate(%{"id" => "b", "score" => 0.91})
+        provider_candidate(%{"id" => "a", "title" => "Something Else", "score" => 0.5})
       ]
 
       draft = Seed.build(item(%{matches: matches(candidates, confidence: 0.5), tags: %{}}))
 
       refute draft.work.approved
-      assert Enum.any?(Draft.unresolved(draft), &(&1.label == "Which book"))
+      assert Enum.any?(Draft.unresolved(draft), &(&1.label =~ "already have"))
     end
 
     test "linking a book does not re-decide the book's own fields" do
       book = insert(:book, title: "Leviathan Wakes")
+      local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}]
 
-      candidates = [
-        %{"source" => "local", "id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}
-      ]
-
-      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+      draft = Seed.build(item(%{matches: matches([], local: local), tags: %{}}))
 
       refute Enum.any?(Draft.unresolved(draft), &(&1.label == "Title"))
       refute Enum.any?(Draft.unresolved(draft), &(&1.section == :work and &1.label == "Author"))
@@ -264,14 +270,12 @@ defmodule Ambry.Inbox.DraftTest do
       series = insert(:series)
       book = insert(:book, series_books: [build(:series_book, series: series, book_number: 1)])
 
-      candidates = [
-        %{"source" => "local", "id" => book.id, "title" => book.title, "score" => 1.0}
-      ]
+      local = [%{"id" => book.id, "title" => book.title, "score" => 1.0}]
 
       draft =
         Seed.build(
           item(%{
-            matches: matches(candidates),
+            matches: matches([], local: local),
             tags: %{"series" => series.name, "series_number" => "1"}
           })
         )
@@ -369,9 +373,9 @@ defmodule Ambry.Inbox.DraftTest do
           })
         )
 
-      # offered, so the operator can still choose it
-      assert length(draft.recording.candidates) == 1
-      # but nothing of its metadata was adopted
+      # offered, so the operator can still tick it
+      assert draft.recording.sources == []
+      # and nothing of its metadata was adopted
       assert draft.recording.publisher.value == nil
       assert draft.recording.published.value == nil
       assert draft.recording.cover.value == nil
@@ -387,7 +391,7 @@ defmodule Ambry.Inbox.DraftTest do
 
       assert Enum.any?(
                Draft.unresolved(draft),
-               &(&1.label == "Which recording this is" and &1.state == :unconfirmed)
+               &(&1.label =~ "describe this recording" and &1.state == :unconfirmed)
              )
     end
 
@@ -401,40 +405,50 @@ defmodule Ambry.Inbox.DraftTest do
     end
   end
 
-  describe "choosing a candidate" do
-    test "picking a different book refills the work's fields from it" do
+  describe "ticking records" do
+    test "ticking a second record adds its values without replacing the first" do
       candidates = [
-        provider_candidate(%{"id" => "hc-1", "title" => "Leviathan Wakes"}),
+        provider_candidate(%{"id" => "hc-1", "description" => "Hardcover's"}),
         provider_candidate(%{
-          "id" => "hc-2",
-          "title" => "Caliban's War",
-          "published" => "2012-06-26",
-          "score" => 0.6
+          "source" => "provider:rreading_glasses",
+          "provider_name" => "rreading-glasses",
+          "id" => "rg-1",
+          "title" => "Something Else Entirely",
+          "description" => "rreading-glasses'",
+          "score" => 0.4
         })
       ]
 
       item = item(%{matches: matches(candidates), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
 
-      assert item.draft.work.title.value == "Leviathan Wakes"
-      assert item.draft.work.selected_id == "hc-1"
+      # only the top record is ticked to begin with
+      assert length(item.draft.work.sources) == 1
 
-      draft = Draft.Edit.choose_work(item.draft, item, "provider:hardcover", "hc-2")
+      draft = Draft.Edit.toggle_source(item.draft, item, :work, Enum.at(candidates, 1))
 
-      # the list is a question with one right answer, so choosing has to move
-      # the fields — it used to only flip `mode`, which is why every row
-      # rendered as chosen and clicking one did nothing visible
-      assert draft.work.title.value == "Caliban's War"
-      assert draft.work.published.value == "2012-06-26"
-      assert draft.work.selected_id == "hc-2"
-      assert draft.work.approved
+      assert length(draft.work.sources) == 2
+      values = Enum.map(draft.recording.description.candidates, & &1.value)
+      assert "Hardcover's" in values
+      assert "rreading-glasses'" in values
     end
 
-    test "a typed value survives choosing a different book" do
-      candidates = [
-        provider_candidate(%{"id" => "hc-1"}),
-        provider_candidate(%{"id" => "hc-2", "title" => "Caliban's War", "score" => 0.6})
-      ]
+    test "un-ticking a record takes its values back out" do
+      candidates = [provider_candidate(%{"description" => "Hardcover's"})]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert item.draft.recording.description.value == "Hardcover's"
+
+      draft = Draft.Edit.toggle_source(item.draft, item, :work, hd(candidates))
+
+      assert draft.work.sources == []
+      assert draft.recording.description.candidates == []
+    end
+
+    test "a typed value survives the ticked set changing" do
+      candidates = [provider_candidate(%{"id" => "hc-1"})]
 
       item = item(%{matches: matches(candidates), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
@@ -444,30 +458,46 @@ defmodule Ambry.Inbox.DraftTest do
           "work" => %{"title" => %{"value" => "What I Actually Want"}}
         })
 
-      draft = Draft.Edit.choose_work(item.draft, item, "provider:hardcover", "hc-2")
+      draft = Draft.Edit.toggle_source(item.draft, item, :work, hd(candidates))
 
-      # 1d again: curation outranks any source, including a source the
-      # operator just picked
+      # 1d again: curation outranks any source, including the absence of one
       assert draft.work.title.value == "What I Actually Want"
       assert draft.work.title.source == "manual"
     end
 
-    test "clicking the already-chosen book confirms rather than resetting" do
-      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+    test "linking an existing book settles the first decision" do
+      book = insert(:book, title: "Leviathan Wakes")
+      local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 0.8}]
+
+      item = item(%{matches: matches([provider_candidate(%{})], local: local)})
       {:ok, item} = Inbox.prepare_draft(item)
+      refute item.draft.work.approved
 
-      touched = Draft.Edit.approve_credit(item.draft, :work, 0, true)
-      assert Enum.at(touched.work.authors, 0).approved
+      draft = Draft.Edit.link_book(item.draft, item, book.id)
 
-      draft = Draft.Edit.choose_work(touched, item, "provider:hardcover", "hc-1")
-
-      assert Enum.at(draft.work.authors, 0).approved
+      assert draft.work.mode == :link
+      assert draft.work.book_id == book.id
+      assert draft.work.approved
     end
 
-    test "choosing a recording settles the book it is known to be of" do
+    test "saying it is a different book settles it as new" do
+      book = insert(:book, title: "Leviathan Wakes")
+      local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 0.8}]
+
+      item = item(%{matches: matches([provider_candidate(%{})], local: local)})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.new_book(item.draft, item)
+
+      assert draft.work.mode == :create
+      assert draft.work.book_id == nil
+      assert draft.work.approved
+    end
+
+    test "ticking an edition ticks the work it came from" do
       work = [
         provider_candidate(%{"id" => "hc-1"}),
-        provider_candidate(%{"id" => "hc-2", "title" => "Caliban's War", "score" => 0.6})
+        provider_candidate(%{"id" => "hc-2", "title" => "Caliban's War", "score" => 0.4})
       ]
 
       recording = [
@@ -478,7 +508,6 @@ defmodule Ambry.Inbox.DraftTest do
           "title" => "Caliban's War",
           "narrators" => ["Jefferson Mays"],
           "publisher" => "Orbit",
-          "published" => "2012-06-26",
           "score" => 0.4,
           # editions come out of a work's own list, so which work is not a
           # second question
@@ -493,16 +522,13 @@ defmodule Ambry.Inbox.DraftTest do
         })
 
       {:ok, item} = Inbox.prepare_draft(item)
-      assert item.draft.work.selected_id == "hc-1"
 
-      draft = Draft.Edit.choose_recording(item.draft, item, "provider:hardcover", "ed-9")
+      draft = Draft.Edit.toggle_source(item.draft, item, :recording, hd(recording))
 
-      assert draft.recording.selected_id == "ed-9"
       assert draft.recording.publisher.value == "Orbit"
       # a file is a recording of exactly one work, so identifying the
       # recording answers the book question too
-      assert draft.work.selected_id == "hc-2"
-      assert draft.work.title.value == "Caliban's War"
+      assert Enum.any?(draft.work.sources, &(&1.id == "hc-2"))
     end
 
     test "a recording in no catalogue is a real answer" do
@@ -526,10 +552,10 @@ defmodule Ambry.Inbox.DraftTest do
       {:ok, item} = Inbox.prepare_draft(item)
       refute item.draft.recording.approved
 
-      draft = Draft.Edit.choose_uncatalogued(item.draft, item)
+      draft = Draft.Edit.uncatalogued(item.draft, item)
 
       assert draft.recording.approved
-      assert draft.recording.selected_source == nil
+      assert draft.recording.sources == []
       assert Draft.Recording.uncatalogued?(draft.recording)
     end
 
@@ -554,48 +580,10 @@ defmodule Ambry.Inbox.DraftTest do
 
       draft = item |> Seed.build() |> Draft.Edit.approve_all()
 
-      # the leading candidate here is, by construction, the wrong recording of
+      # the leading record here is, by construction, the wrong recording of
       # the right book — the one thing this button must not paper over
       refute draft.recording.approved
       assert draft.recording.publisher.value == nil
-    end
-  end
-
-  describe "sources that agree" do
-    test "a format label is not a disagreement" do
-      # Audible titles carry "(Unabridged)" and work-level providers don't, so
-      # treating the two as rival answers made the operator arbitrate a
-      # non-question on a large share of imports
-      draft =
-        Seed.build(
-          item(%{
-            matches: matches([provider_candidate(%{"title" => "Neuromancer (Unabridged)"})]),
-            tags: %{"book_title" => "Neuromancer"}
-          })
-        )
-
-      assert draft.work.title.approved
-      # and the clean spelling wins the field
-      assert draft.work.title.value == "Neuromancer"
-
-      # one chip, crediting everybody who said it — two chips reading
-      # "Hardcover: Neuromancer" and "the file's tags: Neuromancer
-      # (Unabridged)" is a choice nobody wants to make
-      assert [only] = draft.work.title.candidates
-      assert only.label == "Hardcover, The file's tags"
-    end
-
-    test "genuinely different titles still disagree" do
-      draft =
-        Seed.build(
-          item(%{
-            matches: matches([provider_candidate(%{"title" => "Neuromancer"})]),
-            tags: %{"book_title" => "Count Zero"}
-          })
-        )
-
-      refute draft.work.title.approved
-      assert Draft.Field.state(draft.work.title) == :ambiguous
     end
   end
 
@@ -604,23 +592,21 @@ defmodule Ambry.Inbox.DraftTest do
     # about it. Collapsing them to a winner left the operator choosing between
     # one provider and the file's tags.
     test "a corroborating provider still gets to propose its own values" do
-      candidate =
+      candidates = [
         provider_candidate(%{
           "description" => "Hardcover's description",
-          "cover_url" => "https://example.test/hardcover.jpg",
-          "merged" => [
-            %{
-              "source" => "provider:rreading_glasses",
-              "provider_name" => "rreading-glasses",
-              "id" => "rg-1",
-              "title" => "Leviathan Wakes",
-              "description" => "rreading-glasses' description",
-              "cover_url" => "https://example.test/rg.jpg"
-            }
-          ]
+          "cover_url" => "https://example.test/hardcover.jpg"
+        }),
+        provider_candidate(%{
+          "source" => "provider:rreading_glasses",
+          "provider_name" => "rreading-glasses",
+          "id" => "rg-1",
+          "description" => "rreading-glasses' description",
+          "cover_url" => "https://example.test/rg.jpg"
         })
+      ]
 
-      draft = Seed.build(item(%{matches: matches([candidate]), tags: %{}}))
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
 
       values = Enum.map(draft.recording.description.candidates, & &1.value)
       assert "Hardcover's description" in values

--- a/test/ambry/inbox/lookup_test.exs
+++ b/test/ambry/inbox/lookup_test.exs
@@ -1,0 +1,171 @@
+defmodule Ambry.Inbox.LookupTest do
+  @moduledoc """
+  Asking providers things after an item has been matched.
+
+  The boundary these tests exist to hold: everything here writes *evidence*
+  and never a decision. New records appear un-ticked, and a record the draft
+  already points at keeps its identity — otherwise a re-search would silently
+  un-tick whatever the operator had chosen.
+  """
+
+  use Ambry.DataCase
+  use Patch
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers
+  alias Ambry.Repo
+
+  setup do
+    patch(Providers, :search_books, fn _id, _query, _opts -> {:ok, []} end)
+    patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
+    patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :not_stubbed} end)
+    :ok
+  end
+
+  describe "research/3" do
+    test "adds what it finds without disturbing what's ticked" do
+      item = item_with_records()
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      ticked = item.draft.work.sources
+      assert ticked != []
+
+      patch(Providers, :search_books, fn _id, _query, _opts ->
+        {:ok, [book("A Book Nobody Guessed", ["Someone"])]}
+      end)
+
+      {:ok, item} = Inbox.research(item, "work", %{"title" => "something else"})
+
+      titles = Enum.map(Draft.Seed.records(item, "work"), & &1["title"])
+      assert "A Book Nobody Guessed" in titles
+      # the original record is still there and still ticked
+      assert "Leviathan Wakes" in titles
+      assert item.draft.work.sources == ticked
+    end
+
+    test "remembers the query the operator wrote" do
+      item = item_with_records()
+
+      {:ok, item} =
+        Inbox.research(item, "work", %{"title" => "Nemesis Games", "author" => "Corey"})
+
+      assert get_in(item.matches, ["work", "query_fields"]) == %{
+               "title" => "Nemesis Games",
+               "author" => "Corey"
+             }
+    end
+
+    test "an empty search does nothing at all" do
+      item = item_with_records()
+      before = item.matches
+
+      {:ok, item} = Inbox.research(item, "work", %{"title" => "  ", "author" => ""})
+
+      assert item.matches == before
+    end
+  end
+
+  describe "retry_provider/3" do
+    # A rate limit during matching used to cost an item that provider's records
+    # until somebody re-ran the whole match.
+    test "replaces the failure with what the provider says this time" do
+      item =
+        item_with_records(
+          providers: [
+            %{
+              "id" => "hardcover",
+              "name" => "Hardcover",
+              "status" => "failed",
+              "count" => 0,
+              "reason" => ":rate_limited"
+            }
+          ]
+        )
+
+      patch(Providers, :search_books, fn _id, _query, _opts ->
+        {:ok, [book("Leviathan Wakes", ["James S.A. Corey"])]}
+      end)
+
+      {:ok, item} = Inbox.retry_provider(item, "work", "hardcover")
+
+      outcomes = get_in(item.matches, ["work", "providers"])
+      assert [%{"id" => "hardcover", "status" => "ok"}] = outcomes
+    end
+
+    test "an unknown provider is a no-op rather than a crash" do
+      item = item_with_records()
+
+      assert {:ok, ^item} = Inbox.retry_provider(item, "work", "no-such-provider")
+    end
+  end
+
+  describe "hydrate_record/3" do
+    test "fills in a thin record and marks it fetched" do
+      item = item_with_records()
+
+      patch(Providers, :book_details, fn _id, _book_id, _opts ->
+        {:ok, %Provider.Book{provider: "test", id: "hc-1", description: "The full description"}}
+      end)
+
+      ref = {"provider:hardcover", "hc-1"}
+      {:ok, item} = Inbox.hydrate_record(item, "work", ref)
+
+      assert [record] = Draft.Seed.records(item, "work")
+      assert record["description"] == "The full description"
+      assert record["hydrated"]
+    end
+
+    test "a record already fetched is left alone" do
+      item = item_with_records(hydrated: true)
+
+      patch(Providers, :book_details, fn _id, _book_id, _opts ->
+        flunk("should not re-fetch a record that is already hydrated")
+      end)
+
+      assert {:ok, _item} = Inbox.hydrate_record(item, "work", {"provider:hardcover", "hc-1"})
+    end
+  end
+
+  defp item_with_records(opts \\ []) do
+    record =
+      %{
+        "source" => "provider:hardcover",
+        "provider_name" => "Hardcover",
+        "id" => "hc-1",
+        "title" => "Leviathan Wakes",
+        "authors" => ["James S.A. Corey"],
+        "published" => "2011-06-15",
+        "published_format" => "full",
+        "score" => 0.95
+      }
+      |> then(&if Keyword.get(opts, :hydrated), do: Map.put(&1, "hydrated", true), else: &1)
+
+    %InboxItem{}
+    |> InboxItem.changeset(%{
+      path: "/downloads/Leviathan Wakes",
+      files: ["/downloads/Leviathan Wakes/book.m4b"],
+      matches: %{
+        "work" => %{
+          "candidates" => [record],
+          "local" => [],
+          "confidence" => 0.95,
+          "providers" => Keyword.get(opts, :providers, [])
+        },
+        "recording" => %{"candidates" => []}
+      }
+    })
+    |> Repo.insert!()
+  end
+
+  defp book(title, authors) do
+    %Provider.Book{
+      provider: "test",
+      id: "id-#{:erlang.phash2(title)}",
+      title: title,
+      authors: Enum.map(authors, &%Provider.Contributor{name: &1, role: "author"})
+    }
+  end
+end

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -224,47 +224,53 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
-  describe "identity — one answer, not a shortlist" do
-    test "exactly one work candidate is marked as chosen", %{conn: conn} do
-      # Every provider row used to wear a checkmark the moment the work was
-      # approved, which said the release was all of them at once.
-      item = probed_item() |> with_work_candidates()
+  describe "records are evidence, not identities" do
+    test "the top record is ticked and the rest are not", %{conn: conn} do
+      item = probed_item() |> with_work_records()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert view |> element("[data-role='candidate'][data-selected='true']") |> has_element?()
-      assert view |> render() |> selected_candidates() |> length() == 1
+      assert view |> render() |> used_records() |> length() == 1
     end
 
-    test "choosing another candidate moves the fields", %{conn: conn} do
-      item = probed_item() |> with_work_candidates()
+    test "ticking a second record adds its values to the field chips", %{conn: conn} do
+      item = probed_item() |> with_work_records()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert Inbox.get_item!(item.id).draft.work.title.value == "The Way of Kings"
-
       view
-      |> element("[phx-click='choose-work'][phx-value-id='hc-2']")
+      |> element("input[phx-click='toggle-source'][phx-value-id='hc-2']")
       |> render_click()
 
       work = Inbox.get_item!(item.id).draft.work
 
-      assert work.selected_id == "hc-2"
+      assert length(work.sources) == 2
+      # both databases now get a say, which is the whole point
       assert "Words of Radiance" in Enum.map(work.title.candidates, & &1.value)
-
-      # and the new candidate genuinely contradicts the file's tags, so the
-      # title stops being settled rather than silently taking one side
-      refute work.title.approved
-      assert "2014-03-04" in Enum.map(work.published.candidates, & &1.value)
     end
 
-    test "the search that produced the candidates is visible", %{conn: conn} do
-      item = probed_item() |> with_work_candidates()
+    test "an existing book is asked about separately from the records", %{conn: conn} do
+      book = insert(:book, title: "The Way of Kings")
+      item = probed_item() |> with_work_records(local: book)
 
-      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "Searched for"
-      assert html =~ "The Way of Kings"
+      assert html =~ "Is this a book you already have?"
+
+      view |> element("button[phx-click='link-book']") |> render_click()
+
+      work = Inbox.get_item!(item.id).draft.work
+      assert work.mode == :link
+      assert work.book_id == book.id
+    end
+
+    test "the search that produced the records can be re-run", %{conn: conn} do
+      item = probed_item() |> with_work_records()
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Search again"
+      assert has_element?(view, "form#research-work input[name='title']")
     end
 
     test "the file's own tags are visible", %{conn: conn} do
@@ -288,9 +294,9 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
-  # Two plausible works from one provider, so the candidate list is a real
+  # Two plausible works from one provider, so the record list is a real
   # question rather than a formality.
-  defp with_work_candidates(item) do
+  defp with_work_records(item, opts \\ []) do
     candidate = fn id, title, published ->
       %{
         "source" => "provider:hardcover",
@@ -304,6 +310,12 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       }
     end
 
+    local =
+      case Keyword.get(opts, :local) do
+        nil -> []
+        book -> [%{"id" => book.id, "title" => book.title, "score" => 0.8}]
+      end
+
     {:ok, item} =
       item
       |> InboxItem.changeset(%{
@@ -313,6 +325,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
               candidate.("hc-1", "The Way of Kings", "2010-08-31"),
               candidate.("hc-2", "Words of Radiance", "2014-03-04")
             ],
+            "local" => local,
             "confidence" => 0.95,
             "query" => "The Way of Kings Brandon Sanderson",
             "query_fields" => %{
@@ -329,10 +342,10 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     item
   end
 
-  defp selected_candidates(html) do
+  defp used_records(html) do
     html
     |> Floki.parse_document!()
-    |> Floki.find("[data-role='candidate'][data-selected='true']")
+    |> Floki.find("[data-role='record'][data-used='true']")
   end
 
   defp probed_item(opts \\ []) do

--- a/test/support/inbox_helpers.ex
+++ b/test/support/inbox_helpers.ex
@@ -43,7 +43,7 @@ defmodule Ambry.InboxHelpers do
       "mode" => to_string(work.mode),
       "book_id" => work.book_id,
       "approved" => true,
-      "candidates" => work.candidates,
+      "sources" => Enum.map(work.sources, &Map.from_struct/1),
       "title" => settled_field(work.title, opts[:title]),
       "published" => settled_field(work.published, opts[:published]),
       "published_format" => settled_field(work.published_format, nil),
@@ -55,7 +55,7 @@ defmodule Ambry.InboxHelpers do
   defp settled_recording(recording, opts) do
     %{
       "approved" => true,
-      "candidates" => recording.candidates,
+      "sources" => Enum.map(recording.sources, &Map.from_struct/1),
       "title" => settled_field(recording.title, nil),
       "published" => settled_field(recording.published, nil),
       "publisher" => settled_field(recording.publisher, nil),


### PR DESCRIPTION
From the design conversation that settled the shape of the import form. The
previous pass established "this file is a recording of exactly one work" and
then drew the wrong conclusion from it — that the candidate list is
single-select. The list isn't a list of *identities*; it's a list of **provider
records**, documents *about* a work.

> Just because we got back "Leviathan Wakes" from Hardcover and "Leviathan
> Wakes" from rreading-glasses doesn't mean these are two different works. They
> are the same work in two different catalogues. Same identity.

Three questions had been folded into one radio list:

| | Kind | Cardinality |
|---|---|---|
| Existing Book, or a new one | **outcome** | one |
| Which records describe this | **evidence** | many |
| Which record each field takes its value from | **preference** | one per field |

## Local Books leave the ranked list

Reverses 1g's *"local records are first-class candidates, ranked ahead of
provider results"*. The premise holds — reusing a Book is the best outcome and
is what stops duplicates — but "rank it first" became "put it in the same
list", and a ranked list implies its rows are the same kind of thing.

Existing-or-new is now the **first question on the form**, asked separately and
rendered differently, with its own high bar (`@strong_local 0.95`): attaching a
recording to the wrong existing book is worse than one duplicate Book, and much
harder to notice afterwards.

**"None of these — create a new book" is gone.** Choosing a provider record and
creating a Book from it *is* creating a new book — the button and the record
rows were answering one question in two contradictory registers.

## The merge is gone, but its two jobs aren't

`merge_agreeing/1` fused two providers returning the same work into a winner.
Deleting it was straightforward; it was also doing two load-bearing things that
needed replacing rather than removing:

- **Corroboration → confidence.** Without it #1186's bug returns: two providers
  agreeing read as a close runner-up and drop the best-corroborated match in the
  library to 0.5. Confidence now groups by `agreement_key/1` **for scoring
  only** — the rows stay separate.
- **Other providers' ids for one work.** The editions lookup iterated
  `best["merged"]`, so the only way it knew rreading-glasses' id was that
  rreading-glasses had *lost a merge*. Deleting the merge without replacing this
  would have silently reduced edition coverage.

## The editions lookup was asking one provider, ever

An `Enum.find_value` where `fetch_editions` always returns a truthy tuple — so
the first editions-capable provider won whether it returned seven editions,
zero, or a 429.

Exactly backwards, because coverage across databases is the entire point:
**Hardcover and rreading-glasses are not storefronts.** They hold edition
records too, including out-of-print ones Audible has scrubbed. Measured for
Neuromancer: Audible 1 audio edition, Hardcover 7 — including a narrator
Audible doesn't list at all. It asks every capable record now.

## Matching is thorough; the form is dynamic

Scan cost had been shaping the design on a wrong assumption. Hundreds of items
at once is the one-time cold start, not daily operation, and nothing waits on
the job:

- **`RunMatch` retries.** `max_attempts: 1` → `5`, with a backoff starting past
  the ~30s `Retry-After` the shared instances send — spending the immediate
  retry on being told no again is pure waste. A 429 no longer costs an item that
  provider's records permanently.
- **It hydrates every record about the top work**, not just the best one. They
  all feed the field candidates, so a thin one means the operator can't take the
  other database's description after all.
- **The form queries live** for the case the ranked list exists for — the right
  answer isn't in it. Ticking an unhydrated record fetches its details, and its
  editions when it's a work record. A failed provider's chip **is** the retry
  button. Each level has an editable query that re-runs the search and appends
  what it finds. (`Ambry.Inbox.Lookup`, via `start_async`.)

**Everything form-time writes evidence, never decisions.** New records arrive
un-ticked; records already present keep their identity and payload, so a
re-search can't silently un-tick a curated choice. `Seed.restale/2` hashes
`{files, probe}` and not `matches`, so adding records doesn't stale a draft —
already true, now load-bearing.

Deliberate loosening: form-time calls bypass the serial `metadata` queue, since
queueing behind a cold-start scan would make the form unusable. The 7d/30d
provider cache absorbs most of it.

## Not changed

**Provenance.** Each field still records exactly one source; considered and
rejected as unnecessary.

## Verification

`mix check` clean; 1086 tests pass under `--warnings-as-errors`. New coverage
for ticking/un-ticking records and the field chips following, edition records
ticking the work they came from, separate local-book linking, corroboration
scoring without merging, hydration of the whole top group, and the whole
`Lookup` module (re-search adds without disturbing ticks, retry replaces a
failure, hydrate marks fetched and doesn't re-fetch).

ROADMAP.md updated (3e "Records are evidence, identity is an outcome" and
"Matching is thorough; the form is dynamic"; the 1g local-records bullet marked
reversed). It lives outside this repo, so it isn't in this diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
