### PR TITLE
Tell the operator when the form is still waiting on a job

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -483,6 +483,11 @@ defmodule Ambry.Inbox do
   defdelegate progress(items), to: Progress, as: :statuses
 
   @doc """
+  What a background job is doing to one item.
+  """
+  defdelegate job_status(item), to: Progress, as: :status
+
+  @doc """
   Takes an item out of the queue without touching its files.
 
   Dismissals are remembered by path, so a rescan doesn't offer it again.

--- a/lib/ambry/inbox/progress.ex
+++ b/lib/ambry/inbox/progress.ex
@@ -19,10 +19,17 @@ defmodule Ambry.Inbox.Progress do
 
   ## Failures outlive their jobs
 
-  These workers run `max_attempts: 1`, so a failure goes straight to
-  `discarded` — visible for a day and then gone forever. Anything worth
+  A failure is visible for a day and then gone forever, so anything worth
   telling the operator about tomorrow is written onto the item's `issue`
   instead, and that's what the `:issue` status reflects.
+
+  ## Retrying is not the same as queued
+
+  Matching retries with a backoff measured in minutes, because the shared
+  metadata instances rate-limit with a ~30s `Retry-After` and spending the
+  immediate retry on being told no again is waste. An item mid-backoff looks
+  exactly like one that was never matched — blank — so `:retrying` is its own
+  status rather than being folded into `:queued`.
   """
 
   import Ecto.Query
@@ -42,6 +49,7 @@ defmodule Ambry.Inbox.Progress do
   Statuses:
 
     * `:working` — a job is executing right now
+    * `:retrying` — a job failed and is waiting to try again
     * `:queued` — a job is waiting to run
     * `:failed` — a job gave up, and recently enough to still be in the table
     * `:issue` — the item itself records a problem, which outlives the job
@@ -64,7 +72,8 @@ defmodule Ambry.Inbox.Progress do
   defp status(%InboxItem{} = item, states) do
     cond do
       "executing" in states -> :working
-      Enum.any?(states, &(&1 in ~w(available scheduled retryable))) -> :queued
+      "retryable" in states -> :retrying
+      Enum.any?(states, &(&1 in ~w(available scheduled))) -> :queued
       Enum.any?(states, &(&1 in ~w(discarded cancelled))) -> :failed
       item.issue -> :issue
       is_nil(item.probe) -> :never_ran

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -369,6 +369,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       unresolved: Draft.unresolved(item.draft),
       progress: Draft.progress(item.draft),
       destination: Inbox.destination_preflight(item),
+      # Matching retries with a backoff measured in minutes, so an item can be
+      # legitimately mid-work while the form looks like nothing was found.
+      job: Inbox.job_status(item),
       # Roots are configuration and can change between seeding a draft and
       # approving it, so they're read now rather than frozen into the draft.
       roots: Ambry.Library.library_roots()
@@ -396,6 +399,22 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   ## rendering helpers
+
+  @doc """
+  What a background job is doing to this item, if anything.
+
+  The form is where somebody looks when a match seems wrong, and "still
+  working" is a completely different answer from "nothing was found" —
+  especially now that a rate-limited provider means minutes of backoff rather
+  than an immediate give-up.
+  """
+  def job_label(:working), do: {"Still matching…", :blue}
+  def job_label(:retrying), do: {"A provider couldn't be reached — waiting to try again", :yellow}
+  def job_label(:queued), do: {"Queued for matching", :blue}
+  def job_label(:failed), do: {"Matching gave up — try Start over", :red}
+  def job_label(:never_ran), do: {"The files were never read", :red}
+  def job_label(:incomplete), do: {"Never finished matching", :yellow}
+  def job_label(_settled), do: nil
 
   @doc "What the item's files say they are, for the evidence header."
   def evidence(%InboxItem{probe: probe}) when is_map(probe) do

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -7,6 +7,18 @@
           <p class="truncate font-bold">{@page_title}</p>
           <p class="truncate text-sm dark:text-zinc-500">{@item.path}</p>
           <p class="text-sm italic dark:text-zinc-500">{evidence(@item)}</p>
+
+          <%!-- "Still working" and "found nothing" look identical in a form
+                full of empty fields, and matching now backs off for minutes
+                rather than giving up on the first rate limit. --%>
+          <.badge
+            :if={job_label(@job)}
+            color={elem(job_label(@job), 1)}
+            class="mt-1 text-xs"
+            data-role="job-status"
+          >
+            {elem(job_label(@job), 0)}
+          </.badge>
         </div>
 
         <div class="flex-none text-right">

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -149,6 +149,8 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # here — the row already shows its matches or its issue, and repeating
   # "done" on every settled row is noise that hides the rows that aren't.
   defp progress_label(:working), do: "Working on it…"
+  defp progress_label(:retrying), do: "A provider couldn't be reached — waiting to try again."
+
   defp progress_label(:queued), do: "Queued"
   defp progress_label(:failed), do: "A background job failed — try re-probing or re-matching."
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -283,6 +283,40 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "background work" do
+    # Matching now backs off for minutes rather than giving up on the first
+    # rate limit, so an item can be legitimately mid-work while the form looks
+    # like nothing was found. Those must not look the same.
+    test "says when matching is still pending", %{conn: conn} do
+      # discovery enqueues the probe and match jobs, so a fresh item has them
+      item = probed_item()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Queued for matching"
+    end
+
+    test "says when a provider is being retried", %{conn: conn} do
+      item = probed_item()
+      retryable_jobs(item)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # "waiting out a rate limit" and "queued" are the same blank form and
+      # completely different situations
+      assert html =~ "waiting to try again"
+    end
+
+    test "an item nothing is happening to says nothing about jobs", %{conn: conn} do
+      item = probed_item() |> with_work_records()
+      forget_jobs(item)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "[data-role='job-status']")
+    end
+  end
+
   describe "destination" do
     test "says where the file is going before anything is committed", %{conn: conn} do
       item = probed_item() |> settle()
@@ -340,6 +374,29 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
     {:ok, item} = Inbox.rebuild_draft(item)
     item
+  end
+
+  # The Oban pruner deletes jobs after a day, so absence of a job is the
+  # normal state of an item that was matched last week.
+  defp forget_jobs(item) do
+    import Ecto.Query
+
+    Repo.delete_all(
+      from(j in "oban_jobs",
+        where: fragment("?->>'inbox_item_id'", j.args) == ^to_string(item.id)
+      )
+    )
+  end
+
+  defp retryable_jobs(item) do
+    import Ecto.Query
+
+    Repo.update_all(
+      from(j in "oban_jobs",
+        where: fragment("?->>'inbox_item_id'", j.args) == ^to_string(item.id)
+      ),
+      set: [state: "retryable"]
+    )
   end
 
   defp used_records(html) do


### PR DESCRIPTION
Follow-up to #1190, closing a gap that PR opened.

Matching now retries with a backoff measured in minutes (past the ~30s
`Retry-After` the shared instances send). That's the right behaviour, but it
means an item can be legitimately mid-work while the form shows nothing but
empty fields — **indistinguishable from a provider having no record of the
book**. Before the retry, matching gave up immediately and this window barely
existed.

Two fixes:

- **`Progress` gained a `:retrying` status.** It had been folding `retryable`
  into `:queued`, which was accurate when nothing retried and is a lie now.
  "Queued" and "waiting out a rate limit" want different patience from the
  operator, and the second one resolves itself.
- **The form's evidence header shows job status.** The staged import form's 3e
  spec listed it there from the start ("release name, files, duration, tags,
  probe, *3f job status*, '9 of 14 resolved'") and the walking skeleton never
  built it. The list page had it; the page somebody actually stares at when a
  match looks wrong did not.

## Verification

`mix check` clean; 1097 tests pass under `--warnings-as-errors`. New coverage
for a pending match, a retrying one, and an item nothing is happening to —
that last one has to delete the jobs first, because the Oban pruner deletes
them after a day and "no jobs" is the normal state of an item matched last
week. That fallback is why `Progress` isn't a two-line query.

ROADMAP.md updated under 3e. It lives outside this repo, so it isn't in this
diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
