### PR TITLE
Fix four defects found exercising the records model

### DIFF
--- a/lib/ambry/inbox/draft/candidate.ex
+++ b/lib/ambry/inbox/draft/candidate.ex
@@ -21,12 +21,34 @@ defmodule Ambry.Inbox.Draft.Candidate do
     field :value, :string
     field :source, :string
     field :label, :string
+
+    # What identifies this proposal among the others. NOT the same as `source`:
+    # two records from one provider both propose a release date, and keying the
+    # choice on the provider alone selected both chips and could only ever
+    # apply the first — the other value was unreachable.
+    field :key, :string
   end
 
   @doc false
   def changeset(candidate, attrs) do
     candidate
-    |> cast(attrs, [:value, :source, :label])
+    |> cast(attrs, [:value, :source, :label, :key])
     |> validate_required([:source])
+    |> ensure_key()
   end
+
+  defp ensure_key(changeset) do
+    case get_field(changeset, :key) do
+      nil -> put_change(changeset, :key, get_field(changeset, :source))
+      _present -> changeset
+    end
+  end
+
+  @doc """
+  The key for a proposal coming from one provider record.
+
+  The record's id is what makes it distinct — the provider alone isn't enough
+  when a provider returned more than one record.
+  """
+  def key_for(%{"source" => source, "id" => id}), do: "#{source}##{id}"
 end

--- a/lib/ambry/inbox/draft/credit.ex
+++ b/lib/ambry/inbox/draft/credit.ex
@@ -49,6 +49,13 @@ defmodule Ambry.Inbox.Draft.Credit do
     field :source, :string
     field :approved, :boolean, default: false
 
+    # Set the moment the operator touches this credit. Field values are cheap
+    # to re-derive when the ticked records change; a credit is not — it may
+    # carry a linked identity, a renamed pen name, two people behind it — and
+    # rebuilding it from proposals threw all of that away every time another
+    # record was ticked.
+    field :curated, :boolean, default: false
+
     # candidate identities that matched the name, so the operator can choose
     # rather than retype
     embeds_many :candidates, __MODULE__.Match, on_replace: :delete
@@ -87,7 +94,7 @@ defmodule Ambry.Inbox.Draft.Credit do
   @doc false
   def changeset(credit, attrs) do
     credit
-    |> cast(attrs, [:name, :kind, :mode, :identity_id, :source, :approved])
+    |> cast(attrs, [:name, :kind, :mode, :identity_id, :source, :approved, :curated])
     |> validate_required([:kind])
     |> cast_embed(:candidates)
     |> cast_embed(:people)

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -28,8 +28,8 @@ defmodule Ambry.Inbox.Draft.Edit do
   @doc """
   Accepts one of a scalar's proposed candidates.
   """
-  def choose_field(draft, section, name, source) do
-    update_field(draft, section, name, &Field.choose(&1, source))
+  def choose_field(draft, section, name, key) do
+    update_field(draft, section, name, &Field.choose(&1, key))
   end
 
   @doc """
@@ -50,7 +50,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   def link_book(draft, %InboxItem{} = item, book_id) do
     draft
     |> update_in([Access.key(:work)], &%{&1 | mode: :link, book_id: book_id, approved: true})
-    |> reseed(item)
+    |> reseed(item, :both)
   end
 
   @doc """
@@ -63,7 +63,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   def new_book(draft, %InboxItem{} = item) do
     draft
     |> update_in([Access.key(:work)], &%{&1 | mode: :create, book_id: nil, approved: true})
-    |> reseed(item)
+    |> reseed(item, :both)
   end
 
   @doc """
@@ -87,7 +87,7 @@ defmodule Ambry.Inbox.Draft.Edit do
       settle(%{decision | sources: sources}, level)
     end)
     |> follow_work(item, level, record)
-    |> reseed(item)
+    |> reseed(item, scope(level, record))
   end
 
   @doc """
@@ -102,7 +102,7 @@ defmodule Ambry.Inbox.Draft.Edit do
     |> update_in([Access.key(:recording)], fn recording ->
       %{recording | sources: [], approved: true, doubt: :none, doubt_detail: nil}
     end)
-    |> reseed(item)
+    |> reseed(item, :recording)
   end
 
   # Ticking a record answers the question the level was asking, and a doubt
@@ -128,6 +128,12 @@ defmodule Ambry.Inbox.Draft.Edit do
 
   defp follow_work(draft, _item, _level, _record), do: draft
 
+  # Which levels a change has to re-derive. Ticking a recording record that
+  # named its work has moved the work's ticked set too.
+  defp scope(:work, _record), do: :work
+  defp scope(:recording, %{"of_work" => %{"source" => source}}) when is_binary(source), do: :both
+  defp scope(:recording, _record), do: :recording
+
   @doc """
   Re-derives every field from the currently ticked records.
 
@@ -135,7 +141,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   — because a record that was a summary when it was ticked may now have a
   description and a cover to offer.
   """
-  def resettle(draft, item), do: reseed(draft, item)
+  def resettle(draft, item), do: reseed(draft, item, :both)
 
   @doc """
   Whether a level currently counts this record.
@@ -144,9 +150,16 @@ defmodule Ambry.Inbox.Draft.Edit do
   def uses?(draft, :recording, record), do: Recording.uses?(draft.recording, record)
 
   # Fields are derived from whichever records are ticked, so every change to
-  # the ticked set re-derives them. Typed values survive.
-  defp reseed(draft, item) do
-    work = Seed.reseed_work(draft.work, item)
+  # the ticked set re-derives them. Typed values and curated credits survive.
+  #
+  # Ticking a *recording* record leaves the work alone unless the record said
+  # which work it belongs to — otherwise choosing an edition rebuilt the
+  # authors the operator had just finished curating.
+  defp reseed(draft, item, level) do
+    work =
+      if level in [:work, :both],
+        do: Seed.reseed_work(draft.work, item),
+        else: draft.work
 
     %{draft | work: work, recording: Seed.reseed_recording(draft.recording, work, item)}
   end
@@ -158,7 +171,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   """
   def link_credit(draft, section, index, identity_id) do
     update_credit(draft, section, index, fn credit ->
-      %{credit | mode: :link, identity_id: identity_id, approved: true}
+      %{credit | mode: :link, identity_id: identity_id, approved: true, curated: true}
     end)
   end
 
@@ -173,7 +186,7 @@ defmodule Ambry.Inbox.Draft.Edit do
       people =
         if credit.people == [], do: Credit.new_person_default(credit.name), else: credit.people
 
-      %{credit | mode: :create, identity_id: nil, people: people}
+      %{credit | mode: :create, identity_id: nil, people: people, curated: true}
     end)
   end
 
@@ -200,7 +213,13 @@ defmodule Ambry.Inbox.Draft.Edit do
       # Clearing the box un-confirms: a credit cannot stay settled with
       # nothing to create. Any other rename keeps the confirmation, so fixing
       # a typo doesn't cost a second click.
-      %{credit | name: name, people: people, approved: credit.approved and blank?(name) == false}
+      %{
+        credit
+        | name: name,
+          people: people,
+          curated: true,
+          approved: credit.approved and blank?(name) == false
+      }
     end)
   end
 
@@ -211,7 +230,11 @@ defmodule Ambry.Inbox.Draft.Edit do
   Renames the series a link will create.
   """
   def rename_series(draft, index, name) do
-    update_series(draft, index, &%{&1 | name: name, approved: &1.approved and not blank?(name)})
+    update_series(
+      draft,
+      index,
+      &%{&1 | name: name, curated: true, approved: &1.approved and not blank?(name)}
+    )
   end
 
   @doc """
@@ -222,13 +245,13 @@ defmodule Ambry.Inbox.Draft.Edit do
   """
   def add_person(draft, section, index) do
     update_credit(draft, section, index, fn credit ->
-      %{credit | mode: :create, people: credit.people ++ [%PersonRef{name: ""}]}
+      %{credit | mode: :create, curated: true, people: credit.people ++ [%PersonRef{name: ""}]}
     end)
   end
 
   def remove_person(draft, section, index, person_index) do
     update_credit(draft, section, index, fn credit ->
-      %{credit | people: List.delete_at(credit.people, person_index)}
+      %{credit | curated: true, people: List.delete_at(credit.people, person_index)}
     end)
   end
 
@@ -246,7 +269,7 @@ defmodule Ambry.Inbox.Draft.Edit do
           }
         end)
 
-      %{credit | people: people}
+      %{credit | people: people, curated: true}
     end)
   end
 
@@ -254,7 +277,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   Marks a credit settled, or unsettles it for another look.
   """
   def approve_credit(draft, section, index, approved?) do
-    update_credit(draft, section, index, &%{&1 | approved: approved?})
+    update_credit(draft, section, index, &%{&1 | approved: approved?, curated: true})
   end
 
   @doc """
@@ -268,19 +291,19 @@ defmodule Ambry.Inbox.Draft.Edit do
   ## series
 
   def set_series_number(draft, index, number) do
-    update_series(draft, index, &%{&1 | number: presence(number)})
+    update_series(draft, index, &%{&1 | number: presence(number), curated: true})
   end
 
   def approve_series(draft, index, approved?) do
-    update_series(draft, index, &%{&1 | approved: approved?})
+    update_series(draft, index, &%{&1 | approved: approved?, curated: true})
   end
 
   def link_series(draft, index, series_id) do
-    update_series(draft, index, &%{&1 | mode: :link, series_id: series_id})
+    update_series(draft, index, &%{&1 | mode: :link, series_id: series_id, curated: true})
   end
 
   def create_series(draft, index) do
-    update_series(draft, index, &%{&1 | mode: :create, series_id: nil})
+    update_series(draft, index, &%{&1 | mode: :create, series_id: nil, curated: true})
   end
 
   def remove_series(draft, index) do

--- a/lib/ambry/inbox/draft/field.ex
+++ b/lib/ambry/inbox/draft/field.ex
@@ -29,13 +29,18 @@ defmodule Ambry.Inbox.Draft.Field do
     field :approved, :boolean, default: false
     field :required, :boolean, default: false
 
+    # Which candidate was taken. `source` alone can't say: two records from
+    # one provider are two proposals with one source, and the form could
+    # neither highlight the right chip nor apply the second one.
+    field :chosen_key, :string
+
     embeds_many :candidates, Candidate, on_replace: :delete
   end
 
   @doc false
   def changeset(field, attrs) do
     field
-    |> cast(attrs, [:value, :source, :approved, :required])
+    |> cast(attrs, [:value, :source, :approved, :required, :chosen_key])
     |> cast_embed(:candidates)
     |> track_manual_edit(attrs)
     |> validate_settled()
@@ -52,7 +57,10 @@ defmodule Ambry.Inbox.Draft.Field do
 
     case fetch_change(changeset, :value) do
       {:ok, _value} when not explicit_source? ->
-        changeset |> put_change(:source, @manual) |> put_change(:approved, true)
+        changeset
+        |> put_change(:source, @manual)
+        |> put_change(:chosen_key, @manual)
+        |> put_change(:approved, true)
 
       _unchanged_or_sourced ->
         changeset
@@ -84,18 +92,31 @@ defmodule Ambry.Inbox.Draft.Field do
   deliberately.
   """
   def edit(%__MODULE__{} = field, value) do
-    %{field | value: presence(value), source: "manual", approved: true}
+    %{field | value: presence(value), source: "manual", chosen_key: "manual", approved: true}
   end
 
   @doc """
   Accepts one of the proposed candidates, recording which one.
   """
-  def choose(%__MODULE__{} = field, source) do
-    case Enum.find(field.candidates, &(&1.source == source)) do
-      nil -> field
-      candidate -> %{field | value: candidate.value, source: candidate.source, approved: true}
+  def choose(%__MODULE__{} = field, key) do
+    case Enum.find(field.candidates, &(&1.key == key)) do
+      nil ->
+        field
+
+      candidate ->
+        %{
+          field
+          | value: candidate.value,
+            source: candidate.source,
+            chosen_key: candidate.key,
+            approved: true
+        }
     end
   end
+
+  @doc "Whether this candidate is the one the field took."
+  def chose?(%__MODULE__{chosen_key: nil}, _candidate), do: false
+  def chose?(%__MODULE__{} = field, candidate), do: field.chosen_key == candidate.key
 
   @doc """
   Settles the field as deliberately empty.
@@ -103,7 +124,8 @@ defmodule Ambry.Inbox.Draft.Field do
   Waiving is an approval, not an omission — it's what makes "every piece is
   resolved" reachable on a record with optional fields nobody filled in.
   """
-  def waive(%__MODULE__{} = field), do: %{field | value: nil, source: nil, approved: true}
+  def waive(%__MODULE__{} = field),
+    do: %{field | value: nil, source: nil, chosen_key: nil, approved: true}
 
   @doc """
   Whether this field still needs a human.

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -208,8 +208,8 @@ defmodule Ambry.Inbox.Draft.Seed do
         published: published,
         published_format:
           keep_manual(work.published_format, published_format_field(sources, tags, published)),
-        authors: author_credits(sources, tags),
-        series: series_links(sources, tags, book_id)
+        authors: keep_curated(work.authors, author_credits(sources, tags)),
+        series: keep_curated(work.series, series_links(sources, tags, book_id))
     }
   end
 
@@ -239,10 +239,39 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp from_records(records, key), do: Enum.map(records, &candidate(&1, key))
 
+  # A credit or series the operator has touched survives re-derivation
+  # untouched. A field value is cheap to recompute; a credit is not — it may
+  # carry a linked identity, a renamed pen name, or two people behind it, and
+  # rebuilding it from proposals threw all of that away the moment another
+  # record was ticked.
+  #
+  # Fresh proposals that nothing curated already covers are appended, so
+  # ticking a record still brings its people in.
+  defp keep_curated(existing, fresh) do
+    curated = Enum.filter(existing, & &1.curated)
+    taken = MapSet.new(curated, &down(&1.name || ""))
+
+    curated ++ Enum.reject(fresh, &MapSet.member?(taken, down(&1.name || "")))
+  end
+
   # A field the operator typed is theirs; re-seeding from another candidate
   # must not quietly undo a correction. Everything else is provider data being
   # replaced by other provider data, which is exactly what was asked for.
   defp keep_manual(%Field{source: "manual"} = existing, _fresh), do: existing
+
+  # A chip the operator picked stays picked while its proposal is still on
+  # offer — re-deriving because some other record was ticked must not quietly
+  # move a value they chose.
+  defp keep_manual(%Field{chosen_key: key}, fresh) when is_binary(key) do
+    case Enum.find(fresh.candidates, &(&1.key == key)) do
+      nil ->
+        fresh
+
+      chosen ->
+        %{fresh | value: chosen.value, source: chosen.source, chosen_key: key, approved: true}
+    end
+  end
+
   defp keep_manual(_existing, fresh), do: fresh
 
   # Reusing a Book already in the library is the best outcome there is — it's
@@ -454,7 +483,7 @@ defmodule Ambry.Inbox.Draft.Seed do
             )
           ),
         cover: keep_manual(recording.cover, cover_field(describing, tags, item)),
-        narrators: narrator_credits(mine, tags)
+        narrators: keep_curated(recording.narrators, narrator_credits(mine, tags))
     }
   end
 
@@ -530,7 +559,8 @@ defmodule Ambry.Inbox.Draft.Seed do
         %Candidate{
           value: List.first(item.files),
           source: "embedded",
-          label: "Embedded in the file"
+          label: "Embedded in the file",
+          key: "embedded"
         }
       end
 
@@ -561,7 +591,7 @@ defmodule Ambry.Inbox.Draft.Seed do
     |> Enum.flat_map(fn record ->
       record |> Map.get(key) |> names() |> List.wrap() |> Enum.map(&{&1, source_of(record)})
     end)
-    |> Enum.uniq_by(fn {name, _source} -> down(name) end)
+    |> Enum.uniq_by(fn {name, _source} -> normalize(name) end)
   end
 
   # The file only gets a say when no record proposed anybody. A tag name is a
@@ -835,7 +865,9 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp combine(held, incoming, prefer) do
     winner = if prefer.(held.value, incoming.value) == incoming.value, do: incoming, else: held
 
-    %{winner | label: join_labels(held.label, incoming.label)}
+    # The surviving chip keeps the key it had when it was held, so a choice
+    # already made doesn't come unstuck when another source agrees with it.
+    %{winner | label: join_labels(held.label, incoming.label), key: held.key}
   end
 
   defp join_labels(one, one), do: one
@@ -861,22 +893,43 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp candidate(best, key) do
     case presence(best[key]) do
-      nil -> nil
-      value -> %Candidate{value: to_string(value), source: source_of(best), label: label_of(best)}
+      nil ->
+        nil
+
+      value ->
+        %Candidate{
+          value: to_string(value),
+          source: source_of(best),
+          label: label_of(best),
+          key: Candidate.key_for(best)
+        }
     end
   end
 
   defp tag_candidate(tags, key) do
     case presence(tags[key]) do
-      nil -> nil
-      value -> %Candidate{value: to_string(value), source: "tags", label: "The file's tags"}
+      nil ->
+        nil
+
+      value ->
+        %Candidate{
+          value: to_string(value),
+          source: "tags",
+          label: "The file's tags",
+          key: "tags"
+        }
     end
   end
 
   defp release_candidate(nil), do: nil
 
   defp release_candidate(value),
-    do: %Candidate{value: value, source: "release_name", label: "The release name"}
+    do: %Candidate{
+      value: value,
+      source: "release_name",
+      label: "The release name",
+      key: "release_name"
+    }
 
   defp source_of(%{"source" => source}), do: source
   defp source_of(_other), do: nil

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -30,6 +30,10 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
     field :source, :string
     field :approved, :boolean, default: false
 
+    # Touched by the operator — a number they supplied, a series they renamed
+    # or pointed elsewhere. Survives re-derivation.
+    field :curated, :boolean, default: false
+
     embeds_many :candidates, __MODULE__.Match, on_replace: :delete
   end
 
@@ -55,7 +59,7 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
   @doc false
   def changeset(series_link, attrs) do
     series_link
-    |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved])
+    |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved, :curated])
     |> cast_embed(:candidates)
     |> validate_number()
     |> validate_link()

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -109,6 +109,7 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :record, :map, required: true
   attr :used, :boolean, required: true
   attr :level, :string, required: true
+  attr :working, :boolean, default: false
 
   @doc """
   One provider record, and whether it counts.
@@ -142,7 +143,10 @@ defmodule AmbryWeb.Admin.Decisions do
         <p class="truncate text-sm">{candidate_title(@record)}</p>
         <p class="truncate text-xs dark:text-zinc-500">{candidate_facts(@record)}</p>
       </div>
-      <span :if={@record["score"]} class="flex-none pt-0.5 text-xs dark:text-zinc-600">
+      <span :if={@working} class="flex-none pt-0.5 text-xs dark:text-zinc-400">
+        fetching…
+      </span>
+      <span :if={!@working && @record["score"]} class="flex-none pt-0.5 text-xs dark:text-zinc-600">
         {round(@record["score"] * 100)}%
       </span>
     </label>
@@ -353,12 +357,15 @@ defmodule AmbryWeb.Admin.Decisions do
 
       <div class="flex items-start gap-3">
         <%!-- A URL in a text box is not a cover. Seeing the image is the only
-              way to catch a provider that returned the wrong edition's art,
-              and it costs one tag. --%>
-        <img
+              way to catch a provider that returned the wrong edition's art —
+              and its dimensions, because a thumbnail and a full-size cover
+              look identical here and only one of them is worth importing.
+              Routed through the admin proxy like every other import preview,
+              or tracking protection blocks the provider CDN. --%>
+        <.image_with_size
           :if={@preview && @field.value not in [nil, ""] && web_image?(@field.value)}
-          src={@field.value}
-          alt=""
+          id={"#{@section}-#{@name}"}
+          src={proxied_remote_image_url(@field.value)}
           class="h-24 w-24 flex-none rounded-sm object-cover"
         />
         <p
@@ -395,15 +402,24 @@ defmodule AmbryWeb.Admin.Decisions do
           phx-click="choose-field"
           phx-value-section={@section}
           phx-value-field={@name}
-          phx-value-source={candidate.source}
+          phx-value-key={candidate.key}
           class={[
             "rounded-sm border px-2 py-1 text-left text-xs",
-            @field.source == candidate.source && "border-brand dark:border-brand-dark",
-            @field.source != candidate.source && "border-zinc-300 dark:border-zinc-700"
+            Field.chose?(@field, candidate) && "border-brand dark:border-brand-dark",
+            !Field.chose?(@field, candidate) && "border-zinc-300 dark:border-zinc-700"
           ]}
         >
           <span class="dark:text-zinc-500">{candidate.label || source_words(candidate.source)}:</span>
-          <span>{truncate(candidate.value)}</span>
+          <span :if={!@preview}>{truncate(candidate.value)}</span>
+
+          <%!-- Choosing between two covers by URL is choosing blind. --%>
+          <.image_with_size
+            :if={@preview && web_image?(candidate.value)}
+            id={"#{@section}-#{@name}-#{candidate.key}"}
+            src={proxied_remote_image_url(candidate.value)}
+            class="mt-1 h-20 w-20 rounded-sm object-cover"
+          />
+          <span :if={@preview && !web_image?(candidate.value)} class="block">the file's own art</span>
         </button>
 
         <%!-- Choosing "none" is an approval, not an omission. It's what makes

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -86,7 +86,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def handle_event("choose-field", %{"section" => section, "field" => field} = params, socket) do
     {:noreply,
-     edit(socket, &Draft.Edit.choose_field(&1, atom(section), atom(field), params["source"]))}
+     edit(socket, &Draft.Edit.choose_field(&1, atom(section), atom(field), params["key"]))}
   end
 
   def handle_event("waive-field", %{"section" => section, "field" => field}, socket) do
@@ -328,30 +328,36 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   # Ticking a thin record is the moment its details start to matter; ticking a
   # work record is the moment its editions do.
+  # Ticking a thin record is the moment its details start to matter; ticking a
+  # work record is the moment its editions do. Both are provider calls, so
+  # they happen off the render and the row says it's working.
   defp enrich(socket, level, record) do
     item = socket.assigns.item
     ref = Inbox.record_ref(record)
 
     cond do
-      !record["hydrated"] and Draft.Edit.uses?(socket.assigns.item.draft, atom(level), record) ->
+      not Draft.Edit.uses?(item.draft, atom(level), record) ->
+        # un-ticking: nothing to fetch
         socket
-        |> assign(enriching: ref)
-        |> start_async({:enrich, ref}, fn ->
-          with {:ok, item} <- Inbox.hydrate_record(item, level, ref),
-               "work" <- level do
-            Inbox.fetch_editions(item, [ref])
-          end
-        end)
 
-      level == "work" and Draft.Edit.uses?(socket.assigns.item.draft, :work, record) ->
+      record["hydrated"] && level != "work" ->
         socket
-        |> assign(enriching: ref)
-        |> start_async({:enrich, ref}, fn -> Inbox.fetch_editions(item, [ref]) end)
 
       true ->
         socket
+        |> assign(enriching: ref)
+        |> start_async({:enrich, ref}, fn -> fetch(item, level, ref, record) end)
     end
   end
+
+  defp fetch(item, level, ref, record) do
+    with {:ok, item} <- hydrate_if_thin(item, level, ref, record) do
+      if level == "work", do: Inbox.fetch_editions(item, [ref]), else: {:ok, item}
+    end
+  end
+
+  defp hydrate_if_thin(item, _level, _ref, %{"hydrated" => true}), do: {:ok, item}
+  defp hydrate_if_thin(item, level, ref, _record), do: Inbox.hydrate_record(item, level, ref)
 
   defp edit(socket, fun) do
     draft = fun.(socket.assigns.item.draft)
@@ -543,6 +549,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def provider_outcomes(_item, _level), do: []
+
+  @doc "How a provider record is referred to."
+  defdelegate record_ref(record), to: Inbox
 
   @doc "The provider records found for a level."
   defdelegate records(item, level), to: Seed

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -187,6 +187,7 @@
           record={record}
           level="work"
           used={Work.uses?(@item.draft.work, record)}
+          working={@enriching == record_ref(record)}
         />
 
         <.provider_outcomes_row
@@ -359,6 +360,7 @@
           record={record}
           level="recording"
           used={Recording.uses?(@item.draft.recording, record)}
+          working={@enriching == record_ref(record)}
         />
 
         <.provider_outcomes_row

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -587,6 +587,116 @@ defmodule Ambry.Inbox.DraftTest do
     end
   end
 
+  describe "curation survives re-derivation" do
+    # Field values are cheap to recompute; a credit is not. It may carry a
+    # linked identity, a renamed pen name, or two people behind it — and
+    # ticking any other record was rebuilding it from proposals and throwing
+    # all of that away.
+    test "ticking a recording record leaves curated authors alone" do
+      work = [provider_candidate(%{"authors" => ["David Wong"]})]
+
+      recording = [
+        %{
+          "source" => "provider:audible",
+          "provider_name" => "Audible",
+          "id" => "B01",
+          "title" => "What the Hell Did I Just Read",
+          "narrators" => ["Kirby Heyborne"],
+          "score" => 0.9
+        }
+      ]
+
+      item = item(%{matches: matches(work, recording: recording), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      # the operator sets up the pen name: one author, a differently-named
+      # person behind it
+      draft =
+        item.draft
+        |> Draft.Edit.set_person(:work, 0, 0, %{name: "Jason Pargin", person_id: nil})
+        |> Draft.Edit.approve_credit(:work, 0, true)
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      after_tick = Draft.Edit.toggle_source(item.draft, item, :recording, hd(recording))
+
+      assert [credit] = after_tick.work.authors
+      assert credit.name == "David Wong"
+      assert [%{name: "Jason Pargin"}] = credit.people
+      assert credit.approved
+    end
+
+    test "un-ticking a work record leaves a curated credit behind" do
+      work = [provider_candidate(%{"authors" => ["David Wong"]})]
+
+      item = item(%{matches: matches(work), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.rename_credit(item.draft, :work, 0, "Jason Pargin")
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      after_untick = Draft.Edit.toggle_source(item.draft, item, :work, hd(work))
+
+      assert [%{name: "Jason Pargin"}] = after_untick.work.authors
+    end
+
+    test "an untouched credit still follows the records" do
+      work = [provider_candidate(%{"authors" => ["David Wong"]})]
+
+      item = item(%{matches: matches(work), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      assert [_credit] = item.draft.work.authors
+
+      after_untick = Draft.Edit.toggle_source(item.draft, item, :work, hd(work))
+
+      # nobody curated it, so it goes when its source does
+      assert after_untick.work.authors == []
+    end
+  end
+
+  describe "choosing between chips" do
+    # Two records from ONE provider both propose a release date. Keying the
+    # choice on the provider selected both chips and could only ever apply
+    # the first — the other value was unreachable.
+    test "two proposals from one provider are separately choosable" do
+      candidates = [
+        provider_candidate(%{"id" => "a", "published" => "2017-10-03"}),
+        provider_candidate(%{"id" => "b", "published" => "2018-05-01", "score" => 0.94})
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert [first, second] = draft.work.published.candidates
+      assert first.key != second.key
+
+      chosen = Draft.Field.choose(draft.work.published, second.key)
+
+      assert chosen.value == second.value
+      assert Draft.Field.chose?(chosen, second)
+      refute Draft.Field.chose?(chosen, first)
+    end
+
+    test "a chosen chip stays chosen when the ticked set changes" do
+      candidates = [
+        provider_candidate(%{"id" => "a", "published" => "2017-10-03"}),
+        provider_candidate(%{"id" => "b", "published" => "2018-05-01", "score" => 0.94})
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      [_first, second] = item.draft.work.published.candidates
+      draft = Draft.Edit.choose_field(item.draft, :work, :published, second.key)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+      assert item.draft.work.published.value == "2018-05-01"
+
+      # re-deriving because something else was ticked must not move a value
+      # the operator picked
+      after_reseed = Draft.Edit.resettle(item.draft, item)
+      assert after_reseed.work.published.value == "2018-05-01"
+    end
+  end
+
   describe "mixing sources" do
     # Two providers agreeing on WHICH work this is do not agree on everything
     # about it. Collapsing them to a winner left the operator choosing between

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -5,6 +5,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.InboxItem
   alias Ambry.Repo
 
@@ -108,7 +109,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       view
       |> element(
-        "button[phx-click='choose-field'][phx-value-field='title'][phx-value-source='tags']"
+        "button[phx-click='choose-field'][phx-value-field='title'][phx-value-key='tags']"
       )
       |> render_click()
 
@@ -283,6 +284,30 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "fetching on demand" do
+    # The `with` here had no `else`, so ticking a RECORDING record returned a
+    # bare "recording" rather than {:ok, item} and the operator got an
+    # instant "couldn't be reached" for a call that had actually succeeded.
+    test "ticking a recording record does not report a failure", %{conn: conn} do
+      item = probed_item() |> with_recording_records()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("input[phx-click='toggle-source'][phx-value-id='B01']")
+        |> render_click()
+
+      refute html =~ "couldn&#39;t be reached"
+      assert render_async(view)
+
+      assert Recording.uses?(Inbox.get_item!(item.id).draft.recording, %{
+               "source" => "provider:audible",
+               "id" => "B01"
+             })
+    end
+  end
+
   describe "background work" do
     # Matching now backs off for minutes rather than giving up on the first
     # rate limit, so an item can be legitimately mid-work while the form looks
@@ -397,6 +422,34 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       ),
       set: [state: "retryable"]
     )
+  end
+
+  defp with_recording_records(item) do
+    {:ok, item} =
+      item
+      |> InboxItem.changeset(%{
+        matches: %{
+          "work" => %{"candidates" => [], "local" => []},
+          "recording" => %{
+            "candidates" => [
+              %{
+                "source" => "provider:audible",
+                "provider_name" => "Audible",
+                "id" => "B01",
+                "title" => "The Way of Kings",
+                "narrators" => ["Michael Kramer", "Kate Reading"],
+                "score" => 0.4,
+                "hydrated" => true
+              }
+            ],
+            "confidence" => 0.4
+          }
+        }
+      })
+      |> Repo.update()
+
+    {:ok, item} = Inbox.rebuild_draft(item)
+    item
   end
 
   defp used_records(html) do


### PR DESCRIPTION
From a staging pass on "What the Hell Did I Just Read" by David Wong. Four
defects, all in the code from #1190, plus the cover-preview oversight.

## The instant "couldn't be reached"

Ticking a recording record reported a failure for a call that had **succeeded**.

```elixir
with {:ok, item} <- Inbox.hydrate_record(item, level, ref),
     "work" <- level do
  Inbox.fetch_editions(item, [ref])
end
```

No `else`. At the recording level the second clause doesn't match, so the
`with` returns the bare string `"recording"` — `handle_async` doesn't match
`{:ok, {:ok, item}}` and falls to the catch-all error branch. The tell was that
the toast appeared **instantly** rather than after a timeout.

## A chip you couldn't choose

`Field.choose/2` keyed on `source`, which is the **provenance** string — so two
records from Audible are two proposals with one key. Clicking either date chip
highlighted both and always applied the first; the other value was unreachable.

Candidates now carry a `key` of their own (`provider:audible#B01`) and the
field records `chosen_key` alongside `source`. Provenance is untouched and
still records exactly one source, per the earlier decision.

## Ticking a record destroyed curated credits

Re-deriving rebuilt the credit list from proposals, so a pen name the operator
had just set up vanished the moment they ticked an edition.

- **`curated` flags** on `Credit` and `SeriesLink`, set by every `Draft.Edit`
  operation that touches one and honoured by re-derivation. An untouched credit
  still follows the records; a curated one is the operator's.
- **Re-derivation is level-scoped.** Ticking a *recording* record leaves the
  work alone unless the record named which work it belongs to. It had been
  rebuilding both levels every time.

A field value is cheap to recompute. A credit — a linked identity, a renamed
pen name, two people behind one name — is not.

A chosen *chip* could be moved by re-derivation for the same reason; it now
stays chosen while its proposal is still on offer.

## Cover previews

Now use `image_with_size` (the existing hook every other import surface uses)
and `proxied_remote_image_url`, on both the chosen value and each candidate
chip. Two covers are unchoosable by URL alone, and a thumbnail and a full-size
cover look identical without dimensions. The preview added in #1188 was
hand-rolled — an oversight, not a decision, and it also wasn't proxied, so
tracking protection could block it.

## Duplicate author rows

Two providers agreeing on "David Wong" produced two credit rows. The dedupe key
only downcased and trimmed; it now uses the full `normalize/1`, which collapses
internal whitespace too.

**Caveat:** I couldn't reproduce it with identical strings — a test with two
records both naming "David Wong" already produced one credit. If it recurs, the
two records genuinely spell the name differently ("Wong, David"), which is 1b's
known multi-value-splitting problem and wants a different fix than deduping.

## Not in this PR: person bios and photos

Answering the operator's question — **it's a gap, not a stretch goal.** 3b says
approval should cover "proposed new people arriving complete (bio + photo via
the person-level providers)". The walking skeleton deliberately deferred the
image-*picker grid*, but it left out person imagery entirely. The person-level
providers (Wikidata, TMDB, Audnexus, Hardcover, rreading-glasses) all exist and
are wired into the person form; nothing connects them to a credit being created
in the inbox. So importing a new author still means visiting the person form
afterwards, which is exactly the "never has to leave the inbox" promise 3b
makes. Recorded in the ROADMAP as the next piece of inbox work.

## Verification

`mix check` clean; 1103 tests pass under `--warnings-as-errors`. New coverage
for curated credits surviving a tick and an un-tick (and an untouched one still
following its record), two same-provider proposals being separately choosable,
a chosen chip surviving re-derivation, and ticking a recording record not
reporting a failure.

ROADMAP.md updated under 3e. It lives outside this repo, so it isn't in this
diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
