### PR TITLE
Make the cover decision something you can actually look at

### DIFF
--- a/lib/ambry/images.ex
+++ b/lib/ambry/images.ex
@@ -72,10 +72,40 @@ defmodule Ambry.Images do
     end
   end
 
-  defp ffmpeg(source, destination) do
+  @doc """
+  Reads an audio file's embedded cover art into memory.
+
+  `extract_embedded/1` writes into the uploads directory because its caller is
+  importing. A *preview* must not: looking at an inbox item you then dismiss
+  would leave an orphaned image behind every time.
+  """
+  def read_embedded(audio_path) do
+    destination = Path.join(System.tmp_dir!(), "ambry-cover-#{Ecto.UUID.generate()}")
+
+    try do
+      with {_output, 0} <- ffmpeg(audio_path, destination, ["-f", "image2"]),
+           {:ok, binary} <- File.read(destination),
+           {:ok, mime} <- sniff(binary) do
+        {:ok, binary, mime}
+      else
+        _no_image -> {:error, :no_embedded_image}
+      end
+    after
+      File.rm(destination)
+    end
+  end
+
+  # The attached picture keeps its original encoding under `-c:v copy`, so the
+  # bytes say what it is and the filename can't.
+  defp sniff(<<0xFF, 0xD8, _rest::binary>>), do: {:ok, "image/jpeg"}
+  defp sniff(<<0x89, "PNG\r\n", 0x1A, "\n", _rest::binary>>), do: {:ok, "image/png"}
+  defp sniff(_other), do: :error
+
+  defp ffmpeg(source, destination, extra \\ []) do
     System.cmd(
       "ffmpeg",
-      ["-nostdin", "-y", "-i", source, "-an", "-c:v", "copy", "-frames:v", "1", destination],
+      ["-nostdin", "-y", "-i", source, "-an", "-c:v", "copy", "-frames:v", "1"] ++
+        extra ++ [destination],
       stderr_to_stdout: true
     )
   rescue

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -482,7 +482,13 @@ defmodule Ambry.Inbox.Draft.Seed do
               from_records(describing, "description") ++ [tag_candidate(tags, "description")]
             )
           ),
-        cover: keep_manual(recording.cover, cover_field(describing, tags, item)),
+        # NOT `describing`: a work-level record's image is the *work's* cover,
+        # which is a portrait print jacket. Audiobook art is square by
+        # definition — the data model says so, Book carries no cover at all —
+        # so offering a print cover here is offering the wrong artifact. The
+        # same databases DO have square art, on their audio *editions*, and
+        # those arrive as recording records.
+        cover: keep_manual(recording.cover, cover_field(mine, tags, item)),
         narrators: keep_curated(recording.narrators, narrator_credits(mine, tags))
     }
   end
@@ -838,7 +844,7 @@ defmodule Ambry.Inbox.Draft.Seed do
       # one answer, whether from one source or several that turned out to mean
       # the same thing
       [only] ->
-        %{field | value: only.value, source: only.source, approved: true}
+        %{field | value: only.value, source: only.source, chosen_key: only.key, approved: true}
 
       _several ->
         %{field | approved: false}

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -320,6 +320,7 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :placeholder, :string, default: nil
   attr :hint, :string, default: nil
   attr :preview, :boolean, default: false
+  attr :embedded_src, :string, default: nil, doc: "where the file's own art can be seen"
 
   @doc """
   One scalar decision: what the sources proposed, what it will be, and where
@@ -363,17 +364,11 @@ defmodule AmbryWeb.Admin.Decisions do
               Routed through the admin proxy like every other import preview,
               or tracking protection blocks the provider CDN. --%>
         <.image_with_size
-          :if={@preview && @field.value not in [nil, ""] && web_image?(@field.value)}
+          :if={@preview && preview_src(@field.value, @embedded_src)}
           id={"#{@section}-#{@name}"}
-          src={proxied_remote_image_url(@field.value)}
+          src={preview_src(@field.value, @embedded_src)}
           class="h-24 w-24 flex-none rounded-sm object-cover"
         />
-        <p
-          :if={@preview && @field.value not in [nil, ""] && !web_image?(@field.value)}
-          class="flex h-24 w-24 flex-none items-center justify-center rounded-sm border border-zinc-300 text-center text-xs dark:border-zinc-700 dark:text-zinc-500"
-        >
-          embedded in the file
-        </p>
 
         <div class="min-w-0 flex-grow">
           <.inputs_for :let={decision} field={@form[@name]}>
@@ -414,12 +409,11 @@ defmodule AmbryWeb.Admin.Decisions do
 
           <%!-- Choosing between two covers by URL is choosing blind. --%>
           <.image_with_size
-            :if={@preview && web_image?(candidate.value)}
+            :if={@preview && preview_src(candidate.value, @embedded_src)}
             id={"#{@section}-#{@name}-#{candidate.key}"}
-            src={proxied_remote_image_url(candidate.value)}
+            src={preview_src(candidate.value, @embedded_src)}
             class="mt-1 h-20 w-20 rounded-sm object-cover"
           />
-          <span :if={@preview && !web_image?(candidate.value)} class="block">the file's own art</span>
         </button>
 
         <%!-- Choosing "none" is an approval, not an omission. It's what makes
@@ -741,10 +735,18 @@ defmodule AmbryWeb.Admin.Decisions do
   def state_words(:stale), do: {"files changed", :red}
   def state_words(_other), do: {"needs confirming", :yellow}
 
-  @doc "Whether a cover value is something a browser can render inline."
-  def web_image?("http://" <> _rest), do: true
-  def web_image?("https://" <> _rest), do: true
-  def web_image?(_other), do: false
+  @doc """
+  Where a cover value can actually be looked at.
+
+  A provider URL goes through the admin proxy, because tracking protection
+  blocks the CDNs directly. The file's own art isn't a URL at all — the value
+  is the audio file to extract from — so it gets an endpoint that extracts it
+  on demand rather than a line of text saying it exists.
+  """
+  def preview_src(nil, _embedded), do: nil
+  def preview_src("", _embedded), do: nil
+  def preview_src("http" <> _rest = url, _embedded), do: proxied_remote_image_url(url)
+  def preview_src(_local_path, embedded), do: embedded
 
   @doc "Whose proposal this is, in words rather than an id."
   def source_words(nil), do: "nothing"

--- a/lib/ambry_web/controllers/admin/inbox_cover_controller.ex
+++ b/lib/ambry_web/controllers/admin/inbox_cover_controller.ex
@@ -1,0 +1,34 @@
+defmodule AmbryWeb.Admin.InboxCoverController do
+  @moduledoc """
+  Serves an inbox item's embedded cover art, for the import form's preview.
+
+  The embedded candidate's *value* is the audio file to extract from, not a
+  URL, so it had nothing to render and the form said "the file's own art" in
+  words — which is exactly the wrong answer for the one decision where seeing
+  the picture is the whole point. Publishers ship wrong, low-resolution and
+  occasionally hilarious embedded art, and choosing between it and a
+  provider's cover blind isn't choosing.
+
+  Extracted per request rather than imported: an operator who looks at an item
+  and then dismisses it must not leave an orphaned image behind.
+  """
+
+  use AmbryWeb, :controller
+
+  alias Ambry.Images
+  alias Ambry.Inbox
+
+  def show(conn, %{"id" => id}) do
+    # The path comes from the item's own files, never from a parameter.
+    with {:ok, item} <- Inbox.fetch_item(id),
+         [path | _rest] <- item.files,
+         {:ok, binary, mime} <- Images.read_embedded(path) do
+      conn
+      |> put_resp_content_type(mime, nil)
+      |> put_resp_header("cache-control", "private, max-age=3600")
+      |> send_resp(200, binary)
+    else
+      _no_image -> send_resp(conn, 404, "Not Found")
+    end
+  end
+end

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -441,6 +441,8 @@
               form={recording}
               placeholder="image URL"
               preview={true}
+              embedded_src={~p"/admin/inbox/#{@item}/embedded-cover"}
+              hint="Audiobook art is square; a portrait jacket is a print cover."
               field={@item.draft.recording.cover}
             />
 

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -217,6 +217,7 @@ defmodule AmbryWeb.Router do
     end
 
     get "/image-proxy", ImageProxyController, :show
+    get "/inbox/:id/embedded-cover", InboxCoverController, :show
 
     live_dashboard "/dashboard", metrics: AmbryWeb.Telemetry
     oban_dashboard "/oban"

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -655,6 +655,16 @@ defmodule Ambry.Inbox.DraftTest do
   end
 
   describe "choosing between chips" do
+    # A settled field is one somebody already answered; its chip has to look
+    # answered, or the form says "sources disagree" in green and nothing else.
+    test "an auto-settled field arrives with its chip already chosen" do
+      draft = Seed.build(item(%{matches: matches([provider_candidate(%{})]), tags: %{}}))
+
+      assert draft.work.title.approved
+      assert [chip] = draft.work.title.candidates
+      assert Draft.Field.chose?(draft.work.title, chip)
+    end
+
     # Two records from ONE provider both propose a release date. Keying the
     # choice on the provider selected both chips and could only ever apply
     # the first — the other value was unreachable.
@@ -721,10 +731,38 @@ defmodule Ambry.Inbox.DraftTest do
       values = Enum.map(draft.recording.description.candidates, & &1.value)
       assert "Hardcover's description" in values
       assert "rreading-glasses' description" in values
+    end
+
+    # A work-level record's image is the *work's* cover — a portrait print
+    # jacket. Audiobook art is square by definition; Book carries no cover at
+    # all in this data model. The same databases DO have square art, on their
+    # audio editions, and those arrive as recording records.
+    test "a work record's cover is never offered as the recording's" do
+      work = [provider_candidate(%{"cover_url" => "https://example.test/print-jacket.jpg"})]
+
+      recording = [
+        %{
+          "source" => "provider:hardcover",
+          "provider_name" => "Hardcover editions",
+          "id" => "ed-1",
+          "title" => "Leviathan Wakes",
+          "narrators" => ["Jefferson Mays"],
+          "cover_url" => "https://example.test/square-audio.jpg",
+          "score" => 1.0
+        }
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches: matches(work, recording: recording, recording_confidence: 1.0),
+            tags: %{}
+          })
+        )
 
       covers = Enum.map(draft.recording.cover.candidates, & &1.value)
-      assert "https://example.test/hardcover.jpg" in covers
-      assert "https://example.test/rg.jpg" in covers
+      assert "https://example.test/square-audio.jpg" in covers
+      refute "https://example.test/print-jacket.jpg" in covers
     end
 
     # The operator's example: description from a work-level provider, cover

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -308,6 +308,36 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "cover previews" do
+    test "the file's own art is served rather than described in words", %{conn: conn} do
+      item = probed_item(cover_art: true)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # the embedded candidate's value is the audio file, not a URL, so it
+      # needs an endpoint that extracts it — a line of text saying art exists
+      # is the wrong answer for the one decision that is entirely visual
+      assert html =~ "/admin/inbox/#{item.id}/embedded-cover"
+    end
+
+    test "the endpoint returns the extracted image", %{conn: conn} do
+      item = probed_item(cover_art: true)
+
+      conn = get(conn, ~p"/admin/inbox/#{item}/embedded-cover")
+
+      assert response_content_type(conn, :jpg) =~ "image/jpeg"
+      assert byte_size(response(conn, 200)) > 0
+    end
+
+    test "an item with no embedded art 404s rather than erroring", %{conn: conn} do
+      item = probed_item()
+
+      conn = get(conn, ~p"/admin/inbox/#{item}/embedded-cover")
+
+      assert response(conn, 404)
+    end
+  end
+
   describe "background work" do
     # Matching now backs off for minutes rather than giving up on the first
     # rate limit, so an item can be legitimately mid-work while the form looks
@@ -464,7 +494,11 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     release = Path.join(root, name)
     File.mkdir_p!(release)
-    File.cp!(tagged_fixture(Keyword.get(opts, :dated, true)), Path.join(release, "book.m4b"))
+
+    File.cp!(
+      tagged_fixture(Keyword.get(opts, :dated, true), Keyword.get(opts, :cover_art, false)),
+      Path.join(release, "book.m4b")
+    )
 
     {:ok, _counts} = Inbox.discover(root)
     {items, _more} = Inbox.list_items(filter: name)
@@ -473,7 +507,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     item
   end
 
-  defp tagged_fixture(dated?) do
+  defp tagged_fixture(dated?, cover_art?) do
     dir = Ambry.Paths.source_media_disk_path("tagged-#{Ecto.UUID.generate()}")
     File.mkdir_p!(dir)
     path = Path.join(dir, "tagged.m4b")
@@ -494,9 +528,63 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
           "artist=Brandon Sanderson",
           "-metadata",
           "composer=Michael Kramer, Kate Reading"
-        ] ++ if(dated?, do: ["-metadata", "date=2010-08-31"], else: []) ++ [path]
+        ] ++
+          if(dated?, do: ["-metadata", "date=2010-08-31"], else: []) ++
+          [path]
       )
 
-    path
+    if cover_art?, do: attach_cover(path), else: path
+  end
+
+  # Cover art rides along as an attached_pic video stream. ffmpeg's mov muxer
+  # is fussy about writing one, so the art goes into an mp3 — which the probe
+  # and the extractor treat identically.
+  defp attach_cover(path) do
+    art = Path.rootname(path) <> ".jpg"
+    with_art = Path.rootname(path) <> "-art.mp3"
+
+    {_output, 0} =
+      System.cmd("ffmpeg", [
+        "-v",
+        "quiet",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=red:s=64x64:d=1",
+        "-frames:v",
+        "1",
+        art
+      ])
+
+    {_output, 0} =
+      System.cmd("ffmpeg", [
+        "-v",
+        "quiet",
+        "-y",
+        "-i",
+        valid_audio(:mp3),
+        "-i",
+        art,
+        "-map",
+        "0:a",
+        "-map",
+        "1:v",
+        "-c",
+        "copy",
+        "-id3v2_version",
+        "3",
+        "-metadata",
+        "album=The Way of Kings",
+        "-metadata",
+        "artist=Brandon Sanderson",
+        "-metadata",
+        "composer=Michael Kramer, Kate Reading",
+        "-metadata",
+        "date=2010-08-31",
+        with_art
+      ])
+
+    with_art
   end
 end


### PR DESCRIPTION
Three from the staging pass after #1192.

## The file's own art couldn't be previewed

The embedded candidate's *value* is the audio file to extract from, not a URL,
so the form rendered the words "embedded in the file" — the wrong answer for
the one decision that is entirely visual. Publishers ship wrong,
low-resolution and occasionally hilarious embedded art, and choosing between
it and a provider's cover blind isn't choosing.

New `AmbryWeb.Admin.InboxCoverController`, backed by `Images.read_embedded/1`.
**Deliberately not `extract_embedded/1`**: that writes into the uploads
directory because its caller is *importing*, and a preview doing the same
leaves an orphaned image behind every item you open and then dismiss. The new
one extracts to a temp file, sniffs the magic bytes for the content type
(`-c:v copy` keeps the publisher's original encoding, so the filename can't
say what it is), and cleans up.

The path comes from the item's own `files`, never from a parameter.

## Auto-settled chips stopped looking chosen

`chosen_key` — new in #1192 — was set by an operator click and by
`track_manual_edit/2`, but **not by the seeder**. So a field that auto-settled
showed a filled value with no highlighted chip until you clicked the one
already in use.

## Work records were offering print jackets as audiobook covers

A work-level record's image is the *work's* cover: a portrait print jacket.
Audiobook art is square by definition, and Book carries no cover at all in
this data model — covers belong to recordings.

Removed from the recording's cover pool. They still feed description and
publisher, which are genuinely book facts a database often has better than a
storefront does.

**The fix wasn't filtering by shape, it was asking the right question of the
same provider.** Hardcover's `@editions_query` already selects `image { url }`
per edition, and `edition_to_book/1` already maps it — so square audio-edition
art was always available and arriving as recording records. The print cover
was only winning because I'd let work records into that pool in #1189.

## Verification

`mix check` clean; 1108 tests pass under `--warnings-as-errors`. New coverage
for the embedded-cover endpoint (returns the image, 404s when there's no art),
the preview being wired to it, an auto-settled field arriving with its chip
chosen, and a work record's cover being excluded while its audio edition's is
offered.

One trap worth noting: `mix check` went green with a dead default argument in
a test helper that `mix test --warnings-as-errors` rejects — the known gap
between the two, caught before pushing this time.

ROADMAP.md updated under 3e. It lives outside this repo, so it isn't in this
diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
