### PR TITLE
Only records of a recording describe that recording

### DIFF
--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -161,7 +161,7 @@ defmodule Ambry.Inbox.Draft.Edit do
         do: Seed.reseed_work(draft.work, item),
         else: draft.work
 
-    %{draft | work: work, recording: Seed.reseed_recording(draft.recording, work, item)}
+    %{draft | work: work, recording: Seed.reseed_recording(draft.recording, item)}
   end
 
   defp records(item, level), do: Seed.records(item, level)

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -98,7 +98,7 @@ defmodule Ambry.Inbox.Draft.Seed do
       evidence: evidence(item),
       stale: false,
       work: work,
-      recording: recording(recording_level, work, hints, tags, item),
+      recording: recording(recording_level, hints, tags, item),
       destination: destination(item)
     }
   end
@@ -419,7 +419,7 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## recording
 
-  defp recording(level, work, hints, tags, item) do
+  defp recording(level, hints, tags, item) do
     records = records(level)
 
     # **Only a recording we actually believe in gets to fill anything in.**
@@ -444,27 +444,33 @@ defmodule Ambry.Inbox.Draft.Seed do
       # mysteriously stayed empty.
       approved: doubt in [:none, :nothing_found]
     }
-    |> put_recording_fields(records, work, tags, item)
+    |> put_recording_fields(records, tags, item)
   end
 
   @doc """
   Re-derives a recording's fields from whichever records are currently ticked.
   """
-  def reseed_recording(%Recording{} = recording, %Work{} = work, %InboxItem{} = item) do
-    put_recording_fields(recording, records(item, "recording"), work, item.tags || %{}, item)
+  def reseed_recording(%Recording{} = recording, %InboxItem{} = item) do
+    put_recording_fields(recording, records(item, "recording"), item.tags || %{}, item)
   end
 
-  # The work's records get a say in the recording's *descriptive* fields —
-  # description, cover and publisher are facts about the book that a database
-  # often has better than a storefront does, and the operator has to be able to
-  # take the description from one and the cover from another.
+  # **Only records of this recording describe this recording.** Work-level
+  # records used to feed description, publisher and cover, and all three were
+  # wrong:
   #
-  # The release date deliberately does NOT draw from them: a work-level
-  # record's date is the work's original publication date, which is a
-  # different fact wearing the same name.
-  defp put_recording_fields(%Recording{} = recording, records, work, tags, item) do
+  #   * `publisher` means who is responsible for the *audiobook* — Audible
+  #     Studios, Macmillan Audio, Graphic Audio, Soundbooth Theater. A work
+  #     record's publisher is whoever printed the book, which is a different
+  #     company answering a different question.
+  #   * `description` from an audio edition carries what the print blurb
+  #     doesn't: the performance, the narrator, awards it won for the reading.
+  #   * `cover` from a work record is a portrait print jacket, and audiobook
+  #     art is square.
+  #
+  # A database's audio *editions* answer all three properly, and those arrive
+  # as recording records.
+  defp put_recording_fields(%Recording{} = recording, records, tags, item) do
     mine = used(records, recording.sources)
-    describing = mine ++ work_records(work, item)
 
     %{
       recording
@@ -473,28 +479,24 @@ defmodule Ambry.Inbox.Draft.Seed do
         publisher:
           keep_manual(
             recording.publisher,
-            scalar(from_records(describing, "publisher") ++ [tag_candidate(tags, "publisher")])
+            scalar(from_records(mine, "publisher") ++ [tag_candidate(tags, "publisher")])
           ),
+        # Two databases will never write the same description, and two cover
+        # URLs are two pictures nothing here can compare without fetching and
+        # looking at them. Reporting either as "sources disagree" asks the
+        # operator to arbitrate a non-question on every single import — these
+        # are alternatives, so one is taken and the rest stay one click away.
         description:
           keep_manual(
             recording.description,
-            scalar(
-              from_records(describing, "description") ++ [tag_candidate(tags, "description")]
+            scalar(from_records(mine, "description") ++ [tag_candidate(tags, "description")],
+              alternatives: true
             )
           ),
-        # NOT `describing`: a work-level record's image is the *work's* cover,
-        # which is a portrait print jacket. Audiobook art is square by
-        # definition — the data model says so, Book carries no cover at all —
-        # so offering a print cover here is offering the wrong artifact. The
-        # same databases DO have square art, on their audio *editions*, and
-        # those arrive as recording records.
         cover: keep_manual(recording.cover, cover_field(mine, tags, item)),
         narrators: keep_curated(recording.narrators, narrator_credits(mine, tags))
     }
   end
-
-  defp work_records(%Work{} = work, %InboxItem{} = item),
-    do: item |> records("work") |> used(work.sources)
 
   # An ASIN hit is identity, so it needs no corroboration. Otherwise the
   # narrator decides: when the file names a reader and the candidate names a
@@ -570,7 +572,8 @@ defmodule Ambry.Inbox.Draft.Seed do
         }
       end
 
-    (from_records(sources, "cover_url") ++ [embedded]) |> scalar(required: false)
+    (from_records(sources, "cover_url") ++ [embedded])
+    |> scalar(required: false, alternatives: true)
   end
 
   ## credits
@@ -821,6 +824,7 @@ defmodule Ambry.Inbox.Draft.Seed do
     required = Keyword.get(opts, :required, false)
     same? = Keyword.get(opts, :equivalence, &(normalize(&1) == normalize(&2)))
     prefer = Keyword.get(opts, :prefer, fn held, _incoming -> held end)
+    alternatives? = Keyword.get(opts, :alternatives, false)
 
     candidates =
       candidates
@@ -844,11 +848,29 @@ defmodule Ambry.Inbox.Draft.Seed do
       # one answer, whether from one source or several that turned out to mean
       # the same thing
       [only] ->
-        %{field | value: only.value, source: only.source, chosen_key: only.key, approved: true}
+        take(field, only)
+
+      # Several *alternatives* rather than several claims about one fact. Two
+      # databases never write the same description, and two cover URLs are two
+      # pictures nothing here can compare — calling either "sources disagree"
+      # makes the operator arbitrate a non-question on every import. The best
+      # record's answer is taken; the rest stay one click away.
+      [first | _rest] when alternatives? ->
+        take(field, first)
 
       _several ->
         %{field | approved: false}
     end
+  end
+
+  defp take(field, candidate) do
+    %{
+      field
+      | value: candidate.value,
+        source: candidate.source,
+        chosen_key: candidate.key,
+        approved: true
+    }
   end
 
   # Proposals that mean the same thing become one chip, crediting everybody

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -31,6 +31,20 @@ defmodule Ambry.Inbox.DraftTest do
     )
   end
 
+  defp recording_record(attrs) do
+    Map.merge(
+      %{
+        "source" => "provider:audible",
+        "provider_name" => "Audible",
+        "id" => "B01",
+        "title" => "Leviathan Wakes",
+        "narrators" => ["Jefferson Mays"],
+        "score" => 1.0
+      },
+      attrs
+    )
+  end
+
   defp matches(work_candidates, opts \\ []) do
     %{
       "work" => %{
@@ -317,7 +331,7 @@ defmodule Ambry.Inbox.DraftTest do
       refute Enum.any?(Draft.unresolved(draft), &(&1.label == "Publisher"))
     end
 
-    test "embedded art and a provider cover is a choice, not a winner" do
+    test "embedded art and a provider cover: the provider's is taken, both offered" do
       candidates = [provider_candidate(%{})]
 
       recording = [
@@ -338,7 +352,12 @@ defmodule Ambry.Inbox.DraftTest do
           })
         )
 
-      refute draft.recording.cover.approved
+      # Two cover URLs are two pictures nothing here can compare. Calling that
+      # "sources disagree" made the operator arbitrate a non-question on every
+      # import with embedded art — so the provider's is taken and the file's
+      # own stays one click away.
+      assert draft.recording.cover.approved
+      assert draft.recording.cover.value == "https://example.test/cover.jpg"
       assert length(draft.recording.cover.candidates) == 2
     end
 
@@ -408,13 +427,13 @@ defmodule Ambry.Inbox.DraftTest do
   describe "ticking records" do
     test "ticking a second record adds its values without replacing the first" do
       candidates = [
-        provider_candidate(%{"id" => "hc-1", "description" => "Hardcover's"}),
+        provider_candidate(%{"id" => "hc-1", "published" => "2011-06-15"}),
         provider_candidate(%{
           "source" => "provider:rreading_glasses",
           "provider_name" => "rreading-glasses",
           "id" => "rg-1",
           "title" => "Something Else Entirely",
-          "description" => "rreading-glasses'",
+          "published" => "2012-01-20",
           "score" => 0.4
         })
       ]
@@ -428,23 +447,23 @@ defmodule Ambry.Inbox.DraftTest do
       draft = Draft.Edit.toggle_source(item.draft, item, :work, Enum.at(candidates, 1))
 
       assert length(draft.work.sources) == 2
-      values = Enum.map(draft.recording.description.candidates, & &1.value)
-      assert "Hardcover's" in values
-      assert "rreading-glasses'" in values
+      values = Enum.map(draft.work.published.candidates, & &1.value)
+      assert "2011-06-15" in values
+      assert "2012-01-20" in values
     end
 
     test "un-ticking a record takes its values back out" do
-      candidates = [provider_candidate(%{"description" => "Hardcover's"})]
+      candidates = [provider_candidate(%{"published" => "2011-06-15"})]
 
       item = item(%{matches: matches(candidates), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
 
-      assert item.draft.recording.description.value == "Hardcover's"
+      assert item.draft.work.published.value == "2011-06-15"
 
       draft = Draft.Edit.toggle_source(item.draft, item, :work, hd(candidates))
 
       assert draft.work.sources == []
-      assert draft.recording.description.candidates == []
+      assert draft.work.published.candidates == []
     end
 
     test "a typed value survives the ticked set changing" do
@@ -708,49 +727,53 @@ defmodule Ambry.Inbox.DraftTest do
   end
 
   describe "mixing sources" do
-    # Two providers agreeing on WHICH work this is do not agree on everything
-    # about it. Collapsing them to a winner left the operator choosing between
-    # one provider and the file's tags.
+    # Two databases agreeing on WHICH recording this is do not agree on
+    # everything about it. Collapsing them to a winner left the operator
+    # choosing between one provider and the file's tags.
     test "a corroborating provider still gets to propose its own values" do
-      candidates = [
-        provider_candidate(%{
-          "description" => "Hardcover's description",
-          "cover_url" => "https://example.test/hardcover.jpg"
-        }),
-        provider_candidate(%{
-          "source" => "provider:rreading_glasses",
-          "provider_name" => "rreading-glasses",
-          "id" => "rg-1",
-          "description" => "rreading-glasses' description",
-          "cover_url" => "https://example.test/rg.jpg"
-        })
-      ]
-
-      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
-
-      values = Enum.map(draft.recording.description.candidates, & &1.value)
-      assert "Hardcover's description" in values
-      assert "rreading-glasses' description" in values
-    end
-
-    # A work-level record's image is the *work's* cover — a portrait print
-    # jacket. Audiobook art is square by definition; Book carries no cover at
-    # all in this data model. The same databases DO have square art, on their
-    # audio editions, and those arrive as recording records.
-    test "a work record's cover is never offered as the recording's" do
-      work = [provider_candidate(%{"cover_url" => "https://example.test/print-jacket.jpg"})]
-
       recording = [
-        %{
+        recording_record(%{"id" => "B01", "publisher" => "Audible Studios"}),
+        recording_record(%{
           "source" => "provider:hardcover",
           "provider_name" => "Hardcover editions",
           "id" => "ed-1",
-          "title" => "Leviathan Wakes",
-          "narrators" => ["Jefferson Mays"],
-          "cover_url" => "https://example.test/square-audio.jpg",
-          "score" => 1.0
-        }
+          "publisher" => "Recorded Books",
+          "score" => 0.99
+        })
       ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches:
+              matches([provider_candidate(%{})], recording: recording, recording_confidence: 1.0),
+            tags: %{}
+          })
+        )
+
+      publishers = Enum.map(draft.recording.publisher.candidates, & &1.value)
+      assert "Audible Studios" in publishers
+      assert "Recorded Books" in publishers
+      # two audio publishers IS a real disagreement, unlike a description
+      refute draft.recording.publisher.approved
+    end
+
+    # `publisher` on a recording means who is responsible for the *audiobook*
+    # — Audible Studios, Graphic Audio, Soundbooth Theater. A work record's
+    # publisher is whoever printed the book: a different company answering a
+    # different question. Same for the description, which on an audio edition
+    # carries the performance and the narrator, and for the cover, which is a
+    # portrait print jacket.
+    test "a work record never describes the recording" do
+      work = [
+        provider_candidate(%{
+          "publisher" => "Orbit",
+          "description" => "The print blurb",
+          "cover_url" => "https://example.test/print-jacket.jpg"
+        })
+      ]
+
+      recording = [recording_record(%{"publisher" => "Recorded Books"})]
 
       draft =
         Seed.build(
@@ -760,62 +783,20 @@ defmodule Ambry.Inbox.DraftTest do
           })
         )
 
-      covers = Enum.map(draft.recording.cover.candidates, & &1.value)
-      assert "https://example.test/square-audio.jpg" in covers
-      refute "https://example.test/print-jacket.jpg" in covers
-    end
+      assert draft.recording.publisher.value == "Recorded Books"
+      refute "Orbit" in Enum.map(draft.recording.publisher.candidates, & &1.value)
+      refute "The print blurb" in Enum.map(draft.recording.description.candidates, & &1.value)
 
-    # The operator's example: description from a work-level provider, cover
-    # from the recording-level one.
-    test "the work's sources describe the recording too" do
-      recording = [
-        %{
-          "source" => "provider:audible",
-          "provider_name" => "Audible",
-          "id" => "B01",
-          "title" => "Leviathan Wakes",
-          "narrators" => ["Jefferson Mays"],
-          "cover_url" => "https://example.test/audible.jpg",
-          "score" => 1.0
-        }
-      ]
-
-      draft =
-        Seed.build(
-          item(%{
-            matches:
-              matches([provider_candidate(%{"description" => "The work-level description"})],
-                recording: recording,
-                recording_confidence: 1.0
-              ),
-            tags: %{}
-          })
-        )
-
-      assert "The work-level description" in Enum.map(
-               draft.recording.description.candidates,
-               & &1.value
-             )
-
-      assert "https://example.test/audible.jpg" in Enum.map(
+      refute "https://example.test/print-jacket.jpg" in Enum.map(
                draft.recording.cover.candidates,
                & &1.value
              )
     end
 
-    # A work-level provider's date is the work's ORIGINAL publication date,
+    # A work-level record's date is the work's ORIGINAL publication date,
     # which is a different fact wearing the same name.
     test "the work's date is never offered as the recording's release date" do
-      recording = [
-        %{
-          "source" => "provider:audible",
-          "id" => "B01",
-          "title" => "Leviathan Wakes",
-          "narrators" => ["Jefferson Mays"],
-          "published" => "2011-06-15",
-          "score" => 1.0
-        }
-      ]
+      recording = [recording_record(%{"published" => "2011-06-15"})]
 
       draft =
         Seed.build(
@@ -830,6 +811,34 @@ defmodule Ambry.Inbox.DraftTest do
         )
 
       refute "1999-01-02" in Enum.map(draft.recording.published.candidates, & &1.value)
+    end
+
+    # Two databases never write the same description, so treating them as
+    # rival claims made this ambiguous on essentially every import.
+    test "descriptions are alternatives, not a disagreement" do
+      recording = [
+        recording_record(%{"id" => "B01", "description" => "Audible's blurb"}),
+        recording_record(%{
+          "source" => "provider:hardcover",
+          "id" => "ed-1",
+          "description" => "Hardcover's blurb",
+          "score" => 0.99
+        })
+      ]
+
+      draft =
+        Seed.build(
+          item(%{
+            matches:
+              matches([provider_candidate(%{})], recording: recording, recording_confidence: 1.0),
+            tags: %{"description" => "the file's own blurb"}
+          })
+        )
+
+      assert draft.recording.description.approved
+      assert draft.recording.description.value == "Audible's blurb"
+      # and the others stay one click away
+      assert length(draft.recording.description.candidates) == 3
     end
   end
 


### PR DESCRIPTION
Reverses the "the work's sources describe the recording too" part of #1189.
Each of the three fields was wrong for its own reason.

## `publisher`

Means **who is responsible for the audiobook** — Audible Studios, Macmillan
Audio, Graphic Audio, Soundbooth Theater. A work record's publisher is whoever
printed the book: a different company answering a different question, and
never a legitimate value for this field.

## `description`

An audio edition's description carries what a print blurb doesn't — the
performance, the narrator, awards won for the reading.

## `cover`

Already fixed in #1193, for the same shape of reason (portrait print jacket vs
square audiobook art).

**None of this costs the mixing-sources goal**, because a database's audio
*editions* are recording records. Hardcover's edition list is exactly where its
square art and its audio publisher live — so "description from one database,
cover from another" still works, and now works with the right data.

## Two fields stopped being arbitrable

`scalar/2` gained `alternatives: true`, for fields where several distinct
values is the normal case rather than a conflict:

- **Descriptions.** Two databases will never write the same one, so "sources
  disagree" fired on essentially every import with more than one record.
- **Covers.** Two URLs are two pictures, and nothing here fetches or compares
  them. Declaring them in conflict is a category error, not a judgement.

The best record's answer is taken; the rest stay one click away as chips.

**Publisher and the dates deliberately keep arbitrating.** Two audio
publishers, or two release dates, are a real conflict about one fact — that's
the difference between an alternative and a disagreement.

## On "pre-select the largest square image"

Implemented as *"take the best record's cover"* rather than by measuring. The
recording records are score-ordered, so the cover comes from the edition we're
most confident is this recording, with embedded art last. Actually measuring
would mean fetching every candidate image server-side and decoding it — doable
now that matching is allowed to be slow, but a lot of machinery for a
tie-break the operator can make visually in one click, especially now that
every chip renders with its dimensions.

Say the word if the score ordering turns out to pick badly in practice and
it's worth the fetch.

## Verification

`mix check` clean; 1108 tests pass under `--warnings-as-errors`. Coverage
rewritten against recording records: a work record describing nothing about
the recording, two audio publishers still disagreeing, descriptions being
alternatives, and the provider cover winning over embedded art with both
still offered.

ROADMAP.md updated under 3e. It lives outside this repo, so it isn't in this
diff.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek
