### PR TITLE
Fix in-progress audiobooks resetting to zero on load

### DIFF
--- a/lib/ambry/playback/playthrough.ex
+++ b/lib/ambry/playback/playthrough.ex
@@ -69,7 +69,7 @@ defmodule Ambry.Playback.Playthrough do
   end
 
   # Lifecycle events
-  defp apply_event_type(state, %{type: :start} = event) do
+  defp apply_event_type(%{started_at: nil} = state, %{type: :start} = event) do
     %{
       state
       | status: :in_progress,
@@ -78,6 +78,10 @@ defmodule Ambry.Playback.Playthrough do
         position: event.position,
         rate: event.playback_rate
     }
+  end
+
+  defp apply_event_type(state, %{type: :start} = event) do
+    %{state | status: :in_progress, media_id: event.media_id}
   end
 
   defp apply_event_type(state, %{type: :finish} = event) do

--- a/test/ambry/playback_test.exs
+++ b/test/ambry/playback_test.exs
@@ -101,6 +101,53 @@ defmodule Ambry.PlaybackTest do
 
       assert {:ok, 3} = Playback.record_events(events, playthrough.user_id)
     end
+
+    test "a duplicate start event does not reset progress made since the real start" do
+      playthrough = insert(:playthrough)
+
+      real_start = DateTime.utc_now() |> DateTime.truncate(:millisecond)
+      progress_made = DateTime.add(real_start, 60, :second)
+      reopened = DateTime.add(real_start, 3600, :second)
+
+      initial_events = [
+        %{
+          id: Ecto.UUID.generate(),
+          playthrough_id: playthrough.id,
+          type: :start,
+          timestamp: real_start,
+          position: Decimal.new("0"),
+          playback_rate: Decimal.new("1.0"),
+          media_id: playthrough.media_id
+        },
+        %{
+          id: Ecto.UUID.generate(),
+          playthrough_id: playthrough.id,
+          type: :pause,
+          timestamp: progress_made,
+          position: Decimal.new("100"),
+          playback_rate: Decimal.new("1.0")
+        }
+      ]
+
+      {:ok, 2} = Playback.record_events(initial_events, playthrough.user_id)
+      assert Decimal.equal?(Playback.get_playthrough(playthrough.id).position, Decimal.new("100"))
+
+      reopen_event = [
+        %{
+          id: Ecto.UUID.generate(),
+          playthrough_id: playthrough.id,
+          type: :start,
+          timestamp: reopened,
+          position: Decimal.new("0"),
+          playback_rate: Decimal.new("1.0"),
+          media_id: playthrough.media_id
+        }
+      ]
+
+      {:ok, 1} = Playback.record_events(reopen_event, playthrough.user_id)
+
+      assert Decimal.equal?(Playback.get_playthrough(playthrough.id).position, Decimal.new("100"))
+    end
   end
 
   describe "list_events_changed_since/2" do


### PR DESCRIPTION
https://github.com/ambry-app/ambry/issues/1049
## Summary
- Loading an in-progress audiobook was resetting playback progress to zero.
- Root cause: `Playthrough.reduce/3` rebuilds a book's saved position by replaying every event for that playthrough. The `:start` event handler unconditionally overwrote `position`/`rate`, so a duplicate/late `:start` event (e.g. re-opening an already-in-progress book) would clobber real progress with the event's own position (typically 0).
- Fix: `:start` now only sets the initial position/rate the first time a playthrough starts (`started_at` still nil). A later `:start` for an already-started playthrough is treated as a lifecycle marker only, matching how `:resume` already avoids touching position.

## Test plan
- Added a regression test in `test/ambry/playback_test.exs` that reproduces the bug (start → pause at position 100 → duplicate start with position 0) and asserts progress stays at 100.
- Verified red/green: reverting the fix makes the new test fail with the exact reported symptom (position resets to 0); with the fix applied it passes.