### PR TITLE
Fix three defects in the import form's person and date layers

### DIFF
--- a/lib/ambry/inbox/approval.ex
+++ b/lib/ambry/inbox/approval.ex
@@ -115,8 +115,12 @@ defmodule Ambry.Inbox.Approval do
   # deleted and whose record didn't survive.
   defp create(item, file, probe, destination) do
     Repo.transact(fn ->
-      with {:ok, book} <- resolve_book(item.draft.work),
-           {:ok, media} <- create_media(item, book, probe),
+      # People first, and for the whole draft at once: the same human can be
+      # behind two credits, and each credit creating its own left a
+      # self-narrated book with two Person rows of one name.
+      with {:ok, people} <- resolve_people(item.draft),
+           {:ok, book} <- resolve_book(item.draft.work, people),
+           {:ok, media} <- create_media(item, book, probe, people),
            {:ok, _item} <- link(item, media),
            {:ok, media, placement} <- place(destination, book, media, file),
            {:ok, media} <- publish(media) do
@@ -127,20 +131,20 @@ defmodule Ambry.Inbox.Approval do
 
   ## the work
 
-  defp resolve_book(%{mode: :link, book_id: book_id} = work) do
+  defp resolve_book(%{mode: :link, book_id: book_id} = work, _people) do
     case Repo.get(Book, book_id) do
       nil -> {:error, :book_not_found}
       book -> add_series(book, work.series)
     end
   end
 
-  defp resolve_book(%{mode: :create} = work) do
+  defp resolve_book(%{mode: :create} = work, people) do
     Books.create_book(
       %{
         title: Field.value(work.title),
         published: Field.date(work.published),
         published_format: Field.atom(work.published_format, :full),
-        book_authors: author_params(work.authors),
+        book_authors: author_params(work.authors, people),
         series_books: series_params(work.series)
       },
       provenance:
@@ -169,9 +173,9 @@ defmodule Ambry.Inbox.Approval do
     end
   end
 
-  defp author_params(credits) do
+  defp author_params(credits, people) do
     Enum.map(credits, fn credit ->
-      {:ok, author} = resolve_identity(credit)
+      {:ok, author} = resolve_identity(credit, people)
       %{author_id: author.id}
     end)
   end
@@ -193,10 +197,10 @@ defmodule Ambry.Inbox.Approval do
   # The identity is what a credit resolves to — never a Person. Person appears
   # only when creating, and how many of them there are is just the length of
   # the list the operator left behind.
-  defp resolve_identity(%Credit{mode: :link, kind: :author, identity_id: id}),
+  defp resolve_identity(%Credit{mode: :link, kind: :author, identity_id: id}, _people),
     do: {:ok, Repo.get!(Author, id)}
 
-  defp resolve_identity(%Credit{mode: :link, kind: :narrator, identity_id: id}),
+  defp resolve_identity(%Credit{mode: :link, kind: :narrator, identity_id: id}, _people),
     do: {:ok, Repo.get!(Narrator, id)}
 
   # An identity's own changeset only casts its name — identities are normally
@@ -204,10 +208,9 @@ defmodule Ambry.Inbox.Approval do
   # people". So the link rows go in explicitly. Each `AuthorPerson` in the
   # list is one human behind the credit; the list being longer than one is the
   # entire composite-author case.
-  defp resolve_identity(%Credit{mode: :create, kind: :author} = credit) do
-    with {:ok, people} <- resolve_people(credit.people),
-         {:ok, author} <- %Author{} |> Author.changeset(%{name: credit.name}) |> Repo.insert() do
-      Enum.each(people, fn person ->
+  defp resolve_identity(%Credit{mode: :create, kind: :author} = credit, people) do
+    with {:ok, author} <- %Author{} |> Author.changeset(%{name: credit.name}) |> Repo.insert() do
+      Enum.each(behind(credit, people), fn person ->
         Repo.insert!(%AuthorPerson{author_id: author.id, person_id: person.id})
       end)
 
@@ -218,24 +221,50 @@ defmodule Ambry.Inbox.Approval do
   # Narrators stay one-to-one with a Person by design — composite narrator
   # identities aren't a real-world thing — so only the first reference is used
   # and the form caps the control at one.
-  defp resolve_identity(%Credit{mode: :create, kind: :narrator} = credit) do
-    with {:ok, [person | _rest]} <- resolve_people(credit.people) do
-      %Narrator{}
-      |> Narrator.changeset(%{name: credit.name})
-      |> Ecto.Changeset.put_change(:person_id, person.id)
-      |> Repo.insert()
-    end
+  defp resolve_identity(%Credit{mode: :create, kind: :narrator} = credit, people) do
+    [person | _rest] = behind(credit, people)
+
+    %Narrator{}
+    |> Narrator.changeset(%{name: credit.name})
+    |> Ecto.Changeset.put_change(:person_id, person.id)
+    |> Repo.insert()
   end
 
+  defp behind(%Credit{} = credit, people),
+    do: Enum.map(credit.people, &Map.fetch!(people, PersonRef.key(&1)))
+
+  # Every human the draft implies, created once each and looked up by
+  # `PersonRef.key/1`.
+  #
   # A person reference is either somebody already here, or somebody to create
-  # alongside the credit. Creating one is the 1:1 default the form falls back
-  # to; two or more is a shared pen name, and needs no special handling beyond
-  # being a longer list.
-  defp resolve_people(refs) do
-    Enum.reduce_while(refs, {:ok, []}, fn ref, {:ok, acc} ->
+  # alongside the credit. Two or more on one credit is a shared pen name; the
+  # same one on two credits is an author who reads their own work, and that
+  # second case is why this is resolved for the whole draft rather than per
+  # credit — the two credits are independent, the human is not.
+  defp resolve_people(%Draft{} = draft) do
+    draft
+    |> pending_refs()
+    |> Enum.reduce_while({:ok, %{}}, fn {key, ref}, {:ok, resolved} ->
       case resolve_person(ref) do
-        {:ok, person} -> {:cont, {:ok, acc ++ [person]}}
+        {:ok, person} -> {:cont, {:ok, Map.put(resolved, key, person)}}
         {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  # One entry per distinct human, in the order the form lists them, with the
+  # photo and bio folded together across every reference to them.
+  defp pending_refs(%Draft{} = draft) do
+    creating = Enum.filter(draft.work.authors ++ draft.recording.narrators, &(&1.mode == :create))
+
+    creating
+    |> Enum.flat_map(& &1.people)
+    |> Enum.reduce([], fn ref, kept ->
+      key = PersonRef.key(ref)
+
+      case Enum.find_index(kept, fn {held, _ref} -> held == key end) do
+        nil -> kept ++ [{key, ref}]
+        index -> List.update_at(kept, index, fn {k, held} -> {k, PersonRef.merge(held, ref)} end)
       end
     end)
   end
@@ -278,7 +307,7 @@ defmodule Ambry.Inbox.Approval do
 
   ## the recording
 
-  defp create_media(item, book, probe) do
+  defp create_media(item, book, probe, people) do
     recording = item.draft.recording
 
     Media.create_media(
@@ -292,7 +321,7 @@ defmodule Ambry.Inbox.Approval do
         status: :pending,
         duration: probe.duration,
         chapters: probe.chapters,
-        media_narrators: narrator_params(recording.narrators),
+        media_narrators: narrator_params(recording.narrators, people),
         media_tracks: [track_params(probe)],
         title: Field.value(recording.title),
         published: Field.date(recording.published),
@@ -311,9 +340,9 @@ defmodule Ambry.Inbox.Approval do
     )
   end
 
-  defp narrator_params(credits) do
+  defp narrator_params(credits, people) do
     Enum.map(credits, fn credit ->
-      {:ok, narrator} = resolve_identity(credit)
+      {:ok, narrator} = resolve_identity(credit, people)
       %{narrator_id: narrator.id}
     end)
   end

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -39,6 +39,7 @@ defmodule Ambry.Inbox.Draft do
   import Ecto.Changeset
 
   alias Ambry.Inbox.Draft.Destination
+  alias Ambry.Inbox.Draft.PersonRef
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Work
 
@@ -112,6 +113,30 @@ defmodule Ambry.Inbox.Draft do
   Whether this draft can be imported.
   """
   def resolved?(draft), do: unresolved(draft) == []
+
+  @doc """
+  Which credits each pending person is behind, keyed by `PersonRef.key/1`.
+
+  Almost always one, and the interesting answer is two: an author who reads
+  their own book is one human with an Author identity and a Narrator identity,
+  and the two credits proposing to create them have no idea about each other.
+  Approval already resolves them to one Person — this is what lets the form
+  *say* so before the operator presses import, which is the difference between
+  a sensible default and a surprise.
+  """
+  def sharing(nil), do: %{}
+
+  def sharing(%__MODULE__{} = draft) do
+    (tagged(draft.work && draft.work.authors, :author) ++
+       tagged(draft.recording && draft.recording.narrators, :narrator))
+    |> Enum.filter(fn {_kind, credit} -> credit.mode == :create end)
+    |> Enum.flat_map(fn {kind, credit} -> Enum.map(credit.people, &{PersonRef.key(&1), kind}) end)
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Map.new(fn {key, kinds} -> {key, Enum.uniq(kinds)} end)
+  end
+
+  defp tagged(nil, _kind), do: []
+  defp tagged(credits, kind), do: Enum.map(credits, &{kind, &1})
 
   @doc """
   How far along the operator is, for the queue and the form header.

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -292,6 +292,19 @@ defmodule Ambry.Inbox.Draft.Edit do
     end)
   end
 
+  @doc """
+  Says whether an identically-named person elsewhere in this draft is the same
+  human.
+
+  The default is that they are, because an author reading their own book is
+  the ordinary reason one name turns up on two credits and two humans of one
+  name on a single audiobook is not. Saying otherwise is the escape hatch, and
+  it counts as curation like every other operator judgement here.
+  """
+  def set_person_distinct(draft, section, index, person_index, distinct?) do
+    update_person(draft, section, index, person_index, &%{&1 | distinct: distinct?})
+  end
+
   defp update_person(draft, section, index, person_index, fun) do
     update_credit(draft, section, index, fn credit ->
       %{credit | curated: true, people: List.update_at(credit.people, person_index, fun)}
@@ -395,7 +408,7 @@ defmodule Ambry.Inbox.Draft.Edit do
     do: %{field | approved: true}
 
   defp settle_if_possible(%Field{candidates: [first | _rest]} = field),
-    do: %{field | value: first.value, source: first.source, approved: true}
+    do: Field.take(field, first)
 
   defp settle_if_possible(%Field{required: false} = field), do: %{field | approved: true}
   defp settle_if_possible(field), do: field

--- a/lib/ambry/inbox/draft/field.ex
+++ b/lib/ambry/inbox/draft/field.ex
@@ -100,17 +100,84 @@ defmodule Ambry.Inbox.Draft.Field do
   """
   def choose(%__MODULE__{} = field, key) do
     case Enum.find(field.candidates, &(&1.key == key)) do
-      nil ->
-        field
+      nil -> field
+      candidate -> take(field, candidate)
+    end
+  end
 
-      candidate ->
-        %{
-          field
-          | value: candidate.value,
-            source: candidate.source,
-            chosen_key: candidate.key,
-            approved: true
-        }
+  @doc """
+  Settles the field on a proposal.
+
+  The one place a candidate becomes a field's value, because keeping it in one
+  place is the only thing that works: hand-rolled versions of these four
+  assignments in the seeder and in `Draft.Edit` have each forgotten
+  `chosen_key` at least once, and a value whose candidate the field can't name
+  renders as a filled box with no chip highlighted — settled to the model,
+  unsettled to the eye.
+  """
+  def take(%__MODULE__{} = field, %Candidate{} = candidate) do
+    %{
+      field
+      | value: candidate.value,
+        source: candidate.source,
+        chosen_key: candidate.key,
+        approved: true
+    }
+  end
+
+  @doc """
+  Aligns a display-format field with the date it describes.
+
+  The format is not an opinion of its own — it says how much of the date is
+  real — so it is never a question the operator should be left holding while
+  the date beside it is already settled. Two rules, and the order between them
+  is the whole of it:
+
+    * **Most dates answer this themselves.** Year-only knowledge arrives as a
+      literal January 1st and month-only knowledge as the 1st of the month, so
+      an imprecise date always lands on a 1st. Any other day is a full date,
+      and a proposal saying otherwise is not about this value — nothing
+      records October 3rd to mean "2017". So the date outranks the records
+      here, which it does nowhere else in the form.
+    * **A date on a 1st is genuinely ambiguous**, and takes the format from
+      whichever record won the date. Matched on the candidate **key**, because
+      source can't do this job: two records from one provider share a source,
+      and proposals that agree are collapsed to a single one carrying a single
+      source, so matching by source finds the wrong proposal or — far more
+      often — none at all. That was this rule quietly not running.
+
+  Only ever fills a format nobody has settled. An approved format was settled
+  by the seeder or chosen by the operator, and re-deriving over the top of
+  either is the curation-outranks-re-derivation rule broken.
+  """
+  def follow_date(%__MODULE__{approved: true} = format, _date), do: format
+
+  def follow_date(%__MODULE__{} = format, %__MODULE__{approved: true} = date) do
+    case date(date) do
+      %Date{day: day} when day != 1 -> full(format)
+      _ambiguous_or_unparseable -> follow_proposal(format, date)
+    end
+  end
+
+  def follow_date(%__MODULE__{} = format, _date), do: format
+
+  defp follow_proposal(format, date) do
+    candidate =
+      Enum.find(format.candidates, &(is_binary(date.chosen_key) and &1.key == date.chosen_key)) ||
+        Enum.find(format.candidates, &(is_binary(date.source) and &1.source == date.source))
+
+    case candidate do
+      %Candidate{} = candidate -> take(format, candidate)
+      nil -> format
+    end
+  end
+
+  # Points the chip at the record that said so where one did, so the operator
+  # sees an answer with a provider behind it rather than a bare value.
+  defp full(format) do
+    case Enum.find(format.candidates, &(&1.value == "full")) do
+      %Candidate{} = candidate -> take(format, candidate)
+      nil -> %{format | value: "full", source: "date", chosen_key: "date", approved: true}
     end
   end
 

--- a/lib/ambry/inbox/draft/person_ref.ex
+++ b/lib/ambry/inbox/draft/person_ref.ex
@@ -6,6 +6,21 @@ defmodule Ambry.Inbox.Draft.PersonRef do
   Two or more of these on one credit is a shared pen name — that is the whole
   of the composite-author case as far as an import is concerned. There is no
   separate composite mode, because "how many people" is a number, not a kind.
+
+  ## One human, two credits
+
+  A person can be behind more than one credit on the same import, and the
+  ordinary case of that is an author who reads their own book. Both credits
+  propose creating somebody of the same name, and resolving each in isolation
+  made the same human twice — two Person rows, one photo and bio between them,
+  and nothing afterwards to say they were ever meant to be one.
+
+  So sameness is decided by `key/1` rather than by which credit a reference
+  hangs off: two new people of one name **are** one person unless the operator
+  says otherwise, which is what `distinct` says. Two humans who share a name
+  and both worked on one audiobook is not a case worth charging every
+  self-narrated import a decision for — and where it does happen, saying so is
+  one click, on a row that already tells you what it's about to do.
   """
 
   use Ecto.Schema
@@ -28,6 +43,11 @@ defmodule Ambry.Inbox.Draft.PersonRef do
     # which provider the photo and bio came from, for 1d provenance
     field :image_source, :string
     field :description_source, :string
+
+    # "the identically-named person on the other credit is somebody else".
+    # The escape hatch from the same-person default, and the only thing here
+    # that is a claim about the world rather than about this row.
+    field :distinct, :boolean, default: false
   end
 
   # Deliberately permissive: a draft has to be *storable* while it's still
@@ -43,8 +63,46 @@ defmodule Ambry.Inbox.Draft.PersonRef do
       :description,
       :image_url,
       :image_source,
-      :description_source
+      :description_source,
+      :distinct
     ])
+  end
+
+  @doc """
+  Which human this reference means, as far as one import can tell.
+
+  References sharing a key are one person and are created once. Somebody
+  already in the library is keyed by their id; somebody new, by their name,
+  because a name is all an import has to go on and two credits proposing to
+  create "Andy Weir" mean the one Andy Weir.
+
+  A reference the operator has marked `distinct` is keyed by itself, so it can
+  never join a group — which is the whole of the escape hatch.
+  """
+  def key(%__MODULE__{person_id: id}) when not is_nil(id), do: {:person, id}
+  def key(%__MODULE__{distinct: true} = ref), do: {:distinct, ref}
+  def key(%__MODULE__{name: name}) when is_binary(name), do: {:new, normalize(name)}
+  def key(%__MODULE__{} = ref), do: {:distinct, ref}
+
+  defp normalize(name),
+    do: name |> String.downcase() |> String.replace(~r/\s+/, " ") |> String.trim()
+
+  @doc """
+  Folds a reference into the one it shares a key with.
+
+  Whichever row the operator found the photo or the bio on, the person gets
+  it: they went looking on the author row or the narrator row, not on a
+  particular row, and the one Person created from both should carry whatever
+  either of them found.
+  """
+  def merge(%__MODULE__{} = held, %__MODULE__{} = other) do
+    %{
+      held
+      | description: held.description || other.description,
+        description_source: held.description_source || other.description_source,
+        image_url: held.image_url || other.image_url,
+        image_source: held.image_source || other.image_source
+    }
   end
 
   @doc "Whether this reference actually says who it means."

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -382,32 +382,20 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp parse_date(_other), do: nil
 
-  # The display format is not an opinion of its own — it says how much of the
-  # date is real, so it belongs to whichever source won the date. Left to
-  # decide itself it would report "sources disagree" on exactly the imports
-  # the rule above just settled: the tag says year, the provider says full.
-  defp follow_date_source(%Field{} = format, %Field{approved: true, source: source})
-       when is_binary(source) do
-    case Enum.find(format.candidates, &(&1.source == source)) do
-      nil -> format
-      winner -> %{format | value: winner.value, source: winner.source, approved: true}
-    end
-  end
-
-  defp follow_date_source(format, _published), do: format
-
   defp published_field(sources, tags) do
     (from_records(sources, "published") ++ [tag_candidate(tags, "published")])
     |> scalar(required: true, equivalence: &same_date?/2, prefer: &more_precise/2)
   end
 
-  # Not derivable from the date: year-only knowledge arrives as a literal
-  # Jan 1st, and rendering that as a real release day is the exact bug the
-  # v1.9.0 punch list fixed for the import forms.
+  # Not derivable from the date *upwards*: year-only knowledge arrives as a
+  # literal Jan 1st, and rendering that as a real release day is the exact bug
+  # the v1.9.0 punch list fixed for the import forms. Derivable downwards,
+  # though — see `Field.follow_date/2`, which is what stops the format sitting
+  # unanswered beside a date that has plainly already answered it.
   defp published_format_field(sources, tags, published) do
     (from_records(sources, "published_format") ++ [tag_candidate(tags, "published_format")])
     |> scalar(required: false)
-    |> follow_date_source(published)
+    |> Field.follow_date(published)
     |> default_to("full")
   end
 
@@ -863,15 +851,7 @@ defmodule Ambry.Inbox.Draft.Seed do
     end
   end
 
-  defp take(field, candidate) do
-    %{
-      field
-      | value: candidate.value,
-        source: candidate.source,
-        chosen_key: candidate.key,
-        approved: true
-    }
-  end
+  defp take(field, candidate), do: Field.take(field, candidate)
 
   # Proposals that mean the same thing become one chip, crediting everybody
   # who said it.

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -52,7 +52,41 @@ defmodule Ambry.Inbox.Draft.Work do
     |> cast_embed(:published_format)
     |> cast_embed(:authors)
     |> cast_embed(:series)
+    |> align_published_format()
     |> validate_link()
+  end
+
+  # Every route into the draft ends here — typing a date, clicking a date chip,
+  # ticking a record — so this is the one place the format can be kept in step
+  # with the date without each of those routes remembering to. It was only ever
+  # aligned at seed time, which left choosing a date by hand settling one half
+  # of a two-column fact and leaving the other half reported as undecided.
+  #
+  # Only fills a format nobody has settled; see `Field.follow_date/2`.
+  defp align_published_format(changeset) do
+    case {get_field(changeset, :published), get_field(changeset, :published_format)} do
+      {%Field{} = published, %Field{} = format} ->
+        case Field.follow_date(format, published) do
+          ^format -> changeset
+          aligned -> settle_format(changeset, aligned)
+        end
+
+      _nothing_to_align ->
+        changeset
+    end
+  end
+
+  # As a map of the four fields that moved, which is the only thing an
+  # `on_replace: :update` embed accepts — it has no way to tell a struct meant
+  # as "these fields changed" from one meant as "replace the whole embed", so
+  # it refuses both structs and changesets. The candidates are deliberately not
+  # among them: alignment settles a decision, it never edits the evidence.
+  defp settle_format(changeset, aligned) do
+    put_change(
+      changeset,
+      :published_format,
+      Map.take(aligned, [:value, :source, :chosen_key, :approved])
+    )
   end
 
   defp validate_link(changeset) do

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -444,6 +444,9 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :reveal, :string, required: true, doc: ~s(the unfold link — "This is a pen name")
   attr :backing, :string, required: true, doc: ~s(the unfolded label — "Pen name of")
   attr :expanded, :boolean, required: true
+  attr :kind, :atom, required: true, doc: ":author or :narrator"
+  attr :sharing, :map, default: %{}, doc: "PersonRef key => the credits behind it"
+  attr :bios, :map, default: %{}, doc: "person index => bios the picker found"
 
   @doc """
   One credit, resolved to an identity.
@@ -566,6 +569,9 @@ defmodule AmbryWeb.Admin.Decisions do
         section={@section}
         index={@index}
         person_index={0}
+        kind={@kind}
+        sharing={@sharing}
+        bios={@bios[0]}
       />
 
       <%!-- Folded away until it matters, and unfolded automatically the moment
@@ -635,6 +641,9 @@ defmodule AmbryWeb.Admin.Decisions do
             section={@section}
             index={@index}
             person_index={person_index}
+            kind={@kind}
+            sharing={@sharing}
+            bios={@bios[person_index]}
           />
         </div>
 
@@ -664,6 +673,9 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :section, :string, required: true
   attr :index, :integer, required: true
   attr :person_index, :integer, required: true
+  attr :kind, :atom, required: true, doc: "which credit this row hangs off"
+  attr :sharing, :map, default: %{}, doc: "PersonRef key => the credits behind it"
+  attr :bios, :any, default: nil, doc: "bios the picker found for this person, or nil"
 
   @doc """
   The face and bio a new person will be created with.
@@ -672,44 +684,127 @@ defmodule AmbryWeb.Admin.Decisions do
   entity, and a person with no face is unfinished — every credit imported
   without one was a trip to the person form afterwards.
 
-  Shown circular, because that is the frame it will appear in and the whole
-  reason the picker offers alternatives at all.
+  ## A photo is picked by looking; a bio is picked by reading
+
+  They are two different decisions and they were sharing one modal, which
+  meant picking a photo dismissed the bios and picking a bio meant opening the
+  thing again. So only the photo — the decision that genuinely needs a grid of
+  alternatives at display size, in the circular frame — opens anything. The
+  bios come back from the same search and land here as chips, exactly the way
+  a description's proposals do on a decision row, and picking one opens and
+  closes nothing.
   """
   def person_face(assigns) do
     ~H"""
-    <div :if={is_nil(@person.person_id)} class="flex items-center gap-2" data-role="person-face">
-      <.image_with_size
-        :if={@person.image_url}
-        id={"person-#{@section}-#{@index}-#{@person_index}-photo"}
-        src={proxied_remote_image_url(@person.image_url)}
-        class="h-12 w-12 flex-none rounded-full object-cover object-top"
-      />
+    <div :if={is_nil(@person.person_id)} class="space-y-1" data-role="person-face">
+      <div class="flex items-center gap-2">
+        <.image_with_size
+          :if={@person.image_url}
+          id={"person-#{@section}-#{@index}-#{@person_index}-photo"}
+          src={proxied_remote_image_url(@person.image_url)}
+          class="h-12 w-12 flex-none rounded-full object-cover object-top"
+        />
 
-      <span
-        :if={is_nil(@person.image_url)}
-        class="h-12 w-12 flex-none rounded-full border border-dashed border-zinc-300 dark:border-zinc-700"
-      />
+        <span
+          :if={is_nil(@person.image_url)}
+          class="h-12 w-12 flex-none rounded-full border border-dashed border-zinc-300 dark:border-zinc-700"
+        />
 
-      <button
-        type="button"
-        phx-click="find-person-images"
-        phx-value-section={@section}
-        phx-value-index={@index}
-        phx-value-person={@person_index}
-        disabled={blank_name?(@person, @fallback_name)}
-        class="flex-none rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
-      >
-        {if @person.image_url || @person.description,
-          do: "Change photo or bio…",
-          else: "Find a photo and bio…"}
-      </button>
+        <button
+          type="button"
+          phx-click="find-person-images"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          phx-value-person={@person_index}
+          disabled={blank_name?(@person, @fallback_name)}
+          class="flex-none rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
+        >
+          {if @person.image_url || @person.description,
+            do: "Change photo or bio…",
+            else: "Find a photo and bio…"}
+        </button>
 
-      <p :if={@person.description} class="line-clamp-2 min-w-0 text-xs dark:text-zinc-500">
-        {@person.description}
+        <p :if={@person.description} class="line-clamp-2 min-w-0 text-xs dark:text-zinc-500">
+          {@person.description}
+        </p>
+      </div>
+
+      <%!-- The same human on two credits: an author reading their own book.
+            Approval creates them once; this is where the form says so, on the
+            row that would otherwise look like it was about to make a second
+            person of the same name. --%>
+      <p :if={shared_with(@sharing, @person, @kind)} class="text-xs italic dark:text-zinc-500">
+        Same person as the {shared_with(@sharing, @person, @kind)} — one {@person.name || @fallback_name} will be created.
+        <button
+          type="button"
+          phx-click="person-distinct"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          phx-value-person={@person_index}
+          phx-value-distinct="true"
+          class="underline"
+        >
+          Not the same person?
+        </button>
       </p>
+
+      <p :if={@person.distinct} class="text-xs italic dark:text-zinc-500">
+        A different person who happens to share the name.
+        <button
+          type="button"
+          phx-click="person-distinct"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          phx-value-person={@person_index}
+          phx-value-distinct="false"
+          class="underline"
+        >
+          Undo
+        </button>
+      </p>
+
+      <div :if={@bios not in [nil, []]} class="flex flex-wrap items-center gap-2 pt-1">
+        <span class="text-xs dark:text-zinc-500">Bio:</span>
+
+        <button
+          :for={bio <- @bios}
+          type="button"
+          phx-click="pick-person-bio"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          phx-value-person={@person_index}
+          phx-value-provider={bio.provider_id}
+          phx-value-bio={bio.id}
+          title={bio.description}
+          class={[
+            "max-w-full rounded-sm border px-2 py-1 text-left text-xs",
+            if(@person.description == bio.description,
+              do: "border-brand dark:border-brand-dark",
+              else: "border-zinc-300 dark:border-zinc-700"
+            )
+          ]}
+        >
+          <span class="dark:text-zinc-500">{bio.provider_name}:</span>
+          <span class="line-clamp-1">{truncate(bio.description)}</span>
+        </button>
+      </div>
     </div>
     """
   end
+
+  # Which *other* credit the same human is behind, in the words the row needs.
+  defp shared_with(sharing, %PersonRef{distinct: false} = person, kind) do
+    sharing
+    |> Map.get(PersonRef.key(person), [])
+    |> List.delete(kind)
+    |> case do
+      [:author] -> "author"
+      [:narrator] -> "narrator"
+      _only_this_one -> nil
+    end
+  end
+
+  defp shared_with(_sharing, %PersonRef{}, _kind), do: nil
 
   attr :link, SeriesLink, required: true
   attr :index, :integer, required: true
@@ -834,6 +929,7 @@ defmodule AmbryWeb.Admin.Decisions do
   def source_words("release_name"), do: "the release name"
   def source_words("embedded"), do: "the file's embedded art"
   def source_words("default"), do: "the default"
+  def source_words("date"), do: "the date itself"
   def source_words("local"), do: "the library"
   def source_words("provider:" <> id), do: id
   def source_words(other), do: other

--- a/lib/ambry_web/components/admin/person_picker.ex
+++ b/lib/ambry_web/components/admin/person_picker.ex
@@ -27,6 +27,17 @@ defmodule AmbryWeb.Admin.PersonPicker do
   Bios come from the same fan-out and are picked separately: Wikipedia's lead
   paragraph, TMDB's biography and a book database's author blurb are three
   different texts about one person.
+
+  ## Where the bios are shown is the caller's business
+
+  A photo is picked by *looking* and a bio by *reading*, and putting both in
+  one modal made each one dismiss the other — picking a photo closed the sheet
+  on the bios you hadn't read yet, so getting both meant opening the same
+  search twice. So a caller that has somewhere better to put them says
+  `bios={false}` and takes them from the `{:person_bios_found, context, bios}`
+  message this sends as soon as a provider answers. Everything found while the
+  operator was choosing a photo is theirs to render, whether or not the modal
+  is still open by then.
   """
 
   use AmbryWeb, :live_component
@@ -44,6 +55,7 @@ defmodule AmbryWeb.Admin.PersonPicker do
       socket
       |> assign(assigns)
       |> assign_new(:context, fn -> nil end)
+      |> assign_new(:bios, fn -> true end)
       |> assign(
         providers: providers,
         matches: Map.new(providers, &{&1.id, AsyncResult.loading()})
@@ -108,7 +120,7 @@ defmodule AmbryWeb.Admin.PersonPicker do
             </button>
           </div>
 
-          <div :if={match.description} class="flex items-start gap-3">
+          <div :if={@bios && match.description} class="flex items-start gap-3">
             <button
               type="button"
               phx-click="pick-bio"
@@ -165,6 +177,16 @@ defmodule AmbryWeb.Admin.PersonPicker do
   end
 
   defp put_matches(socket, provider_id, matches) do
+    # Sent whether or not this picker renders them, and as each provider
+    # answers rather than once at the end — a caller showing bios elsewhere
+    # should get the fast provider's straight away rather than waiting on the
+    # slow one, exactly as the grid does.
+    bios = Enum.filter(matches, & &1.description)
+
+    if bios != [] do
+      send(self(), {:person_bios_found, socket.assigns.context, bios})
+    end
+
     assign(
       socket,
       matches: Map.update!(socket.assigns.matches, provider_id, &AsyncResult.ok(&1, matches))

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -44,6 +44,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
   alias Ambry.People
+  alias Ambry.Provenance
 
   require Logger
 
@@ -60,6 +61,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(people: People.people_for_select())
      |> assign(expanded: MapSet.new())
      |> assign(researching: nil, retrying: nil, enriching: nil, picker: nil)
+     # What the person search turned up, keyed by the credit and person it was
+     # run for. Evidence about a human rather than a decision about this
+     # import, and nothing outlives the page — so assigns, not the draft.
+     |> assign(person_bios: %{})
      |> load(item)}
   end
 
@@ -72,6 +77,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   """
   def expanded?(expanded, section, index, credit) do
     MapSet.member?(expanded, {section, index}) or not Credit.simple?(credit)
+  end
+
+  @doc """
+  The bios found for each person behind one credit, by their position in it.
+  """
+  def bios_for(person_bios, section, index) do
+    for {{s, i, person}, bios} <- person_bios, s == section, i == index, into: %{} do
+      {person, bios}
+    end
   end
 
   @impl Phoenix.LiveView
@@ -192,6 +206,46 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def handle_event("close-picker", _params, socket), do: {:noreply, assign(socket, picker: nil)}
+
+  def handle_event("pick-person-bio", params, socket) do
+    %{"section" => section, "index" => index, "person" => person} = params
+    key = {section, to_int(index), to_int(person)}
+
+    case Enum.find(Map.get(socket.assigns.person_bios, key, []), &(&1.id == params["bio"])) do
+      nil ->
+        {:noreply, socket}
+
+      bio ->
+        {:noreply,
+         edit(
+           socket,
+           &Draft.Edit.set_person_bio(
+             &1,
+             atom(section),
+             to_int(index),
+             to_int(person),
+             bio.description,
+             Provenance.provider_source(bio.provider_id)
+           )
+         )}
+    end
+  end
+
+  def handle_event("person-distinct", params, socket) do
+    %{"section" => section, "index" => index, "person" => person} = params
+
+    {:noreply,
+     edit(
+       socket,
+       &Draft.Edit.set_person_distinct(
+         &1,
+         atom(section),
+         to_int(index),
+         to_int(person),
+         params["distinct"] == "true"
+       )
+     )}
+  end
 
   def handle_event("add-person", %{"section" => section, "index" => i}, socket) do
     {:noreply, edit(socket, &Draft.Edit.add_person(&1, atom(section), to_int(i)))}
@@ -325,20 +379,16 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      )}
   end
 
-  def handle_info({:person_bio_picked, context, description, source}, socket) do
+  # Arrives while the operator is looking at the photo grid, provider by
+  # provider, and is kept for the row rather than the modal — so choosing a
+  # photo and choosing a bio stop being the same click twice over.
+  def handle_info({:person_bios_found, context, bios}, socket) do
+    key = {context.section, context.index, context.person}
+
     {:noreply,
-     socket
-     |> assign(picker: nil)
-     |> edit(
-       &Draft.Edit.set_person_bio(
-         &1,
-         atom(context.section),
-         context.index,
-         context.person,
-         description,
-         source
-       )
-     )}
+     update(socket, :person_bios, fn found ->
+       Map.update(found, key, bios, &Enum.uniq_by(&1 ++ bios, fn bio -> bio.description end))
+     end)}
   end
 
   @impl Phoenix.LiveView
@@ -425,6 +475,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       form: to_form(Inbox.change_draft(item)),
       unresolved: Draft.unresolved(item.draft),
       progress: Draft.progress(item.draft),
+      # Which pending people are behind more than one credit — a self-narrated
+      # book is one human, and the credits can't see each other.
+      sharing: Draft.sharing(item.draft),
       destination: Inbox.destination_preflight(item),
       # Matching retries with a backoff measured in minutes, so an item can be
       # legitimately mid-work while the form looks like nothing was found.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -5,6 +5,7 @@
       module={AmbryWeb.Admin.PersonPicker}
       query={@picker.query}
       context={@picker}
+      bios={false}
     />
   </.modal>
 
@@ -291,6 +292,9 @@
           reveal="This is a pen name"
           backing="Pen name of"
           expanded={expanded?(@expanded, "work", index, credit)}
+          kind={:author}
+          sharing={@sharing}
+          bios={bios_for(@person_bios, "work", index)}
         />
       </div>
 
@@ -484,6 +488,9 @@
           reveal="This is a stage name"
           backing="Stage name of"
           expanded={expanded?(@expanded, "recording", index, credit)}
+          kind={:narrator}
+          sharing={@sharing}
+          bios={bios_for(@person_bios, "recording", index)}
         />
       </div>
     </section>

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -146,21 +146,25 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     new_params = Map.merge(socket.assigns.form.params, picked)
     changeset = People.change_person(socket.assigns.person, new_params)
 
+    # The picker stays open: a photo and a bio are two decisions off one
+    # search, and closing on the first made getting both mean running the
+    # search twice. It closes when the operator says so.
     {:noreply,
      socket
      |> assign_form(changeset)
-     |> assign(
-       image_picker: false,
-       provenance_hints: Map.merge(socket.assigns.provenance_hints, hints)
-     )}
+     |> assign(provenance_hints: Map.merge(socket.assigns.provenance_hints, hints))}
   end
 
   # A bio is picked the same way a photo is; the person form already knows how
   # to take an imported field, so this rides the existing import path.
   def handle_info({:person_bio_picked, _context, description, source}, socket) do
     send(self(), {:import, %{"person" => %{"description" => description}}, source})
-    {:noreply, assign(socket, image_picker: false)}
+    {:noreply, socket}
   end
+
+  # This surface shows its bios inside the picker, so it has nowhere else to
+  # put them.
+  def handle_info({:person_bios_found, _context, _bios}, socket), do: {:noreply, socket}
 
   def handle_info({:import, %{"person" => person_params}, source}, socket) do
     hints = ProvenanceHints.from_import(person_params, source)

--- a/test/ambry/inbox/approval_test.exs
+++ b/test/ambry/inbox/approval_test.exs
@@ -5,9 +5,11 @@ defmodule Ambry.Inbox.ApprovalTest do
   alias Ambry.Books
   alias Ambry.Books.Book
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
   alias Ambry.Media
   alias Ambry.People.Author
   alias Ambry.People.Narrator
+  alias Ambry.People.Person
 
   describe "approve/1" do
     test "creates the whole graph from a tagged file" do
@@ -140,6 +142,67 @@ defmodule Ambry.Inbox.ApprovalTest do
       assert [first | _rest] = media.narrators
       assert Repo.get!(Narrator, first.id).person_id
     end
+
+    # An author reading their own book is one human wearing two hats. The
+    # author credit and the narrator credit have no idea about each other, so
+    # each created its own Person and the library got two Brandon Sandersons —
+    # one with the photo and bio, one without.
+    test "an author who narrates their own book is created once" do
+      item = tagged_item(narrator: "Brandon Sanderson")
+
+      assert {:ok, media} = Inbox.approve_item(item)
+
+      assert [person] = Repo.all(where(Person, name: "Brandon Sanderson"))
+
+      book = Books.get_book!(media.book_id)
+      assert [author] = book.authors
+
+      assert [author_person] =
+               Repo.get!(Author, author.id) |> Repo.preload(:people) |> Map.get(:people)
+
+      assert author_person.id == person.id
+
+      media = media.id |> Media.get_media!() |> Repo.preload(:narrators)
+      assert [narrator] = media.narrators
+      assert Repo.get!(Narrator, narrator.id).person_id == person.id
+    end
+
+    test "saying they are two different people of one name creates both" do
+      item = tagged_item(narrator: "Brandon Sanderson")
+
+      draft = Draft.Edit.set_person_distinct(item.draft, :recording, 0, 0, true)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      assert {:ok, _media} = Inbox.approve_item(item)
+
+      assert [_one, _other] = Repo.all(where(Person, name: "Brandon Sanderson"))
+    end
+
+    # Whichever row the operator went looking on, the one person gets what was
+    # found — they were finding a photo of a human, not decorating a row.
+    test "a photo found on one credit reaches the person created for both" do
+      item = tagged_item(narrator: "Brandon Sanderson")
+
+      draft =
+        Draft.Edit.set_person_image(
+          item.draft,
+          :recording,
+          0,
+          0,
+          "https://example.test/face.jpg",
+          "provider:tmdb"
+        )
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      %{web_path: web_path} = Ambry.Factory.valid_image(:person)
+      patch(Ambry.Images, :import_url, fn _url -> {:ok, web_path} end)
+
+      assert {:ok, _media} = Inbox.approve_item(item)
+
+      assert [person] = Repo.all(where(Person, name: "Brandon Sanderson"))
+      assert person.image_path == web_path
+    end
   end
 
   describe "approve/1 refusals" do
@@ -221,7 +284,7 @@ defmodule Ambry.Inbox.ApprovalTest do
     case Keyword.get(opts, :files) do
       nil ->
         File.cp!(
-          tagged_fixture(Keyword.get(opts, :dated, true)),
+          tagged_fixture(Keyword.get(opts, :dated, true), Keyword.get(opts, :narrator)),
           Path.join(release, "book.m4b")
         )
 
@@ -269,7 +332,7 @@ defmodule Ambry.Inbox.ApprovalTest do
     if Keyword.get(opts, :settle, true), do: settle(item), else: item
   end
 
-  defp tagged_fixture(dated?) do
+  defp tagged_fixture(dated?, narrator) do
     dir = Ambry.Paths.source_media_disk_path("fixture-#{Ecto.UUID.generate()}")
     File.mkdir_p!(dir)
     path = Path.join(dir, "tagged.m4b")
@@ -289,7 +352,7 @@ defmodule Ambry.Inbox.ApprovalTest do
           "-metadata",
           "artist=Brandon Sanderson",
           "-metadata",
-          "composer=Michael Kramer, Kate Reading"
+          "composer=#{narrator || "Michael Kramer, Kate Reading"}"
         ] ++ if(dated?, do: ["-metadata", "date=2010-08-31"], else: []) ++ [path]
       )
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -726,6 +726,124 @@ defmodule Ambry.Inbox.DraftTest do
     end
   end
 
+  # The display format says how much of the date is real, so it is never a
+  # question the operator should be left holding while the date beside it is
+  # settled. It was matched to the date by *source*, which two records from one
+  # provider make ambiguous and which collapsing agreeing proposals makes
+  # unfindable — so the rule routinely did nothing at all.
+  describe "the date's display format" do
+    test "settles as full when the settled date can only be a full one" do
+      # the reported bug: the records disagree about the format, so the field
+      # was left reported as undecided beside a date that had plainly already
+      # decided it — October 3rd is not a year in disguise
+      candidates = [
+        provider_candidate(%{
+          "id" => "a",
+          "published" => "2017-10-03",
+          "published_format" => "year"
+        }),
+        provider_candidate(%{
+          "source" => "provider:rreading_glasses",
+          "id" => "rg-1",
+          "published" => "2017-10-03",
+          "published_format" => "full",
+          "score" => 0.94
+        })
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert draft.work.published.value == "2017-10-03"
+      assert draft.work.published_format.value == "full"
+      assert draft.work.published_format.approved
+    end
+
+    test "takes the winning record's format when the date lands on a 1st" do
+      # year-only knowledge arrives as a literal Jan 1st and month-only as the
+      # 1st of the month, so a date on a 1st really is undecidable by itself
+      # and the derivation must not overrule the record that proposed it
+      candidates = [
+        provider_candidate(%{
+          "id" => "a",
+          "published" => "2017-01-01",
+          "published_format" => "year"
+        }),
+        provider_candidate(%{
+          "source" => "provider:rreading_glasses",
+          "id" => "rg-1",
+          "published" => "2017-01-01",
+          "published_format" => "full",
+          "score" => 0.94
+        })
+      ]
+
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      assert draft.work.published.value == "2017-01-01"
+      assert draft.work.published_format.value == "year"
+    end
+
+    test "an auto-settled format highlights the chip it took" do
+      draft = Seed.build(item(%{matches: matches([provider_candidate(%{})]), tags: %{}}))
+
+      assert [chip] = draft.work.published_format.candidates
+      assert Draft.Field.chose?(draft.work.published_format, chip)
+    end
+
+    test "follows a date the operator picks by hand" do
+      # two years apart, so the date can't settle itself and the operator has
+      # to choose — at which point the format has to follow, and only the
+      # seeder knew how to do that
+      candidates = [
+        provider_candidate(%{
+          "id" => "a",
+          "published" => "2016-01-01",
+          "published_format" => "year"
+        }),
+        provider_candidate(%{
+          "id" => "b",
+          "published" => "2017-10-03",
+          "published_format" => "full",
+          "score" => 0.94
+        })
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      refute item.draft.work.published.approved
+
+      [_first, second] = item.draft.work.published.candidates
+      draft = Draft.Edit.choose_field(item.draft, :work, :published, second.key)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      assert item.draft.work.published.value == "2017-10-03"
+      assert item.draft.work.published_format.value == "full"
+      assert item.draft.work.published_format.approved
+    end
+
+    test "never overrules a format the operator settled themselves" do
+      candidates = [
+        provider_candidate(%{"published" => "2017-10-03", "published_format" => "full"})
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        update_in(
+          item.draft,
+          [Access.key(:work), Access.key(:published_format)],
+          &Draft.Field.edit(&1, "year")
+        )
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      assert item.draft.work.published_format.value == "year"
+      assert item.draft.work.published_format.source == "manual"
+    end
+  end
+
   describe "mixing sources" do
     # Two databases agreeing on WHICH recording this is do not agree on
     # everything about it. Collapsing them to a winner left the operator

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -7,6 +7,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Metadata.PersonSearch
   alias Ambry.Repo
 
   setup :register_and_log_in_admin_user
@@ -205,6 +206,30 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert Enum.map(author.people, & &1.name) |> Enum.sort() == ["Daniel Abraham", "Ty Franck"]
     end
 
+    # Reachable from the DEFAULT state, not after unfolding: a self-narrated
+    # import is the ordinary case, and a note explaining what is about to
+    # happen is no use inside a control nobody would open.
+    test "a self-narrated book says it will create one person", %{conn: conn} do
+      item = probed_item(narrator: "Brandon Sanderson")
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Same person as the author"
+
+      # and the escape hatch is right there when two humans really do share a
+      # name
+      html =
+        view
+        |> element(
+          ~s{button[phx-click='person-distinct'][phx-value-section='recording'][phx-value-distinct='true']}
+        )
+        |> render_click()
+
+      assert html =~ "A different person who happens to share the name"
+      assert [%{people: [person]}] = Inbox.get_item!(item.id).draft.recording.narrators
+      assert person.distinct
+    end
+
     test "an existing identity is linked rather than duplicated", %{conn: conn} do
       author = insert(:author, name: "Brandon Sanderson")
       item = probed_item()
@@ -353,7 +378,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
              |> length() >= 2
     end
 
-    test "a picked photo and bio are staged on the person", %{conn: conn} do
+    test "a picked photo is staged on the person", %{conn: conn} do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
@@ -364,18 +389,48 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
          "https://example.test/face.jpg", "provider:tmdb"}
       )
 
-      send(
-        view.pid,
-        {:person_bio_picked, %{section: "work", index: 0, person: 0}, "A bio.",
-         "provider:wikidata"}
-      )
-
       render(view)
 
       assert [%{people: [person]}] = Inbox.get_item!(item.id).draft.work.authors
       assert person.image_url == "https://example.test/face.jpg"
       assert person.image_source == "provider:tmdb"
-      assert person.description == "A bio."
+    end
+
+    # A photo is picked by looking and a bio by reading. Sharing one modal
+    # meant each dismissed the other, so the bios come back to the row as
+    # chips and picking one opens and closes nothing.
+    test "bios land on the credit row and are picked without a modal", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      send(
+        view.pid,
+        {:person_bios_found, %{section: "work", index: 0, person: 0},
+         [
+           %PersonSearch.Match{
+             provider_id: "wikidata",
+             provider_name: "Wikidata",
+             id: "Q1",
+             name: "Brandon Sanderson",
+             description: "An American author of epic fantasy."
+           }
+         ]}
+      )
+
+      html = render(view)
+
+      assert html =~ "An American author of epic fantasy."
+      refute html =~ "A photo for"
+
+      view
+      |> element(
+        ~s{button[phx-click='pick-person-bio'][phx-value-section='work'][phx-value-bio='Q1']}
+      )
+      |> render_click()
+
+      assert [%{people: [person]}] = Inbox.get_item!(item.id).draft.work.authors
+      assert person.description == "An American author of epic fantasy."
       assert person.description_source == "provider:wikidata"
     end
   end
@@ -568,7 +623,11 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     File.mkdir_p!(release)
 
     File.cp!(
-      tagged_fixture(Keyword.get(opts, :dated, true), Keyword.get(opts, :cover_art, false)),
+      tagged_fixture(
+        Keyword.get(opts, :dated, true),
+        Keyword.get(opts, :cover_art, false),
+        Keyword.get(opts, :narrator)
+      ),
       Path.join(release, "book.m4b")
     )
 
@@ -579,7 +638,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     item
   end
 
-  defp tagged_fixture(dated?, cover_art?) do
+  defp tagged_fixture(dated?, cover_art?, narrator) do
     dir = Ambry.Paths.source_media_disk_path("tagged-#{Ecto.UUID.generate()}")
     File.mkdir_p!(dir)
     path = Path.join(dir, "tagged.m4b")
@@ -599,7 +658,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
           "-metadata",
           "artist=Brandon Sanderson",
           "-metadata",
-          "composer=Michael Kramer, Kate Reading"
+          "composer=#{narrator || "Michael Kramer, Kate Reading"}"
         ] ++
           if(dated?, do: ["-metadata", "date=2010-08-31"], else: []) ++
           [path]

--- a/test/ambry_web/live/admin/person_picker_test.exs
+++ b/test/ambry_web/live/admin/person_picker_test.exs
@@ -148,8 +148,10 @@ defmodule AmbryWeb.Admin.PersonPickerTest do
 
     html = render(view)
 
-    # modal closed, form switched to url_import with the picked URL staged
-    refute html =~ "A photo for"
+    # The picker STAYS OPEN: a photo and a bio are two decisions off one
+    # search, and closing on the first made getting both mean running the whole
+    # search again.
+    assert html =~ "A photo for"
 
     assert view |> element("#person-form input[name='person[image_import_url]']") |> render() =~
              "Special:FilePath"


### PR DESCRIPTION
Found exercising the form on staging. One is a data-integrity bug, one is the third appearance of a defect fixed twice before, and one is a click count that made a feature not worth using. Written up in ROADMAP 3e under "Third staging pass".

### A self-narrated book created the same human twice

An author who reads their own work is one person with an Author identity and a Narrator identity. The two credits have no idea about each other, so `Approval.resolve_person/1` resolved each credit's people in isolation and inserted **two Person rows of one name** — one carrying the photo and bio, one bare. This fired regardless of what the form showed, and also whenever an author already in the library picked up a narrator credit they had no Narrator identity for.

Sameness moves off "which credit is this hanging from" and onto `PersonRef.key/1`: two new people of one name are one person, and approval resolves the whole draft's people once. Two humans sharing a name and both working on one audiobook is not worth charging every self-narrated import a decision for — so the default is same-person, the row **says so before import** (`Draft.sharing/1`, rendered from the collapsed state rather than inside the pen-name fold), and `distinct` is the one-click escape. Photo and bio merge across every reference to a person.

### The date's display format wasn't being pre-selected

Three compounding bugs in one four-line function, two of them re-appearances:

- `follow_date_source/2` matched the format's proposals to the date's winner by **`source`** — the source-vs-key confusion #1192 fixed for `Field.choose/2`. Worse than ambiguous: `collapse/3` folds agreeing proposals into a single candidate carrying a single source, so the winning date's source is frequently not on *any* format proposal and the rule silently did nothing.
- It never set **`chosen_key`** — the same omission as "auto-settled chips stopped looking chosen", fixed once in the seeder and still present in two other hand-rolled settlements.
- It ran **only at seed time**, so choosing a date by hand settled one half of a two-column fact.

Fixed by making the derivation the *first* rule rather than the fallback: **most dates answer this themselves.** Year-only knowledge arrives as a literal January 1st and month-only as the 1st of the month, so an imprecise date always lands on a 1st — any other day is a full date whatever a record claims. Only a date on a 1st is genuinely ambiguous, and takes the format from whichever record won the date, matched by key. Now `Field.follow_date/2`, applied from `Work.changeset/2` so every route into the draft goes through it.

The structural half: **four places constructed or settled a `%Field{}` by hand**, which is why the same invariant kept being forgotten somewhere new. Settlement now funnels through `Field.take/2`.

### Picking a photo dismissed the bios

They shared one modal and choosing either closed it, so getting both meant opening the same search twice. A photo is picked by *looking* and a bio by *reading*: only the photo opens anything, because only it needs a grid of alternatives at display size in the circular frame. `PersonPicker` sends `{:person_bios_found, context, bios}` as each provider answers, so the bios land on the credit row as chips — picked the way a description's proposals are, opening and closing nothing. The person form keeps them inline and simply stops closing on a pick.

### Verification

- `mix check` green (format, warnings-as-errors compile, credo, dialyzer).
- `mix test --force --warnings-as-errors`: 1126 passed, 1 skipped.
- New coverage: date-format alignment (5 cases incl. the Jan-1 guard and picking a date by hand), self-narrated approval (one person / `distinct` makes two / photo merges across credits), bio chips picked without a modal, and the shared-person note asserted **reachable from the default state** rather than after unfolding.
- Dead-rendered `/admin/inbox/:id` over HTTP against a self-narrated fixture to confirm all three appear on the collapsed row.

### Suggested staging pass

Open a self-narrated book (memoir/nonfiction read by its author) that isn't in the library yet. The author and narrator rows should each say "Same person as the …" before you import; importing should leave exactly one Person. Then check that a book with a real release day pre-selects **Full Date**, and that "Find a photo and bio…" gives you a photo grid *and* leaves bio chips on the row behind it.

https://claude.ai/code/session_0124KNBEwRRBKrsy3eYyLJek