### PR TITLE
Two matching fixes from the seventh real-library batch

### DIFF
--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -947,11 +947,18 @@ defmodule Ambry.Inbox.AutoMatch do
   # containment, same as the seeder's `same_title?/2` and for the same
   # reason: one title has to be the WHOLE of the other's head, or "The
   # Expanse: Leviathan Wakes" agrees with "The Expanse: Caliban's War".
+  #
+  # Compared as `title_key/1`, not `normalize/1`: Audible says "Path of
+  # Daggers" where every other catalogue says "The Path of Daggers", and the
+  # bare-normalized compare read the article as a rival spelling — the
+  # corroborated recording split into two groups and the doubt penalty cut a
+  # five-record consensus to 0.437 while its sibling item, whose titles
+  # happened to match verbatim, sat at 0.951.
   defp same_stated_title?(one, other) do
-    a = normalize(one)
-    b = normalize(other)
+    a = title_key(one)
+    b = title_key(other)
 
-    a == b or normalize(title_head(one)) == b or normalize(title_head(other)) == a
+    a == b or title_key(title_head(one)) == b or title_key(title_head(other)) == a
   end
 
   # A record that names fewer of the same people is compatible with one that

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -89,9 +89,17 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
   @doc """
   Whether this membership still needs a human.
 
-  A number is required to be *settled*, not to be present: "this book has no
-  number in this series" is a real answer, and waiving it is an approval.
+  A membership needs a number to settle. "Unnumbered member of this series"
+  reads like a real answer, but `books_series.book_number` is a required
+  column, so it is not one the library can store — approving without a
+  number only moved the refusal to approval time, where it surfaced as a
+  changeset error behind the generic couldn't-add message (found on
+  Memory's Legion, whose providers propose the Expanse membership with no
+  number). The storable answers are a number or removing the membership;
+  making memberships genuinely unnumberable is a data-model change (nullable
+  column, every ordered surface, sync), deliberately not made here.
   """
+  def resolved?(%__MODULE__{number: nil}), do: false
   def resolved?(%__MODULE__{approved: true, mode: :link, series_id: id}), do: not is_nil(id)
 
   # A blank name is storable — clearing the box to retype is the first half of

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -844,6 +844,27 @@ defmodule Ambry.Inbox.AutoMatchTest do
       assert length(matches["recording"]["candidates"]) == 2
     end
 
+    # Audible writes "Path of Daggers" where every other catalogue keeps the
+    # article. An article is not a rival spelling: read as one, the same
+    # Kramer/Reading recording split into two groups and the doubt penalty
+    # cut a five-record consensus to 0.437, while the sibling item whose
+    # titles happened to match verbatim sat at 0.951.
+    test "a title differing only by a leading article corroborates, not rivals" do
+      patch_recording_results([
+        book("The Path of Daggers", ["Robert Jordan"],
+          narrators: ["Kate Reading", "Michael Kramer"]
+        ),
+        book("Path of Daggers", ["Robert Jordan"], narrators: ["Michael Kramer", "Kate Reading"])
+      ])
+
+      %{matches: matches} =
+        AutoMatch.match(
+          item(title: "The Path of Daggers", author: "Robert Jordan", narrator: "Kate Reading")
+        )
+
+      assert matches["recording"]["confidence"] > 0.8
+    end
+
     test "an item with nothing to go on proposes nothing rather than guessing" do
       %{matches: matches} = AutoMatch.match(%InboxItem{path: "/downloads/", tags: %{}})
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -749,6 +749,22 @@ defmodule Ambry.Inbox.DraftTest do
       assert SeriesLink.state(link) == :missing
     end
 
+    # `book_number` is a required column, so an approved-but-numberless
+    # membership is not storable — approving it read as resolved and the
+    # refusal surfaced at insert time as "Couldn't add this to the library."
+    # (Memory's Legion, whose Expanse membership arrives unnumbered).
+    test "approving a numberless membership does not settle it" do
+      candidates = [provider_candidate(%{"series" => ["The Expanse"]})]
+      draft = Seed.build(item(%{matches: matches(candidates), tags: %{}}))
+
+      draft = Ambry.Inbox.Draft.Edit.approve_series(draft, 0, true)
+
+      assert [link] = draft.work.series
+      assert link.approved
+      refute SeriesLink.resolved?(link)
+      assert SeriesLink.state(link) == :missing
+    end
+
     test "a number from the tags settles it" do
       candidates = [provider_candidate(%{"series" => ["The Expanse"]})]
 


### PR DESCRIPTION
Both found running 21 real releases through the merged matcher (findings written up in ROADMAP 3e under "The seventh batch").

**An article is not a rival spelling in the agreeing group.** `agrees?/2` compared stated titles with `normalize/1`, which keeps leading articles — so Audible's "Path of Daggers" split away from every other catalogue's "The Path of Daggers", and the doubt penalty cut a five-record consensus to 0.437 (the verbatim-titled sibling item sat at 0.951). Compared as `title_key/1` now; live re-match went 0.437 → 0.838. Regression test is red without the fix.

**A numberless series membership cannot settle.** `books_series.book_number` is a required column, so an approved-but-numberless membership passed the form as resolved and then died at insert behind the generic "Couldn't add this to the library." (Memory's Legion — its Expanse membership arrives unnumbered from every provider). A numberless link now never resolves; the storable answers are a number or removing the membership.

`mix check` green, 1232 tests passing with `--warnings-as-errors`.

https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199