### PR TITLE
One import-form paradigm across all three levels

### DIFF
--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -97,6 +97,34 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   @doc """
+  Adds or removes a person record from those describing this human.
+
+  The same rule as `toggle_source/4`, at the third level: the exact-name gate
+  decides the initial ticks, and from there the checkbox does. The photo and
+  bio pools re-derive from the ticked set — with anything the operator chose
+  or typed surviving, as always — which is also how a differently-spelled
+  record of the right human gets to contribute a face the gate couldn't
+  auto-admit.
+  """
+  def toggle_person_source(draft, %InboxItem{} = item, key, record) do
+    matched = get_in(item.matches, ["people", key])
+
+    update_person(draft, key, fn person ->
+      sources =
+        if Enum.any?(person.sources, &SourceRef.points_at?(&1, record)) do
+          Enum.reject(person.sources, &SourceRef.points_at?(&1, record))
+        else
+          person.sources ++ [SourceRef.of(record)]
+        end
+
+      Seed.rederive_person_evidence(
+        %{person | sources: sources, curated: true, evidence_curated: true},
+        matched
+      )
+    end)
+  end
+
+  @doc """
   Settles the recording as one no catalogue lists, described by the file alone.
 
   A real answer rather than a failure: a delisted edition disappears from

--- a/lib/ambry/inbox/draft/person_decision.ex
+++ b/lib/ambry/inbox/draft/person_decision.ex
@@ -65,6 +65,11 @@ defmodule Ambry.Inbox.Draft.PersonDecision do
     # changed record set never discards a photo they went and found.
     field :curated, :boolean, default: false
 
+    # Set when the operator ticks or unticks a record — evidence curation is
+    # its own act: adding or renaming a person must not freeze their ticks
+    # (that's `curated`), but a hand-picked ticked set must survive a refresh.
+    field :evidence_curated, :boolean, default: false
+
     # Why nothing was adopted, mirroring the work and recording levels. A
     # person nobody could find is a normal outcome, not a failure — plenty of
     # narrators are in no database at all.
@@ -90,6 +95,7 @@ defmodule Ambry.Inbox.Draft.PersonDecision do
       :person_id,
       :approved,
       :curated,
+      :evidence_curated,
       :doubt,
       :doubt_detail
     ])

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -219,9 +219,13 @@ defmodule Ambry.Inbox.Draft.Seed do
     end
   end
 
+  # The candidate's own score and the decision's confidence are different
+  # numbers — confidence sinks when rivals score nearly as well — and quoting
+  # the confidence as if it were the candidate's match ("38%" under a list
+  # whose top row says 73%) read as a contradiction. Name both, and say what
+  # the gap means.
   defp weak_work_detail(best, confidence) do
-    "The closest is #{best["title"]}#{written_by(best["authors"])}, and it isn't a close " <>
-      "enough match (#{round(confidence * 100)}%) to describe this book."
+    doubt_detail(best, confidence, "#{best["title"]}#{written_by(best["authors"])}", "book")
   end
 
   defp written_by(authors) do
@@ -697,8 +701,22 @@ defmodule Ambry.Inbox.Draft.Seed do
   end
 
   defp low_confidence_detail(best, confidence) do
-    "The closest is #{best["title"]}#{narrated_by(best["narrators"])}, and it isn't a close " <>
-      "enough match (#{round(confidence * 100)}%) to describe this file."
+    doubt_detail(best, confidence, "#{best["title"]}#{narrated_by(best["narrators"])}", "file")
+  end
+
+  # Shared by the work and recording doubts; `what` is "book" or "file".
+  defp doubt_detail(best, confidence, described, what) do
+    score = round((best["score"] || 0.0) * 100)
+    conf = round(confidence * 100)
+    lead = "The closest is #{described} at #{score}%"
+
+    if conf < score - 5 do
+      lead <>
+        ", but other candidates score nearly as well — only #{conf}% sure overall, " <>
+        "not enough to describe this #{what} unconfirmed."
+    else
+      lead <> " — not a close enough match to describe this #{what}."
+    end
   end
 
   defp narrated_by(narrators) do
@@ -1031,22 +1049,54 @@ defmodule Ambry.Inbox.Draft.Seed do
   # Evidence is matched against what the person is called *now*, not what the
   # credit says: the credit holds the pen name, and the human behind it being
   # renamed is precisely when somebody searches again. Mode, link, approval
-  # and every settled field stay the operator's.
+  # and every settled field stay the operator's — and so is the ticked set,
+  # once they've touched it: a person whose evidence the operator curated
+  # keeps their ticks through a refresh, exactly as a work's do.
   defp refreshed_person(%PersonDecision{} = person, named, matched) do
     {credited, source} = named || {person.key, nil}
     name = Field.value(person.name) || credited
     candidates = named_candidates(matched, name)
     {doubt, detail} = person_doubt(matched, candidates, name)
 
+    {sources, pool} =
+      if person.evidence_curated,
+        do: {person.sources, ticked_candidates(matched, person.sources)},
+        else: {Enum.map(candidates, &SourceRef.of/1), candidates}
+
     %{
       person
       | doubt: doubt,
         doubt_detail: detail,
-        sources: Enum.map(candidates, &SourceRef.of/1),
-        name: keep_manual(person.name, person_name_field(credited, source, candidates)),
-        image: keep_manual(person.image, person_image_field(candidates)),
-        description: keep_manual(person.description, person_description_field(candidates))
+        sources: sources,
+        name: keep_manual(person.name, person_name_field(credited, source, pool)),
+        image: keep_manual(person.image, person_image_field(pool)),
+        description: keep_manual(person.description, person_description_field(pool))
     }
+  end
+
+  @doc """
+  Re-derives a person's photo and bio pools from their ticked records.
+
+  Ticking a record is what makes it speak — the same rule the work and
+  recording levels live by. The exact-name gate decides the initial ticks;
+  from there the operator's checkbox does, which is also how a
+  differently-spelled record of the right human (the gate can't admit it)
+  gets to contribute a face after all.
+  """
+  def rederive_person_evidence(%PersonDecision{} = person, matched) do
+    pool = ticked_candidates(matched, person.sources)
+
+    %{
+      person
+      | image: keep_manual(person.image, person_image_field(pool)),
+        description: keep_manual(person.description, person_description_field(pool))
+    }
+  end
+
+  defp ticked_candidates(matched, sources) do
+    candidates = (matched && Map.get(matched, "candidates")) || []
+
+    Enum.filter(candidates, fn record -> Enum.any?(sources, &SourceRef.points_at?(&1, record)) end)
   end
 
   # What each credited human is called and who said so, taken from the credit

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -22,6 +22,7 @@ defmodule AmbryWeb.Admin.Decisions do
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.PersonDecision
   alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.SourceRef
   alias AmbryWeb.Components.EntityResolver
 
   @doc """
@@ -45,6 +46,10 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :outcomes, :list, required: true
   attr :level, :string, default: nil
   attr :retrying, :any, default: nil
+
+  attr :retryable, :boolean,
+    default: true,
+    doc: "person-level outcomes have no per-provider retry yet"
 
   @doc """
   What each provider said when asked — including the ones that couldn't
@@ -73,7 +78,7 @@ defmodule AmbryWeb.Admin.Decisions do
             the retry. --%>
       <button
         :for={outcome <- @outcomes}
-        :if={outcome["status"] == "failed"}
+        :if={outcome["status"] == "failed" and @retryable}
         type="button"
         phx-click="retry-provider"
         phx-value-level={@level}
@@ -86,6 +91,15 @@ defmodule AmbryWeb.Admin.Decisions do
           do: "asking again…",
           else: "couldn't be reached — retry"}
       </button>
+
+      <span
+        :for={outcome <- @outcomes}
+        :if={outcome["status"] == "failed" and not @retryable}
+        title={outcome["reason"]}
+        class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600"
+      >
+        {outcome["name"]}: couldn't be reached
+      </span>
     </div>
     """
   end
@@ -128,7 +142,9 @@ defmodule AmbryWeb.Admin.Decisions do
 
   attr :record, :map, required: true
   attr :used, :boolean, required: true
-  attr :level, :string, required: true
+  attr :level, :string, default: nil
+  attr :event, :string, default: "toggle-source"
+  attr :person_key, :string, default: nil, doc: "set for person records — routes the toggle"
   attr :working, :boolean, default: false
 
   @doc """
@@ -153,8 +169,9 @@ defmodule AmbryWeb.Admin.Decisions do
       <input
         type="checkbox"
         checked={@used}
-        phx-click="toggle-source"
+        phx-click={@event}
         phx-value-level={@level}
+        phx-value-key={@person_key}
         phx-value-source={@record["source"]}
         phx-value-id={@record["id"]}
         class="mt-1 h-4 w-4 flex-none rounded-sm"
@@ -212,6 +229,39 @@ defmodule AmbryWeb.Admin.Decisions do
 
       <span :if={@linked} class="flex-none text-xs dark:text-zinc-500">using this book</span>
     </div>
+    """
+  end
+
+  attr :at, :string, required: true, doc: "where this renders — DOM ids key on place, not person"
+  attr :person_key, :string, required: true
+  attr :name, :string, default: nil
+  attr :running, :boolean, default: false
+
+  @doc """
+  The person level's search-again form — the work-level pattern with a name
+  where the work has title and author.
+  """
+  def person_research_form(assigns) do
+    ~H"""
+    <form
+      id={"research-person-#{@at}"}
+      phx-submit="research-person"
+      class="flex flex-wrap items-end gap-2"
+    >
+      <input type="hidden" name="key" value={@person_key} />
+
+      <label class="text-xs dark:text-zinc-500">
+        name <input type="text" name="name" value={@name} class={input_classes("mt-1 block")} />
+      </label>
+
+      <button
+        type="submit"
+        disabled={@running}
+        class="rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
+      >
+        {if @running, do: "Searching…", else: "Search again"}
+      </button>
+    </form>
     """
   end
 
@@ -278,7 +328,10 @@ defmodule AmbryWeb.Admin.Decisions do
 
   @doc "A candidate's headline: what it is."
   def candidate_title(candidate) do
-    [candidate["title"], candidate["authors"] && Enum.join(candidate["authors"], ", ")]
+    [
+      candidate["title"] || candidate["name"],
+      candidate["authors"] && Enum.join(candidate["authors"], ", ")
+    ]
     |> Enum.reject(&(&1 in [nil, "", []]))
     |> Enum.join(" — ")
   end
@@ -293,6 +346,10 @@ defmodule AmbryWeb.Admin.Decisions do
     [
       candidate["narrators"] not in [nil, []] &&
         "read by #{Enum.join(candidate["narrators"], ", ")}",
+      # person records: whether it brings a face, and the words that tell a
+      # namesake apart
+      candidate["images"] not in [nil, []] && "has a photo",
+      is_binary(candidate["name"]) && bio_snippet(candidate["description"]),
       year(candidate["published"]),
       candidate["publisher"],
       series_line(candidate["series"]),
@@ -308,6 +365,15 @@ defmodule AmbryWeb.Admin.Decisions do
   defp year(nil), do: nil
   defp year(published) when is_binary(published), do: String.slice(published, 0, 4)
   defp year(_other), do: nil
+
+  defp bio?(description), do: is_binary(description) and String.trim(description) != ""
+
+  # The first words of the bio are what tells a namesake apart — "an English
+  # professional footballer" is a sentence the operator must get to read
+  # before ticking.
+  defp bio_snippet(description) do
+    if bio?(description), do: String.slice(description, 0, 90)
+  end
 
   # Series arrive as `%{"name", "number"}` now and as bare strings in matches
   # stored before that; both render.
@@ -399,11 +465,34 @@ defmodule AmbryWeb.Admin.Decisions do
               options={@options}
             />
             <.input
-              :if={@type != "select"}
+              :if={@type not in ["select", "textarea"]}
               field={decision[:value]}
               type={@type}
               placeholder={@placeholder}
             />
+            <%!-- A description is markdown, and markdown in a plain box is
+                  written blind — the same textarea/preview pair the person
+                  form has had all along. --%>
+            <div :if={@type == "textarea"} class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <.input
+                id={"#{@section}-#{@name}-input"}
+                field={decision[:value]}
+                type="textarea"
+                placeholder={@placeholder}
+                phx-hook="maintain-attrs"
+                data-attrs="style"
+              />
+              <div class="relative">
+                <div
+                  id={"#{@section}-#{@name}-preview"}
+                  phx-hook="scroll-match"
+                  data-target={"#{@section}-#{@name}-input"}
+                  class="absolute inset-0 hidden overflow-auto rounded-sm border border-zinc-300 dark:border-zinc-800 sm:block"
+                >
+                  <.markdown content={@field.value || ""} class="p-2" />
+                </div>
+              </div>
+            </div>
           </.inputs_for>
         </div>
       </div>
@@ -468,6 +557,14 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :identity_backing, :map,
     default: %{},
     doc: "identity id => the backing people's names, where they add something"
+
+  attr :person_records, :map,
+    default: %{},
+    doc: "person key => the provider records of people by that name"
+
+  attr :person_outcomes, :map,
+    default: %{},
+    doc: "person key => what each person provider said when asked"
 
   attr :persons, :list, required: true, doc: "the PersonDecisions this credit references"
   attr :appearances, :map, default: %{}, doc: "person key => every credit referencing them"
@@ -595,6 +692,8 @@ defmodule AmbryWeb.Admin.Decisions do
         appears={@appearances[hd(@persons).key] || []}
         searching={@searching_person == hd(@persons).key}
         expanded={@photos_expanded[hd(@persons).key] || false}
+        records={@person_records[hd(@persons).key] || []}
+        outcomes={@person_outcomes[hd(@persons).key] || []}
       />
 
       <%!-- Folded away until it matters, and unfolded automatically the moment
@@ -658,6 +757,8 @@ defmodule AmbryWeb.Admin.Decisions do
             appears={@appearances[person.key] || []}
             searching={@searching_person == person.key}
             expanded={@photos_expanded[person.key] || false}
+            records={@person_records[person.key] || []}
+            outcomes={@person_outcomes[person.key] || []}
           />
         </div>
 
@@ -690,6 +791,8 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :appears, :list, default: [], doc: "every credit referencing this person"
   attr :searching, :boolean, default: false
   attr :expanded, :boolean, default: false, doc: "whether the whole photo set is showing"
+  attr :records, :list, default: [], doc: "the provider records of people by this name"
+  attr :outcomes, :list, default: [], doc: "what each person provider said when asked"
 
   # Enough to see there are alternatives without the row becoming a contact
   # sheet. TMDB keeps every headshot anyone has uploaded and a working actor
@@ -765,20 +868,6 @@ defmodule AmbryWeb.Admin.Decisions do
           class="h-12 w-12 flex-none rounded-full border border-dashed border-zinc-300 dark:border-zinc-700"
         />
 
-        <button
-          type="button"
-          phx-click="find-person"
-          phx-value-key={@person.key}
-          disabled={is_nil(Field.value(@person.name)) or @searching}
-          class="flex-none rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
-        >
-          {cond do
-            @searching -> "Looking…"
-            @photos != [] or @bios != [] -> "Look again"
-            true -> "Find a photo and bio…"
-          end}
-        </button>
-
         <%!-- The same human on two credits: an author reading their own book.
               Approval creates them once, so this is where the form says so —
               on the row that would otherwise look like it was about to make a
@@ -804,6 +893,40 @@ defmodule AmbryWeb.Admin.Decisions do
       <p :if={@person.doubt == :low_confidence} class="text-xs italic dark:text-zinc-500">
         {@person.doubt_detail}
       </p>
+
+      <%!-- The same evidence rule as the work and recording levels, one
+            paradigm across all three: tick every record of THIS human, and
+            the photo and bio pools draw from the ticked set. The exact-name
+            gate decides the initial ticks; a differently-spelled record of
+            the right person is exactly what the checkbox is for. --%>
+      <p :if={@records != []} class="text-xs dark:text-zinc-400">
+        Tick every record of <em>this person</em> — the photos and bios on offer come from the
+        ticked ones. Databases know several people by many names, so check before ticking.
+      </p>
+
+      <.record_row
+        :for={record <- @records}
+        record={record}
+        event="toggle-person-source"
+        person_key={@person.key}
+        used={Enum.any?(@person.sources, &SourceRef.points_at?(&1, record))}
+      />
+
+      <.provider_outcomes_row outcomes={@outcomes} retryable={false} />
+
+      <details>
+        <summary class="cursor-pointer text-xs dark:text-zinc-400">
+          Not the right person? Search again
+        </summary>
+        <div class="pt-2">
+          <.person_research_form
+            at={@at}
+            person_key={@person.key}
+            name={Field.value(@person.name)}
+            running={@searching}
+          />
+        </div>
+      </details>
 
       <div :if={@photos != []} class="flex flex-wrap items-center gap-2">
         <span class="text-xs dark:text-zinc-500">Photos:</span>
@@ -851,16 +974,31 @@ defmodule AmbryWeb.Admin.Decisions do
       <%!-- The same text box the recording's description gets, for the same
             reason: an imported blurb is a starting point. --%>
       <div class="space-y-1">
-        <form id={"person-bio-#{@at}"} phx-change="person-bio" phx-submit="person-bio">
-          <input type="hidden" name="key" value={@person.key} />
-          <textarea
-            name="description"
-            rows="3"
-            placeholder="a short bio"
-            phx-debounce="500"
-            class={input_classes("block w-full")}
-          >{@description}</textarea>
-        </form>
+        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <form id={"person-bio-#{@at}"} phx-change="person-bio" phx-submit="person-bio">
+            <input type="hidden" name="key" value={@person.key} />
+            <textarea
+              id={"person-bio-#{@at}-input"}
+              name="description"
+              rows="3"
+              placeholder="a short bio"
+              phx-debounce="500"
+              phx-hook="maintain-attrs"
+              data-attrs="style"
+              class={input_classes("block w-full")}
+            >{@description}</textarea>
+          </form>
+          <div class="relative">
+            <div
+              id={"person-bio-#{@at}-preview"}
+              phx-hook="scroll-match"
+              data-target={"person-bio-#{@at}-input"}
+              class="absolute inset-0 hidden overflow-auto rounded-sm border border-zinc-300 dark:border-zinc-800 sm:block"
+            >
+              <.markdown content={@description || ""} class="p-2" />
+            </div>
+          </div>
+        </div>
 
         <div :if={@bios != []} class="flex flex-wrap items-center gap-2">
           <span class="text-xs dark:text-zinc-500">Proposed:</span>

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -135,6 +135,20 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
+  # The person level's records and provider outcomes, keyed by person, for
+  # the same evidence rows the work and recording sections render.
+  defp person_records(item) do
+    for {key, matched} <- item.matches["people"] || %{}, into: %{} do
+      {key, matched["candidates"] || []}
+    end
+  end
+
+  defp person_outcomes(item) do
+    for {key, matched} <- item.matches["people"] || %{}, into: %{} do
+      {key, matched["providers"] || []}
+    end
+  end
+
   @impl Phoenix.LiveView
   def handle_event("validate", %{"inbox_item" => params}, socket) do
     # Autosave: the form and the stored draft are never allowed to disagree,
@@ -328,6 +342,38 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def handle_event("approve-person", %{"key" => key} = params, socket) do
     {:noreply, edit(socket, &Draft.Edit.approve_person(&1, key, params["approved"] == "true"))}
+  end
+
+  # The person level's record checkboxes — the same evidence rule the work
+  # and recording levels have, one paradigm across all three.
+  def handle_event("toggle-person-source", %{"key" => key} = params, socket) do
+    item = socket.assigns.item
+
+    record =
+      Enum.find(
+        get_in(item.matches, ["people", key, "candidates"]) || [],
+        &(&1["source"] == params["source"] and to_string(&1["id"]) == to_string(params["id"]))
+      )
+
+    if record do
+      {:noreply, edit(socket, &Draft.Edit.toggle_person_source(&1, item, key, record))}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  # The person level's search-again form — the work-level pattern, with a
+  # name instead of title/author fields. A blank name falls back to what the
+  # draft currently calls them.
+  def handle_event("research-person", %{"key" => key} = params, socket) do
+    item = socket.assigns.item
+    typed = params["name"] |> to_string() |> String.trim()
+    name = if typed == "", do: person_name(item.draft, key), else: typed
+
+    {:noreply,
+     socket
+     |> assign(searching_person: key)
+     |> start_async({:person_search, key}, fn -> Inbox.research_person(item, key, name) end)}
   end
 
   def handle_event("approve-credit", %{"section" => s, "index" => i} = params, socket) do

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -341,6 +341,8 @@
             expanded={expanded?(@expanded, "work", index, credit)}
             kind={:author}
             identity_backing={@author_backing}
+            person_records={person_records(@item)}
+            person_outcomes={person_outcomes(@item)}
             persons={Draft.people_for(@item.draft, credit)}
             appearances={@appearances}
             searching_person={@searching_person}
@@ -540,6 +542,8 @@
             expanded={expanded?(@expanded, "recording", index, credit)}
             kind={:narrator}
             identity_backing={@narrator_backing}
+            person_records={person_records(@item)}
+            person_outcomes={person_outcomes(@item)}
             persons={Draft.people_for(@item.draft, credit)}
             appearances={@appearances}
             searching_person={@searching_person}

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -198,8 +198,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     %{
       "filter" => Keyword.get(overrides, :filter, socket.assigns.list_opts.filter),
       "page" => Keyword.get(overrides, :page, to_string(socket.assigns.list_opts.page)),
-      "status" =>
-        Keyword.get(overrides, :status, socket.assigns.status && to_string(socket.assigns.status)),
+      "status" => Keyword.get(overrides, :status, to_string(socket.assigns.status || "all")),
       "ready" =>
         Keyword.get(overrides, :ready, socket.assigns.ready && to_string(socket.assigns.ready))
     }
@@ -210,7 +209,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp parse_status(status) when status in ["pending", "dismissed", "approved"],
     do: String.to_existing_atom(status)
 
-  defp parse_status(_anything), do: nil
+  # "all" is the explicit choice; the DEFAULT is pending — the inbox is a
+  # work queue, and opening it means "what needs me", not "everything ever".
+  defp parse_status("all"), do: nil
+  defp parse_status(_anything), do: :pending
 
   defp parse_ready("true"), do: true
   defp parse_ready(_anything), do: nil

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -15,7 +15,7 @@
       <div class="flex gap-2">
         <span
           phx-click="filter-status"
-          phx-value-status=""
+          phx-value-status="all"
           class={["cursor-pointer text-sm", !@status && !@ready && "font-bold underline"]}
         >
           All

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -568,16 +568,9 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       refute has_element?(view, "button[phx-click='toggle-people'][disabled]")
 
-      assert has_element?(
-               view,
-               "button[phx-click='find-person']"
-             )
-
-      # and the narrator credits get their own, since they create people too
-      assert has_element?(
-               view,
-               "button[phx-click='find-person']"
-             )
+      # the search-again form is the person level's re-search, same pattern
+      # as the work and recording levels
+      assert has_element?(view, "form[phx-submit='research-person']")
     end
 
     test "each person behind a pen name gets their own photo", %{conn: conn} do
@@ -624,8 +617,8 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
       view
-      |> element(~s{button[phx-click='find-person'][phx-value-key='brandonsanderson']})
-      |> render_click()
+      |> element("form#research-person-work-0-0")
+      |> render_submit(%{"key" => "brandonsanderson", "name" => "Brandon Sanderson"})
 
       html = render_async(view)
 
@@ -639,6 +632,29 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       person = person_keyed(item, "brandonsanderson")
       assert Field.value(person.description) == "An American author of epic fantasy."
       assert person.description.source == "provider:wikidata"
+    end
+
+    # The person level's records are evidence with checkboxes, the same rule
+    # as the work and recording levels. Unticking the only record of a
+    # namesake — the goalkeeper who shares a narrator's name — takes his face
+    # and bio out of the pools instead of leaving them as the leading
+    # suggestions.
+    test "unticking a person record takes its face out of the pools", %{conn: conn} do
+      item = probed_item(person_photo: "https://example.test/face.jpg")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("input[phx-click='toggle-person-source'][phx-value-key='brandonsanderson']")
+      |> render_click()
+
+      person = person_keyed(item, "brandonsanderson")
+      assert person.sources == []
+      assert person.image.candidates == []
+      assert Field.value(person.image) == nil
+
+      # and the tick survives a rebuild of the rest of the draft
+      assert person.evidence_curated
     end
 
     # A person's description is a description like any other: the recording's
@@ -669,8 +685,8 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
       view
-      |> element(~s{button[phx-click='find-person'][phx-value-key='brandonsanderson']})
-      |> render_click()
+      |> element("form#research-person-work-0-0")
+      |> render_submit(%{"key" => "brandonsanderson", "name" => "Brandon Sanderson"})
 
       render_async(view)
 

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -139,6 +139,11 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert Inbox.get_item!(item.id).status == :dismissed
     assert File.exists?(file)
 
+    # the default view is pending, so the dismissed item has left it
+    refute has_element?(view, "span[phx-click='restore'][phx-value-id='#{item.id}']")
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=dismissed")
+
     view |> element("span[phx-click='restore'][phx-value-id='#{item.id}']") |> render_click()
 
     assert Inbox.get_item!(item.id).status == :pending


### PR DESCRIPTION
Four operator-reported issues from working the form (ROADMAP 3e "Second redesign slice"):

1. **The inbox defaults to pending** — it's a work queue; "All" is now the explicit choice, and the choice survives searching and paging.
2. **The doubt banner's 38%-vs-73% contradiction**: it quoted the *decision confidence* as if it were the top candidate's match score. It now names both numbers and what the gap means ("The closest is X at 73%, but other candidates score nearly as well — only 38% sure overall…"); when they agree, one number.
3. **Every description box on the import form** (recording description, person bios) gained the admin forms' textarea/markdown-preview pair, with the same scroll-match/maintain-attrs hooks.
4. **The person sections now use the exact same paradigm as work and recording**: record checkboxes as evidence — the photo/bio pools derive from the *ticked* records via `Edit.toggle_person_source`/`Seed.rederive_person_evidence` (the exact-name gate sets the initial ticks; the operator's checkbox rules from there, which is also how a differently-spelled record of the right human contributes a face the gate couldn't auto-admit) — provider outcome chips, and the same collapsed "Search again" form (a name field) replacing the bespoke "Look again" button. A person record's row leads with the bio's opening words, so "an English professional footballer" gets read before it gets ticked. `evidence_curated` is deliberately separate from `curated`: identity edits must not freeze ticks, but a hand-picked ticked set survives every refresh.

`mix check` green, 1239 tests with `--warnings-as-errors` (2 new: numberless untick takes a face out of the pools; dismissed items leave the default view). Verified rendering on the live dev form.
https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199