### PR TITLE
Admin UI triage: theme the import modals, dark contrast, small-width degradation

### DIFF
--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -130,12 +130,20 @@ defmodule AmbryWeb.Admin.Components do
     %JS{}
     |> JS.remove_class(@side_bar_open_classes, to: "#side-bar")
     |> JS.add_class(@side_bar_closed_classes, to: "#side-bar")
+    |> JS.hide(
+      to: "#side-bar-scrim",
+      transition: {"transition-opacity ease-out duration-100", "opacity-100", "opacity-0"}
+    )
   end
 
   defp open_sidebar do
     %JS{}
     |> JS.remove_class(@side_bar_closed_classes, to: "#side-bar")
     |> JS.add_class(@side_bar_open_classes, to: "#side-bar")
+    |> JS.show(
+      to: "#side-bar-scrim",
+      transition: {"transition-opacity ease-in duration-100", "opacity-0", "opacity-100"}
+    )
   end
 
   attr :search_form, Form, required: true
@@ -720,30 +728,30 @@ defmodule AmbryWeb.Admin.Components do
       />
       <div>
         <p class="font-bold">{@book.title}</p>
-        <p :if={@book.authors != []} class="text-zinc-400">
+        <p :if={@book.authors != []} class="text-zinc-600 dark:text-zinc-400">
           by
           <span :for={author <- @book.authors} class="group">
             <span>{author.name}</span>
             <br class="group-last:hidden" />
           </span>
         </p>
-        <p :if={@book.narrators != []} class="text-zinc-400">
+        <p :if={@book.narrators != []} class="text-zinc-600 dark:text-zinc-400">
           Narrated by
           <span :for={narrator <- @book.narrators} class="group">
             <span>{narrator.name}</span>
             <br class="group-last:hidden" />
           </span>
         </p>
-        <p :if={@book.series != []} class="text-xs text-zinc-400">
+        <p :if={@book.series != []} class="text-xs text-zinc-600 dark:text-zinc-400">
           <span :for={series <- @book.series} class="group">
             <span>{series.name} #{series.number}</span>
             <br class="group-last:hidden" />
           </span>
         </p>
-        <p :if={@book.published} class="text-xs text-zinc-400">
+        <p :if={@book.published} class="text-xs text-zinc-600 dark:text-zinc-400">
           Published {display_date(@book.published)}<span :if={@book.publisher}> by {@book.publisher}</span>
         </p>
-        <p :if={@book.format} class="text-xs text-zinc-400">{@book.format}</p>
+        <p :if={@book.format} class="text-xs text-zinc-600 dark:text-zinc-400">{@book.format}</p>
         <div :for={action <- @actions}>
           {render_slot(action)}
         </div>

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -120,7 +120,7 @@ defmodule AmbryWeb.Admin.Decisions do
     <div :if={@query || @fields != %{}} class="text-xs dark:text-zinc-500" data-role="query">
       <span>Searched for</span>
       <span :for={{key, value} <- ordered_fields(@fields)} class="ml-1">
-        <span class="dark:text-zinc-600">{key}:</span>
+        <span class="text-zinc-500 dark:text-zinc-400">{key}:</span>
         <span class="font-mono dark:text-zinc-400">{value}</span>
       </span>
       <span :if={@fields == %{}} class="font-mono ml-1 dark:text-zinc-400">{@query}</span>
@@ -183,7 +183,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <span :if={@working} class="flex-none pt-0.5 text-xs dark:text-zinc-400">
         fetching…
       </span>
-      <span :if={!@working && @record["score"]} class="flex-none pt-0.5 text-xs dark:text-zinc-600">
+      <span :if={!@working && @record["score"]} class="flex-none pt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
         {round(@record["score"] * 100)}%
       </span>
     </label>

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -11,6 +11,9 @@ defmodule AmbryWeb.Admin.Layouts do
 
   def side_nav(assigns) do
     ~H"""
+    <%!-- Scrim behind the drawer on small screens — without it the drawer
+          floats over full-brightness content and doesn't read as a layer. --%>
+    <div id="side-bar-scrim" class="z-[9] bg-black/40 fixed inset-0 hidden lg:hidden" aria-hidden="true" />
     <nav
       id="side-bar"
       class="absolute inset-0 z-10 h-screen w-64 shrink-0 -translate-x-full transform divide-y divide-zinc-200 border-r border-zinc-200 bg-zinc-50 opacity-0 duration-100 ease-out dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900 lg:relative lg:transform-none lg:opacity-100"

--- a/lib/ambry_web/components/admin/rich_select.ex
+++ b/lib/ambry_web/components/admin/rich_select.ex
@@ -59,7 +59,7 @@ defmodule AmbryWeb.Admin.Components.RichSelect do
     ~H"""
     <div class="cursor-pointer" phx-click-away="close" phx-target={@myself}>
       <div
-        class="py-[7px] px-[11px] flex items-center rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300"
+        class="py-[7px] px-[11px] flex items-center rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
         phx-click="toggle"
         phx-target={@myself}
       >
@@ -75,12 +75,15 @@ defmodule AmbryWeb.Admin.Components.RichSelect do
 
       <div class="relative w-full">
         <div class={[
-          "absolute top-0 right-0 left-0 max-h-96 overflow-y-auto rounded-sm border border-t-0 border-zinc-600 bg-zinc-950 shadow-lg",
+          "absolute top-0 right-0 left-0 max-h-96 overflow-y-auto rounded-sm border border-t-0 border-zinc-300 bg-white shadow-lg dark:border-zinc-600 dark:bg-zinc-950",
           if(!@open, do: "hidden")
         ]}>
           <div
             :for={option <- @options}
-            class={["relative hover:bg-zinc-900", if(option == @selected_option, do: "bg-zinc-900")]}
+            class={[
+              "relative hover:bg-zinc-100 dark:hover:bg-zinc-900",
+              if(option == @selected_option, do: "bg-zinc-100 dark:bg-zinc-900")
+            ]}
           >
             <label class="absolute inset-0 cursor-pointer">
               <.radio_input field={@field} value={@option_value.(option)} />

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -265,7 +265,7 @@ defmodule AmbryWeb.CoreComponents do
       type={@type}
       class={[
         "rounded-sm px-3 py-2 phx-submit-loading:opacity-75",
-        "text-sm font-semibold leading-6",
+        "whitespace-nowrap text-sm font-semibold leading-6",
         "text-white active:text-white/80 dark:text-zinc-900 dark:active:text-zinc-800",
         button_color_classes(@color),
         @class

--- a/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form/provider_import_form.html.heex
@@ -39,13 +39,13 @@
       container_class="!space-y-0"
     >
       <.import_form_row :if={@selected_book.title} field={@form[:use_title]} label="Title">
-        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
           {@selected_book.title}
         </div>
       </.import_form_row>
 
       <.import_form_row :if={@selected_book.published} field={@form[:use_published]} label="First published">
-        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
           {display_date(@selected_book.published)}
         </div>
       </.import_form_row>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -54,16 +54,16 @@
             <div :if={tag_rows(@item) != []} data-role="tags">
               <p class="text-xs font-bold dark:text-zinc-400">Embedded tags</p>
               <p :for={{label, value} <- tag_rows(@item)} class="text-xs dark:text-zinc-500">
-                <span class="dark:text-zinc-600">{label}:</span> {value}
+                <span class="text-zinc-500 dark:text-zinc-400">{label}:</span> {value}
               </p>
             </div>
 
             <div :if={hint_rows(@item) != []} data-role="hints">
               <p class="text-xs font-bold dark:text-zinc-400">Used to search</p>
               <p :for={{label, value} <- hint_rows(@item)} class="text-xs dark:text-zinc-500">
-                <span class="dark:text-zinc-600">{label}:</span> {value}
+                <span class="text-zinc-500 dark:text-zinc-400">{label}:</span> {value}
               </p>
-              <p class="pt-1 text-xs italic dark:text-zinc-600">
+              <p class="pt-1 text-xs italic text-zinc-500 dark:text-zinc-400">
                 Taken from the tags first and the release name second.
               </p>
             </div>
@@ -614,7 +614,7 @@
 
       <%!-- ==================== THE BUTTON ==================== --%>
       <section class="sticky bottom-0 border-t border-zinc-300 bg-white py-4 dark:border-zinc-700 dark:bg-zinc-900">
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
           <.button
             phx-click="import"
             disabled={@unresolved != [] or @destination.blocker != nil}
@@ -625,7 +625,9 @@
 
           <.button type="button" color={:zinc} phx-click="dismiss">Dismiss</.button>
 
-          <.brand_link navigate={~p"/admin/inbox"}>Back to the inbox</.brand_link>
+          <.brand_link navigate={~p"/admin/inbox"} class="whitespace-nowrap">
+            Back to the inbox
+          </.brand_link>
 
           <%!-- Why the button is off, always. A blocker that only showed up as a
               red line further up the page could leave this disabled while the

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -231,8 +231,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp kind_word(:external_collection), do: "adopted in place"
   defp kind_word(:library_root), do: "already in the library tree"
 
-  defp location_color(%Location{kind: :downloads}), do: "bg-blue-100 dark:bg-blue-900"
-  defp location_color(_other), do: "bg-zinc-200 dark:bg-zinc-800"
+  defp location_color(%Location{kind: :downloads}),
+    do: "bg-blue-100 text-blue-900 dark:bg-blue-950 dark:text-blue-300"
+
+  defp location_color(_other), do: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
 
   @doc """
   The candidate's name — usually the release name, and the most recognizable

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -73,12 +73,18 @@
           {probe_summary(item)}
         </p>
 
-        <div :for={match <- match_summary(item)} class="flex items-center gap-2 text-sm">
+        <%!-- flex-wrap so that when width runs out the meta pieces drop to a
+              second line instead of the candidate title (the answer) being
+              the first thing to ellipsize. --%>
+        <div :for={match <- match_summary(item)} class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm">
           <span class="w-20 flex-none text-zinc-500 dark:text-zinc-500">{match.level}</span>
           <.badge color={elem(confidence_label(match.confidence), 1)} class="text-xs">
             {elem(confidence_label(match.confidence), 0)}
           </.badge>
-          <span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+          <%!-- basis-48 + grow keeps the title from being shrunk out of
+                existence (meta wraps down instead); max-w-fit stops the grow
+                at the title's own width so the provenance stays beside it. --%>
+          <span class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap">
             {candidate_label(match.best)}
           </span>
           <span :if={candidate_origin(match.best)} class="flex-none text-xs text-zinc-500">
@@ -101,7 +107,7 @@
           {progress_label(@progress[item.id])}
         </p>
 
-        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs dark:text-zinc-600">
+        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-500 dark:text-zinc-500">
           <%!-- Where this came from decides what approving it does to the
                 bytes, so it belongs on the row rather than one click away. --%>
           <span class={["mr-1 rounded-sm px-1 py-0.5", location_color(item.location)]}>

--- a/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/chapters/audible_import_form.html.heex
@@ -45,7 +45,7 @@
           <div class="flex flex-wrap gap-2">
             <div
               :for={chapter <- chapters.chapters}
-              class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300"
+              class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
             >
               {chapter.title}
             </div>

--- a/lib/ambry_web/live/admin/media_live/chapters/source_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/chapters/source_import_form.html.heex
@@ -31,7 +31,7 @@
         <div class="flex flex-wrap gap-2">
           <div
             :for={chapter <- chapters}
-            class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300"
+            class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
           >
             {chapter.title}
           </div>

--- a/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form/provider_import_form.html.heex
@@ -39,13 +39,13 @@
       container_class="!space-y-0"
     >
       <.import_form_row :if={@selected_book.published} field={@form[:use_published]} label="Published">
-        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
           {display_date(@selected_book.published)}
         </div>
       </.import_form_row>
 
       <.import_form_row :if={@selected_book.publisher} field={@form[:use_publisher]} label="Publisher">
-        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+        <div class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
           {@selected_book.publisher}
         </div>
       </.import_form_row>
@@ -53,7 +53,7 @@
       <.import_form_row :if={@selected_book.description} field={@form[:use_description]} label="Description">
         <.markdown
           content={@selected_book.description}
-          class="max-h-64 max-w-max overflow-y-auto rounded-sm border border-zinc-600 bg-zinc-800 p-2"
+          class="max-h-64 max-w-max overflow-y-auto rounded-sm border border-zinc-300 bg-white p-2 dark:border-zinc-600 dark:bg-zinc-800"
         />
       </.import_form_row>
 

--- a/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form/import_form.html.heex
@@ -38,7 +38,7 @@
 
       <.simple_form for={@form} phx-submit="import" phx-target={@myself} container_class="!space-y-0">
         <.import_form_row :if={author.name != ""} field={@form[:use_name]} label="Name">
-          <div class="py-[7px] px-[11px] rounded-sm border border-zinc-600 bg-zinc-800 text-zinc-300">
+          <div class="py-[7px] px-[11px] rounded-sm border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
             {author.name}
           </div>
         </.import_form_row>
@@ -46,7 +46,7 @@
         <.import_form_row :if={author.description} field={@form[:use_description]} label="Description">
           <.markdown
             content={author.description}
-            class="max-h-64 max-w-max overflow-y-auto rounded-sm border border-zinc-600 bg-zinc-800 p-2"
+            class="max-h-64 max-w-max overflow-y-auto rounded-sm border border-zinc-300 bg-white p-2 dark:border-zinc-600 dark:bg-zinc-800"
           />
         </.import_form_row>
 


### PR DESCRIPTION
The P0 items from the admin design review — the things that are broken today, ahead of the larger token/component pass.

## Light mode never reached the provider-import modals

The "Import from …" modals (book, media, person, chapters) hard-coded dark styling on their result cards and prefilled value boxes (`border-zinc-600 bg-zinc-800 text-zinc-300`), so a light-mode session got near-black inputs inside a light modal. All sites now use the same light/dark pair as the app's inputs. Same treatment for the `rich_select` dropdown surface and `book_card`'s secondary text.

## Dark-mode contrast

- The inbox location chip (`Downloads · imported`) set only backgrounds and inherited the path line's `dark:text-zinc-600`, which on `blue-950` was unreadable. The chip color helpers now carry their own text colors.
- Record confidence percentages (how evidence ranks) and the "What the files say" key labels move from `zinc-600` to `zinc-400` on dark.

## Small widths degrade by dropping meta, not answers

- The inbox match line was a nowrap flex where the candidate title was the only shrinkable child — at anything under ~1200px of content width it ellipsized to "The De…" while `(Hardcover)` and `+7 others` kept full width. The line now wraps: `basis-48 grow` keeps the title alive and the meta drops to a second line when space runs out; `max-w-fit` stops the grow at the title's own width so provenance stays right beside it at desktop widths (desktop rendering is pixel-identical to before).
- Buttons get `whitespace-nowrap` in the shared `<.button>` component — "Add to the library" rendered as a three-line block at 390px. The import form's action bar wraps as a whole (`flex-wrap`) so the hint text drops below instead of cramming.
- The mobile nav drawer gets a scrim (`bg-black/40`, with a fade) so it reads as a layer instead of floating over full-brightness content.

## Verification

Walked in a real (headless Chromium) browser at 390 / 768 / 1024 / 1440, light and dark, before and after: modal is native-looking in light mode, the chip and percentages are legible on dark, 768px match lines show ~24 title characters instead of 6, the 390px action bar is one row, and the drawer dims the page behind it. `mix test`: 1239 passed.

One review item resolved as not-a-bug along the way: the person photo-picker's "transparent modal" was the app-wide frosted-sheet modal design (`bg-white/90 backdrop-blur`) rendering as intended — the actually-broken part was the unthemed content inside it, fixed above.

https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199