### PR TITLE
Admin UI system pass: one button identity, chip taxonomy, evidence meters, rhythm scale

### DIFF
--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -63,12 +63,16 @@ defmodule AmbryWeb.Admin.Decisions do
   def provider_outcomes_row(assigns) do
     ~H"""
     <div :if={@outcomes != []} class="flex flex-wrap items-center gap-2" data-role="provider-outcomes">
-      <span class="text-xs dark:text-zinc-500">Asked:</span>
+      <span class="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+        Asked
+      </span>
 
+      <%!-- A count is information, not an option — filled and quiet, so it
+            can't be mistaken for the clickable proposal chips nearby. --%>
       <span
         :for={outcome <- @outcomes}
         :if={outcome["status"] != "failed"}
-        class="rounded-sm border border-zinc-300 px-2 py-0.5 text-xs dark:border-zinc-700"
+        class="rounded-sm bg-zinc-100 px-2 py-0.5 text-xs tabular-nums text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
       >
         {outcome["name"]}: {outcome["count"]}
       </span>
@@ -177,18 +181,35 @@ defmodule AmbryWeb.Admin.Decisions do
         class="mt-1 h-4 w-4 flex-none rounded-sm"
       />
       <div class="min-w-0 flex-grow">
-        <p class="truncate text-sm">{candidate_title(@record)}</p>
+        <p class="truncate text-sm font-medium">{candidate_title(@record)}</p>
         <p class="truncate text-xs dark:text-zinc-500">{candidate_facts(@record)}</p>
       </div>
       <span :if={@working} class="flex-none pt-0.5 text-xs dark:text-zinc-400">
         fetching…
       </span>
-      <span :if={!@working && @record["score"]} class="flex-none pt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
-        {round(@record["score"] * 100)}%
+      <%!-- The meter makes the ranking visible before the number is read —
+            eight cards with bare percentages all carried identical visual
+            weight whether they were a 100% match or a 6% study guide. --%>
+      <span :if={!@working && @record["score"]} class="flex flex-none flex-col items-end gap-1 pt-0.5">
+        <span class="text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
+          {round(@record["score"] * 100)}%
+        </span>
+        <span class="h-1 w-16 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+          <span
+            class={["block h-full rounded-full", meter_color(@record["score"])]}
+            style={"width: #{round(@record["score"] * 100)}%"}
+          />
+        </span>
       </span>
     </label>
     """
   end
+
+  # High reads as the accent, the murky middle as a warning, and junk as
+  # neutral — the same bands the matcher's own trust thresholds use.
+  defp meter_color(score) when score >= 0.75, do: "bg-brand dark:bg-brand-dark"
+  defp meter_color(score) when score >= 0.4, do: "bg-amber-500 dark:bg-amber-400"
+  defp meter_color(_score), do: "bg-zinc-400 dark:bg-zinc-600"
 
   attr :book, :map, required: true
   attr :linked, :boolean, required: true
@@ -419,7 +440,11 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def decision_row(assigns) do
     ~H"""
-    <div class="space-y-1">
+    <%!-- One slot order for every field — label row, control, options, hint —
+          with an 8px beat inside the cluster. The 28px to the *next* field
+          comes from the section, so the ratio between "mine" and "not mine"
+          stays legible (see the admin design review, rhythm rules). --%>
+    <div class="space-y-2">
       <div class="flex items-center gap-2">
         <.label>{@label}</.label>
 
@@ -431,16 +456,14 @@ defmodule AmbryWeb.Admin.Decisions do
           {elem(state_words(Field.state(@field)), 0)}
         </.badge>
 
-        <span :if={@field.approved && @field.source} class="text-xs dark:text-zinc-500">
+        <span :if={@field.approved && @field.source} class="text-xs text-zinc-500 dark:text-zinc-400">
           from {source_words(@field.source)}
         </span>
 
-        <span :if={@field.approved && is_nil(@field.source)} class="text-xs dark:text-zinc-500">
+        <span :if={@field.approved && is_nil(@field.source)} class="text-xs text-zinc-500 dark:text-zinc-400">
           left empty on purpose
         </span>
       </div>
-
-      <p :if={@hint} class="text-xs italic dark:text-zinc-500">{@hint}</p>
 
       <div class="flex items-start gap-3">
         <%!-- A URL in a text box is not a cover. Seeing the image is the only
@@ -497,23 +520,27 @@ defmodule AmbryWeb.Admin.Decisions do
         </div>
       </div>
 
-      <div :if={@field.candidates != []} class="flex flex-wrap items-center gap-2 pt-1">
-        <span class="text-xs dark:text-zinc-500">Proposed:</span>
+      <%!-- Options hang visibly *inside* their field: indented to the
+            control's inner padding, so a wrapped chip row still reads as
+            belonging to the input above it and not to the next label. --%>
+      <div :if={@field.candidates != []} class="flex flex-wrap items-center gap-2 pl-3">
+        <span class="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+          Proposed
+        </span>
 
-        <button
+        <.proposal_chip
           :for={candidate <- @field.candidates}
-          type="button"
-          phx-click="choose-field"
-          phx-value-section={@section}
-          phx-value-field={@name}
-          phx-value-key={candidate.key}
-          class={[
-            "rounded-sm border px-2 py-1 text-left text-xs",
-            Field.chose?(@field, candidate) && "border-brand dark:border-brand-dark",
-            !Field.chose?(@field, candidate) && "border-zinc-300 dark:border-zinc-700"
-          ]}
+          chosen={Field.chose?(@field, candidate)}
+          event="choose-field"
+          values={%{section: @section, field: @name, key: candidate.key}}
         >
-          <span class="dark:text-zinc-500">{candidate.label || source_words(candidate.source)}:</span>
+          <span class={[
+            "text-[10px] flex-none rounded-sm px-1 uppercase tracking-wide",
+            Field.chose?(@field, candidate) && "bg-brand/90 text-zinc-900 dark:bg-brand-dark",
+            !Field.chose?(@field, candidate) && "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+          ]}>
+            {candidate.label || source_words(candidate.source)}
+          </span>
           <span :if={!@preview}>{truncate(candidate.value)}</span>
 
           <%!-- Choosing between two covers by URL is choosing blind. --%>
@@ -523,22 +550,22 @@ defmodule AmbryWeb.Admin.Decisions do
             src={preview_src(candidate.value, @embedded_src)}
             class="mt-1 h-20 w-20 rounded-sm object-cover"
           />
-        </button>
+        </.proposal_chip>
 
         <%!-- Choosing "none" is an approval, not an omission. It's what makes
               "every piece is settled" reachable on a record with optional
               fields nobody filled in. --%>
-        <button
+        <.proposal_chip
           :if={!@field.required}
-          type="button"
-          phx-click="waive-field"
-          phx-value-section={@section}
-          phx-value-field={@name}
-          class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+          chosen={@field.approved && is_nil(@field.source)}
+          event="waive-field"
+          values={%{section: @section, field: @name}}
         >
           None
-        </button>
+        </.proposal_chip>
       </div>
+
+      <p :if={@hint} class="pl-3 text-xs text-zinc-500 dark:text-zinc-400">{@hint}</p>
     </div>
     """
   end
@@ -1062,11 +1089,19 @@ defmodule AmbryWeb.Admin.Decisions do
       class={[
         "max-w-full rounded-sm border text-left text-xs",
         @shape == "circle" && "rounded-full p-0.5",
-        @shape != "circle" && "px-2 py-1",
-        @chosen && "border-brand dark:border-brand-dark",
-        !@chosen && "border-zinc-300 dark:border-zinc-700"
+        @shape != "circle" && "inline-flex items-center gap-1.5 px-2 py-1",
+        @chosen && "border-brand bg-brand/10 dark:border-brand-dark dark:bg-brand-dark/10",
+        !@chosen && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
       ]}
     >
+      <%!-- The chosen chip is the single most important state on the form, and
+            a 1px border-hue change was nearly invisible — so it says so three
+            ways: border, tint, and a check. --%>
+      <.icon
+        :if={@chosen && @shape != "circle"}
+        name="fa-check"
+        class="h-3 w-3 flex-none text-lime-700 dark:text-brand-dark"
+      />
       {render_slot(@inner_block)}
     </button>
     """

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -264,9 +264,9 @@ defmodule AmbryWeb.CoreComponents do
     <button
       type={@type}
       class={[
-        "rounded-sm px-3 py-2 phx-submit-loading:opacity-75",
+        "rounded-sm border px-3 py-2 phx-submit-loading:opacity-75",
         "whitespace-nowrap text-sm font-semibold leading-6",
-        "text-white active:text-white/80 dark:text-zinc-900 dark:active:text-zinc-800",
+        "active:opacity-80 disabled:pointer-events-none disabled:opacity-40",
         button_color_classes(@color),
         @class
       ]}
@@ -277,20 +277,25 @@ defmodule AmbryWeb.CoreComponents do
     """
   end
 
+  # One identity in both themes: the primary action is the brand fill with
+  # near-black text everywhere, secondary actions are outlined (a solid gray
+  # fill is the universal costume of a *disabled* button), and destructive
+  # actions are outlined red — visible without shouting. Every variant carries
+  # a border so the variants line up at the same height.
   defp button_color_classes(:brand) do
-    "bg-zinc-900 hover:bg-zinc-700 dark:bg-brand-dark dark:hover:bg-lime-600"
+    "border-transparent bg-brand text-zinc-900 hover:bg-lime-600 dark:bg-brand-dark dark:hover:bg-lime-500"
   end
 
   defp button_color_classes(:yellow) do
-    "bg-yellow-500 hover:bg-yellow-700 dark:bg-yellow-400 dark:hover:bg-yellow-600"
+    "border-transparent bg-yellow-500 text-zinc-900 hover:bg-yellow-600 dark:bg-yellow-400 dark:hover:bg-yellow-500"
   end
 
   defp button_color_classes(:red) do
-    "bg-red-500 hover:bg-red-700 dark:bg-red-400 dark:hover:bg-red-600"
+    "border-red-600 bg-transparent text-red-600 hover:bg-red-600/10 dark:border-red-400 dark:text-red-400 dark:hover:bg-red-400/10"
   end
 
   defp button_color_classes(:zinc) do
-    "bg-zinc-600 hover:bg-zinc-800 dark:bg-zinc-400 dark:hover:bg-zinc-600"
+    "border-zinc-400 bg-transparent text-zinc-900 hover:bg-zinc-900/5 dark:border-zinc-500 dark:text-zinc-100 dark:hover:bg-white/10"
   end
 
   @doc """

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -6,7 +6,7 @@
           over the whole thing rather than in a badge. --%>
     <.busy_overlay busy={@busy} label={busy_label(@job)} class="sticky top-0 h-screen" />
 
-    <div class="max-w-4xl space-y-8 pb-16" inert={@busy}>
+    <div class="max-w-4xl space-y-14 pb-16" inert={@busy}>
       <%!-- the evidence: what was found, before anybody interpreted it --%>
       <section class="space-y-1 rounded-sm border border-zinc-300 p-4 dark:border-zinc-700">
         <div class="flex items-start justify-between gap-4">
@@ -117,7 +117,7 @@
       </section>
 
       <%!-- ==================== THE WORK ==================== --%>
-      <section id="work" class="space-y-4">
+      <section id="work" class="space-y-7">
         <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
           The work — which book this is a recording of
         </h2>
@@ -287,6 +287,7 @@
           for={@form}
           phx-change="validate"
           autocomplete="off"
+          container_class="!space-y-7"
         >
           <.inputs_for :let={draft} field={@form[:draft]}>
             <.inputs_for :let={work} field={draft[:work]}>
@@ -378,7 +379,7 @@
       </section>
 
       <%!-- ==================== THE RECORDING ==================== --%>
-      <section id="recording" class="space-y-4">
+      <section id="recording" class="space-y-7">
         <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
           The recording — which reading of it these files are
         </h2>
@@ -467,7 +468,13 @@
           </p>
         </div>
 
-        <.simple_form id="recording-form" for={@form} phx-change="validate" autocomplete="off">
+        <.simple_form
+          id="recording-form"
+          for={@form}
+          phx-change="validate"
+          autocomplete="off"
+          container_class="!space-y-7"
+        >
           <.inputs_for :let={draft} field={@form[:draft]}>
             <.inputs_for :let={recording} field={draft[:recording]}>
               <.decision_row


### PR DESCRIPTION
**Stacked on #1208** — the P1 "system pass" from the admin design review, applied to the import form first since it's the flagship surface. Checks will show SKIPPED until retargeted to main (CI only runs against main); per our stacked-PR flow, retarget this to main once #1208 merges, before merging this one.

## One button identity in both themes (commit 1, global)

`button(:brand)` was `bg-zinc-900` in light and lime in dark — the primary action changed personality with the OS setting, and light mode had no brand presence at all. Now: **primary = brand lime fill with near-black text in both themes** (also fixes `:yellow`'s white-on-yellow contrast), **secondary/destructive = outlined** (a solid gray fill is the universal costume of a disabled button — "Take the top suggestion…" looked unclickable), and actually-disabled buttons render at 40% opacity instead of full strength.

Note this deliberately touches the public site too (login, settings forms) — that's the point of "one identity", but it's the most reviewable call in the stack.

## Import form application (commit 2)

- **Rhythm:** 8px inside a field cluster / 28px between fields / 56px between sections. Before: 12px vs 20px — below the ~3× ratio where grouping is perceived, which is why the form read as one column of evenly-spaced lines.
- **One slot order** per field: label row (label + state badge + provenance) → control → options → hint. Options and hints indent 12px to the control's inner padding so a wrapped chip row reads as belonging to its field.
- **Chip taxonomy:** proposal chips show a source tag + value and the chosen one says so three ways (border, tint, check) — previously a 1px border-hue change. `decision_row` now routes through the shared `proposal_chip` instead of hand-writing its own chips (the exact call-site drift that component's docstring warns about). "Asked" counts are filled-and-quiet so they can't be mistaken for options. "None" gets a real chosen state.
- **Evidence meters:** each record card gets a confidence meter banded like the matcher's own trust thresholds (≥75% brand / ≥40% amber / junk neutral) next to the percentage.
- De-italicized hints/provenance; raised the remaining `zinc-600`-on-dark text.

## Verification

Screenshotted at 1440 in both themes against the pre-change captures; `mix test` 1239 green (behavior untouched — events, params, and data-roles all unchanged).

Not in this PR (still P1-adjacent, noted in ROADMAP): sizing inputs to content (a date still gets a 900px box) — wants a small `.input` width API rather than per-site classes.

https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199