### PR TITLE
Admin UI: the inbox index becomes a real queue

### DIFF
--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -151,14 +151,22 @@ defmodule AmbryWeb.Admin.Components do
   defp admin_table_search_form(assigns) do
     ~H"""
     <.form for={@search_form} phx-submit="search" data-role="search-form">
-      <input
-        id={@search_form.id}
-        type="search"
-        name={@search_form[:query].name}
-        value={@search_form[:query].value}
-        placeholder="Search"
-        class="w-full border-0 border-b border-zinc-200 bg-transparent px-0 placeholder:font-bold placeholder:text-zinc-500 focus:border-0 focus:border-b focus:border-lime-500 focus:outline-none focus:ring-0 dark:border-zinc-800 dark:focus:border-lime-400"
-      />
+      <%!-- A real field, not a bare underline — the search is an interactive
+            control and should look like one before it's focused. --%>
+      <div class="relative max-w-md">
+        <.icon
+          name="fa-magnifying-glass"
+          class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-zinc-400 dark:text-zinc-500"
+        />
+        <input
+          id={@search_form.id}
+          type="search"
+          name={@search_form[:query].name}
+          value={@search_form[:query].value}
+          placeholder="Search"
+          class="w-full rounded-sm border border-zinc-300 bg-white py-1.5 pr-3 pl-9 text-sm text-zinc-900 placeholder:text-zinc-500 focus:ring-lime-500/20 focus:border-lime-500 focus:outline-none focus:ring-2 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:focus:border-lime-400"
+        />
+      </div>
     </.form>
     """
   end
@@ -318,7 +326,9 @@ defmodule AmbryWeb.Admin.Components do
 
   defp admin_table_row(assigns) do
     ~H"""
-    <div class="relative flex cursor-pointer items-center gap-4 p-4" {@rest}>
+    <%!-- flex-wrap below sm lets a row's right rail drop to a full-width
+          bottom line instead of squeezing the content column on phones. --%>
+    <div class="relative flex cursor-pointer flex-wrap items-center gap-x-4 gap-y-2 p-4 sm:flex-nowrap" {@rest}>
       {render_slot(@inner_block)}
     </div>
     """

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -217,6 +217,55 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp parse_ready("true"), do: true
   defp parse_ready(_anything), do: nil
 
+  # The segmented filter: the active segment reads as a raised tab, the rest
+  # recede. Spans rather than buttons so the existing test selectors (and the
+  # click affordance pattern used across this page) stay put.
+  defp segment_class(active?) do
+    [
+      "flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-sm px-3 py-1 font-semibold",
+      if(active?,
+        do: "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-100",
+        else: "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+      )
+    ]
+  end
+
+  defp segment_label(:pending), do: "Pending"
+  defp segment_label(:dismissed), do: "Dismissed"
+  defp segment_label(:approved), do: "Approved"
+
+  # Pending work glows amber and settled-but-unimported glows lime — but only
+  # while there IS any; a zero is just a zero.
+  defp segment_count_class(status, count) do
+    [
+      "rounded-full px-1.5 text-xs font-bold tabular-nums",
+      case {status, count} do
+        {_status, 0} -> "bg-zinc-200 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
+        {:pending, _n} -> "bg-amber-100 text-amber-700 dark:bg-amber-900/60 dark:text-amber-300"
+        {:ready, _n} -> "bg-lime-100 text-lime-700 dark:bg-lime-900/60 dark:text-lime-300"
+        _other -> "bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+      end
+    ]
+  end
+
+  # Row actions wear words. An unlabeled 16px icon is neither a label nor a
+  # touch target, and the queue's actions are consequential enough to name.
+  defp action_class(tone) do
+    [
+      "flex cursor-pointer items-center gap-1 whitespace-nowrap rounded-sm border px-2 py-0.5 text-xs font-semibold transition-colors",
+      case tone do
+        :brand ->
+          "border-lime-600/60 text-lime-700 hover:bg-lime-600/10 dark:border-lime-400/60 dark:text-lime-400 dark:hover:bg-lime-400/10"
+
+        :danger ->
+          "border-zinc-300 text-zinc-600 hover:border-red-500 hover:text-red-600 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-red-400 dark:hover:text-red-400"
+
+        :neutral ->
+          "border-zinc-300 text-zinc-600 hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+      end
+    ]
+  end
+
   defp status_color(:pending), do: :yellow
   defp status_color(:approved), do: :brand
   defp status_color(:dismissed), do: :gray

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -7,36 +7,34 @@
       next_page_path={@next_page_path}
       prev_page_path={@prev_page_path}
     />
-    <div class="flex items-center gap-4 pt-2">
+    <div class="flex flex-wrap items-center gap-3 pt-2">
       <.button phx-click="scan">
         <.icon name="fa-magnifying-glass" class="mr-2 h-4 w-4" /> Scan for new
       </.button>
 
-      <div class="flex gap-2">
-        <span
-          phx-click="filter-status"
-          phx-value-status="all"
-          class={["cursor-pointer text-sm", !@status && !@ready && "font-bold underline"]}
-        >
+      <%!-- The filters are the queue's primary navigation — a segmented
+            control, not a row of text links. Counts ride along so the state
+            of the queue is readable without clicking anything. --%>
+      <div class="inline-flex max-w-full items-center gap-0.5 overflow-x-auto rounded-sm border border-zinc-300 bg-zinc-100 p-0.5 text-sm dark:border-zinc-700 dark:bg-zinc-900">
+        <span phx-click="filter-status" phx-value-status="all" class={segment_class(!@status && !@ready)}>
           All
         </span>
         <span
           :for={status <- @statuses}
           phx-click="filter-status"
           phx-value-status={status}
-          class={["cursor-pointer text-sm", !@ready && @status == status && "font-bold underline"]}
+          class={segment_class(!@ready && @status == status)}
         >
-          {status} ({Map.get(@counts, status, 0)})
+          {segment_label(status)}
+          <span class={segment_count_class(status, Map.get(@counts, status, 0))}>
+            {Map.get(@counts, status, 0)}
+          </span>
         </span>
 
         <%!-- Everything settled, waiting on a click. The point of the whole
               form is that this bucket is where items end up. --%>
-        <span
-          phx-click="filter-ready"
-          class={["cursor-pointer text-sm text-lime-600", @ready && "font-bold underline"]}
-          data-role="ready-filter"
-        >
-          ready ({@ready_count})
+        <span phx-click="filter-ready" class={segment_class(@ready)} data-role="ready-filter">
+          Ready <span class={segment_count_class(:ready, @ready_count)}>{@ready_count}</span>
         </span>
       </div>
     </div>
@@ -117,55 +115,61 @@
         </p>
       </div>
 
+      <%!-- One rail with fixed slots — status, meta, actions, date — instead
+            of two competing columns. On phones it drops to a full-width
+            bottom line (the row container wraps) rather than squeezing the
+            titles; the actions carry words because a 16px icon is neither a
+            label nor a touch target. --%>
       <div
-        class="hidden w-36 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex"
+        class="flex w-full flex-none flex-wrap items-center gap-x-3 gap-y-2 sm:w-44 sm:flex-col sm:items-end"
         inert={busy?(@progress[item.id])}
       >
-        <div class="flex gap-4">
-          <span :if={file_count(item) > 1} title="Audio files">
-            {file_count(item)} <.icon name="fa-file-audio" class="inline h-4 w-4 text-current" />
-          </span>
-          <span :if={item.tags && item.tags["asin"]} title={"ASIN #{item.tags["asin"]}"}>
-            <.icon name="fa-tag" class="inline h-4 w-4 text-current" />
-          </span>
-          <span :if={item.tags && item.tags["has_cover_art"]} title="Embedded cover art">
-            <.icon name="fa-image" class="inline h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
-
-      <div
-        class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap"
-        inert={busy?(@progress[item.id])}
-      >
-        <div class="flex items-center gap-2 pb-2">
+        <div class="flex items-center gap-2">
           <.badge :if={item.ready and item.status == :pending} color={:brand} class="text-xs">
             ready
           </.badge>
           <.badge color={status_color(item.status)} class="text-xs">{item.status}</.badge>
+        </div>
 
+        <div class="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+          <span
+            :if={file_count(item) > 1}
+            title="Audio files"
+            class="rounded-sm bg-zinc-100 px-1.5 py-0.5 tabular-nums dark:bg-zinc-800"
+          >
+            <span class="font-bold text-zinc-700 dark:text-zinc-300">{file_count(item)}</span> files
+          </span>
+          <span :if={item.tags && item.tags["asin"]} title={"ASIN #{item.tags["asin"]}"}>
+            <.icon name="fa-tag" class="inline h-3.5 w-3.5 text-current" />
+          </span>
+          <span :if={item.tags && item.tags["has_cover_art"]} title="Embedded cover art">
+            <.icon name="fa-image" class="inline h-3.5 w-3.5 text-current" />
+          </span>
+        </div>
+
+        <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
           <%!-- Only a settled item can be imported from here. Anything else
                 opens the form, because the queue has no way to say what's
                 outstanding and the form's whole job is to. --%>
           <span
             :if={item.status == :pending and item.ready}
+            role="button"
             phx-click="approve"
             phx-value-id={item.id}
             title="Add to the library"
             data-confirm="Add this to the library?"
+            class={action_class(:brand)}
           >
-            <.icon name="fa-check" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-lime-500" />
+            <.icon name="fa-check" class="h-3 w-3 text-current" /> Approve
           </span>
 
           <.link
             :if={item.status == :pending and not item.ready}
             navigate={~p"/admin/inbox/#{item}"}
             title="Settle what's outstanding"
+            class={action_class(:neutral)}
           >
-            <.icon
-              name="fa-pen-to-square"
-              class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-blue-400"
-            />
+            <.icon name="fa-pen-to-square" class="h-3 w-3 text-current" /> Open
           </.link>
 
           <%!-- One action, because "re-read the files" and "look for matches
@@ -174,36 +178,39 @@
                 same question. Re-reads the folder, re-probes, and re-queries
                 every provider with the cache bypassed. --%>
           <span
+            role="button"
             phx-click="rescan"
             phx-value-id={item.id}
             title="Re-read the files and ask the providers again"
+            class={action_class(:neutral)}
           >
-            <.icon name="fa-rotate" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-blue-400" />
+            <.icon name="fa-rotate" class="h-3 w-3 text-current" /> Re-match
           </span>
 
           <span
             :if={item.status != :dismissed}
+            role="button"
             phx-click="dismiss"
             phx-value-id={item.id}
             title="Dismiss (files are not touched)"
+            class={action_class(:danger)}
           >
-            <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
+            <.icon name="fa-xmark" class="h-3 w-3 text-current" /> Dismiss
           </span>
 
           <span
             :if={item.status == :dismissed}
+            role="button"
             phx-click="restore"
             phx-value-id={item.id}
             title="Put back in the queue"
+            class={action_class(:brand)}
           >
-            <.icon
-              name="fa-rotate-left"
-              class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-lime-500"
-            />
+            <.icon name="fa-rotate-left" class="h-3 w-3 text-current" /> Restore
           </span>
         </div>
 
-        <p class="text-sm italic dark:text-zinc-500">
+        <p class="text-xs text-zinc-500 dark:text-zinc-400">
           Found {Calendar.strftime(item.inserted_at, "%x")}
         </p>
       </div>


### PR DESCRIPTION
**Stacked on #1209** (which stacks on #1208). Checks show SKIPPED until retargeted to main; per our stacked-PR flow, retarget children to main before merging parents.

The P2 pass from the admin design review — the inbox is the operator's daily queue and now reads like one:

- **Segmented status filter with live counts** replacing the row of text links — Pending's count glows amber and Ready's lime, but only while nonzero. Same events, same `data-role`s; the one test that clicks these passes unchanged.
- **A real search field** (icon + border + focus ring) replacing the bare underline, in the shared `list_controls`, so every admin index gets it.
- **One right rail with fixed slots** (status → meta → actions → date) replacing the two competing columns. The floating unlabeled "27" becomes a labeled **"27 files"** chip; actions carry words (Open / Re-match / Dismiss / Approve / Restore) with tone-coded outlines instead of 16px icon-only targets.
- **Phones:** the rail drops to a full-width line inside the card (shared `admin_table_row` gains `flex-wrap` below `sm`) instead of squeezing the title column; the segment bar scrolls horizontally.

Verified by screenshot at 1440 light/dark and 390; `mix test` 1239 green (one unrelated flake in `Ambry.Search.IndexTest` reproduced on a clean tree and passes in isolation).

Deliberately not here: the sort-header → "Sort ▾" select below `md` for the other index pages (books at 390 wraps its six sort links into a pile) — separate concern, noted in ROADMAP.

https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199