### PR TITLE
Admin nav: grouped by workflow

### DIFF
--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -30,68 +30,77 @@ defmodule AmbryWeb.Admin.Layouts do
           <.title class="h-6 lg:h-7" />
         </.link>
       </div>
+      <%!-- Grouped by how the admin is actually used: the daily intake loop,
+            the catalog it feeds, and the once-a-quarter machinery — instead
+            of twelve peers in one flat list. --%>
       <div class="py-3">
         <.link navigate={~p"/admin"} class={nav_class(@active_path == "/admin")}>
-          <.icon name="fa-binoculars" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-binoculars" class="h-5 w-5 text-current" />
           <p>Overview</p>
         </.link>
-        <.link navigate={~p"/admin/people"} class={nav_class(@active_path =~ "/admin/people")}>
-          <.icon name="fa-user-group" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
-          <p>Authors & Narrators</p>
-        </.link>
-        <.link navigate={~p"/admin/books"} class={nav_class(@active_path =~ "/admin/books")}>
-          <.icon name="fa-book" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
-          <p>Books</p>
-        </.link>
-        <.link navigate={~p"/admin/series"} class={nav_class(@active_path =~ "/admin/series")}>
-          <.icon name="fa-book-journal-whills" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
-          <p>Series</p>
-        </.link>
-        <.link navigate={~p"/admin/universes"} class={nav_class(@active_path =~ "/admin/universes")}>
-          <.icon name="fa-globe" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
-          <p>Universes</p>
-        </.link>
+
+        <p class={group_class()}>Intake</p>
         <.link navigate={~p"/admin/inbox"} class={nav_class(@active_path =~ "/admin/inbox")}>
-          <.icon name="fa-inbox" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-inbox" class="h-5 w-5 text-current" />
           <p>Inbox</p>
         </.link>
         <.link navigate={~p"/admin/locations"} class={nav_class(@active_path =~ "/admin/locations")}>
-          <.icon name="fa-folder-tree" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-folder-tree" class="h-5 w-5 text-current" />
           <p>Locations</p>
         </.link>
+
+        <p class={group_class()}>Library</p>
+        <.link navigate={~p"/admin/books"} class={nav_class(@active_path =~ "/admin/books")}>
+          <.icon name="fa-book" class="h-5 w-5 text-current" />
+          <p>Books</p>
+        </.link>
+        <.link navigate={~p"/admin/people"} class={nav_class(@active_path =~ "/admin/people")}>
+          <.icon name="fa-user-group" class="h-5 w-5 text-current" />
+          <p>Authors & Narrators</p>
+        </.link>
+        <.link navigate={~p"/admin/series"} class={nav_class(@active_path =~ "/admin/series")}>
+          <.icon name="fa-book-journal-whills" class="h-5 w-5 text-current" />
+          <p>Series</p>
+        </.link>
+        <.link navigate={~p"/admin/universes"} class={nav_class(@active_path =~ "/admin/universes")}>
+          <.icon name="fa-globe" class="h-5 w-5 text-current" />
+          <p>Universes</p>
+        </.link>
         <.link navigate={~p"/admin/media"} class={nav_class(@active_path =~ "/admin/media")}>
-          <.icon name="fa-file-audio" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-file-audio" class="h-5 w-5 text-current" />
           <p>Media</p>
         </.link>
+
+        <p class={group_class()}>System</p>
         <.link navigate={~p"/admin/audit"} class={nav_class(@active_path =~ "/admin/audit")}>
-          <.icon name="fa-file-waveform" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-file-waveform" class="h-5 w-5 text-current" />
           <p>File Audit</p>
         </.link>
         <.link
           navigate={~p"/admin/metadata-providers"}
           class={nav_class(@active_path =~ "/admin/metadata-providers")}
         >
-          <.icon name="fa-screwdriver-wrench" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-screwdriver-wrench" class="h-5 w-5 text-current" />
           <p>Metadata Providers</p>
         </.link>
         <.link navigate={~p"/admin/settings"} class={nav_class(@active_path =~ "/admin/settings")}>
-          <.icon name="fa-sliders" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-sliders" class="h-5 w-5 text-current" />
           <p>Settings</p>
         </.link>
         <.link navigate={~p"/admin/users"} class={nav_class(@active_path =~ "/admin/users")}>
-          <.icon name="fa-users-gear" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-users-gear" class="h-5 w-5 text-current" />
           <p>Manage Users</p>
         </.link>
       </div>
       <div class="py-3">
         <.link navigate={~p"/admin/dashboard"} class={nav_class()}>
-          <.icon name="fa-brands-phoenix-framework" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-brands-phoenix-framework" class="h-5 w-5 text-current" />
           <p>Phoenix Dashboard</p>
         </.link>
       </div>
       <div class="absolute bottom-0 w-full py-3">
         <.link navigate={~p"/"} class={nav_class()}>
-          <.icon name="fa-arrow-right-from-bracket" class="scale-[-1] h-6 w-6 text-current lg:h-7 lg:w-7" />
+          <.icon name="fa-arrow-right-from-bracket" class="scale-[-1] h-5 w-5 text-current" />
           <p>Exit Admin</p>
         </.link>
       </div>
@@ -99,9 +108,20 @@ defmodule AmbryWeb.Admin.Layouts do
     """
   end
 
+  # The active item wears the brand — a bar plus a tint — instead of the same
+  # gray fill hover uses; inactive rows carry a transparent bar so nothing
+  # shifts when the selection moves.
   defp nav_class(active? \\ false)
-  defp nav_class(true), do: "flex items-center px-4 py-2 gap-4 bg-zinc-300 dark:bg-zinc-700"
+
+  defp nav_class(true),
+    do:
+      "flex items-center gap-3 border-l-[3px] border-brand bg-brand/10 px-4 py-2 text-sm font-semibold dark:border-brand-dark dark:bg-brand-dark/10"
 
   defp nav_class(false),
-    do: "flex items-center px-4 py-2 gap-4 hover:bg-zinc-300 dark:hover:bg-zinc-700"
+    do:
+      "flex items-center gap-3 border-l-[3px] border-transparent px-4 py-2 text-sm hover:bg-zinc-200 dark:hover:bg-zinc-800"
+
+  defp group_class,
+    do:
+      "px-4 pt-4 pb-1 text-[10px] font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-400"
 end


### PR DESCRIPTION
**Stacked on #1211** (→ #1210 → #1209 → #1208). Checks show SKIPPED until retargeted to main; retarget children before merging parents.

The P4 nav slice from the admin design review: the sidebar's twelve flat peers become three labeled groups matching how the admin is used — **Intake** (Inbox, Locations), **Library** (Books, Authors & Narrators, Series, Universes, Media), **System** (File Audit, Metadata Providers, Settings, Manage Users) — with Overview on top. The active item wears a 3px brand bar + tint in both themes instead of the same gray fill hover uses; rows tighten to `text-sm` with 20px icons.

Deliberately **not** here (operator decisions, per the review):
- landing page = inbox (route/behavior change)
- pending-count badge on Inbox (needs a data path into the layout — a component-render DB call is the wrong shape)

Verified by screenshot in both themes; full suite green.

https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199