### PR TITLE
The admin design language, and the composition pass

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -7,6 +7,10 @@ const path = require("path")
 
 module.exports = {
   content: ["./js/**/*.js", "../lib/*_web.ex", "../lib/*_web/**/*.*ex"],
+  // Class strategy so the admin can force dark regardless of OS preference —
+  // the public root layout mirrors the OS preference onto <html> with an
+  // inline script, so the public app behaves exactly as it did under "media".
+  darkMode: "class",
   theme: {
     extend: {
       colors: {

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -2,108 +2,149 @@
 
 The rules every admin surface follows. They exist because the admin grew one
 widget at a time and read like it: five kinds of pill in one card, three left
-edges on one form, labels quieter than the chips they named. Each rule below
+edges on one form, labels quieter than the chips they named, and a thousand
+1px lines on pure black that went mushy on a 4K monitor. Each rule below
 kills one class of that. When a new surface is built or an old one is
 touched, it follows this document; when a rule has to bend, this document
 gets amended, not silently ignored.
 
-The public-facing app shares the tokens (brand color, button identity) but
-not the composition rules — it's a reading surface, not an operating one.
+The public-facing app shares the brand tokens but not the composition rules —
+it's a reading surface, not an operating one, and it still has a light mode.
 
-## 1. Geometry
+## 0. One theme
 
-**Two left edges, never three.** Every container (page column, card) has
-exactly two x-positions:
+**The admin is dark-only, by decision** (2026-08-09): one operator, one
+theme, half the styling overhead. `class="dark"` is hardcoded on the admin
+root layout's `<html>` (Tailwind runs dark mode off the class; the public
+root layout mirrors the OS preference onto the class with an inline script),
+plus `color-scheme: dark` so native controls follow. Admin surfaces write
+**absolute colors** — no `dark:` prefixes in new admin code. Existing
+`dark:` classes still work (the class is always present); strip them to
+absolute values whenever a surface is touched.
 
-- **The box edge** — where cards, inputs, record rows, buttons, and section
-  rules sit. This is the container's padding edge.
-- **The text rail** — box edge + 12px (`pl-3`), matching the inset of text
-  *inside* the inputs. Every bare-text element sits here: labels, hints,
-  helper prose, microlabels, option rows, eyebrows.
+## 1. Elevation, not borders
 
-The result: box edges align with box edges, text aligns with text (including
-the text inside inputs), and nothing zigzags. Section headings are the one
-exception — they own a full-width border and sit on the box edge.
+Pure black under hairlines is what made the old admin harsh and "mushy" at
+high DPI — horizontal and vertical 1px lines don't even render the same
+weight. So the admin separates surfaces by **background contrast and
+spacing**, and (almost) never by border:
 
-**One label column for annotated rows.** Any run of "label: value" rows —
-match lines on an inbox card, `Proposed`/`Asked` rows on the form, the
-source/path line — shares a fixed label column via grid
-(`grid-cols-[<w>_minmax(0,1fr)]`), sized once per surface, with the value
-cell owning its own wrapping. Wrapped content stays in the value column;
-it never falls back under the label. Colored elements (badges, chips) in
-these rows therefore all start on the same rail.
+| Level | Color | What sits on it |
+|---|---|---|
+| Ground | `zinc-950` (body) | page titles, section headings, helper prose |
+| Block | `zinc-900`, `rounded-lg p-4` | one decision, one queue item, one card |
+| Well | `zinc-800` (or `/60`) | inputs, evidence rows, chips, nested panes |
+| Hover | one step lighter (`white/5`, `zinc-700`) | interactive wells |
+
+Rules that fall out of this:
+
+- **No 1px container borders.** A box is a fill. If an edge must be drawn,
+  it is ≥2px: a `ring-2 ring-inset` for selection, a `border-l-4` rail for
+  state, a `border-l-2` indent guide. Dashed 1px borders are allowed only on
+  ghost escape hatches, where looking faint is the point.
+- **Section headings carry no underline.** `text-xl font-bold text-zinc-100`
+  plus the 56px section gap is the divider.
+- **Inputs are filled, not outlined**: `bg-zinc-800`, transparent border,
+  soft brand focus ring (`focus:ring-brand-dark/20`).
+- **Shadows are for layers that float** (sticky bars, menus), not for cards.
+
+## 2. State rails — where the decisions are
+
+Every **decision block** (a `decision_row`, a series row, the work/recording
+identity clusters, the library-root chooser, an inbox queue item) wears a
+`border-l-4` rail that says its state at a scroll:
+
+| Rail | Meaning |
+|---|---|
+| `border-amber-400/70` | waiting on the operator |
+| `border-brand-dark/60` | settled / ready |
+| `border-red-400/70` | blocked (nothing proposed it, files changed) |
+| none / `border-zinc-700` | informational, or out of the queue |
+
+Evidence blocks (record lists) get no rail — they inform decisions, they
+aren't one. The rail is the *only* thing that encodes settledness at block
+level; don't also dim, collapse, or re-order.
+
+## 3. Geometry
+
+**Two left edges, never three.** Every container has exactly two
+x-positions: the **box edge** (cards, inputs, record rows, buttons) and the
+**text rail** — box edge + 12px (`pl-3`), matching the text inset inside the
+inputs — where every bare-text element sits (labels, hints, helper prose,
+microlabels, eyebrows).
+
+**One label column for annotated rows.** Any run of "label: value" rows
+(match lines, `Proposed`/`Asked` rows, the source line) shares a fixed label
+column via grid (`grid-cols-[<w>_minmax(0,1fr)]`), sized once per surface;
+wrapped content stays in the value column.
 
 **Rhythm is 8 · 28 · 56** (`gap-2` / `gap-7` / `gap-14`): inside a field
-cluster / between fields / between sections. Inside a card, lines group into
-blocks — identity, detail, alert — separated by 8px (`mt-2`), never one flat
-pitch. A gap states a relationship; equal gaps say "siblings".
+cluster / between blocks / between sections. Queue cards stack with
+`space-y-3`.
 
-**Corners share baselines.** When a card has a right rail, the rail's first
-element aligns with the title line and its last element with the content's
-last line (`self-stretch` + `justify-between`). A rail element that aligns
-with nothing reads as floating.
+**Corners share baselines.** A card's right rail aligns its first element
+with the title line and its last with the content's last line
+(`self-stretch` + `justify-between`).
 
-## 2. Type
+## 4. Type
 
 | Role | Spec |
 |---|---|
-| Page title | `text-2xl font-bold` |
-| Section heading | `text-xl font-bold` + `border-b`, on the box edge |
-| Field label | `text-sm font-semibold`, on the text rail |
-| Body / control text | `text-sm` |
-| Hint / helper / meta | `text-xs` or `text-sm`, `text-zinc-500 dark:text-zinc-400` — **never italic** |
-| Microlabel (`Proposed`, `Asked`, eyebrows) | `text-[11px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400` — use `<.microlabel>` |
-| Paths, queries, identifiers | `font-mono text-xs`, muted |
+| Page title | `text-2xl font-bold text-zinc-100` |
+| Section heading | `text-xl font-bold text-zinc-100`, no rule |
+| Field label | `text-sm font-semibold` (zinc-200), on the text rail |
+| Body / control text | `text-sm text-zinc-300` |
+| Hint / helper / meta | `text-xs`/`text-sm` `text-zinc-400` (`zinc-500` for the faintest) — **never italic** |
+| Microlabel (`Proposed`, `Asked`) | `<.microlabel>`: 11px medium uppercase tracking-wider muted |
+| Paths, queries, identifiers | `font-mono text-xs`, muted; a repeated common prefix is printed once |
 
-Italics are reserved for actual titles of works. Emphasis in helper prose is
-weight or color, not slant. Digits that stack use `tabular-nums`.
+Italics are reserved for actual titles of works. Emphasis is weight, not
+slant. Digits that stack use `tabular-nums`. Body text is `zinc-300` on
+`zinc-950` — pure white on pure black is glare, not contrast.
 
-## 3. Color
+## 5. Color
 
-Semantic only — color states a fact, never decorates:
+Semantic only — color states a fact, never decorates. Lime = chosen /
+settled / primary. Amber = needs attention. Red = blocker, with an icon,
+normal weight. Blue = location/info. Everything else zinc.
 
-| Meaning | Light | Dark |
-|---|---|---|
-| Selected / primary / success | lime (`brand` #84cc16, text `lime-700`) | lime (`brand-dark` #a3e635, text `lime-400`) |
-| Needs attention / pending / disagreement | amber | amber |
-| Blocker / destructive | red — with an icon, **normal weight**; red text never shouts in bold sentences | red |
-| Location / info | blue | blue |
-| Everything else | zinc | zinc |
+Fills for meaning are **soft tints with colored text** (`bg-amber-400/15
+text-amber-300`), never solid bright chips. The one solid lime is the
+primary button and the chosen chip's source tag.
 
-Muted text floor: `zinc-500` on light, `zinc-400` on dark. `zinc-600` on a
-dark ground fails; don't use it.
+## 6. Pills and buttons — one costume per job
 
-## 4. Pills — one costume per job
-
-| Job | Anatomy | Weight |
-|---|---|---|
-| **Status badge** (`pending`, `near-certain`) | `.badge`: soft fill + border, one height | quiet |
-| **Count chip** (`27 files`, `Hardcover: 3`) | filled `zinc-100/zinc-800`, `tabular-nums`, never bordered | quiet |
-| **Option chip** (proposed values) — *chosen* | lime border + `brand/10` tint + ✓ + **filled** lime source tag | the loudest pill on the page |
-| **Option chip** — *unchosen* | plain `zinc-300/zinc-700` border; source tag is bare uppercase muted text, **no fill** | quiet |
-| **Option chip** — *escape hatch* (`None`) | dashed border, muted text (`ghost`) | quietest |
-| **Action mini-button** (row actions) | outlined, worded, icon + label, **uniform width per rail** (`w-28`) | quiet until hover |
+| Job | Anatomy |
+|---|---|
+| Primary action | solid `bg-brand-dark text-zinc-900` (the loudest thing on the page) |
+| Secondary button | filled `bg-zinc-800 text-zinc-200 hover:bg-zinc-700`, borderless |
+| Quiet row action | filled `bg-white/5 text-zinc-300 hover:bg-white/10`, worded, uniform width per rail |
+| Danger | `bg-red-400/10 text-red-300`, or red text revealed on hover |
+| Status badge | `<.badge>`: soft tint + colored text, borderless |
+| Count chip | `bg-white/10 text-zinc-300 tabular-nums` |
+| Option chip — *chosen* | `bg-brand-dark/15` + `ring-2 ring-inset ring-brand-dark/50` + ✓ + filled lime source tag |
+| Option chip — *unchosen* | `bg-zinc-800 hover:bg-zinc-700`; source tag bare muted uppercase |
+| Option chip — *escape hatch* (`None`) | dashed `border-zinc-600 text-zinc-400`, transparent |
+| Evidence row — *ticked* | well: `bg-brand-dark/10` + `ring-2 ring-inset ring-brand-dark/50` + lime checkbox |
+| Evidence row — *unticked* | `bg-zinc-800/60 hover:bg-zinc-800` |
 
 If two pills on one surface do the same job, they wear the same costume, the
 same height, and start on the same rail.
 
-## 5. Controls
+## 7. Controls
 
-- **Adjacent bar controls share exact height.** A button next to a
-  segmented control next to a search input in one toolbar: all the same
-  height (the `<.button>` height, 42px). No exceptions — a 4px mismatch
-  reads as a bug.
+- **Adjacent bar controls share exact height** — no exceptions.
 - **Inputs are sized to their content**: dates `max-w-48`, format selects
   `max-w-56`, names/publishers `max-w-md`, titles `max-w-xl`, URLs and
-  descriptions full width. A date in a 900px box is not "roomy", it's
-  unanchored.
-- Buttons never wrap their label; when a bar runs out of room the bar
-  wraps as a whole.
+  descriptions full width.
+- Checkbox checked state is lime (`text-lime-600`), never the browser blue.
+- Buttons never wrap their label; when a bar runs out of room the bar wraps
+  as a whole.
 - Below `sm`, right rails fold into the card as a full-width bottom line;
-  below `lg`, the nav is a drawer with a scrim. Truncation drops meta
-  before content, and the candidate title is always the last thing to give.
+  below `lg`, the nav is a drawer with a scrim. Truncation drops meta before
+  content, and the candidate title is always the last thing to give.
 
-## 6. Voice
+## 8. Voice
 
 Labels name what the operator decides, not what the system stores. Hints
 teach in one sentence, lowercase-calm, no exclamation. Alerts say what's

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -1,0 +1,111 @@
+# The admin design language
+
+The rules every admin surface follows. They exist because the admin grew one
+widget at a time and read like it: five kinds of pill in one card, three left
+edges on one form, labels quieter than the chips they named. Each rule below
+kills one class of that. When a new surface is built or an old one is
+touched, it follows this document; when a rule has to bend, this document
+gets amended, not silently ignored.
+
+The public-facing app shares the tokens (brand color, button identity) but
+not the composition rules — it's a reading surface, not an operating one.
+
+## 1. Geometry
+
+**Two left edges, never three.** Every container (page column, card) has
+exactly two x-positions:
+
+- **The box edge** — where cards, inputs, record rows, buttons, and section
+  rules sit. This is the container's padding edge.
+- **The text rail** — box edge + 12px (`pl-3`), matching the inset of text
+  *inside* the inputs. Every bare-text element sits here: labels, hints,
+  helper prose, microlabels, option rows, eyebrows.
+
+The result: box edges align with box edges, text aligns with text (including
+the text inside inputs), and nothing zigzags. Section headings are the one
+exception — they own a full-width border and sit on the box edge.
+
+**One label column for annotated rows.** Any run of "label: value" rows —
+match lines on an inbox card, `Proposed`/`Asked` rows on the form, the
+source/path line — shares a fixed label column via grid
+(`grid-cols-[<w>_minmax(0,1fr)]`), sized once per surface, with the value
+cell owning its own wrapping. Wrapped content stays in the value column;
+it never falls back under the label. Colored elements (badges, chips) in
+these rows therefore all start on the same rail.
+
+**Rhythm is 8 · 28 · 56** (`gap-2` / `gap-7` / `gap-14`): inside a field
+cluster / between fields / between sections. Inside a card, lines group into
+blocks — identity, detail, alert — separated by 8px (`mt-2`), never one flat
+pitch. A gap states a relationship; equal gaps say "siblings".
+
+**Corners share baselines.** When a card has a right rail, the rail's first
+element aligns with the title line and its last element with the content's
+last line (`self-stretch` + `justify-between`). A rail element that aligns
+with nothing reads as floating.
+
+## 2. Type
+
+| Role | Spec |
+|---|---|
+| Page title | `text-2xl font-bold` |
+| Section heading | `text-xl font-bold` + `border-b`, on the box edge |
+| Field label | `text-sm font-semibold`, on the text rail |
+| Body / control text | `text-sm` |
+| Hint / helper / meta | `text-xs` or `text-sm`, `text-zinc-500 dark:text-zinc-400` — **never italic** |
+| Microlabel (`Proposed`, `Asked`, eyebrows) | `text-[11px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400` — use `<.microlabel>` |
+| Paths, queries, identifiers | `font-mono text-xs`, muted |
+
+Italics are reserved for actual titles of works. Emphasis in helper prose is
+weight or color, not slant. Digits that stack use `tabular-nums`.
+
+## 3. Color
+
+Semantic only — color states a fact, never decorates:
+
+| Meaning | Light | Dark |
+|---|---|---|
+| Selected / primary / success | lime (`brand` #84cc16, text `lime-700`) | lime (`brand-dark` #a3e635, text `lime-400`) |
+| Needs attention / pending / disagreement | amber | amber |
+| Blocker / destructive | red — with an icon, **normal weight**; red text never shouts in bold sentences | red |
+| Location / info | blue | blue |
+| Everything else | zinc | zinc |
+
+Muted text floor: `zinc-500` on light, `zinc-400` on dark. `zinc-600` on a
+dark ground fails; don't use it.
+
+## 4. Pills — one costume per job
+
+| Job | Anatomy | Weight |
+|---|---|---|
+| **Status badge** (`pending`, `near-certain`) | `.badge`: soft fill + border, one height | quiet |
+| **Count chip** (`27 files`, `Hardcover: 3`) | filled `zinc-100/zinc-800`, `tabular-nums`, never bordered | quiet |
+| **Option chip** (proposed values) — *chosen* | lime border + `brand/10` tint + ✓ + **filled** lime source tag | the loudest pill on the page |
+| **Option chip** — *unchosen* | plain `zinc-300/zinc-700` border; source tag is bare uppercase muted text, **no fill** | quiet |
+| **Option chip** — *escape hatch* (`None`) | dashed border, muted text (`ghost`) | quietest |
+| **Action mini-button** (row actions) | outlined, worded, icon + label, **uniform width per rail** (`w-28`) | quiet until hover |
+
+If two pills on one surface do the same job, they wear the same costume, the
+same height, and start on the same rail.
+
+## 5. Controls
+
+- **Adjacent bar controls share exact height.** A button next to a
+  segmented control next to a search input in one toolbar: all the same
+  height (the `<.button>` height, 42px). No exceptions — a 4px mismatch
+  reads as a bug.
+- **Inputs are sized to their content**: dates `max-w-48`, format selects
+  `max-w-56`, names/publishers `max-w-md`, titles `max-w-xl`, URLs and
+  descriptions full width. A date in a 900px box is not "roomy", it's
+  unanchored.
+- Buttons never wrap their label; when a bar runs out of room the bar
+  wraps as a whole.
+- Below `sm`, right rails fold into the card as a full-width bottom line;
+  below `lg`, the nav is a drawer with a scrim. Truncation drops meta
+  before content, and the candidate title is always the last thing to give.
+
+## 6. Voice
+
+Labels name what the operator decides, not what the system stores. Hints
+teach in one sentence, lowercase-calm, no exclamation. Alerts say what's
+wrong and what to do, with an icon carrying the severity so the words don't
+have to.

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -459,6 +459,22 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  @doc """
+  A microlabel — the quiet uppercase word that names a row of things
+  (`Proposed`, `Asked`, an eyebrow). One spec everywhere, per the admin
+  design language (docs/admin-design-language.md §2).
+  """
+  attr :class, :string, default: nil
+  slot :inner_block, required: true
+
+  def microlabel(assigns) do
+    ~H"""
+    <span class={["text-[11px] font-medium uppercase tracking-wider text-zinc-500 dark:text-zinc-400", @class]}>
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
   defp badge_color(:yellow),
     do: "border-yellow-200 bg-yellow-50 dark:border-yellow-400 dark:bg-yellow-400"
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -40,7 +40,7 @@ defmodule AmbryWeb.Admin.Components do
 
   defp layout_header(assigns) do
     ~H"""
-    <header id="nav-header" class="space-y-4 border-zinc-100 p-4 dark:border-zinc-900">
+    <header id="nav-header" class="space-y-4 p-4">
       <div class="flex items-center gap-3">
         <span class="cursor-pointer lg:hidden" phx-click={open_sidebar()}>
           <.icon name="fa-bars" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
@@ -49,7 +49,7 @@ defmodule AmbryWeb.Admin.Components do
           <.logo class="h-6 w-6 lg:h-7 lg:w-7" />
           <.title class="hidden h-6 sm:block lg:h-7" />
         </.link>
-        <div class="grow overflow-hidden text-ellipsis whitespace-nowrap pl-0 text-2xl font-bold sm:pl-4 lg:pl-0">
+        <div class="grow overflow-hidden text-ellipsis whitespace-nowrap pl-0 text-2xl font-bold text-zinc-100 sm:pl-4 lg:pl-0">
           {@title}
         </div>
         <div
@@ -88,7 +88,7 @@ defmodule AmbryWeb.Admin.Components do
         <.admin_table_search_form search_form={@search_form} />
       </div>
       <div :if={@new_path}>
-        <.link navigate={@new_path} class="flex items-center font-bold text-lime-500 hover:underline dark:text-lime-400">
+        <.link navigate={@new_path} class="flex items-center font-bold text-lime-700 hover:underline dark:text-lime-400">
           {@new_text} <.icon name="fa-plus" class="ml-2 h-4 w-4 text-current" />
         </.link>
       </div>
@@ -288,6 +288,10 @@ defmodule AmbryWeb.Admin.Components do
   attr :filter, :string, default: nil
   attr :row_click, :any, default: nil
 
+  attr :row_class, :any,
+    default: nil,
+    doc: "optional fun row -> extra classes; how a row wears per-item state (e.g. a state rail)"
+
   slot :empty
   slot :row, required: true
 
@@ -303,7 +307,11 @@ defmodule AmbryWeb.Admin.Components do
       </p>
     <% else %>
       <.admin_table_container>
-        <.admin_table_row :for={row <- @rows} phx-click={@row_click && @row_click.(row)}>
+        <.admin_table_row
+          :for={row <- @rows}
+          class={@row_class && @row_class.(row)}
+          phx-click={@row_click && @row_click.(row)}
+        >
           {render_slot(@row, row)}
         </.admin_table_row>
       </.admin_table_container>
@@ -315,12 +323,15 @@ defmodule AmbryWeb.Admin.Components do
 
   defp admin_table_container(assigns) do
     ~H"""
-    <div class="divide-y divide-zinc-200 rounded-sm border border-zinc-200 bg-zinc-50 dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+    <%!-- Rows are separate raised cards on the ground, not one bordered slab
+          sliced by hairline dividers — elevation and gaps do the separating. --%>
+    <div class="space-y-3">
       {render_slot(@inner_block)}
     </div>
     """
   end
 
+  attr :class, :any, default: nil
   attr :rest, :global
   slot :inner_block, required: true
 
@@ -328,7 +339,13 @@ defmodule AmbryWeb.Admin.Components do
     ~H"""
     <%!-- flex-wrap below sm lets a row's right rail drop to a full-width
           bottom line instead of squeezing the content column on phones. --%>
-    <div class="relative flex cursor-pointer flex-wrap items-center gap-x-4 gap-y-2 p-4 sm:flex-nowrap" {@rest}>
+    <div
+      class={[
+        "relative flex cursor-pointer flex-wrap items-center gap-x-4 gap-y-2 rounded-lg bg-zinc-900 p-4 sm:flex-nowrap",
+        @class
+      ]}
+      {@rest}
+    >
       {render_slot(@inner_block)}
     </div>
     """
@@ -360,7 +377,7 @@ defmodule AmbryWeb.Admin.Components do
     ~H"""
     <div
       :if={@busy}
-      class="bg-zinc-200/75 absolute inset-0 z-20 flex items-center justify-center gap-2 rounded-sm dark:bg-zinc-900/80"
+      class="bg-zinc-950/70 backdrop-blur-[1px] absolute inset-0 z-20 flex items-center justify-center gap-2 rounded-lg"
       data-role="busy-overlay"
       aria-live="polite"
       {@rest}
@@ -375,7 +392,7 @@ defmodule AmbryWeb.Admin.Components do
 
   def sort_button_bar(assigns) do
     ~H"""
-    <div class="flex flex-wrap justify-between divide-zinc-200 rounded-sm border border-zinc-200 bg-zinc-50 font-bold dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900">
+    <div class="flex flex-wrap justify-between rounded-lg bg-zinc-900 font-bold">
       {render_slot(@inner_block)}
     </div>
     """
@@ -450,8 +467,11 @@ defmodule AmbryWeb.Admin.Components do
 
   def badge(assigns) do
     ~H"""
+    <%!-- A soft tint with colored text, not a solid bright pill: status is
+          information, and a page of solid chips shouts. Borderless — the
+          admin separates by fill, not hairlines. --%>
     <div
-      class={["inline-block whitespace-nowrap rounded-sm border px-1 text-zinc-900", badge_color(@color), @class]}
+      class={["inline-block whitespace-nowrap rounded-sm px-1.5", badge_color(@color), @class]}
       {@rest}
     >
       {render_slot(@inner_block)}
@@ -475,13 +495,11 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
-  defp badge_color(:yellow),
-    do: "border-yellow-200 bg-yellow-50 dark:border-yellow-400 dark:bg-yellow-400"
-
-  defp badge_color(:blue), do: "border-blue-200 bg-blue-50 dark:border-blue-400 dark:bg-blue-400"
-  defp badge_color(:red), do: "border-red-200 bg-red-50 dark:border-red-400 dark:bg-red-400"
-  defp badge_color(:brand), do: "border-lime-200 bg-lime-50 dark:border-lime-400 dark:bg-lime-400"
-  defp badge_color(:gray), do: "border-zinc-200 bg-zinc-100 dark:border-zinc-400 dark:bg-zinc-400"
+  defp badge_color(:yellow), do: "bg-amber-400/15 text-amber-300"
+  defp badge_color(:blue), do: "bg-blue-400/15 text-blue-300"
+  defp badge_color(:red), do: "bg-red-400/15 text-red-300"
+  defp badge_color(:brand), do: "bg-brand-dark/15 text-lime-300"
+  defp badge_color(:gray), do: "bg-white/10 text-zinc-300"
 
   attr :field, FormField, required: true
 
@@ -571,7 +589,10 @@ defmodule AmbryWeb.Admin.Components do
         data-role="move-up"
         class="disabled:opacity-25"
       >
-        <.icon name="fa-chevron-up" class="h-3 w-3 text-current transition-colors hover:text-blue-600" />
+        <.icon
+          name="fa-chevron-up"
+          class="h-3 w-3 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+        />
       </button>
       <button
         type="button"
@@ -584,7 +605,10 @@ defmodule AmbryWeb.Admin.Components do
         data-role="move-down"
         class="disabled:opacity-25"
       >
-        <.icon name="fa-chevron-down" class="h-3 w-3 text-current transition-colors hover:text-blue-600" />
+        <.icon
+          name="fa-chevron-down"
+          class="h-3 w-3 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+        />
       </button>
     </div>
     """
@@ -600,7 +624,7 @@ defmodule AmbryWeb.Admin.Components do
       name={@field.name <> "[]"}
       value="new"
       phx-click={JS.dispatch("change")}
-      class="text-brand flex cursor-pointer items-center gap-1 hover:underline dark:text-brand-dark"
+      class="flex cursor-pointer items-center gap-1 text-lime-700 hover:underline dark:text-brand-dark"
     >
       {render_slot(@inner_block)}
       <.icon name="fa-plus" class="h-4 w-4 text-current" />

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -36,9 +36,8 @@ defmodule AmbryWeb.Admin.Decisions do
   def input_classes(extra \\ nil) do
     [
       "rounded-sm text-sm focus:outline-none focus:ring-4",
-      "bg-white text-zinc-900 placeholder:text-zinc-500 dark:bg-zinc-800 dark:text-zinc-300",
-      "border-zinc-300 focus:border-zinc-400 focus:ring-zinc-800/5",
-      "dark:border-zinc-600 dark:focus:border-zinc-400 dark:focus:ring-zinc-200/5",
+      "bg-zinc-800 text-zinc-200 placeholder:text-zinc-500",
+      "focus:ring-brand-dark/20 border-transparent focus:border-transparent",
       extra
     ]
   end
@@ -75,7 +74,7 @@ defmodule AmbryWeb.Admin.Decisions do
         <span
           :for={outcome <- @outcomes}
           :if={outcome["status"] != "failed"}
-          class="rounded-sm bg-zinc-100 px-2 py-0.5 text-xs tabular-nums text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+          class="bg-white/10 rounded-sm px-2 py-0.5 text-xs tabular-nums text-zinc-300"
         >
           {outcome["name"]}: {outcome["count"]}
         </span>
@@ -92,7 +91,7 @@ defmodule AmbryWeb.Admin.Decisions do
           phx-value-provider={outcome["id"]}
           disabled={@retrying == outcome["id"]}
           title={outcome["reason"]}
-          class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600 disabled:opacity-50"
+          class="bg-red-400/10 rounded-sm px-2 py-0.5 text-xs text-red-300 hover:bg-red-400/20 disabled:opacity-50"
         >
           {outcome["name"]}: {if @retrying == outcome["id"],
             do: "asking again…",
@@ -103,7 +102,7 @@ defmodule AmbryWeb.Admin.Decisions do
           :for={outcome <- @outcomes}
           :if={outcome["status"] == "failed" and not @retryable}
           title={outcome["reason"]}
-          class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600"
+          class="bg-red-400/10 rounded-sm px-2 py-0.5 text-xs text-red-300"
         >
           {outcome["name"]}: couldn't be reached
         </span>
@@ -129,9 +128,9 @@ defmodule AmbryWeb.Admin.Decisions do
       <span>Searched for</span>
       <span :for={{key, value} <- ordered_fields(@fields)} class="ml-1">
         <span class="text-zinc-500 dark:text-zinc-400">{key}:</span>
-        <span class="font-mono dark:text-zinc-400">{value}</span>
+        <span class="font-mono text-zinc-600 dark:text-zinc-400">{value}</span>
       </span>
-      <span :if={@fields == %{}} class="font-mono ml-1 dark:text-zinc-400">{@query}</span>
+      <span :if={@fields == %{}} class="font-mono ml-1 text-zinc-600 dark:text-zinc-400">{@query}</span>
       <p class="pt-0.5">
         A provider whose narrow search comes back empty may widen it, so what matched can be broader
         than this.
@@ -167,9 +166,9 @@ defmodule AmbryWeb.Admin.Decisions do
     ~H"""
     <label
       class={[
-        "flex cursor-pointer items-start gap-3 rounded-sm border p-2",
-        @used && "border-brand bg-brand/5 dark:border-brand-dark dark:bg-brand-dark/10",
-        !@used && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+        "flex cursor-pointer items-start gap-3 rounded-md p-2.5",
+        @used && "bg-brand-dark/10 ring-brand-dark/50 ring-2 ring-inset",
+        !@used && "bg-zinc-800/60 hover:bg-zinc-800"
       ]}
       data-role="record"
       data-used={@used && "true"}
@@ -182,13 +181,13 @@ defmodule AmbryWeb.Admin.Decisions do
         phx-value-key={@person_key}
         phx-value-source={@record["source"]}
         phx-value-id={@record["id"]}
-        class="mt-1 h-4 w-4 flex-none rounded-sm"
+        class="mt-1 h-4 w-4 flex-none rounded-sm border-zinc-600 bg-zinc-700 text-lime-600 focus:ring-lime-500"
       />
       <div class="min-w-0 flex-grow">
         <p class="truncate text-sm font-medium">{candidate_title(@record)}</p>
-        <p class="truncate text-xs dark:text-zinc-500">{candidate_facts(@record)}</p>
+        <p class="truncate text-xs text-zinc-500 dark:text-zinc-400">{candidate_facts(@record)}</p>
       </div>
-      <span :if={@working} class="flex-none pt-0.5 text-xs dark:text-zinc-400">
+      <span :if={@working} class="flex-none pt-0.5 text-xs text-zinc-500 dark:text-zinc-400">
         fetching…
       </span>
       <%!-- The meter makes the ranking visible before the number is read —
@@ -198,7 +197,7 @@ defmodule AmbryWeb.Admin.Decisions do
         <span class="text-xs tabular-nums text-zinc-500 dark:text-zinc-400">
           {round(@record["score"] * 100)}%
         </span>
-        <span class="h-1 w-16 overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+        <span class="h-1 w-16 overflow-hidden rounded-full bg-zinc-700">
           <span
             class={["block h-full rounded-full", meter_color(@record["score"])]}
             style={"width: #{round(@record["score"] * 100)}%"}
@@ -230,16 +229,16 @@ defmodule AmbryWeb.Admin.Decisions do
     ~H"""
     <div
       class={[
-        "flex items-start gap-3 rounded-sm border p-3",
-        @linked && "border-brand bg-brand/5 dark:border-brand-dark dark:bg-brand-dark/10",
-        !@linked && "border-zinc-300 dark:border-zinc-700"
+        "flex items-start gap-3 rounded-md p-3",
+        @linked && "bg-brand-dark/10 ring-brand-dark/50 ring-2 ring-inset",
+        !@linked && "bg-zinc-800/60"
       ]}
       data-role="local-book"
       data-linked={@linked && "true"}
     >
       <div class="min-w-0 flex-grow">
         <p class="truncate text-sm font-semibold">{candidate_title(@book)}</p>
-        <p class="truncate text-xs dark:text-zinc-500">{candidate_facts(@book)}</p>
+        <p class="truncate text-xs text-zinc-500 dark:text-zinc-400">{candidate_facts(@book)}</p>
       </div>
 
       <button
@@ -247,12 +246,12 @@ defmodule AmbryWeb.Admin.Decisions do
         type="button"
         phx-click="link-book"
         phx-value-id={@book["id"]}
-        class="flex-none rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+        class="bg-white/5 flex-none rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
       >
         Yes — another edition of this
       </button>
 
-      <span :if={@linked} class="flex-none text-xs dark:text-zinc-500">using this book</span>
+      <span :if={@linked} class="flex-none text-xs text-zinc-500 dark:text-zinc-400">using this book</span>
     </div>
     """
   end
@@ -275,14 +274,14 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <input type="hidden" name="key" value={@person_key} />
 
-      <label class="text-xs dark:text-zinc-500">
+      <label class="text-xs text-zinc-500 dark:text-zinc-400">
         name <input type="text" name="name" value={@name} class={input_classes("mt-1 block")} />
       </label>
 
       <button
         type="submit"
         disabled={@running}
-        class="rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
+        class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10 disabled:opacity-50"
       >
         {if @running, do: "Searching…", else: "Search again"}
       </button>
@@ -310,7 +309,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <input type="hidden" name="level" value={@level} />
 
-      <label class="text-xs dark:text-zinc-500">
+      <label class="text-xs text-zinc-500 dark:text-zinc-400">
         title
         <input
           type="text"
@@ -320,7 +319,7 @@ defmodule AmbryWeb.Admin.Decisions do
         />
       </label>
 
-      <label class="text-xs dark:text-zinc-500">
+      <label class="text-xs text-zinc-500 dark:text-zinc-400">
         author
         <input
           type="text"
@@ -330,7 +329,7 @@ defmodule AmbryWeb.Admin.Decisions do
         />
       </label>
 
-      <label :if={@level == "recording"} class="text-xs dark:text-zinc-500">
+      <label :if={@level == "recording"} class="text-xs text-zinc-500 dark:text-zinc-400">
         narrator
         <input
           type="text"
@@ -343,7 +342,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <button
         type="submit"
         disabled={@running}
-        class="rounded-sm border border-zinc-300 px-2 py-1 text-xs disabled:opacity-50 dark:border-zinc-700"
+        class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10 disabled:opacity-50"
       >
         {if @running, do: "Searching…", else: "Search again"}
       </button>
@@ -453,7 +452,7 @@ defmodule AmbryWeb.Admin.Decisions do
           option row) sits on the text rail (pl-3), aligned with the text
           INSIDE the control; only boxes touch the margin edge. See
           docs/admin-design-language.md §1. --%>
-    <div class="space-y-2">
+    <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", decision_rail(@field)]}>
       <div class="flex items-center gap-2 pl-3">
         <.label>{@label}</.label>
 
@@ -521,7 +520,7 @@ defmodule AmbryWeb.Admin.Decisions do
                   id={"#{@section}-#{@name}-preview"}
                   phx-hook="scroll-match"
                   data-target={"#{@section}-#{@name}-input"}
-                  class="absolute inset-0 hidden overflow-auto rounded-sm border border-zinc-300 dark:border-zinc-800 sm:block"
+                  class="bg-zinc-800/50 absolute inset-0 hidden overflow-auto rounded-sm sm:block"
                 >
                   <.markdown content={@field.value || ""} class="p-2" />
                 </div>
@@ -553,8 +552,8 @@ defmodule AmbryWeb.Admin.Decisions do
                   filled tag on every chip made the whole row heavy. --%>
             <span class={[
               "text-[10px] flex-none uppercase tracking-wide",
-              Field.chose?(@field, candidate) && "bg-brand/90 rounded-sm px-1 text-zinc-900 dark:bg-brand-dark",
-              !Field.chose?(@field, candidate) && "text-zinc-500 dark:text-zinc-400"
+              Field.chose?(@field, candidate) && "bg-brand-dark rounded-sm px-1 text-zinc-900",
+              !Field.chose?(@field, candidate) && "text-zinc-500"
             ]}>
               {candidate.label || source_words(candidate.source)}
             </span>
@@ -641,7 +640,7 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def credit_row(assigns) do
     ~H"""
-    <div class="space-y-2 rounded-sm border border-zinc-300 p-3 dark:border-zinc-700">
+    <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
       <div class="flex items-center justify-between gap-2">
         <div class="flex min-w-0 items-center gap-2">
           <.icon
@@ -659,7 +658,7 @@ defmodule AmbryWeb.Admin.Decisions do
             {elem(state_words(Credit.state(@credit)), 0)}
           </.badge>
 
-          <span :if={@credit.source} class="text-xs dark:text-zinc-500">
+          <span :if={@credit.source} class="text-xs text-zinc-500 dark:text-zinc-400">
             from {source_words(@credit.source)}
           </span>
         </div>
@@ -672,7 +671,7 @@ defmodule AmbryWeb.Admin.Decisions do
             phx-value-section={@section}
             phx-value-index={@index}
             phx-value-approved="true"
-            class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+            class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
           >
             Confirm
           </button>
@@ -750,7 +749,7 @@ defmodule AmbryWeb.Admin.Decisions do
         phx-click="toggle-people"
         phx-value-section={@section}
         phx-value-index={@index}
-        class="text-xs underline dark:text-zinc-400"
+        class="text-xs text-zinc-500 underline dark:text-zinc-400"
       >
         {@reveal}
       </button>
@@ -760,7 +759,7 @@ defmodule AmbryWeb.Admin.Decisions do
 
         <div
           :for={{person, person_index} <- Enum.with_index(@persons)}
-          class="space-y-1 border-l border-zinc-200 pl-3 dark:border-zinc-700"
+          class="space-y-1 border-l-2 border-zinc-700 pl-3"
         >
           <form
             id={"credit-#{@section}-#{@index}-person-#{person_index}"}
@@ -815,7 +814,7 @@ defmodule AmbryWeb.Admin.Decisions do
           phx-click="add-person"
           phx-value-section={@section}
           phx-value-index={@index}
-          class="text-xs underline dark:text-zinc-400"
+          class="text-xs text-zinc-500 underline dark:text-zinc-400"
         >
           Add another person
         </button>
@@ -910,7 +909,7 @@ defmodule AmbryWeb.Admin.Decisions do
 
         <span
           :if={is_nil(@image)}
-          class="h-12 w-12 flex-none rounded-full border border-dashed border-zinc-300 dark:border-zinc-700"
+          class="h-12 w-12 flex-none rounded-full border border-dashed border-zinc-700"
         />
 
         <%!-- The same human on two credits: an author reading their own book.
@@ -944,8 +943,8 @@ defmodule AmbryWeb.Admin.Decisions do
             the photo and bio pools draw from the ticked set. The exact-name
             gate decides the initial ticks; a differently-spelled record of
             the right person is exactly what the checkbox is for. --%>
-      <p :if={@records != []} class="text-xs dark:text-zinc-400">
-        Tick every record of <em>this person</em> — the photos and bios on offer come from the
+      <p :if={@records != []} class="text-xs text-zinc-500 dark:text-zinc-400">
+        Tick every record of <span class="font-semibold">this person</span> — the photos and bios on offer come from the
         ticked ones. Databases know several people by many names, so check before ticking.
       </p>
 
@@ -960,7 +959,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <.provider_outcomes_row outcomes={@outcomes} retryable={false} />
 
       <details>
-        <summary class="cursor-pointer text-xs dark:text-zinc-400">
+        <summary class="cursor-pointer text-xs text-zinc-500 dark:text-zinc-400">
           Not the right person? Search again
         </summary>
         <div class="pt-2">
@@ -1000,7 +999,7 @@ defmodule AmbryWeb.Admin.Decisions do
             type="button"
             phx-click="toggle-photos"
             phx-value-key={@person.key}
-            class="text-xs underline dark:text-zinc-400"
+            class="text-xs text-zinc-500 underline dark:text-zinc-400"
           >
             {if @expanded, do: "show fewer", else: "show all #{length(@photos)} photos"}
           </button>
@@ -1011,7 +1010,7 @@ defmodule AmbryWeb.Admin.Decisions do
             phx-click="waive-person-field"
             phx-value-key={@person.key}
             phx-value-field="image"
-            class="text-xs underline dark:text-zinc-400"
+            class="self-center rounded-sm border border-dashed border-zinc-600 px-2 py-1 text-xs text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
           >
             no photo
           </button>
@@ -1040,7 +1039,7 @@ defmodule AmbryWeb.Admin.Decisions do
               id={"person-bio-#{@at}-preview"}
               phx-hook="scroll-match"
               data-target={"person-bio-#{@at}-input"}
-              class="absolute inset-0 hidden overflow-auto rounded-sm border border-zinc-300 dark:border-zinc-800 sm:block"
+              class="bg-zinc-800/50 absolute inset-0 hidden overflow-auto rounded-sm sm:block"
             >
               <.markdown content={@description || ""} class="p-2" />
             </div>
@@ -1060,7 +1059,7 @@ defmodule AmbryWeb.Admin.Decisions do
             >
               <span class={[
                 "text-[10px] flex-none uppercase tracking-wide",
-                Field.chose?(@person.description, bio) && "bg-brand/90 rounded-sm px-1 text-zinc-900 dark:bg-brand-dark",
+                Field.chose?(@person.description, bio) && "bg-brand-dark rounded-sm px-1 text-zinc-900",
                 !Field.chose?(@person.description, bio) && "text-zinc-500 dark:text-zinc-400"
               ]}>
                 {bio.label}
@@ -1116,13 +1115,12 @@ defmodule AmbryWeb.Admin.Decisions do
       {chip_values(@values)}
       title={@title}
       class={[
-        "max-w-full rounded-sm border text-left text-xs",
+        "max-w-full rounded-md text-left text-xs",
         @shape == "circle" && "rounded-full p-0.5",
         @shape != "circle" && "inline-flex items-center gap-1.5 px-2 py-1",
-        @chosen && "border-brand bg-brand/10 dark:border-brand-dark dark:bg-brand-dark/10",
-        !@chosen && !@ghost && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500",
-        !@chosen && @ghost &&
-          "border-dashed border-zinc-300 text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
+        @chosen && "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
+        !@chosen && !@ghost && "bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100",
+        !@chosen && @ghost && "border border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
       ]}
     >
       <%!-- The chosen chip is the single most important state on the form, and
@@ -1131,7 +1129,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <.icon
         :if={@chosen && @shape != "circle"}
         name="fa-check"
-        class="h-3 w-3 flex-none text-lime-700 dark:text-brand-dark"
+        class="text-brand-dark h-3 w-3 flex-none"
       />
       {render_slot(@inner_block)}
     </button>
@@ -1155,7 +1153,10 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def series_row(assigns) do
     ~H"""
-    <div class="flex flex-wrap items-center gap-2 rounded-sm border border-zinc-300 p-3 dark:border-zinc-700">
+    <div class={[
+      "flex flex-wrap items-center gap-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+      (SeriesLink.resolved?(@link) && "border-brand-dark/60") || "border-amber-400/70"
+    ]}>
       <.icon
         :if={SeriesLink.resolved?(@link)}
         name="fa-circle-check"
@@ -1172,7 +1173,7 @@ defmodule AmbryWeb.Admin.Decisions do
 
       <form id={"series-#{@index}-number"} phx-change="set-series-number" class="flex items-center gap-1">
         <input type="hidden" name="index" value={@index} />
-        <label class="text-xs dark:text-zinc-500">Book no.</label>
+        <label class="text-xs text-zinc-500 dark:text-zinc-400">Book no.</label>
         <input
           type="text"
           name="number"
@@ -1209,7 +1210,7 @@ defmodule AmbryWeb.Admin.Decisions do
         phx-click="approve-series"
         phx-value-index={@index}
         phx-value-approved="true"
-        class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700"
+        class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
       >
         Confirm
       </button>
@@ -1219,6 +1220,17 @@ defmodule AmbryWeb.Admin.Decisions do
       </button>
     </div>
     """
+  end
+
+  # The block's left rail is the decision's state, readable from a scroll:
+  # lime = settled, amber = waiting on the operator, red = blocked. A 4px
+  # rail renders crisp at any DPI where a tinted hairline goes mushy.
+  defp decision_rail(field) do
+    cond do
+      field.approved -> "border-brand-dark/60"
+      Field.state(field) == :missing -> "border-red-400/70"
+      true -> "border-amber-400/70"
+    end
   end
 
   @doc """

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -15,7 +15,7 @@ defmodule AmbryWeb.Admin.Decisions do
   use Phoenix.Component
   use AmbryWeb, :verified_routes
 
-  import AmbryWeb.Admin.Components, only: [badge: 1]
+  import AmbryWeb.Admin.Components, only: [badge: 1, microlabel: 1]
   import AmbryWeb.CoreComponents
 
   alias Ambry.Inbox.Draft.Credit
@@ -62,48 +62,52 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def provider_outcomes_row(assigns) do
     ~H"""
-    <div :if={@outcomes != []} class="flex flex-wrap items-center gap-2" data-role="provider-outcomes">
-      <span class="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-        Asked
-      </span>
+    <div
+      :if={@outcomes != []}
+      class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3"
+      data-role="provider-outcomes"
+    >
+      <.microlabel class="pt-1">Asked</.microlabel>
 
-      <%!-- A count is information, not an option — filled and quiet, so it
+      <div class="flex flex-wrap items-center gap-1.5">
+        <%!-- A count is information, not an option — filled and quiet, so it
             can't be mistaken for the clickable proposal chips nearby. --%>
-      <span
-        :for={outcome <- @outcomes}
-        :if={outcome["status"] != "failed"}
-        class="rounded-sm bg-zinc-100 px-2 py-0.5 text-xs tabular-nums text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
-      >
-        {outcome["name"]}: {outcome["count"]}
-      </span>
+        <span
+          :for={outcome <- @outcomes}
+          :if={outcome["status"] != "failed"}
+          class="rounded-sm bg-zinc-100 px-2 py-0.5 text-xs tabular-nums text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300"
+        >
+          {outcome["name"]}: {outcome["count"]}
+        </span>
 
-      <%!-- A provider that was rate-limited during matching used to cost this
+        <%!-- A provider that was rate-limited during matching used to cost this
             item its records until somebody re-ran the whole match. The chip is
             the retry. --%>
-      <button
-        :for={outcome <- @outcomes}
-        :if={outcome["status"] == "failed" and @retryable}
-        type="button"
-        phx-click="retry-provider"
-        phx-value-level={@level}
-        phx-value-provider={outcome["id"]}
-        disabled={@retrying == outcome["id"]}
-        title={outcome["reason"]}
-        class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600 disabled:opacity-50"
-      >
-        {outcome["name"]}: {if @retrying == outcome["id"],
-          do: "asking again…",
-          else: "couldn't be reached — retry"}
-      </button>
+        <button
+          :for={outcome <- @outcomes}
+          :if={outcome["status"] == "failed" and @retryable}
+          type="button"
+          phx-click="retry-provider"
+          phx-value-level={@level}
+          phx-value-provider={outcome["id"]}
+          disabled={@retrying == outcome["id"]}
+          title={outcome["reason"]}
+          class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600 disabled:opacity-50"
+        >
+          {outcome["name"]}: {if @retrying == outcome["id"],
+            do: "asking again…",
+            else: "couldn't be reached — retry"}
+        </button>
 
-      <span
-        :for={outcome <- @outcomes}
-        :if={outcome["status"] == "failed" and not @retryable}
-        title={outcome["reason"]}
-        class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600"
-      >
-        {outcome["name"]}: couldn't be reached
-      </span>
+        <span
+          :for={outcome <- @outcomes}
+          :if={outcome["status"] == "failed" and not @retryable}
+          title={outcome["reason"]}
+          class="rounded-sm border border-red-500 px-2 py-0.5 text-xs text-red-600"
+        >
+          {outcome["name"]}: couldn't be reached
+        </span>
+      </div>
     </div>
     """
   end
@@ -121,14 +125,14 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def query_row(assigns) do
     ~H"""
-    <div :if={@query || @fields != %{}} class="text-xs dark:text-zinc-500" data-role="query">
+    <div :if={@query || @fields != %{}} class="pl-3 text-xs text-zinc-500 dark:text-zinc-400" data-role="query">
       <span>Searched for</span>
       <span :for={{key, value} <- ordered_fields(@fields)} class="ml-1">
         <span class="text-zinc-500 dark:text-zinc-400">{key}:</span>
         <span class="font-mono dark:text-zinc-400">{value}</span>
       </span>
       <span :if={@fields == %{}} class="font-mono ml-1 dark:text-zinc-400">{@query}</span>
-      <p class="italic">
+      <p class="pt-0.5">
         A provider whose narrow search comes back empty may widen it, so what matched can be broader
         than this.
       </p>
@@ -429,6 +433,10 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :preview, :boolean, default: false
   attr :embedded_src, :string, default: nil, doc: "where the file's own art can be seen"
 
+  attr :control_class, :string,
+    default: nil,
+    doc: "sizes the control to its content — a date doesn't get a 900px box"
+
   @doc """
   One scalar decision: what the sources proposed, what it will be, and where
   that came from.
@@ -440,12 +448,13 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def decision_row(assigns) do
     ~H"""
-    <%!-- One slot order for every field — label row, control, options, hint —
-          with an 8px beat inside the cluster. The 28px to the *next* field
-          comes from the section, so the ratio between "mine" and "not mine"
-          stays legible (see the admin design review, rhythm rules). --%>
+    <%!-- One slot order for every field — label row, control, hint, options —
+          with an 8px beat inside the cluster. All bare text (label, hint,
+          option row) sits on the text rail (pl-3), aligned with the text
+          INSIDE the control; only boxes touch the margin edge. See
+          docs/admin-design-language.md §1. --%>
     <div class="space-y-2">
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-2 pl-3">
         <.label>{@label}</.label>
 
         <.badge
@@ -486,12 +495,14 @@ defmodule AmbryWeb.Admin.Decisions do
               field={decision[:value]}
               type="select"
               options={@options}
+              class={@control_class}
             />
             <.input
               :if={@type not in ["select", "textarea"]}
               field={decision[:value]}
               type={@type}
               placeholder={@placeholder}
+              class={@control_class}
             />
             <%!-- A description is markdown, and markdown in a plain box is
                   written blind — the same textarea/preview pair the person
@@ -520,52 +531,59 @@ defmodule AmbryWeb.Admin.Decisions do
         </div>
       </div>
 
-      <%!-- Options hang visibly *inside* their field: indented to the
-            control's inner padding, so a wrapped chip row still reads as
-            belonging to the input above it and not to the next label. --%>
-      <div :if={@field.candidates != []} class="flex flex-wrap items-center gap-2 pl-3">
-        <span class="text-[10px] font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-          Proposed
-        </span>
-
-        <.proposal_chip
-          :for={candidate <- @field.candidates}
-          chosen={Field.chose?(@field, candidate)}
-          event="choose-field"
-          values={%{section: @section, field: @name, key: candidate.key}}
-        >
-          <span class={[
-            "text-[10px] flex-none rounded-sm px-1 uppercase tracking-wide",
-            Field.chose?(@field, candidate) && "bg-brand/90 text-zinc-900 dark:bg-brand-dark",
-            !Field.chose?(@field, candidate) && "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
-          ]}>
-            {candidate.label || source_words(candidate.source)}
-          </span>
-          <span :if={!@preview}>{truncate(candidate.value)}</span>
-
-          <%!-- Choosing between two covers by URL is choosing blind. --%>
-          <.image_with_size
-            :if={@preview && preview_src(candidate.value, @embedded_src)}
-            id={"#{@section}-#{@name}-#{candidate.key}"}
-            src={preview_src(candidate.value, @embedded_src)}
-            class="mt-1 h-20 w-20 rounded-sm object-cover"
-          />
-        </.proposal_chip>
-
-        <%!-- Choosing "none" is an approval, not an omission. It's what makes
-              "every piece is settled" reachable on a record with optional
-              fields nobody filled in. --%>
-        <.proposal_chip
-          :if={!@field.required}
-          chosen={@field.approved && is_nil(@field.source)}
-          event="waive-field"
-          values={%{section: @section, field: @name}}
-        >
-          None
-        </.proposal_chip>
-      </div>
-
       <p :if={@hint} class="pl-3 text-xs text-zinc-500 dark:text-zinc-400">{@hint}</p>
+
+      <%!-- The options row is a two-column grid — microlabel | chips — so a
+            wrapping chip row stays in the chip column instead of falling
+            back under the label, and every chip starts on one rail. --%>
+      <div
+        :if={@field.candidates != []}
+        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3"
+      >
+        <.microlabel class="pt-1.5">Proposed</.microlabel>
+
+        <div class="flex flex-wrap items-center gap-1.5">
+          <.proposal_chip
+            :for={candidate <- @field.candidates}
+            chosen={Field.chose?(@field, candidate)}
+            event="choose-field"
+            values={%{section: @section, field: @name, key: candidate.key}}
+          >
+            <%!-- Only the chosen chip is loud: its source tag fills lime. A
+                  filled tag on every chip made the whole row heavy. --%>
+            <span class={[
+              "text-[10px] flex-none uppercase tracking-wide",
+              Field.chose?(@field, candidate) && "bg-brand/90 rounded-sm px-1 text-zinc-900 dark:bg-brand-dark",
+              !Field.chose?(@field, candidate) && "text-zinc-500 dark:text-zinc-400"
+            ]}>
+              {candidate.label || source_words(candidate.source)}
+            </span>
+            <span :if={!@preview}>{truncate(candidate.value)}</span>
+
+            <%!-- Choosing between two covers by URL is choosing blind. --%>
+            <.image_with_size
+              :if={@preview && preview_src(candidate.value, @embedded_src)}
+              id={"#{@section}-#{@name}-#{candidate.key}"}
+              src={preview_src(candidate.value, @embedded_src)}
+              class="mt-1 h-20 w-20 rounded-sm object-cover"
+            />
+          </.proposal_chip>
+
+          <%!-- Choosing "none" is an approval, not an omission. It's what makes
+                "every piece is settled" reachable on a record with optional
+                fields nobody filled in. Ghost, because it's the escape hatch,
+                not a peer value. --%>
+          <.proposal_chip
+            :if={!@field.required}
+            chosen={@field.approved && is_nil(@field.source)}
+            event="waive-field"
+            values={%{section: @section, field: @name}}
+            ghost
+          >
+            None
+          </.proposal_chip>
+        </div>
+      </div>
     </div>
     """
   end
@@ -697,7 +715,7 @@ defmodule AmbryWeb.Admin.Decisions do
               twice is not. --%>
         <span
           :if={@credit.mode == :link && @identity_backing[@credit.identity_id]}
-          class="text-xs italic dark:text-zinc-500"
+          class="text-xs text-zinc-500 dark:text-zinc-400"
           data-role="identity-backing"
         >
           {@identity_backing[@credit.identity_id]}
@@ -802,7 +820,7 @@ defmodule AmbryWeb.Admin.Decisions do
           Add another person
         </button>
 
-        <p :if={length(@persons) > 1} class="text-xs italic dark:text-zinc-500">
+        <p :if={length(@persons) > 1} class="text-xs text-zinc-500 dark:text-zinc-400">
           A shared pen name — {@credit.name} will be one author credited to {length(@persons)} people.
         </p>
       </div>
@@ -899,7 +917,7 @@ defmodule AmbryWeb.Admin.Decisions do
               Approval creates them once, so this is where the form says so —
               on the row that would otherwise look like it was about to make a
               second person of the same name. --%>
-        <p :if={@shared_with} class="min-w-0 text-xs italic dark:text-zinc-500">
+        <p :if={@shared_with} class="min-w-0 text-xs text-zinc-500 dark:text-zinc-400">
           Same person as the {@shared_with} — one {Field.value(@person.name)} will be created.
           <button
             type="button"
@@ -917,7 +935,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <%!-- Nothing found is a normal outcome, not a failure — plenty of
             narrators are in no database at all — but it should say so rather
             than looking like an empty grid nobody filled in. --%>
-      <p :if={@person.doubt == :low_confidence} class="text-xs italic dark:text-zinc-500">
+      <p :if={@person.doubt == :low_confidence} class="text-xs text-zinc-500 dark:text-zinc-400">
         {@person.doubt_detail}
       </p>
 
@@ -955,47 +973,49 @@ defmodule AmbryWeb.Admin.Decisions do
         </div>
       </details>
 
-      <div :if={@photos != []} class="flex flex-wrap items-center gap-2">
-        <span class="text-xs dark:text-zinc-500">Photos:</span>
+      <div :if={@photos != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
+        <.microlabel class="pt-1">Photos</.microlabel>
 
-        <.proposal_chip
-          :for={photo <- shown_photos(@photos, @expanded)}
-          chosen={Field.chose?(@person.image, photo)}
-          event="pick-person-image"
-          values={%{"key" => @person.key, "candidate" => photo.key}}
-          title={photo.label}
-          shape="circle"
-        >
-          <.image_with_size
-            id={"photo-#{@at}-#{:erlang.phash2(photo.value)}"}
-            src={proxied_remote_image_url(photo.value)}
-            class="h-16 w-16 rounded-full object-cover object-top"
-          />
-        </.proposal_chip>
+        <div class="flex flex-wrap items-center gap-2">
+          <.proposal_chip
+            :for={photo <- shown_photos(@photos, @expanded)}
+            chosen={Field.chose?(@person.image, photo)}
+            event="pick-person-image"
+            values={%{"key" => @person.key, "candidate" => photo.key}}
+            title={photo.label}
+            shape="circle"
+          >
+            <.image_with_size
+              id={"photo-#{@at}-#{:erlang.phash2(photo.value)}"}
+              src={proxied_remote_image_url(photo.value)}
+              class="h-16 w-16 rounded-full object-cover object-top"
+            />
+          </.proposal_chip>
 
-        <%!-- A dozen headshots is normal and would push the rest of the credit
+          <%!-- A dozen headshots is normal and would push the rest of the credit
               off the screen; the point is that alternatives EXIST, not that
               they're all on show. --%>
-        <button
-          :if={length(@photos) > photo_preview()}
-          type="button"
-          phx-click="toggle-photos"
-          phx-value-key={@person.key}
-          class="text-xs underline dark:text-zinc-400"
-        >
-          {if @expanded, do: "show fewer", else: "show all #{length(@photos)} photos"}
-        </button>
+          <button
+            :if={length(@photos) > photo_preview()}
+            type="button"
+            phx-click="toggle-photos"
+            phx-value-key={@person.key}
+            class="text-xs underline dark:text-zinc-400"
+          >
+            {if @expanded, do: "show fewer", else: "show all #{length(@photos)} photos"}
+          </button>
 
-        <button
-          :if={@image}
-          type="button"
-          phx-click="waive-person-field"
-          phx-value-key={@person.key}
-          phx-value-field="image"
-          class="text-xs underline dark:text-zinc-400"
-        >
-          no photo
-        </button>
+          <button
+            :if={@image}
+            type="button"
+            phx-click="waive-person-field"
+            phx-value-key={@person.key}
+            phx-value-field="image"
+            class="text-xs underline dark:text-zinc-400"
+          >
+            no photo
+          </button>
+        </div>
       </div>
 
       <%!-- The same text box the recording's description gets, for the same
@@ -1027,19 +1047,27 @@ defmodule AmbryWeb.Admin.Decisions do
           </div>
         </div>
 
-        <div :if={@bios != []} class="flex flex-wrap items-center gap-2">
-          <span class="text-xs dark:text-zinc-500">Proposed:</span>
+        <div :if={@bios != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
+          <.microlabel class="pt-1.5">Proposed</.microlabel>
 
-          <.proposal_chip
-            :for={bio <- @bios}
-            chosen={Field.chose?(@person.description, bio)}
-            event="pick-person-bio"
-            values={%{"key" => @person.key, "candidate" => bio.key}}
-            title={bio.value}
-          >
-            <span class="dark:text-zinc-500">{bio.label}:</span>
-            <span class="line-clamp-1">{truncate(bio.value)}</span>
-          </.proposal_chip>
+          <div class="flex flex-wrap items-center gap-1.5">
+            <.proposal_chip
+              :for={bio <- @bios}
+              chosen={Field.chose?(@person.description, bio)}
+              event="pick-person-bio"
+              values={%{"key" => @person.key, "candidate" => bio.key}}
+              title={bio.value}
+            >
+              <span class={[
+                "text-[10px] flex-none uppercase tracking-wide",
+                Field.chose?(@person.description, bio) && "bg-brand/90 rounded-sm px-1 text-zinc-900 dark:bg-brand-dark",
+                !Field.chose?(@person.description, bio) && "text-zinc-500 dark:text-zinc-400"
+              ]}>
+                {bio.label}
+              </span>
+              <span class="line-clamp-1">{truncate(bio.value)}</span>
+            </.proposal_chip>
+          </div>
         </div>
       </div>
     </div>
@@ -1069,6 +1097,7 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :values, :map, default: %{}
   attr :title, :string, default: nil
   attr :shape, :string, default: "text"
+  attr :ghost, :boolean, default: false, doc: ~s(escape hatches like "None" — dashed and quiet)
   slot :inner_block, required: true
 
   @doc """
@@ -1091,7 +1120,9 @@ defmodule AmbryWeb.Admin.Decisions do
         @shape == "circle" && "rounded-full p-0.5",
         @shape != "circle" && "inline-flex items-center gap-1.5 px-2 py-1",
         @chosen && "border-brand bg-brand/10 dark:border-brand-dark dark:bg-brand-dark/10",
-        !@chosen && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+        !@chosen && !@ghost && "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500",
+        !@chosen && @ghost &&
+          "border-dashed border-zinc-300 text-zinc-500 hover:border-zinc-400 hover:text-zinc-700 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-200"
       ]}
     >
       <%!-- The chosen chip is the single most important state on the form, and

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.Layouts do
     <div id="side-bar-scrim" class="z-[9] bg-black/40 fixed inset-0 hidden lg:hidden" aria-hidden="true" />
     <nav
       id="side-bar"
-      class="absolute inset-0 z-10 h-screen w-64 shrink-0 -translate-x-full transform divide-y divide-zinc-200 border-r border-zinc-200 bg-zinc-50 opacity-0 duration-100 ease-out dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900 lg:relative lg:transform-none lg:opacity-100"
+      class="absolute inset-0 z-10 h-screen w-64 shrink-0 -translate-x-full transform bg-zinc-900 opacity-0 duration-100 ease-out lg:relative lg:transform-none lg:opacity-100"
       phx-click-away={Components.close_sidebar()}
       phx-window-keydown={Components.close_sidebar()}
       phx-key="escape"
@@ -115,13 +115,12 @@ defmodule AmbryWeb.Admin.Layouts do
 
   defp nav_class(true),
     do:
-      "flex items-center gap-3 border-l-[3px] border-brand bg-brand/10 px-4 py-2 text-sm font-semibold dark:border-brand-dark dark:bg-brand-dark/10"
+      "border-l-[3px] border-brand-dark bg-brand-dark/10 flex items-center gap-3 px-4 py-2 text-sm font-semibold text-zinc-100"
 
   defp nav_class(false),
     do:
-      "flex items-center gap-3 border-l-[3px] border-transparent px-4 py-2 text-sm hover:bg-zinc-200 dark:hover:bg-zinc-800"
+      "hover:bg-white/5 flex items-center gap-3 border-l-[3px] border-transparent px-4 py-2 text-sm text-zinc-400 hover:text-zinc-200"
 
   defp group_class,
-    do:
-      "px-4 pt-4 pb-1 text-[10px] font-bold uppercase tracking-widest text-zinc-500 dark:text-zinc-400"
+    do: "px-4 pt-4 pb-1 text-[10px] font-bold uppercase tracking-widest text-zinc-500"
 end

--- a/lib/ambry_web/components/admin/layouts/root.html.heex
+++ b/lib/ambry_web/components/admin/layouts/root.html.heex
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
-<html lang="en" style="scrollbar-gutter: stable;">
+<%!-- The admin is dark-only, by decision: one operator, one theme, half the
+      styling overhead. The hardcoded class is what forces it (Tailwind runs
+      dark mode off the class); color-scheme keeps native controls dark. --%>
+<html lang="en" class="dark" style="scrollbar-gutter: stable; color-scheme: dark;">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
@@ -33,7 +36,10 @@
       // end viewport fix
     </script>
   </head>
-  <body class="bg-white text-zinc-800 antialiased selection:bg-brand selection:text-white dark:bg-black dark:text-zinc-200 dark:selection:bg-brand-dark dark:selection:text-black">
+  <%!-- zinc-950 ground, not black: pure black under 1px lines is what made
+        borders look harsh and "mushy" on high-DPI — the new admin system
+        separates surfaces by elevation (bg contrast), not hairlines. --%>
+  <body class="bg-zinc-950 text-zinc-300 antialiased selection:bg-brand-dark selection:text-black">
     <div class="flex h-screen flex-col">
       <div class="grow overflow-hidden">
         {@inner_content}

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -290,12 +290,14 @@ defmodule AmbryWeb.CoreComponents do
     "border-transparent bg-yellow-500 text-zinc-900 hover:bg-yellow-600 dark:bg-yellow-400 dark:hover:bg-yellow-500"
   end
 
+  # In dark themes the secondary/danger costumes are quiet fills rather than
+  # outlines — outlined buttons put yet more 1px lines on a dark ground.
   defp button_color_classes(:red) do
-    "border-red-600 bg-transparent text-red-600 hover:bg-red-600/10 dark:border-red-400 dark:text-red-400 dark:hover:bg-red-400/10"
+    "dark:bg-red-400/10 dark:hover:bg-red-400/20 border-red-600 bg-transparent text-red-600 hover:bg-red-600/10 dark:border-transparent dark:text-red-300"
   end
 
   defp button_color_classes(:zinc) do
-    "border-zinc-400 bg-transparent text-zinc-900 hover:bg-zinc-900/5 dark:border-zinc-500 dark:text-zinc-100 dark:hover:bg-white/10"
+    "border-zinc-400 bg-transparent text-zinc-900 hover:bg-zinc-900/5 dark:border-transparent dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
   end
 
   @doc """
@@ -365,8 +367,8 @@ defmodule AmbryWeb.CoreComponents do
           checked={@checked}
           class={[
             "rounded",
-            "border-zinc-300 bg-white text-zinc-900 focus:ring-zinc-900",
-            "dark:border-none dark:bg-zinc-800 dark:text-zinc-800 dark:focus:ring-zinc-900",
+            "border-zinc-300 bg-white text-lime-600 focus:ring-lime-600",
+            "dark:border-zinc-600 dark:bg-zinc-800 dark:text-lime-600 dark:focus:ring-lime-500",
             @class
           ]}
           {@rest}
@@ -507,14 +509,15 @@ defmodule AmbryWeb.CoreComponents do
               "!text-zinc-500 block w-full rounded-sm rounded-b-none border p-0",
               "focus:outline-none focus:ring-4 sm:text-sm sm:leading-6",
               "file:p-[11px] file:cursor-pointer file:rounded-none file:border-0",
-              "file:bg-zinc-600 file:font-bold file:text-zinc-100 hover:file:bg-zinc-500"
+              "file:bg-zinc-200 file:font-bold file:text-zinc-800 hover:file:bg-zinc-300",
+              "dark:file:bg-zinc-600 dark:file:text-zinc-100 dark:hover:file:bg-zinc-500"
             ] ++ input_color_classes(@errors) ++ [@class]
           }
         />
       </div>
       <div
         id={"#{@upload.ref}-drop-area"}
-        class="space-y-4 rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4"
+        class="space-y-4 rounded-b-sm border-2 border-t-0 border-dashed border-zinc-300 bg-zinc-50 p-4 text-zinc-500 dark:border-zinc-600 dark:bg-zinc-950 dark:text-zinc-400"
         phx-drop-target={@upload.ref}
         phx-hook={if @paste_upload, do: "paste-image"}
         data-upload-name={if @paste_upload, do: @upload.name}
@@ -571,7 +574,10 @@ defmodule AmbryWeb.CoreComponents do
         placeholder="https://some-image.com/url"
         class={if @show_preview, do: "rounded-b-none"}
       />
-      <div :if={@show_preview} class="rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4">
+      <div
+        :if={@show_preview}
+        class="rounded-b-sm border-2 border-t-0 border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-600 dark:bg-zinc-950"
+      >
         <.image_with_size id={@field.id} src={proxied_remote_image_url(@field.value)} class={@image_preview_class} />
       </div>
     </div>
@@ -581,11 +587,14 @@ defmodule AmbryWeb.CoreComponents do
   defp input_color_classes(errors) do
     [
       "bg-white text-zinc-900 placeholder:text-zinc-500",
-      "dark:bg-zinc-800 dark:text-zinc-300",
+      "dark:bg-zinc-800 dark:text-zinc-200 dark:placeholder:text-zinc-500",
       "border-zinc-300 focus:border-zinc-400 focus:ring-zinc-800/5",
-      "dark:border-zinc-600 dark:focus:border-zinc-400 dark:focus:ring-zinc-200/5",
+      # Dark controls are filled, not outlined: a transparent border keeps the
+      # box size, the fill separates it from the surface, and focus is a soft
+      # brand ring — no 1px hairlines fighting high-DPI subpixel rendering.
+      "dark:focus:ring-brand-dark/20 dark:border-transparent dark:focus:border-transparent",
       "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400 phx-no-feedback:focus:ring-zinc-800/5",
-      "phx-no-feedback:dark:border-zinc-600 phx-no-feedback:dark:focus:border-zinc-400 phx-no-feedback:dark:focus:ring-zinc-200/5"
+      "phx-no-feedback:dark:focus:ring-brand-dark/20 phx-no-feedback:dark:border-transparent phx-no-feedback:dark:focus:border-transparent"
     ] ++
       if errors == [],
         do: [],
@@ -615,7 +624,7 @@ defmodule AmbryWeb.CoreComponents do
         <:separator>
           <span class="cursor-default select-none text-sm">•</span>
         </:separator>
-        <label class="cursor-pointer select-none whitespace-nowrap text-sm italic leading-6 has-[:checked]:font-semibold has-[:checked]:not-italic has-[:checked]:underline">
+        <label class="cursor-pointer select-none whitespace-nowrap text-sm leading-6 text-zinc-500 has-[:checked]:font-semibold has-[:checked]:text-zinc-800 has-[:checked]:underline dark:text-zinc-400 dark:has-[:checked]:text-zinc-200">
           <input type="radio" name={@field.name} value={value} checked={@field.value == value} class="hidden" /> {label}
         </label>
       </.intersperse>
@@ -986,7 +995,7 @@ defmodule AmbryWeb.CoreComponents do
 
   def note(assigns) do
     ~H"""
-    <p class={["border-l-4 border-zinc-400 pl-4 italic text-zinc-500 dark:border-zinc-500 dark:text-zinc-400", @class]}>
+    <p class={["border-l-4 border-zinc-300 pl-4 text-sm text-zinc-500 dark:border-zinc-600 dark:text-zinc-400", @class]}>
       <%= if @label != [] do %>
         <strong>{render_slot(@label)}:</strong>
       <% else %>

--- a/lib/ambry_web/components/layouts/root.html.heex
+++ b/lib/ambry_web/components/layouts/root.html.heex
@@ -4,6 +4,19 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <meta name="csrf-token" content={get_csrf_token()} />
+    <script type="text/javascript">
+      // Tailwind runs dark mode off a class (so the admin can force it);
+      // out here the class just mirrors the OS preference. Runs inline,
+      // before first paint, to avoid a flash of the wrong theme.
+      (function () {
+        var media = window.matchMedia("(prefers-color-scheme: dark)")
+        var apply = function () {
+          document.documentElement.classList.toggle("dark", media.matches)
+        }
+        apply()
+        media.addEventListener("change", apply)
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href={~p"/favicon.svg"} />
     <link rel="icon" type="image/png" href={~p"/favicon.png"} sizes="16x16" />
     <link rel="icon" type="image/png" href={~p"/favicon-32x32.png"} sizes="32x32" />

--- a/lib/ambry_web/live/admin/audit_live/index.html.heex
+++ b/lib/ambry_web/live/admin/audit_live/index.html.heex
@@ -4,7 +4,7 @@
     <button
       type="button"
       phx-click="reload"
-      class="flex items-center font-bold text-lime-500 hover:underline dark:text-lime-400"
+      class="flex items-center font-bold text-lime-700 hover:underline dark:text-lime-400"
     >
       Reload <.icon name="fa-rotate" class="ml-2 h-4 w-4 text-current" />
     </button>

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -15,7 +15,7 @@
         <.input field={@form[:title]} label="Title" />
 
         <div :if={@import_providers != []} class="row-start-1 space-y-2 sm:col-start-2">
-          <.label>Import from:</.label>
+          <.label>Import from</.label>
           <div class="flex flex-wrap items-center gap-2">
             <.button
               :for={provider <- @import_providers}
@@ -39,7 +39,7 @@
             label="Date display format"
             options={[{"Full Date", "full"}, {"Year & Month", "year_month"}, {"Year Only", "year"}]}
           />
-          <span class="text-sm italic dark:text-zinc-500">
+          <span class="text-sm text-zinc-500 dark:text-zinc-400">
             {preview_date_format(@form)}
           </span>
         </div>

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -36,10 +36,10 @@
       </div>
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="book-title">{book.title}</p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500" data-role="book-authors">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400" data-role="book-authors">
           by {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500" data-role="book-series">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400" data-role="book-series">
           {book.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}
         </p>
       </div>
@@ -53,16 +53,19 @@
       <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
         <div class="flex gap-2 pb-2">
           <.link navigate={~p"/admin/books/#{book}/edit"} data-role="edit-book">
-            <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-pencil"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
           <span phx-click="delete" phx-value-id={book.id} data-confirm="Are you sure?" data-role="delete-book">
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
           </span>
         </div>
-        <p class="text-sm italic dark:text-zinc-500" data-role="book-published">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400" data-role="book-published">
           Published {format_published(book, :short)}
         </p>
-        <p class="text-sm italic dark:text-zinc-500" data-role="book-added">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400" data-role="book-added">
           Added {Calendar.strftime(book.inserted_at, "%x")}
         </p>
       </div>

--- a/lib/ambry_web/live/admin/home_live/index.ex
+++ b/lib/ambry_web/live/admin/home_live/index.ex
@@ -65,9 +65,9 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
     ~H"""
     <div class="relative">
       <.link class="absolute top-0 left-0 h-full w-full" navigate={@navigate}></.link>
-      <div class="space-y-4 divide-y divide-zinc-200 rounded-sm border border-zinc-200 bg-zinc-50 p-2 dark:divide-zinc-800 dark:border-zinc-800 dark:bg-zinc-900 sm:p-4">
-        <.icon name={@icon} class="mx-auto block h-8 w-8 text-current sm:h-12 sm:w-12" />
-        <div class="flex pt-2 sm:pt-4">
+      <div class="rounded-sm border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900">
+        <.icon name={@icon} class="block h-5 w-5 text-zinc-400 dark:text-zinc-500" />
+        <div class="flex gap-8 pt-3">
           {render_slot(@inner_block)}
         </div>
       </div>
@@ -80,11 +80,11 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
 
   defp stat(assigns) do
     ~H"""
-    <div class="grow">
-      <h2 class="text-center font-bold sm:text-xl">
+    <div>
+      <h2 class="text-sm font-semibold text-zinc-500 dark:text-zinc-400">
         {render_slot(@title)}
       </h2>
-      <p class="text-center text-lg font-bold sm:text-2xl">
+      <p class="text-2xl font-bold tabular-nums">
         {render_slot(@stat)}
       </p>
     </div>

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -699,6 +699,45 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   defp format_tag(value) when is_list(value), do: Enum.join(value, ", ")
   defp format_tag(value), do: to_string(value)
 
+  attr :files, :list, required: true
+
+  # The files share one directory almost always; printing it thirty times
+  # buried the one part that differs. One line of where, then the names.
+  defp file_list(assigns) do
+    assigns = assign(assigns, :common, common_dir(assigns.files))
+
+    ~H"""
+    <div :if={@files != []} class="mt-2 rounded-lg bg-zinc-900 p-4">
+      <p :if={@common != ""} class="font-mono truncate text-xs text-zinc-500">{@common}/</p>
+      <ul class="space-y-0.5 pt-1">
+        <li :for={file <- @files} class="font-mono truncate pl-3 text-xs text-zinc-400">
+          {file_label(file, @common)}
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  defp common_dir([]), do: ""
+
+  defp common_dir(files) do
+    files
+    |> Enum.map(&Path.split(Path.dirname(&1)))
+    |> Enum.reduce(fn segments, acc ->
+      acc
+      |> Enum.zip(segments)
+      |> Enum.take_while(fn {a, b} -> a == b end)
+      |> Enum.map(&elem(&1, 0))
+    end)
+    |> case do
+      [] -> ""
+      segments -> Path.join(segments)
+    end
+  end
+
+  defp file_label(file, ""), do: file
+  defp file_label(file, common), do: Path.relative_to(file, common)
+
   @doc """
   The search terms auto-match derived, and where each came from.
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -8,7 +8,7 @@
 
     <div class="max-w-4xl space-y-14 pb-16" inert={@busy}>
       <%!-- the evidence: what was found, before anybody interpreted it --%>
-      <section class="space-y-1 rounded-sm border border-zinc-300 p-4 dark:border-zinc-700">
+      <section class="space-y-1 rounded-lg bg-zinc-900 p-4">
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
             <p class="truncate font-bold">{@page_title}</p>
@@ -87,7 +87,7 @@
       <%!-- The invariant, rendered. Nothing here is a surprise at import time. --%>
       <section
         :if={@unresolved != []}
-        class="bg-amber-500/5 border-amber-500/70 rounded-sm border p-4"
+        class="border-amber-400/80 rounded-lg border-l-4 bg-zinc-900 p-4"
         data-role="unresolved"
       >
         <p class="font-bold">Still to settle</p>
@@ -121,7 +121,7 @@
 
       <%!-- ==================== THE WORK ==================== --%>
       <section id="work" class="space-y-7">
-        <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
+        <h2 class="text-xl font-bold text-zinc-100">
           The work — which book this is a recording of
         </h2>
 
@@ -129,7 +129,13 @@
             records below: linking creates nothing and inherits the book's
             curation, importing a record creates a Book. Ranking the two
             together made the form ask one question that was really two. --%>
-        <div class="space-y-2" data-role="local-books">
+        <div
+          class={[
+            "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+            (@item.draft.work.approved && "border-brand-dark/60") || "border-amber-400/70"
+          ]}
+          data-role="local-books"
+        >
           <div class="flex items-center gap-2 pl-3">
             <.label>Is this a book you already have?</.label>
             <.badge
@@ -192,22 +198,22 @@
             type="button"
             phx-click="new-book"
             class={[
-              "flex items-center gap-1.5 rounded-sm border px-2.5 py-1.5 text-sm",
+              "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm",
               (@item.draft.work.mode == :create and @item.draft.work.approved) &&
-                "border-brand bg-brand/10 dark:border-brand-dark dark:bg-brand-dark/10",
+                "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
               !(@item.draft.work.mode == :create and @item.draft.work.approved) &&
-                "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
+                "bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100"
             ]}
           >
             <.icon
               :if={@item.draft.work.mode == :create and @item.draft.work.approved}
               name="fa-check"
-              class="h-3 w-3 flex-none text-lime-700 dark:text-brand-dark"
+              class="text-brand-dark h-3 w-3 flex-none"
             /> No — this is a different book
           </button>
         </div>
 
-        <div class="space-y-2">
+        <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
           <div class="flex items-center gap-2 pl-3">
             <.label>
               {if @item.draft.work.mode == :link,
@@ -229,7 +235,7 @@
               look different or the empty fields below are unexplained. --%>
           <p
             :if={doubt_message(@item.draft.work)}
-            class="bg-amber-500/10 border-amber-500/70 rounded-sm border p-3 text-sm"
+            class="bg-amber-400/10 border-amber-400/80 rounded-md border-l-4 p-3 text-sm"
             data-role="work-doubt"
           >
             {doubt_message(@item.draft.work)}
@@ -277,7 +283,7 @@
             memberships remain to decide. --%>
         <p
           :if={@item.draft.work.mode == :link}
-          class="rounded-sm bg-zinc-100 p-3 text-sm dark:bg-zinc-800"
+          class="rounded-lg bg-zinc-900 p-4 text-sm"
         >
           Using the book already in the library. Its title, date and authors are left exactly as they
           are — an import fills blanks, it never overwrites curation.
@@ -334,7 +340,7 @@
         <%!-- credits: "Credited as" / "Written by" --%>
         <div :if={@item.draft.work.mode == :create} class="space-y-2">
           <.label class="pl-3">Authors</.label>
-          <p :if={@item.draft.work.authors == []} class="text-sm text-zinc-500 dark:text-zinc-400">
+          <p :if={@item.draft.work.authors == []} class="rounded-lg bg-zinc-900 p-4 text-sm text-zinc-400">
             No author was proposed.
           </p>
 
@@ -374,7 +380,7 @@
             already there.
           </p>
 
-          <p :if={@item.draft.work.series == []} class="text-sm text-zinc-500 dark:text-zinc-400">
+          <p :if={@item.draft.work.series == []} class="rounded-lg bg-zinc-900 p-4 text-sm text-zinc-400">
             No series was proposed.
           </p>
 
@@ -389,12 +395,15 @@
 
       <%!-- ==================== THE RECORDING ==================== --%>
       <section id="recording" class="space-y-7">
-        <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
+        <h2 class="text-xl font-bold text-zinc-100">
           The recording — which reading of it these files are
         </h2>
 
-        <div class="space-y-2">
-          <div class="flex items-center gap-2">
+        <div class={[
+          "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+          (@item.draft.recording.approved && "border-brand-dark/60") || "border-amber-400/70"
+        ]}>
+          <div class="flex items-center gap-2 pl-3">
             <.label>Records describing this recording</.label>
             <.badge
               :if={!@item.draft.recording.approved}
@@ -418,14 +427,15 @@
               the whole difference between "tick one" and "type it in". --%>
           <p
             :if={doubt_message(@item.draft.recording)}
-            class="bg-amber-500/10 border-amber-500/70 rounded-sm border p-3 text-sm"
+            class="bg-amber-400/10 border-amber-400/80 rounded-md border-l-4 p-3 text-sm"
             data-role="doubt"
           >
             {doubt_message(@item.draft.recording)}
           </p>
 
           <p :if={records(@item, "recording") != []} class="text-sm text-zinc-500 dark:text-zinc-400">
-            Tick every record of <em>this reading</em> — the narrator is what tells two recordings of
+            Tick every record of <span class="font-semibold">this reading</span>
+            — the narrator is what tells two recordings of
             one book apart, so check it before ticking. Databases keep editions the storefront has
             delisted, which is often the only place an older reading still exists.
           </p>
@@ -449,9 +459,11 @@
               type="button"
               phx-click="uncatalogued"
               class={[
-                "rounded-sm border px-2 py-1 text-xs",
-                Recording.uncatalogued?(@item.draft.recording) && "border-brand dark:border-brand-dark",
-                !Recording.uncatalogued?(@item.draft.recording) && "border-zinc-300 dark:border-zinc-700"
+                "rounded-md px-2 py-1 text-xs",
+                Recording.uncatalogued?(@item.draft.recording) &&
+                  "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
+                !Recording.uncatalogued?(@item.draft.recording) &&
+                  "border border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
               ]}
             >
               None of these — it's in no catalogue
@@ -544,7 +556,7 @@
 
         <div class="space-y-2">
           <.label class="pl-3">Narrators</.label>
-          <p :if={@item.draft.recording.narrators == []} class="text-sm text-zinc-500 dark:text-zinc-400">
+          <p :if={@item.draft.recording.narrators == []} class="rounded-lg bg-zinc-900 p-4 text-sm text-zinc-400">
             No narrator was proposed.
           </p>
 
@@ -573,17 +585,19 @@
 
       <%!-- ==================== CHAPTERS ==================== --%>
       <section class="space-y-2">
-        <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">Chapters</h2>
-        <p class="text-sm text-zinc-500 dark:text-zinc-400">{chapter_summary(@item)}</p>
-        <p class="text-sm text-zinc-500 dark:text-zinc-400">
-          Markers are taken from the file and never from a provider — provider timestamps describe
-          their own edition, not this rip.
-        </p>
+        <h2 class="text-xl font-bold text-zinc-100">Chapters</h2>
+        <div class="space-y-1 rounded-lg bg-zinc-900 p-4">
+          <p class="text-sm text-zinc-300">{chapter_summary(@item)}</p>
+          <p class="text-sm text-zinc-400">
+            Markers are taken from the file and never from a provider — provider timestamps describe
+            their own edition, not this rip.
+          </p>
+        </div>
       </section>
 
       <%!-- ==================== FILES & DESTINATION ==================== --%>
       <section id="destination" class="space-y-2">
-        <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">
+        <h2 class="text-xl font-bold text-zinc-100">
           Files &amp; destination
         </h2>
 
@@ -593,8 +607,14 @@
 
         <%!-- Any input may feed any output, so the root is chosen here rather
             than fixed on the watched folder. With one root this never asks. --%>
-        <div :if={@item.draft.destination && @item.draft.destination.custody == :managed}>
-          <div class="flex items-center gap-2">
+        <div
+          :if={@item.draft.destination && @item.draft.destination.custody == :managed}
+          class={[
+            "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+            (@item.draft.destination.approved && "border-brand-dark/60") || "border-amber-400/70"
+          ]}
+        >
+          <div class="flex items-center gap-2 pl-3">
             <.label>Library root</.label>
             <.badge
               :if={!@item.draft.destination.approved}
@@ -631,13 +651,11 @@
           {@destination.blocker}
         </p>
 
-        <ul class="pt-2">
-          <li :for={file <- @item.files} class="font-mono truncate text-xs text-zinc-500 dark:text-zinc-400">{file}</li>
-        </ul>
+        <.file_list files={@item.files} />
       </section>
 
       <%!-- ==================== THE BUTTON ==================== --%>
-      <section class="sticky bottom-0 border-t border-zinc-300 bg-white py-4 dark:border-zinc-700 dark:bg-zinc-900">
+      <section class="shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900 p-4">
         <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
           <.button
             phx-click="import"

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -12,8 +12,8 @@
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
             <p class="truncate font-bold">{@page_title}</p>
-            <p class="truncate text-sm dark:text-zinc-500">{@item.path}</p>
-            <p class="text-sm italic dark:text-zinc-500">{evidence(@item)}</p>
+            <p class="font-mono truncate text-xs text-zinc-500 dark:text-zinc-400">{@item.path}</p>
+            <p class="text-sm text-zinc-500 dark:text-zinc-400">{evidence(@item)}</p>
 
             <%!-- "Still working" and "found nothing" look identical in a form
                 full of empty fields, and matching now backs off for minutes
@@ -48,43 +48,46 @@
             one) and the form used to show none of them, so a match that went
             somewhere strange had no visible cause. --%>
         <details :if={tag_rows(@item) != [] or hint_rows(@item) != []} class="pt-2">
-          <summary class="cursor-pointer text-sm dark:text-zinc-400">What the files say</summary>
+          <summary class="cursor-pointer pl-3 text-sm text-zinc-500 dark:text-zinc-400">What the files say</summary>
 
           <div class="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
             <div :if={tag_rows(@item) != []} data-role="tags">
-              <p class="text-xs font-bold dark:text-zinc-400">Embedded tags</p>
-              <p :for={{label, value} <- tag_rows(@item)} class="text-xs dark:text-zinc-500">
+              <p class="text-xs font-bold text-zinc-600 dark:text-zinc-300">Embedded tags</p>
+              <p :for={{label, value} <- tag_rows(@item)} class="text-xs text-zinc-500 dark:text-zinc-400">
                 <span class="text-zinc-500 dark:text-zinc-400">{label}:</span> {value}
               </p>
             </div>
 
             <div :if={hint_rows(@item) != []} data-role="hints">
-              <p class="text-xs font-bold dark:text-zinc-400">Used to search</p>
-              <p :for={{label, value} <- hint_rows(@item)} class="text-xs dark:text-zinc-500">
+              <p class="text-xs font-bold text-zinc-600 dark:text-zinc-300">Used to search</p>
+              <p :for={{label, value} <- hint_rows(@item)} class="text-xs text-zinc-500 dark:text-zinc-400">
                 <span class="text-zinc-500 dark:text-zinc-400">{label}:</span> {value}
               </p>
-              <p class="pt-1 text-xs italic text-zinc-500 dark:text-zinc-400">
+              <p class="pt-1 text-xs text-zinc-500 dark:text-zinc-400">
                 Taken from the tags first and the release name second.
               </p>
             </div>
           </div>
         </details>
 
-        <p :if={@item.issue} class="pt-2 text-sm text-red-600">{@item.issue}</p>
+        <p :if={@item.issue} class="flex items-baseline gap-1.5 pt-2 text-sm text-red-600 dark:text-red-400">
+          <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
+          {@item.issue}
+        </p>
       </section>
 
       <%!-- The one fact this whole form is deciding, said as a sentence. Two
           questions, but a file is a recording of exactly one work — so there
           is one answer to check at a glance. --%>
       <section :if={identity_summary(@item.draft)} class="space-y-1" data-role="identity-summary">
-        <p class="text-xs uppercase tracking-wide dark:text-zinc-500">This release is</p>
-        <p class="text-lg font-bold">{identity_summary(@item.draft)}</p>
+        <.microlabel class="pl-3">This release is</.microlabel>
+        <p class="pl-3 text-lg font-bold">{identity_summary(@item.draft)}</p>
       </section>
 
       <%!-- The invariant, rendered. Nothing here is a surprise at import time. --%>
       <section
         :if={@unresolved != []}
-        class="rounded-sm border border-amber-500 p-4"
+        class="bg-amber-500/5 border-amber-500/70 rounded-sm border p-4"
         data-role="unresolved"
       >
         <p class="font-bold">Still to settle</p>
@@ -110,7 +113,7 @@
           Take the top suggestion for {settleable(@unresolved)} of these
         </.button>
 
-        <p class="pt-2 text-xs italic dark:text-zinc-500">
+        <p class="pt-2 text-xs text-zinc-500 dark:text-zinc-400">
           Anything nothing proposed, any series without a number, and any recording match we doubt is
           left alone — those need a real answer, not a shortcut.
         </p>
@@ -127,7 +130,7 @@
             curation, importing a record creates a Book. Ranking the two
             together made the form ask one question that was really two. --%>
         <div class="space-y-2" data-role="local-books">
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 pl-3">
             <.label>Is this a book you already have?</.label>
             <.badge
               :if={!@item.draft.work.approved}
@@ -138,7 +141,7 @@
             </.badge>
           </div>
 
-          <p class="text-sm dark:text-zinc-400">
+          <p class="max-w-prose pl-3 text-sm text-zinc-500 dark:text-zinc-400">
             If so this becomes another edition of it — no second book, and its existing details are
             left alone.
           </p>
@@ -167,16 +170,14 @@
               value={@library_query}
               placeholder="search the library by title, author or series"
               phx-debounce="300"
-              class={input_classes("min-w-64 flex-grow")}
+              class={input_classes("min-w-64 px-[11px] max-w-xl flex-grow py-2 leading-6")}
             />
-            <button type="submit" class="rounded-sm border border-zinc-300 px-2 py-1 text-xs dark:border-zinc-700">
-              Search
-            </button>
+            <.button type="submit" color={:zinc}>Search</.button>
           </form>
 
           <p
             :if={@library_query not in [nil, ""] and @library_results == []}
-            class="text-sm italic dark:text-zinc-500"
+            class="text-sm text-zinc-500 dark:text-zinc-400"
           >
             Nothing in the library matches that.
           </p>
@@ -191,18 +192,23 @@
             type="button"
             phx-click="new-book"
             class={[
-              "rounded-sm border px-2 py-1 text-xs",
-              (@item.draft.work.mode == :create and @item.draft.work.approved) && "border-brand dark:border-brand-dark",
+              "flex items-center gap-1.5 rounded-sm border px-2.5 py-1.5 text-sm",
+              (@item.draft.work.mode == :create and @item.draft.work.approved) &&
+                "border-brand bg-brand/10 dark:border-brand-dark dark:bg-brand-dark/10",
               !(@item.draft.work.mode == :create and @item.draft.work.approved) &&
-                "border-zinc-300 dark:border-zinc-700"
+                "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-500"
             ]}
           >
-            No — this is a different book
+            <.icon
+              :if={@item.draft.work.mode == :create and @item.draft.work.approved}
+              name="fa-check"
+              class="h-3 w-3 flex-none text-lime-700 dark:text-brand-dark"
+            /> No — this is a different book
           </button>
         </div>
 
         <div class="space-y-2">
-          <div class="flex items-center gap-2">
+          <div class="flex items-center gap-2 pl-3">
             <.label>
               {if @item.draft.work.mode == :link,
                 do: "Records that could fill blanks",
@@ -223,19 +229,19 @@
               look different or the empty fields below are unexplained. --%>
           <p
             :if={doubt_message(@item.draft.work)}
-            class="rounded-sm border border-amber-500 p-3 text-sm"
+            class="bg-amber-500/10 border-amber-500/70 rounded-sm border p-3 text-sm"
             data-role="work-doubt"
           >
             {doubt_message(@item.draft.work)}
           </p>
 
-          <p :if={records(@item, "work") != []} class="text-sm dark:text-zinc-400">
+          <p :if={records(@item, "work") != []} class="max-w-prose pl-3 text-sm text-zinc-500 dark:text-zinc-400">
             Tick every record that's about this book. Two databases having a record of it is normal —
             and each knows things the other doesn't, so the description can come from one and the
             cover from another.
           </p>
 
-          <p :if={records(@item, "work") == []} class="text-sm italic dark:text-zinc-500">
+          <p :if={records(@item, "work") == []} class="text-sm text-zinc-500 dark:text-zinc-400">
             No provider had a record of this. The fields below come from the file's own tags.
           </p>
 
@@ -254,7 +260,7 @@
           />
 
           <details>
-            <summary class="cursor-pointer text-xs dark:text-zinc-400">
+            <summary class="cursor-pointer pl-3 text-xs text-zinc-500 dark:text-zinc-400">
               Not what you're looking for? Search again
             </summary>
             <div class="pt-2">
@@ -296,6 +302,7 @@
                 section="work"
                 name={:title}
                 form={work}
+                control_class="max-w-xl"
                 field={@item.draft.work.title}
               />
 
@@ -305,6 +312,7 @@
                 name={:published}
                 form={work}
                 type="date"
+                control_class="max-w-48"
                 hint="The work's original publication date, not this recording's release date."
                 field={@item.draft.work.published}
               />
@@ -315,6 +323,7 @@
                 name={:published_format}
                 form={work}
                 type="select"
+                control_class="max-w-56"
                 options={[{"Full Date", "full"}, {"Year & Month", "year_month"}, {"Year Only", "year"}]}
                 field={@item.draft.work.published_format}
               />
@@ -324,8 +333,8 @@
 
         <%!-- credits: "Credited as" / "Written by" --%>
         <div :if={@item.draft.work.mode == :create} class="space-y-2">
-          <.label>Authors</.label>
-          <p :if={@item.draft.work.authors == []} class="text-sm italic dark:text-zinc-500">
+          <.label class="pl-3">Authors</.label>
+          <p :if={@item.draft.work.authors == []} class="text-sm text-zinc-500 dark:text-zinc-400">
             No author was proposed.
           </p>
 
@@ -353,19 +362,19 @@
 
         <%!-- each series is its own decision, number included --%>
         <div class="space-y-2">
-          <.label>
+          <.label class="pl-3">
             {if @item.draft.work.mode == :link, do: "Series to add", else: "Series"}
           </.label>
 
           <p
             :if={@item.draft.work.mode == :link and @item.draft.work.series != []}
-            class="text-sm italic dark:text-zinc-500"
+            class="text-sm text-zinc-500 dark:text-zinc-400"
           >
             This book isn't in these yet. Adding is a blank being filled, not a change to what's
             already there.
           </p>
 
-          <p :if={@item.draft.work.series == []} class="text-sm italic dark:text-zinc-500">
+          <p :if={@item.draft.work.series == []} class="text-sm text-zinc-500 dark:text-zinc-400">
             No series was proposed.
           </p>
 
@@ -409,13 +418,13 @@
               the whole difference between "tick one" and "type it in". --%>
           <p
             :if={doubt_message(@item.draft.recording)}
-            class="rounded-sm border border-amber-500 p-3 text-sm"
+            class="bg-amber-500/10 border-amber-500/70 rounded-sm border p-3 text-sm"
             data-role="doubt"
           >
             {doubt_message(@item.draft.recording)}
           </p>
 
-          <p :if={records(@item, "recording") != []} class="text-sm dark:text-zinc-400">
+          <p :if={records(@item, "recording") != []} class="text-sm text-zinc-500 dark:text-zinc-400">
             Tick every record of <em>this reading</em> — the narrator is what tells two recordings of
             one book apart, so check it before ticking. Databases keep editions the storefront has
             delisted, which is often the only place an older reading still exists.
@@ -450,7 +459,7 @@
           </div>
 
           <details>
-            <summary class="cursor-pointer text-xs dark:text-zinc-400">
+            <summary class="cursor-pointer pl-3 text-xs text-zinc-500 dark:text-zinc-400">
               Not what you're looking for? Search again
             </summary>
             <div class="pt-2">
@@ -462,7 +471,7 @@
             </div>
           </details>
 
-          <p class="text-xs italic dark:text-zinc-500">
+          <p class="pl-3 text-xs text-zinc-500 dark:text-zinc-400">
             Every import creates a new recording. Pointing one at an existing recording's files —
             the upgrade/replace case — is a later addition.
           </p>
@@ -482,6 +491,7 @@
                 section="recording"
                 name={:title}
                 form={recording}
+                control_class="max-w-xl"
                 placeholder="only if it differs from the book's title"
                 hint={"Leave empty unless this reading is titled differently — " <>
                 "\"The Way of Kings (1 of 3)\", say."}
@@ -494,6 +504,7 @@
                 name={:published}
                 form={recording}
                 type="date"
+                control_class="max-w-48"
                 hint="When this reading was published, which is rarely the work's own date."
                 field={@item.draft.recording.published}
               />
@@ -503,6 +514,7 @@
                 section="recording"
                 name={:publisher}
                 form={recording}
+                control_class="max-w-md"
                 field={@item.draft.recording.publisher}
               />
 
@@ -531,8 +543,8 @@
         </.simple_form>
 
         <div class="space-y-2">
-          <.label>Narrators</.label>
-          <p :if={@item.draft.recording.narrators == []} class="text-sm italic dark:text-zinc-500">
+          <.label class="pl-3">Narrators</.label>
+          <p :if={@item.draft.recording.narrators == []} class="text-sm text-zinc-500 dark:text-zinc-400">
             No narrator was proposed.
           </p>
 
@@ -562,8 +574,8 @@
       <%!-- ==================== CHAPTERS ==================== --%>
       <section class="space-y-2">
         <h2 class="border-b border-zinc-300 pb-1 text-xl font-bold dark:border-zinc-700">Chapters</h2>
-        <p class="text-sm dark:text-zinc-400">{chapter_summary(@item)}</p>
-        <p class="text-sm italic dark:text-zinc-500">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400">{chapter_summary(@item)}</p>
+        <p class="text-sm text-zinc-500 dark:text-zinc-400">
           Markers are taken from the file and never from a provider — provider timestamps describe
           their own edition, not this rip.
         </p>
@@ -609,13 +621,18 @@
             </select>
           </form>
         </div>
-        <p :if={@destination.summary} class="text-sm dark:text-zinc-400">{@destination.summary}</p>
-        <p :if={@destination.blocker} class="text-sm text-red-600" data-role="destination-blocker">
+        <p :if={@destination.summary} class="text-sm text-zinc-500 dark:text-zinc-400">{@destination.summary}</p>
+        <p
+          :if={@destination.blocker}
+          class="flex items-baseline gap-1.5 pl-3 text-sm text-red-600 dark:text-red-400"
+          data-role="destination-blocker"
+        >
+          <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
           {@destination.blocker}
         </p>
 
         <ul class="pt-2">
-          <li :for={file <- @item.files} class="truncate text-xs dark:text-zinc-500">{file}</li>
+          <li :for={file <- @item.files} class="font-mono truncate text-xs text-zinc-500 dark:text-zinc-400">{file}</li>
         </ul>
       </section>
 
@@ -639,11 +656,11 @@
           <%!-- Why the button is off, always. A blocker that only showed up as a
               red line further up the page could leave this disabled while the
               outstanding count read zero. --%>
-          <p :if={@unresolved != []} class="text-sm dark:text-zinc-500">
+          <p :if={@unresolved != []} class="text-sm text-zinc-500 dark:text-zinc-400">
             {length(@unresolved)} decision{if length(@unresolved) > 1, do: "s"} still to settle.
           </p>
 
-          <p :if={@unresolved == [] and @destination.blocker} class="text-sm text-red-600">
+          <p :if={@unresolved == [] and @destination.blocker} class="text-sm text-red-600 dark:text-red-400">
             Everything is settled, but the files can't be placed yet — see Files &amp; destination.
           </p>
         </div>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -222,7 +222,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # click affordance pattern used across this page) stay put.
   defp segment_class(active?) do
     [
-      "flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-sm px-3 py-1 font-semibold",
+      "flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-sm px-3 py-1.5 font-semibold",
       if(active?,
         do: "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-100",
         else: "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
@@ -252,7 +252,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # touch target, and the queue's actions are consequential enough to name.
   defp action_class(tone) do
     [
-      "flex cursor-pointer items-center gap-1 whitespace-nowrap rounded-sm border px-2 py-0.5 text-xs font-semibold transition-colors",
+      "flex cursor-pointer items-center justify-center gap-1 whitespace-nowrap rounded-sm border px-2 py-0.5 text-xs font-semibold transition-colors sm:w-28",
       case tone do
         :brand ->
           "border-lime-600/60 text-lime-700 hover:bg-lime-600/10 dark:border-lime-400/60 dark:text-lime-400 dark:hover:bg-lime-400/10"

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -222,10 +222,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # click affordance pattern used across this page) stay put.
   defp segment_class(active?) do
     [
-      "flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-sm px-3 py-1.5 font-semibold",
+      "flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1.5 font-semibold",
       if(active?,
-        do: "bg-white text-zinc-900 shadow-sm dark:bg-zinc-700 dark:text-zinc-100",
-        else: "text-zinc-500 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+        do: "bg-zinc-700 text-zinc-100",
+        else: "text-zinc-400 hover:text-zinc-100"
       )
     ]
   end
@@ -240,10 +240,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     [
       "rounded-full px-1.5 text-xs font-bold tabular-nums",
       case {status, count} do
-        {_status, 0} -> "bg-zinc-200 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
-        {:pending, _n} -> "bg-amber-100 text-amber-700 dark:bg-amber-900/60 dark:text-amber-300"
-        {:ready, _n} -> "bg-lime-100 text-lime-700 dark:bg-lime-900/60 dark:text-lime-300"
-        _other -> "bg-zinc-200 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+        {_status, 0} -> "bg-white/5 text-zinc-500"
+        {:pending, _n} -> "bg-amber-400/15 text-amber-300"
+        {:ready, _n} -> "bg-brand-dark/15 text-lime-300"
+        _other -> "bg-white/10 text-zinc-400"
       end
     ]
   end
@@ -252,16 +252,16 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # touch target, and the queue's actions are consequential enough to name.
   defp action_class(tone) do
     [
-      "flex cursor-pointer items-center justify-center gap-1 whitespace-nowrap rounded-sm border px-2 py-0.5 text-xs font-semibold transition-colors sm:w-28",
+      "flex cursor-pointer items-center justify-center gap-1 whitespace-nowrap rounded-md px-2 py-1 text-xs font-semibold transition-colors sm:w-28",
       case tone do
         :brand ->
-          "border-lime-600/60 text-lime-700 hover:bg-lime-600/10 dark:border-lime-400/60 dark:text-lime-400 dark:hover:bg-lime-400/10"
+          "bg-brand-dark/10 text-lime-300 hover:bg-brand-dark/20"
 
         :danger ->
-          "border-zinc-300 text-zinc-600 hover:border-red-500 hover:text-red-600 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-red-400 dark:hover:text-red-400"
+          "bg-white/5 text-zinc-400 hover:bg-red-400/10 hover:text-red-300"
 
         :neutral ->
-          "border-zinc-300 text-zinc-600 hover:border-zinc-400 hover:text-zinc-900 dark:border-zinc-700 dark:text-zinc-400 dark:hover:border-zinc-500 dark:hover:text-zinc-100"
+          "bg-white/5 text-zinc-300 hover:bg-white/10 hover:text-zinc-100"
       end
     ]
   end
@@ -269,6 +269,14 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp status_color(:pending), do: :yellow
   defp status_color(:approved), do: :brand
   defp status_color(:dismissed), do: :gray
+
+  # The card's left edge carries the item's state — a 4px rail reads from
+  # across the room and renders crisp at any DPI, unlike hairline borders.
+  # Amber = needs the operator, lime = ready/done, dim = out of the queue.
+  defp rail_class(%{status: :pending, ready: true}), do: "border-l-4 border-brand-dark"
+  defp rail_class(%{status: :pending}), do: "border-l-4 border-amber-400"
+  defp rail_class(%{status: :approved}), do: "border-brand-dark/40 border-l-4"
+  defp rail_class(_item), do: "border-l-4 border-zinc-700"
 
   # Where an item came from is what decides its custody at approval — whether
   # the file gets brought into the library or referenced where it lies — so
@@ -280,10 +288,9 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp kind_word(:external_collection), do: "adopted in place"
   defp kind_word(:library_root), do: "already in the library tree"
 
-  defp location_color(%Location{kind: :downloads}),
-    do: "bg-blue-100 text-blue-900 dark:bg-blue-950 dark:text-blue-300"
+  defp location_color(%Location{kind: :downloads}), do: "bg-blue-400/15 text-blue-300"
 
-  defp location_color(_other), do: "bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
+  defp location_color(_other), do: "bg-white/10 text-zinc-300"
 
   @doc """
   The candidate's name — usually the release name, and the most recognizable

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -57,62 +57,75 @@
           </p>
         </.link>
 
+        <%!-- One meta line, not two: what the tags say and what the probe
+              measured are both identity, and each extra line raises the
+              card's density for free. --%>
         <p
-          :if={tag_summary(item) != ""}
-          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm italic dark:text-zinc-500"
+          :if={Enum.any?([tag_summary(item), probe_summary(item)], &(&1 != ""))}
+          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-500 dark:text-zinc-400"
         >
-          {tag_summary(item)}
+          {[tag_summary(item), probe_summary(item)] |> Enum.reject(&(&1 == "")) |> Enum.join(" · ")}
         </p>
 
-        <p
-          :if={probe_summary(item) != ""}
-          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm italic dark:text-zinc-500"
-        >
-          {probe_summary(item)}
-        </p>
+        <%!-- The annotated rows — matches and the files' source — share one
+              label column, so every badge and chip starts on the same rail
+              (design language §1). The value cell owns its own wrapping: when
+              width runs out the meta drops a line INSIDE the column, and the
+              candidate title is the last thing to ellipsize. --%>
+        <div class="mt-2 space-y-0.5">
+          <div
+            :for={match <- match_summary(item)}
+            class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2 text-sm"
+          >
+            <span class="text-xs text-zinc-500 dark:text-zinc-400">{match.level}</span>
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <.badge color={elem(confidence_label(match.confidence), 1)} class="text-xs">
+                {elem(confidence_label(match.confidence), 0)}
+              </.badge>
+              <%!-- basis-48 + grow keeps the title from being shrunk out of
+                    existence (meta wraps down instead); max-w-fit stops the grow
+                    at the title's own width so the provenance stays beside it. --%>
+              <span class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap">
+                {candidate_label(match.best)}
+              </span>
+              <span :if={candidate_origin(match.best)} class="flex-none text-xs text-zinc-500 dark:text-zinc-400">
+                ({candidate_origin(match.best)})
+              </span>
+              <span :if={match.alternatives > 0} class="flex-none text-xs text-zinc-500 dark:text-zinc-400">
+                +{match.alternatives} other{if match.alternatives > 1, do: "s"}
+              </span>
+            </div>
+          </div>
 
-        <%!-- flex-wrap so that when width runs out the meta pieces drop to a
-              second line instead of the candidate title (the answer) being
-              the first thing to ellipsize. --%>
-        <div :for={match <- match_summary(item)} class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm">
-          <span class="w-20 flex-none text-zinc-500 dark:text-zinc-500">{match.level}</span>
-          <.badge color={elem(confidence_label(match.confidence), 1)} class="text-xs">
-            {elem(confidence_label(match.confidence), 0)}
-          </.badge>
-          <%!-- basis-48 + grow keeps the title from being shrunk out of
-                existence (meta wraps down instead); max-w-fit stops the grow
-                at the title's own width so the provenance stays beside it. --%>
-          <span class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap">
-            {candidate_label(match.best)}
-          </span>
-          <span :if={candidate_origin(match.best)} class="flex-none text-xs text-zinc-500">
-            ({candidate_origin(match.best)})
-          </span>
-          <span :if={match.alternatives > 0} class="flex-none text-xs text-zinc-500">
-            +{match.alternatives} other{if match.alternatives > 1, do: "s"}
-          </span>
-        </div>
+          <p
+            :if={item.issue}
+            class="mt-2 flex items-baseline gap-1.5 overflow-hidden text-ellipsis text-sm text-red-600 dark:text-red-400"
+          >
+            <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
+            <span class="min-w-0">{item.issue}</span>
+          </p>
 
-        <p :if={item.issue} class="overflow-hidden text-ellipsis text-sm text-red-600">
-          {item.issue}
-        </p>
+          <p
+            :if={progress_label(@progress[item.id])}
+            class="text-xs text-zinc-500 dark:text-zinc-400"
+            data-role="item-progress"
+          >
+            {progress_label(@progress[item.id])}
+          </p>
 
-        <p
-          :if={progress_label(@progress[item.id])}
-          class="text-xs text-zinc-500 dark:text-zinc-400"
-          data-role="item-progress"
-        >
-          {progress_label(@progress[item.id])}
-        </p>
-
-        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-500 dark:text-zinc-500">
           <%!-- Where this came from decides what approving it does to the
-                bytes, so it belongs on the row rather than one click away. --%>
-          <span class={["mr-1 rounded-sm px-1 py-0.5", location_color(item.location)]}>
-            {location_label(item.location)}
-          </span>
-          {item.path}
-        </p>
+                bytes, so it belongs on the row rather than one click away —
+                and on the same rail as the match badges above it. --%>
+          <div class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2">
+            <span class="text-xs text-zinc-500 dark:text-zinc-400">source</span>
+            <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-500 dark:text-zinc-400">
+              <span class={["mr-1 rounded-sm px-1 py-0.5", location_color(item.location)]}>
+                {location_label(item.location)}
+              </span>
+              <span class="font-mono">{item.path}</span>
+            </p>
+          </div>
+        </div>
       </div>
 
       <%!-- One rail with fixed slots — status, meta, actions, date — instead
@@ -120,94 +133,100 @@
             bottom line (the row container wraps) rather than squeezing the
             titles; the actions carry words because a 16px icon is neither a
             label nor a touch target. --%>
+      <%!-- The rail's corners share the card's baselines: status aligns with
+            the title line, the date with the content's last line
+            (self-stretch + justify-between). Actions are uniform width so
+            the right edge reads as a column, not a rag. --%>
       <div
-        class="flex w-full flex-none flex-wrap items-center gap-x-3 gap-y-2 sm:w-44 sm:flex-col sm:items-end"
+        class="flex w-full flex-none flex-wrap items-center gap-x-3 gap-y-2 sm:w-44 sm:flex-col sm:items-end sm:justify-between sm:self-stretch"
         inert={busy?(@progress[item.id])}
       >
-        <div class="flex items-center gap-2">
-          <.badge :if={item.ready and item.status == :pending} color={:brand} class="text-xs">
-            ready
-          </.badge>
-          <.badge color={status_color(item.status)} class="text-xs">{item.status}</.badge>
-        </div>
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 sm:flex-col sm:items-end">
+          <div class="flex items-center gap-2">
+            <.badge :if={item.ready and item.status == :pending} color={:brand} class="text-xs">
+              ready
+            </.badge>
+            <.badge color={status_color(item.status)} class="text-xs">{item.status}</.badge>
+          </div>
 
-        <div class="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
-          <span
-            :if={file_count(item) > 1}
-            title="Audio files"
-            class="rounded-sm bg-zinc-100 px-1.5 py-0.5 tabular-nums dark:bg-zinc-800"
-          >
-            <span class="font-bold text-zinc-700 dark:text-zinc-300">{file_count(item)}</span> files
-          </span>
-          <span :if={item.tags && item.tags["asin"]} title={"ASIN #{item.tags["asin"]}"}>
-            <.icon name="fa-tag" class="inline h-3.5 w-3.5 text-current" />
-          </span>
-          <span :if={item.tags && item.tags["has_cover_art"]} title="Embedded cover art">
-            <.icon name="fa-image" class="inline h-3.5 w-3.5 text-current" />
-          </span>
-        </div>
+          <div class="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+            <span
+              :if={file_count(item) > 1}
+              title="Audio files"
+              class="rounded-sm bg-zinc-100 px-1.5 py-0.5 tabular-nums dark:bg-zinc-800"
+            >
+              <span class="font-bold text-zinc-700 dark:text-zinc-300">{file_count(item)}</span> files
+            </span>
+            <span :if={item.tags && item.tags["asin"]} title={"ASIN #{item.tags["asin"]}"}>
+              <.icon name="fa-tag" class="inline h-3.5 w-3.5 text-current" />
+            </span>
+            <span :if={item.tags && item.tags["has_cover_art"]} title="Embedded cover art">
+              <.icon name="fa-image" class="inline h-3.5 w-3.5 text-current" />
+            </span>
+          </div>
 
-        <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
-          <%!-- Only a settled item can be imported from here. Anything else
+          <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
+            <%!-- Only a settled item can be imported from here. Anything else
                 opens the form, because the queue has no way to say what's
                 outstanding and the form's whole job is to. --%>
-          <span
-            :if={item.status == :pending and item.ready}
-            role="button"
-            phx-click="approve"
-            phx-value-id={item.id}
-            title="Add to the library"
-            data-confirm="Add this to the library?"
-            class={action_class(:brand)}
-          >
-            <.icon name="fa-check" class="h-3 w-3 text-current" /> Approve
-          </span>
+            <span
+              :if={item.status == :pending and item.ready}
+              role="button"
+              phx-click="approve"
+              phx-value-id={item.id}
+              title="Add to the library"
+              data-confirm="Add this to the library?"
+              class={action_class(:brand)}
+            >
+              <.icon name="fa-check" class="h-3 w-3 text-current" /> Approve
+            </span>
 
-          <.link
-            :if={item.status == :pending and not item.ready}
-            navigate={~p"/admin/inbox/#{item}"}
-            title="Settle what's outstanding"
-            class={action_class(:neutral)}
-          >
-            <.icon name="fa-pen-to-square" class="h-3 w-3 text-current" /> Open
-          </.link>
+            <.link
+              :if={item.status == :pending and not item.ready}
+              navigate={~p"/admin/inbox/#{item}"}
+              title="Settle what's outstanding"
+              class={action_class(:neutral)}
+            >
+              <.icon name="fa-pen-to-square" class="h-3 w-3 text-current" /> Open
+            </.link>
 
-          <%!-- One action, because "re-read the files" and "look for matches
+            <%!-- One action, because "re-read the files" and "look for matches
                 again" were never separable: the tags matching leans on come
                 out of the probe, so asking again without re-reading asks the
                 same question. Re-reads the folder, re-probes, and re-queries
                 every provider with the cache bypassed. --%>
-          <span
-            role="button"
-            phx-click="rescan"
-            phx-value-id={item.id}
-            title="Re-read the files and ask the providers again"
-            class={action_class(:neutral)}
-          >
-            <.icon name="fa-rotate" class="h-3 w-3 text-current" /> Re-match
-          </span>
+            <span
+              role="button"
+              phx-click="rescan"
+              phx-value-id={item.id}
+              title="Re-read the files and ask the providers again"
+              class={action_class(:neutral)}
+            >
+              <.icon name="fa-rotate" class="h-3 w-3 text-current" /> Re-match
+            </span>
 
-          <span
-            :if={item.status != :dismissed}
-            role="button"
-            phx-click="dismiss"
-            phx-value-id={item.id}
-            title="Dismiss (files are not touched)"
-            class={action_class(:danger)}
-          >
-            <.icon name="fa-xmark" class="h-3 w-3 text-current" /> Dismiss
-          </span>
+            <span
+              :if={item.status != :dismissed}
+              role="button"
+              phx-click="dismiss"
+              phx-value-id={item.id}
+              title="Dismiss (files are not touched)"
+              class={action_class(:danger)}
+            >
+              <.icon name="fa-xmark" class="h-3 w-3 text-current" /> Dismiss
+            </span>
 
-          <span
-            :if={item.status == :dismissed}
-            role="button"
-            phx-click="restore"
-            phx-value-id={item.id}
-            title="Put back in the queue"
-            class={action_class(:brand)}
-          >
-            <.icon name="fa-rotate-left" class="h-3 w-3 text-current" /> Restore
-          </span>
+            <span
+              :if={item.status == :dismissed}
+              role="button"
+              phx-click="restore"
+              phx-value-id={item.id}
+              title="Put back in the queue"
+              class={action_class(:brand)}
+            >
+              <.icon name="fa-rotate-left" class="h-3 w-3 text-current" /> Restore
+            </span>
+          </div>
         </div>
 
         <p class="text-xs text-zinc-500 dark:text-zinc-400">

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -15,7 +15,7 @@
       <%!-- The filters are the queue's primary navigation — a segmented
             control, not a row of text links. Counts ride along so the state
             of the queue is readable without clicking anything. --%>
-      <div class="inline-flex max-w-full items-center gap-0.5 overflow-x-auto rounded-sm border border-zinc-300 bg-zinc-100 p-0.5 text-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <div class="inline-flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg bg-zinc-900 p-1 text-sm">
         <span phx-click="filter-status" phx-value-status="all" class={segment_class(!@status && !@ready)}>
           All
         </span>
@@ -40,7 +40,7 @@
     </div>
   </:subheader>
 
-  <.flex_table rows={@items} filter={@list_opts.filter}>
+  <.flex_table rows={@items} filter={@list_opts.filter} row_class={&rail_class/1}>
     <:empty>
       Nothing waiting. Use <span class="font-bold">Scan for new</span> to look in the watched folder.
     </:empty>
@@ -153,9 +153,9 @@
             <span
               :if={file_count(item) > 1}
               title="Audio files"
-              class="rounded-sm bg-zinc-100 px-1.5 py-0.5 tabular-nums dark:bg-zinc-800"
+              class="bg-white/10 rounded-sm px-1.5 py-0.5 tabular-nums"
             >
-              <span class="font-bold text-zinc-700 dark:text-zinc-300">{file_count(item)}</span> files
+              <span class="font-bold text-zinc-300">{file_count(item)}</span> files
             </span>
             <span :if={item.tags && item.tags["asin"]} title={"ASIN #{item.tags["asin"]}"}>
               <.icon name="fa-tag" class="inline h-3.5 w-3.5 text-current" />

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -4,7 +4,7 @@
       <.button :if={@locations != []} phx-click="scan" color={:zinc}>Scan all</.button>
       <.link
         navigate={~p"/admin/locations/new"}
-        class="flex items-center font-bold text-lime-500 hover:underline dark:text-lime-400"
+        class="flex items-center font-bold text-lime-700 hover:underline dark:text-lime-400"
       >
         Add location <.icon name="fa-plus" class="ml-2 h-4 w-4 text-current" />
       </.link>
@@ -92,12 +92,15 @@
           >
             <.icon
               name={(location.enabled && "fa-eye") || "fa-eye-slash"}
-              class="h-4 w-4 text-current transition-colors hover:text-blue-600"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
             />
           </span>
 
           <.link navigate={~p"/admin/locations/#{location}/edit"} data-role="edit-location">
-            <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-pencil"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
 
           <span

--- a/lib/ambry_web/live/admin/media_live/chapters.html.heex
+++ b/lib/ambry_web/live/admin/media_live/chapters.html.heex
@@ -6,7 +6,7 @@
   <div class="max-w-3xl">
     <.simple_form id="media-chapters-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
       <div class="space-y-2">
-        <.label>Import from:</.label>
+        <.label>Import from</.label>
         <div class="flex items-center gap-2">
           <.button
             color={:zinc}

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -19,7 +19,7 @@
         <.input field={@form[:book_id]} label="Book" type="autocomplete" options={@books} />
 
         <div class="row-start-1 space-y-2 sm:col-start-2">
-          <.label>Import from:</.label>
+          <.label>Import from</.label>
           <div class="flex flex-wrap items-center gap-2">
             <.button
               :for={provider <- @recording_providers}
@@ -45,7 +45,7 @@
             label="Date display format"
             options={[{"Full Date", "full"}, {"Year & Month", "year_month"}, {"Year Only", "year"}]}
           />
-          <span class="text-sm italic dark:text-zinc-500">
+          <span class="text-sm text-zinc-500 dark:text-zinc-400">
             {preview_date_format(@form)}
           </span>
         </div>
@@ -220,8 +220,8 @@
 
       <div :if={@live_action == :edit} class="space-y-2">
         <.label>Audio file(s)</.label>
-        <div class="max-h-64 overflow-x-auto rounded-sm border-2 border-dashed border-zinc-600 bg-zinc-950 p-4">
-          <p :for={file <- @media.source_files} class="text-sm italic">
+        <div class="max-h-64 overflow-x-auto rounded-sm border-2 border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-600 dark:bg-zinc-950">
+          <p :for={file <- @media.source_files} class="text-sm">
             {Path.basename(file)}
           </p>
         </div>
@@ -257,7 +257,7 @@
           <div>
             <div class="flex items-center rounded-sm rounded-b-none border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 sm:text-sm sm:leading-6">
               <button
-                class="py-[7px] px-[11px] bg-zinc-600 font-bold text-zinc-100 hover:bg-zinc-500"
+                class="py-[7px] px-[11px] bg-zinc-200 font-bold text-zinc-800 hover:bg-zinc-300 dark:bg-zinc-600 dark:text-zinc-100 dark:hover:bg-zinc-500"
                 type="button"
                 phx-click={open_file_browser(@media)}
               >
@@ -267,7 +267,7 @@
                 {Enum.count(@selected_files)} File(s) selected
               </p>
             </div>
-            <div class="max-h-64 space-y-4 overflow-x-auto rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4">
+            <div class="max-h-64 space-y-4 overflow-x-auto rounded-b-sm border-2 border-t-0 border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-600 dark:bg-zinc-950">
               <.icon
                 :if={Enum.empty?(@selected_files)}
                 name="fa-file-circle-exclamation"
@@ -286,7 +286,7 @@
           <.label>Streaming files</.label>
           <button
             type="button"
-            class="flex grow items-center text-lime-500 hover:underline"
+            class="flex grow items-center text-lime-700 hover:underline dark:text-lime-400"
             phx-click={JS.toggle(to: ".files-list-toggle")}
           >
             <span class="files-list-toggle">show</span>
@@ -330,7 +330,7 @@
             <div>
               <button
                 type="button"
-                class="flex items-center pt-2 text-lime-500 hover:underline"
+                class="flex items-center pt-2 text-lime-700 hover:underline dark:text-lime-400"
                 phx-click={JS.toggle(to: ".source-list-toggle")}
               >
                 <span class="source-list-toggle">show source files</span>

--- a/lib/ambry_web/live/admin/media_live/form/file_browser.ex
+++ b/lib/ambry_web/live/admin/media_live/form/file_browser.ex
@@ -333,7 +333,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form.FileBrowser do
 
   defp disallowed_file_node(assigns) do
     ~H"""
-    <.row level={@level} class="italic text-slate-600">
+    <.row level={@level} class="text-zinc-500 dark:text-zinc-400">
       <div class="w-4 flex-none" />
       <.filename title={@file.path}>{@file.path}</.filename>
       <.mtime timestamp={@file.mtime} />
@@ -373,7 +373,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form.FileBrowser do
 
   defp mtime(assigns) do
     ~H"""
-    <div class="w-48 flex-none text-right text-sm italic text-zinc-500">
+    <div class="w-48 flex-none text-right text-sm text-zinc-500 dark:text-zinc-400">
       {@timestamp |> Calendar.strftime("%c")}
     </div>
     """

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -53,13 +53,13 @@
 
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis">{media_display_title(media)}</p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400">
           by {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400">
           narrated by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400">
           {media.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}
         </p>
       </div>
@@ -87,10 +87,16 @@
             <.icon name="fa-book-bookmark" class="h-4 w-4 text-current transition-colors hover:text-yellow-400" />
           </.link>
           <.link navigate={~p"/admin/media/#{media}/edit"}>
-            <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-pencil"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
           <.link navigate={~p"/admin/media/#{media}/replace"} title="Replace audio">
-            <.icon name="fa-upload" class="h-4 w-4 text-current transition-colors hover:text-lime-500" />
+            <.icon
+              name="fa-upload"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
           <span
             phx-click="scan"
@@ -108,13 +114,13 @@
           </span>
         </div>
 
-        <p :if={media.duration} class="text-sm italic dark:text-zinc-500">
+        <p :if={media.duration} class="text-sm text-zinc-500 dark:text-zinc-400">
           Duration {format_timecode(media.duration)}
         </p>
-        <p :if={media.published} class="text-sm italic dark:text-zinc-500">
+        <p :if={media.published} class="text-sm text-zinc-500 dark:text-zinc-400">
           Published {format_published(media, :short)}
         </p>
-        <p class="text-sm italic dark:text-zinc-500">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400">
           Added {Calendar.strftime(media.inserted_at, "%x")}
         </p>
       </div>

--- a/lib/ambry_web/live/admin/media_live/replace.html.heex
+++ b/lib/ambry_web/live/admin/media_live/replace.html.heex
@@ -24,11 +24,11 @@
 
     <div class="space-y-2">
       <.label>Current audio file(s)</.label>
-      <div class="max-h-64 overflow-x-auto rounded-sm border-2 border-dashed border-zinc-600 bg-zinc-950 p-4">
-        <p :if={@media.source_files == []} class="text-sm italic text-zinc-500">
+      <div class="max-h-64 overflow-x-auto rounded-sm border-2 border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-600 dark:bg-zinc-950">
+        <p :if={@media.source_files == []} class="text-sm text-zinc-500 dark:text-zinc-400">
           No source files on record.
         </p>
-        <p :for={file <- @media.source_files} class="text-sm italic">
+        <p :for={file <- @media.source_files} class="text-sm">
           {Path.basename(file)}
         </p>
       </div>
@@ -64,7 +64,7 @@
           <div>
             <div class="flex items-center rounded-sm rounded-b-none border border-zinc-300 bg-white text-zinc-900 dark:border-zinc-600 dark:bg-zinc-800 dark:text-zinc-300 sm:text-sm sm:leading-6">
               <button
-                class="py-[7px] px-[11px] bg-zinc-600 font-bold text-zinc-100 hover:bg-zinc-500"
+                class="py-[7px] px-[11px] bg-zinc-200 font-bold text-zinc-800 hover:bg-zinc-300 dark:bg-zinc-600 dark:text-zinc-100 dark:hover:bg-zinc-500"
                 type="button"
                 phx-click={open_file_browser(@media)}
               >
@@ -74,7 +74,7 @@
                 {Enum.count(@selected_files)} File(s) selected
               </p>
             </div>
-            <div class="max-h-64 space-y-4 overflow-x-auto rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4">
+            <div class="max-h-64 space-y-4 overflow-x-auto rounded-b-sm border-2 border-t-0 border-dashed border-zinc-300 bg-zinc-50 p-4 dark:border-zinc-600 dark:bg-zinc-950">
               <.icon
                 :if={Enum.empty?(@selected_files)}
                 name="fa-file-circle-exclamation"

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -47,6 +47,7 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
 
                 <.button
                   :if={length(providers_for_level(@providers, level)) > 1}
+                  color={:zinc}
                   phx-click="move"
                   phx-value-id={entry.id}
                   phx-value-direction="up"
@@ -57,6 +58,7 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
                 </.button>
                 <.button
                   :if={length(providers_for_level(@providers, level)) > 1}
+                  color={:zinc}
                   phx-click="move"
                   phx-value-id={entry.id}
                   phx-value-direction="down"
@@ -66,7 +68,12 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
                   <.icon name="fa-chevron-down" class="h-3 w-3" />
                 </.button>
 
-                <.button phx-click="toggle" phx-value-id={entry.id} class="!px-2 !py-1">
+                <.button
+                  color={(entry.enabled && :zinc) || :brand}
+                  phx-click="toggle"
+                  phx-value-id={entry.id}
+                  class="!px-2 !py-1"
+                >
                   {(entry.enabled && "Disable") || "Enable"}
                 </.button>
               </div>
@@ -110,6 +117,7 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
                   <.button type="submit">Save</.button>
                   <.button
                     type="button"
+                    color={:zinc}
                     phx-click="clear-cache"
                     phx-value-id={entry.id}
                     data-confirm={"Clear all cached #{entry.display_name} responses?"}
@@ -122,6 +130,7 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
               <div :if={entry.module.config_fields() == []} class="mt-4">
                 <.button
                   type="button"
+                  color={:zinc}
                   phx-click="clear-cache"
                   phx-value-id={entry.id}
                   data-confirm={"Clear all cached #{entry.display_name} responses?"}

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -23,7 +23,7 @@
         <.input field={@form[:name]} label="Name" />
 
         <div :if={@providers != []} class="row-start-1 space-y-2 sm:col-start-2">
-          <.label>Import from:</.label>
+          <.label>Import from</.label>
           <div class="flex items-center gap-2">
             <.button
               :for={provider <- @providers}

--- a/lib/ambry_web/live/admin/person_live/index.html.heex
+++ b/lib/ambry_web/live/admin/person_live/index.html.heex
@@ -37,7 +37,7 @@
       </div>
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="person-name">{person.name}</p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500" data-role="person-aliases">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400" data-role="person-aliases">
           {(person.writing_as ++ person.narrating_as) |> Enum.filter(&(&1 != person.name)) |> Enum.join(", ")}
         </p>
       </div>
@@ -57,13 +57,16 @@
       <div class="flex w-32 flex-none flex-col items-end justify-between whitespace-nowrap">
         <div class="flex gap-2 pb-2">
           <.link navigate={~p"/admin/people/#{person}/edit"} data-role="edit-person">
-            <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-pencil"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
           <span phx-click="delete" phx-value-id={person.id} data-confirm="Are you sure?" data-role="delete-person">
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
           </span>
         </div>
-        <p class="text-sm italic dark:text-zinc-500" data-role="person-added">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400" data-role="person-added">
           Added {Calendar.strftime(person.inserted_at, "%x")}
         </p>
       </div>

--- a/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
@@ -90,10 +90,10 @@
           </div>
         </div>
         <div class="flex w-48 flex-none flex-col items-end justify-center whitespace-nowrap">
-          <p class="text-sm italic dark:text-zinc-500" title={format_full_datetime(playthrough.last_event_at)}>
+          <p class="text-sm text-zinc-500 dark:text-zinc-400" title={format_full_datetime(playthrough.last_event_at)}>
             Last event {format_date(playthrough.last_event_at)}
           </p>
-          <p class="text-sm italic dark:text-zinc-500" title={format_full_datetime(playthrough.started_at)}>
+          <p class="text-sm text-zinc-500 dark:text-zinc-400" title={format_full_datetime(playthrough.started_at)}>
             Started {format_date(playthrough.started_at)}
           </p>
         </div>

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -34,7 +34,7 @@
       </div>
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="series-name">{series.name}</p>
-        <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500" data-role="series-authors">
+        <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400" data-role="series-authors">
           by {series.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
       </div>
@@ -48,13 +48,16 @@
       <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
         <div class="flex gap-2">
           <.link navigate={~p"/admin/series/#{series}/edit"} data-role="edit-series">
-            <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-pencil"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
           <span phx-click="delete" phx-value-id={series.id} data-confirm="Are you sure?" data-role="delete-series">
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
           </span>
         </div>
-        <p class="text-sm italic dark:text-zinc-500" data-role="series-added">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400" data-role="series-added">
           Added {Calendar.strftime(series.inserted_at, "%x")}
         </p>
       </div>

--- a/lib/ambry_web/live/admin/universe_live/index.html.heex
+++ b/lib/ambry_web/live/admin/universe_live/index.html.heex
@@ -44,13 +44,16 @@
       <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
         <div class="flex gap-2">
           <.link navigate={~p"/admin/universes/#{universe}/edit"} data-role="edit-universe">
-            <.icon name="fa-pencil" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-pencil"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
           <span phx-click="delete" phx-value-id={universe.id} data-confirm="Are you sure?" data-role="delete-universe">
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
           </span>
         </div>
-        <p class="text-sm italic dark:text-zinc-500" data-role="universe-added">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400" data-role="universe-added">
           Added {Calendar.strftime(universe.inserted_at, "%x")}
         </p>
       </div>

--- a/lib/ambry_web/live/admin/user_devices_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_devices_live/index.html.heex
@@ -38,7 +38,7 @@
           <p class="overflow-hidden text-ellipsis font-medium">
             {format_device(device)}
           </p>
-          <p class="overflow-hidden text-ellipsis text-sm italic dark:text-zinc-500">
+          <p class="overflow-hidden text-ellipsis text-sm text-zinc-500 dark:text-zinc-400">
             {device.app_id} {format_app_version(device.app_version, device.app_build)}
           </p>
           <p class="font-mono overflow-hidden text-ellipsis text-xs text-zinc-400" title={device.id}>
@@ -55,10 +55,10 @@
         </div>
 
         <div class="flex w-48 flex-none flex-col items-end justify-center whitespace-nowrap">
-          <p class="text-sm italic dark:text-zinc-500" title={format_full_datetime(device.last_seen_at)}>
+          <p class="text-sm text-zinc-500 dark:text-zinc-400" title={format_full_datetime(device.last_seen_at)}>
             Last seen {format_date(device.last_seen_at)}
           </p>
-          <p class="text-sm italic dark:text-zinc-500" title={format_full_datetime(device.inserted_at)}>
+          <p class="text-sm text-zinc-500 dark:text-zinc-400" title={format_full_datetime(device.inserted_at)}>
             First seen {format_date(device.inserted_at)}
           </p>
         </div>

--- a/lib/ambry_web/live/admin/user_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_live/index.html.heex
@@ -71,7 +71,10 @@
           </.link>
 
           <.link navigate={~p"/admin/users/#{user}/devices"} title="Devices">
-            <.icon name="fa-mobile-screen" class="h-4 w-4 text-current transition-colors hover:text-blue-600" />
+            <.icon
+              name="fa-mobile-screen"
+              class="h-4 w-4 text-current transition-colors hover:text-lime-600 dark:hover:text-lime-400"
+            />
           </.link>
 
           <%= if user.id != @current_user.id do %>
@@ -109,10 +112,10 @@
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
           </span>
         </div>
-        <p :if={user.last_login_at} class="text-sm italic dark:text-zinc-500" data-role="user-last-login">
+        <p :if={user.last_login_at} class="text-sm text-zinc-500 dark:text-zinc-400" data-role="user-last-login">
           Last login {Calendar.strftime(user.last_login_at, "%x")}
         </p>
-        <p class="text-sm italic dark:text-zinc-500" data-role="user-joined">
+        <p class="text-sm text-zinc-500 dark:text-zinc-400" data-role="user-joined">
           Joined {Calendar.strftime(user.inserted_at, "%x")}
         </p>
       </div>


### PR DESCRIPTION
**Stacked on #1212** (→ #1211 → #1210 → #1209 → #1208). Retarget children to main before merging parents.

The operator reviewed the stack and called the gap correctly: the widget/color layer landed, but pages still zigzagged — mockup-quality came from *composition*, which is rules, not components. This PR writes the rules down and applies them wholesale.

## `docs/admin-design-language.md`

The durable deliverable: geometry (two left edges — boxes on the margin, all text on a 12px rail matching input text; one label column per run of annotated rows, wraps stay in the value column; 8·28·56 rhythm; rails share the card's corner baselines), type roles (italics for titles only; one `<.microlabel>` spec), semantic color (muted floor zinc-500/400), the pill taxonomy (only the chosen option chip is loud; `None` is a dashed ghost; uniform-width worded actions), and control rules (adjacent bar controls share exact height; inputs sized to content).

## Applied to the import form

Every decision row: label + provenance on the text rail → content-sized control → hint → `Proposed` as a `label | chips` grid (wrapped chips no longer fall back to the page edge). Unchosen chips lose their filled source tags (the row was heavy and made the label look apologetic); outcome rows (`Asked`), photos, and bios join the same grid; the library search input and button share height; "No — this is a different book" is a proper outcome chip with a check; alerts get an icon + normal weight; all italics and light-mode-less muted text swept.

## Applied to the inbox queue

The card from the operator's screenshot: title + **one** meta line (was three), match rows and the source/path line in one shared label-column grid — the blue location chip now starts exactly where the green confidence badges do — the red issue line iconified, and the rail `self-stretch justify-between` with uniform `w-28` actions, so status sits on the title's baseline and "Found …" on the path's. The segmented filter now matches the Scan button height to the pixel.

Verified against the operator's four complaint screenshots, dark + light; 1239 tests green (no behavior changes).

https://claude.ai/code/session_01UzXb61pyzkinj9wcFtn199