### PR TITLE
Two left edges, never three: the text-rail pass

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -23,6 +23,7 @@ import topbar from "topbar"
 
 import { ComboboxNavHook } from "./hooks/combobox-nav"
 import { DispatchValueChangeHook } from "./hooks/dispatch-value-change"
+import { FitOrStackHook } from "./hooks/fit-or-stack"
 import { HeaderScrollspyHook } from "./hooks/header-scrollspy"
 import { ImageSizeHook } from "./hooks/image-size"
 import { InfiniteScrollHook } from "./hooks/infinite-scroll"
@@ -46,6 +47,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     "infinite-scroll": InfiniteScrollHook,
     "combobox-nav": ComboboxNavHook,
     "dispatch-value-change": DispatchValueChangeHook,
+    "fit-or-stack": FitOrStackHook,
     "image-size": ImageSizeHook,
     "scroll-match": ScrollMatchHook,
     "paste-image": PasteImageHook,

--- a/assets/js/hooks/fit-or-stack.js
+++ b/assets/js/hooks/fit-or-stack.js
@@ -1,0 +1,42 @@
+// Either every chip fits on one line, or every chip gets its own line.
+//
+// Flow layout has no native way to say this: flex-wrap happily breaks just
+// the last chip onto a second line, and the CSS-only "switcher" trick keys
+// off a fixed container width and force-stretches children to equal widths,
+// which is wrong for content-sized pills whose count varies per row. So the
+// container is measured — the sum of the chips' natural widths plus gaps
+// against the container — and committed to one of exactly two modes.
+//
+// The measurement never uses nowrap: in a nowrap flex row the chips would
+// shrink to their min-content before overflowing, hiding the overflow the
+// test is looking for. In both wrap and column modes a chip's laid-out
+// width IS its natural width (capped by max-w-full, which only kicks in
+// when it genuinely wouldn't fit anyway).
+export const FitOrStackHook = {
+  mounted() {
+    this.observer = new ResizeObserver(() => this.apply())
+    this.observer.observe(this.el)
+    this.apply()
+  },
+  updated() {
+    // A LiveView patch may swap the chip set and re-writes the class list.
+    this.apply()
+  },
+  destroyed() {
+    this.observer.disconnect()
+  },
+  apply() {
+    const el = this.el
+    const gap = parseFloat(getComputedStyle(el).columnGap) || 0
+    const kids = [...el.children]
+    const natural =
+      kids.reduce((sum, kid) => sum + kid.getBoundingClientRect().width, 0) +
+      gap * Math.max(0, kids.length - 1)
+    const fits = natural <= el.getBoundingClientRect().width + 1
+
+    el.classList.toggle("flex-wrap", fits)
+    el.classList.toggle("items-center", fits)
+    el.classList.toggle("flex-col", !fits)
+    el.classList.toggle("items-start", !fits)
+  },
+}

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -96,6 +96,12 @@ the text off the rail; other engines pick their own widths.
 column via grid (`grid-cols-[<w>_minmax(0,1fr)]`), sized once per surface;
 wrapped content stays in the value column.
 
+**A proposal-chip row is one line or a list, never a partial wrap.** A row
+that breaks just its last chip reads as an accident; either every chip
+shares the line or every chip gets its own. No flow mechanism expresses
+"stack only if they don't all fit", so the `fit-or-stack` hook measures the
+chips' natural widths and commits the row to one of the two modes.
+
 **Rhythm is 8 · 28 · 56** (`gap-2` / `gap-7` / `gap-14`): inside a field
 cluster / between blocks / between sections. Queue cards stack with
 `space-y-3`.

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -72,6 +72,25 @@ x-positions: the **box edge** (cards, inputs, record rows, buttons) and the
 inputs — where every bare-text element sits (labels, hints, helper prose,
 microlabels, eyebrows).
 
+**Text lands on the rail exactly, wherever it lives.** A control's own text
+counts: a borderless pill pads `px-3`; a 1px-bordered box pads `px-[11px]`
+so border + padding = 12 (the inputs' trick, worth a transparent border in
+the borderless state so toggling doesn't shift the box); a card's leading
+checkbox sits on the rail itself. Two pixels shy of the rail reads worse
+than either edge — near-misses are what "feels off" is made of.
+
+**Images are content, not containers.** A bare image (a cover preview, a
+person photo, its empty-state placeholder) sits on the text rail like the
+words around it. The box edge exists so a *container's* padding can land
+its inner text on the rail — an image has no inner text to land. An image
+inside a chip or well follows that container's rules.
+
+**Disclosure markers hang in the gutter.** A fold's summary text sits on
+the rail with its chevron in the 12px gutter to the left — the
+hanging-indicator pattern, always via `<.disclosure>`. Browser-default
+summary markers are never used bare: Firefox draws them `inside`, pushing
+the text off the rail; other engines pick their own widths.
+
 **One label column for annotated rows.** Any run of "label: value" rows
 (match lines, `Proposed`/`Asked` rows, the source line) shares a fixed label
 column via grid (`grid-cols-[<w>_minmax(0,1fr)]`), sized once per surface;

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -494,6 +494,45 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  @doc """
+  A fold, drawn to the geometry rules: the summary text on the text rail,
+  the chevron hanging in the 12px gutter to its left
+  (docs/admin-design-language.md §3).
+
+  Browsers place the native summary marker where they like — Firefox renders
+  it `inside`, which pushes the summary text off the rail by the marker's own
+  width — so the native marker is hidden and the chevron drawn by hand.
+  """
+  attr :summary, :string, required: true
+  attr :class, :string, default: nil, doc: "summary text classes — replaces the size and color"
+  attr :container_class, :string, default: nil
+  attr :rest, :global
+  slot :inner_block, required: true
+
+  def disclosure(assigns) do
+    ~H"""
+    <details class={["group", @container_class]} {@rest}>
+      <summary class={[
+        "relative cursor-pointer list-none pl-3 :[&:-webkit-details-marker]:hidden",
+        @class || "text-xs text-zinc-400"
+      ]}>
+        <%!-- Two icons swapped on open, not one rotated: rotating the CSS-mask
+            span rasterizes a grey sliver of the box edge past the mask. --%>
+        <.icon
+          name="fa-chevron-right"
+          class="absolute top-1/2 left-0 h-2.5 w-2.5 -translate-y-1/2 group-open:hidden"
+        />
+        <.icon
+          name="fa-chevron-down"
+          class="absolute top-1/2 left-0 hidden h-2.5 w-2.5 -translate-y-1/2 group-open:inline-block"
+        />
+        {@summary}
+      </summary>
+      {render_slot(@inner_block)}
+    </details>
+    """
+  end
+
   defp badge_color(:yellow), do: "bg-amber-400/15 text-amber-300"
   defp badge_color(:blue), do: "bg-blue-400/15 text-blue-300"
   defp badge_color(:red), do: "bg-red-400/15 text-red-300"

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -15,7 +15,7 @@ defmodule AmbryWeb.Admin.Decisions do
   use Phoenix.Component
   use AmbryWeb, :verified_routes
 
-  import AmbryWeb.Admin.Components, only: [badge: 1, microlabel: 1]
+  import AmbryWeb.Admin.Components, only: [badge: 1, disclosure: 1, microlabel: 1]
   import AmbryWeb.CoreComponents
 
   alias Ambry.Inbox.Draft.Credit
@@ -164,9 +164,11 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def record_row(assigns) do
     ~H"""
+    <%!-- pl-3, not p-2.5: the checkbox sits on the container's text rail,
+        like the summary text and microlabels around these cards. --%>
     <label
       class={[
-        "flex cursor-pointer items-start gap-3 rounded-md p-2.5",
+        "flex cursor-pointer items-start gap-3 rounded-md py-2.5 pr-2.5 pl-3",
         @used && "bg-brand-dark/10 ring-brand-dark/50 ring-2 ring-inset",
         !@used && "bg-zinc-800/60 hover:bg-zinc-800"
       ]}
@@ -275,7 +277,8 @@ defmodule AmbryWeb.Admin.Decisions do
       <input type="hidden" name="key" value={@person_key} />
 
       <label class="text-xs text-zinc-400">
-        name <input type="text" name="name" value={@name} class={input_classes("mt-1 block")} />
+        <span class="block pl-3">name</span>
+        <input type="text" name="name" value={@name} class={input_classes("mt-1 block")} />
       </label>
 
       <button
@@ -309,8 +312,10 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <input type="hidden" name="level" value={@level} />
 
+      <%!-- The label text is railed; the input below it stays a box on the
+          box edge, so the pl-3 lives on a span, not the label. --%>
       <label class="text-xs text-zinc-400">
-        title
+        <span class="block pl-3">title</span>
         <input
           type="text"
           name="title"
@@ -320,7 +325,7 @@ defmodule AmbryWeb.Admin.Decisions do
       </label>
 
       <label class="text-xs text-zinc-400">
-        author
+        <span class="block pl-3">author</span>
         <input
           type="text"
           name="author"
@@ -330,7 +335,7 @@ defmodule AmbryWeb.Admin.Decisions do
       </label>
 
       <label :if={@level == "recording"} class="text-xs text-zinc-400">
-        narrator
+        <span class="block pl-3">narrator</span>
         <input
           type="text"
           name="narrator"
@@ -480,12 +485,16 @@ defmodule AmbryWeb.Admin.Decisions do
               look identical here and only one of them is worth importing.
               Routed through the admin proxy like every other import preview,
               or tracking protection blocks the provider CDN. --%>
-        <.image_with_size
-          :if={@preview && preview_src(@field.value, @embedded_src)}
-          id={"#{@section}-#{@name}"}
-          src={preview_src(@field.value, @embedded_src)}
-          class="h-24 w-24 flex-none rounded-sm object-cover"
-        />
+        <%!-- pl-3 wrapper: an image is content, not a container — it sits on
+            the text rail (design language §3). On the wrapper, so rows
+            without a preview keep their input on the box edge. --%>
+        <div :if={@preview && preview_src(@field.value, @embedded_src)} class="flex-none pl-3">
+          <.image_with_size
+            id={"#{@section}-#{@name}"}
+            src={preview_src(@field.value, @embedded_src)}
+            class="h-24 w-24 rounded-sm object-cover"
+          />
+        </div>
 
         <div class="min-w-0 flex-grow">
           <.inputs_for :let={decision} field={@form[@name]}>
@@ -640,15 +649,16 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def credit_row(assigns) do
     ~H"""
-    <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
-      <div class="flex items-center justify-between gap-2">
+    <%!-- A decision block, so it wears the state rail like every other one —
+        the rail is the ONLY settledness encoding (design language §2); the
+        check icon it used to grow shifted the title sideways on approval. --%>
+    <div class={[
+      "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+      (Credit.resolved?(@credit) && "border-brand-dark/60") || "border-amber-400/70"
+    ]}>
+      <div class="flex items-center justify-between gap-2 pl-3">
         <div class="flex min-w-0 items-center gap-2">
-          <.icon
-            :if={Credit.resolved?(@credit)}
-            name="fa-circle-check"
-            class="text-brand-dark h-4 w-4 flex-none"
-          />
-          <.label class="text-xs">{@verb}</.label>
+          <.label>{@verb}</.label>
 
           <.badge
             :if={!Credit.resolved?(@credit)}
@@ -749,13 +759,13 @@ defmodule AmbryWeb.Admin.Decisions do
         phx-click="toggle-people"
         phx-value-section={@section}
         phx-value-index={@index}
-        class="text-xs text-zinc-400 underline"
+        class="pl-3 text-xs text-zinc-400 underline"
       >
         {@reveal}
       </button>
 
       <div :if={@credit.mode == :create and @expanded} class="space-y-3">
-        <.label class="text-xs">{@backing}</.label>
+        <.label class="pl-3 text-xs">{@backing}</.label>
 
         <div
           :for={{person, person_index} <- Enum.with_index(@persons)}
@@ -814,12 +824,12 @@ defmodule AmbryWeb.Admin.Decisions do
           phx-click="add-person"
           phx-value-section={@section}
           phx-value-index={@index}
-          class="text-xs text-zinc-400 underline"
+          class="pl-3 text-xs text-zinc-400 underline"
         >
           Add another person
         </button>
 
-        <p :if={length(@persons) > 1} class="text-xs text-zinc-400">
+        <p :if={length(@persons) > 1} class="pl-3 text-xs text-zinc-400">
           A shared pen name — {@credit.name} will be one author credited to {length(@persons)} people.
         </p>
       </div>
@@ -899,7 +909,9 @@ defmodule AmbryWeb.Admin.Decisions do
 
     ~H"""
     <div :if={@person.mode == :create} class="space-y-2" data-role="person-face">
-      <div class="flex items-center gap-2">
+      <%!-- pl-3: an image is content, not a container — it sits on the text
+          rail like the words around it (design language §3). --%>
+      <div class="flex items-center gap-2 pl-3">
         <.image_with_size
           :if={@image}
           id={"person-#{@at}-photo"}
@@ -934,7 +946,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <%!-- Nothing found is a normal outcome, not a failure — plenty of
             narrators are in no database at all — but it should say so rather
             than looking like an empty grid nobody filled in. --%>
-      <p :if={@person.doubt == :low_confidence} class="text-xs text-zinc-400">
+      <p :if={@person.doubt == :low_confidence} class="pl-3 text-xs text-zinc-400">
         {@person.doubt_detail}
       </p>
 
@@ -943,7 +955,7 @@ defmodule AmbryWeb.Admin.Decisions do
             the photo and bio pools draw from the ticked set. The exact-name
             gate decides the initial ticks; a differently-spelled record of
             the right person is exactly what the checkbox is for. --%>
-      <p :if={@records != []} class="text-xs text-zinc-400">
+      <p :if={@records != []} class="max-w-prose pl-3 text-xs text-zinc-400">
         Tick every record of <span class="font-semibold">this person</span> — the photos and bios on offer come from the
         ticked ones. Databases know several people by many names, so check before ticking.
       </p>
@@ -958,10 +970,7 @@ defmodule AmbryWeb.Admin.Decisions do
 
       <.provider_outcomes_row outcomes={@outcomes} retryable={false} />
 
-      <details>
-        <summary class="cursor-pointer text-xs text-zinc-400">
-          Not the right person? Search again
-        </summary>
+      <.disclosure summary="Not the right person? Search again">
         <div class="pt-2">
           <.person_research_form
             at={@at}
@@ -970,7 +979,7 @@ defmodule AmbryWeb.Admin.Decisions do
             running={@searching}
           />
         </div>
-      </details>
+      </.disclosure>
 
       <div :if={@photos != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
         <.microlabel class="pt-1">Photos</.microlabel>
@@ -1153,71 +1162,84 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def series_row(assigns) do
     ~H"""
+    <%!-- The same anatomy as every other decision block: railed header row
+        with the state on the block's left rail (no extra check icon — the
+        rail is the only settledness encoding, §2), controls below with
+        their labels above them. --%>
     <div class={[
-      "flex flex-wrap items-center gap-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+      "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
       (SeriesLink.resolved?(@link) && "border-brand-dark/60") || "border-amber-400/70"
     ]}>
-      <.icon
-        :if={SeriesLink.resolved?(@link)}
-        name="fa-circle-check"
-        class="text-brand-dark h-4 w-4 flex-none"
-      />
+      <div class="flex items-center justify-between gap-2 pl-3">
+        <div class="flex min-w-0 items-center gap-2">
+          <.label>In series</.label>
 
-      <.badge
-        :if={!SeriesLink.resolved?(@link)}
-        color={elem(state_words(SeriesLink.state(@link)), 1)}
-        class="text-xs"
-      >
-        {elem(state_words(SeriesLink.state(@link)), 0)}
-      </.badge>
+          <.badge
+            :if={!SeriesLink.resolved?(@link)}
+            color={elem(state_words(SeriesLink.state(@link)), 1)}
+            class="text-xs"
+          >
+            {elem(state_words(SeriesLink.state(@link)), 0)}
+          </.badge>
+        </div>
 
-      <form id={"series-#{@index}-number"} phx-change="set-series-number" class="flex items-center gap-1">
-        <input type="hidden" name="index" value={@index} />
-        <label class="text-xs text-zinc-400">Book no.</label>
-        <input
-          type="text"
-          name="number"
-          value={@link.number}
-          placeholder="?"
-          class={input_classes("w-16")}
-        />
-      </form>
+        <div class="flex flex-none items-center gap-2">
+          <button
+            :if={!@link.approved and @link.number}
+            type="button"
+            phx-click="approve-series"
+            phx-value-index={@index}
+            phx-value-approved="true"
+            class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
+          >
+            Confirm
+          </button>
 
-      <form
-        id={"series-#{@index}-link"}
-        phx-change="link-series"
-        class="min-w-48 flex flex-grow items-center gap-2"
-      >
-        <input type="hidden" name="index" value={@index} />
-        <%!-- A provider's spelling of a series name is a proposal, not a
+          <button
+            type="button"
+            phx-click="remove-series"
+            phx-value-index={@index}
+            title="Not in this series"
+          >
+            <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-600" />
+          </button>
+        </div>
+      </div>
+
+      <div class="flex flex-wrap items-end gap-x-3 gap-y-2">
+        <form
+          id={"series-#{@index}-link"}
+          phx-change="link-series"
+          class="min-w-48 max-w-md flex-grow"
+        >
+          <input type="hidden" name="index" value={@index} />
+          <%!-- A provider's spelling of a series name is a proposal, not a
               decree. "The Expanse" vs "Expanse" is the operator's call. --%>
-        <.live_component
-          module={EntityResolver}
-          id={"series-#{@index}-resolver"}
-          name="series_id"
-          text_name="name"
-          options={@options}
-          value={if @link.mode == :link, do: @link.series_id}
-          text={@link.name || ""}
-          placeholder="series name"
-          class={input_classes("w-full")}
-        />
-      </form>
+          <.live_component
+            module={EntityResolver}
+            id={"series-#{@index}-resolver"}
+            name="series_id"
+            text_name="name"
+            options={@options}
+            value={if @link.mode == :link, do: @link.series_id}
+            text={@link.name || ""}
+            placeholder="series name"
+            class={input_classes("w-full")}
+          />
+        </form>
 
-      <button
-        :if={!@link.approved and @link.number}
-        type="button"
-        phx-click="approve-series"
-        phx-value-index={@index}
-        phx-value-approved="true"
-        class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
-      >
-        Confirm
-      </button>
-
-      <button type="button" phx-click="remove-series" phx-value-index={@index} title="Not in this series">
-        <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-600" />
-      </button>
+        <form id={"series-#{@index}-number"} phx-change="set-series-number" class="space-y-1">
+          <input type="hidden" name="index" value={@index} />
+          <label class="block pl-3 text-xs text-zinc-400">Book no.</label>
+          <input
+            type="text"
+            name="number"
+            value={@link.number}
+            placeholder="?"
+            class={input_classes("w-16")}
+          />
+        </form>
+      </div>
     </div>
     """
   end

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -550,7 +550,13 @@ defmodule AmbryWeb.Admin.Decisions do
       >
         <.microlabel class="pt-1.5">Proposed</.microlabel>
 
-        <div class="flex flex-wrap items-center gap-1.5">
+        <%!-- One line or a list, never a partial wrap — the hook measures
+            whether every chip fits and commits to exactly one of the two. --%>
+        <div
+          id={"#{@section}-#{@name}-chips"}
+          phx-hook="fit-or-stack"
+          class="flex flex-wrap items-center gap-1.5"
+        >
           <.proposal_chip
             :for={candidate <- @field.candidates}
             chosen={Field.chose?(@field, candidate)}
@@ -1058,7 +1064,11 @@ defmodule AmbryWeb.Admin.Decisions do
         <div :if={@bios != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
           <.microlabel class="pt-1.5">Proposed</.microlabel>
 
-          <div class="flex flex-wrap items-center gap-1.5">
+          <div
+            id={"person-bio-#{@at}-chips"}
+            phx-hook="fit-or-stack"
+            class="flex flex-wrap items-center gap-1.5"
+          >
             <.proposal_chip
               :for={bio <- @bios}
               chosen={Field.chose?(@person.description, bio)}

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -443,6 +443,10 @@ defmodule AmbryWeb.CoreComponents do
     ~H"""
     <div class={["space-y-2", @container_class]}>
       <.label :if={@label} for={@id}>{@label}</.label>
+      <%!-- Firefox's date editor carries ~2px of its own inner inset, which
+          knocks the value off the 12px text rail the px-[11px] + 1px border
+          otherwise lands on. @supports (-moz-appearance) matches only
+          Firefox, so only Firefox gets the compensation. --%>
       <input
         type={@type}
         name={@name}
@@ -450,7 +454,7 @@ defmodule AmbryWeb.CoreComponents do
         value={Form.normalize_value(@type, @value)}
         class={
           ["py-[7px] px-[11px] block w-full rounded-sm", "focus:outline-none focus:ring-4 sm:text-sm sm:leading-6"] ++
-            input_color_classes(@errors) ++ [@class]
+            [@type == "date" && "supports-[-moz-appearance:none]:px-[9px]"] ++ input_color_classes(@errors) ++ [@class]
         }
         {@rest}
       />

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -52,36 +52,45 @@ defmodule AmbryWeb.Components.EntityResolver do
         value={@text}
         phx-hook="dispatch-value-change"
       />
-      <div class="flex">
-        <span
-          :if={@text_name}
-          class="flex w-24 flex-none items-center justify-end rounded-l-sm border border-r-0 border-zinc-600 bg-zinc-900 px-3 text-sm font-semibold text-zinc-400"
-        >
-          {if @value, do: "Existing", else: "Create"}
-        </span>
-        <input
-          type="text"
-          id={"#{@id}-input"}
-          name={"resolver[#{@id}]"}
-          value={display_value(assigns)}
-          placeholder={@placeholder}
-          role="combobox"
-          aria-expanded={to_string(@open)}
-          aria-controls={"#{@id}-list"}
-          aria-autocomplete="list"
-          autocomplete="off"
-          phx-change="filter"
-          phx-focus="open"
-          phx-target={@myself}
-          phx-debounce="150"
-          class={[@class, @text_name && "rounded-l-none border-l-0"]}
-        />
-      </div>
+      <input
+        type="text"
+        id={"#{@id}-input"}
+        name={"resolver[#{@id}]"}
+        value={display_value(assigns)}
+        placeholder={@placeholder}
+        role="combobox"
+        aria-expanded={to_string(@open)}
+        aria-controls={"#{@id}-list"}
+        aria-autocomplete="list"
+        autocomplete="off"
+        phx-change="filter"
+        phx-focus="open"
+        phx-target={@myself}
+        phx-debounce="150"
+        class={[@class, @text_name && "pr-20"]}
+      />
+      <%!-- The mode is a status, not a control — you can't click it into the
+          other mode, picking or typing puts you there — so it wears the
+          status costume: a soft-tint badge at the input's right edge, not
+          the outlined prefix segment it used to be. Absent while the field
+          is empty, because there is no outcome to name yet. --%>
+      <span
+        :if={@text_name && @value}
+        class="bg-brand-dark/15 pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 rounded-sm px-1.5 text-xs text-lime-300"
+      >
+        existing
+      </span>
+      <span
+        :if={@text_name && !@value && present?(@equery)}
+        class="bg-white/10 pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 rounded-sm px-1.5 text-xs text-zinc-300"
+      >
+        new
+      </span>
       <ul
         :if={@open}
         id={"#{@id}-list"}
         role="listbox"
-        class="min-w-48 absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-sm border border-zinc-600 bg-zinc-800 text-sm shadow-lg"
+        class="min-w-48 absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-sm bg-zinc-800 text-sm shadow-lg"
       >
         <li
           :for={{label, id} <- @matches}
@@ -101,13 +110,13 @@ defmodule AmbryWeb.Components.EntityResolver do
           role="option"
           phx-click="create"
           phx-target={@myself}
-          class="cursor-pointer border-t border-zinc-700 px-3 py-2 italic data-[active]:bg-zinc-700 hover:bg-zinc-700"
+          class="cursor-pointer border-t border-zinc-700 px-3 py-2 font-medium text-zinc-200 data-[active]:bg-zinc-700 hover:bg-zinc-700"
         >
           Create “{@equery}”
         </li>
         <li
           :if={@matches == [] and not (@text_name && present?(@equery))}
-          class="px-3 py-2 italic text-zinc-500"
+          class="px-3 py-2 text-zinc-500"
         >
           No matches
         </li>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -10,7 +10,7 @@
       <%!-- the evidence: what was found, before anybody interpreted it --%>
       <section class="space-y-1 rounded-lg bg-zinc-900 p-4">
         <div class="flex items-start justify-between gap-4">
-          <div class="min-w-0">
+          <div class="min-w-0 pl-3">
             <p class="truncate font-bold">{@page_title}</p>
             <p class="font-mono truncate text-xs text-zinc-400">{@item.path}</p>
             <p class="text-sm text-zinc-400">{evidence(@item)}</p>
@@ -47,10 +47,13 @@
         <%!-- Tags are the primary source (98% of real releases carry a usable
             one) and the form used to show none of them, so a match that went
             somewhere strange had no visible cause. --%>
-        <details :if={tag_rows(@item) != [] or hint_rows(@item) != []} class="pt-2">
-          <summary class="cursor-pointer pl-3 text-sm text-zinc-400">What the files say</summary>
-
-          <div class="grid grid-cols-1 gap-4 pt-2 sm:grid-cols-2">
+        <.disclosure
+          :if={tag_rows(@item) != [] or hint_rows(@item) != []}
+          summary="What the files say"
+          class="text-sm text-zinc-400"
+          container_class="pt-2"
+        >
+          <div class="grid grid-cols-1 gap-4 pt-2 pl-3 sm:grid-cols-2">
             <div :if={tag_rows(@item) != []} data-role="tags">
               <p class="text-xs font-bold text-zinc-300">Embedded tags</p>
               <p :for={{label, value} <- tag_rows(@item)} class="text-xs text-zinc-400">
@@ -68,9 +71,9 @@
               </p>
             </div>
           </div>
-        </details>
+        </.disclosure>
 
-        <p :if={@item.issue} class="flex items-baseline gap-1.5 pt-2 text-sm text-red-400">
+        <p :if={@item.issue} class="flex items-baseline gap-1.5 pt-2 pl-3 text-sm text-red-400">
           <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
           {@item.issue}
         </p>
@@ -183,7 +186,7 @@
 
           <p
             :if={@library_query not in [nil, ""] and @library_results == []}
-            class="text-sm text-zinc-400"
+            class="pl-3 text-sm text-zinc-400"
           >
             Nothing in the library matches that.
           </p>
@@ -198,7 +201,7 @@
             type="button"
             phx-click="new-book"
             class={[
-              "flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm",
+              "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm",
               (@item.draft.work.mode == :create and @item.draft.work.approved) &&
                 "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
               !(@item.draft.work.mode == :create and @item.draft.work.approved) &&
@@ -247,7 +250,7 @@
             cover from another.
           </p>
 
-          <p :if={records(@item, "work") == []} class="text-sm text-zinc-400">
+          <p :if={records(@item, "work") == []} class="max-w-prose pl-3 text-sm text-zinc-400">
             No provider had a record of this. The fields below come from the file's own tags.
           </p>
 
@@ -265,10 +268,7 @@
             retrying={@retrying}
           />
 
-          <details>
-            <summary class="cursor-pointer pl-3 text-xs text-zinc-400">
-              Not what you're looking for? Search again
-            </summary>
+          <.disclosure summary="Not what you're looking for? Search again">
             <div class="pt-2">
               <.research_form
                 level="work"
@@ -276,7 +276,7 @@
                 running={@researching == "work"}
               />
             </div>
-          </details>
+          </.disclosure>
         </div>
 
         <%!-- Linking inherits the book's own fields; only additive series
@@ -374,7 +374,7 @@
 
           <p
             :if={@item.draft.work.mode == :link and @item.draft.work.series != []}
-            class="text-sm text-zinc-400"
+            class="max-w-prose pl-3 text-sm text-zinc-400"
           >
             This book isn't in these yet. Adding is a blank being filled, not a change to what's
             already there.
@@ -433,7 +433,7 @@
             {doubt_message(@item.draft.recording)}
           </p>
 
-          <p :if={records(@item, "recording") != []} class="text-sm text-zinc-400">
+          <p :if={records(@item, "recording") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
             Tick every record of <span class="font-semibold">this reading</span>
             — the narrator is what tells two recordings of
             one book apart, so check it before ticking. Databases keep editions the storefront has
@@ -455,25 +455,25 @@
           />
 
           <div class="flex flex-wrap items-center gap-2 pt-1">
+            <%!-- px-[11px]: 1px border + 11px puts the label on the 12px text
+                rail, the same trick the inputs use; the ticked state keeps a
+                transparent border so toggling doesn't shift the box. --%>
             <button
               type="button"
               phx-click="uncatalogued"
               class={[
-                "rounded-md px-2 py-1 text-xs",
+                "px-[11px] rounded-md border py-1 text-xs",
                 Recording.uncatalogued?(@item.draft.recording) &&
-                  "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
+                  "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
                 !Recording.uncatalogued?(@item.draft.recording) &&
-                  "border border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
+                  "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
               ]}
             >
               None of these — it's in no catalogue
             </button>
           </div>
 
-          <details>
-            <summary class="cursor-pointer pl-3 text-xs text-zinc-400">
-              Not what you're looking for? Search again
-            </summary>
+          <.disclosure summary="Not what you're looking for? Search again">
             <div class="pt-2">
               <.research_form
                 level="recording"
@@ -481,7 +481,7 @@
                 running={@researching == "recording"}
               />
             </div>
-          </details>
+          </.disclosure>
 
           <p class="pl-3 text-xs text-zinc-400">
             Every import creates a new recording. Pointing one at an existing recording's files —

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -422,7 +422,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
 
     # A filled field that opens must never list records that don't match what
-    # it holds; and the prefix segment names the outcome the field currently
+    # it holds; and the suffix badge names the outcome the field currently
     # carries.
     test "an open filled field lists only what matches it", %{conn: conn} do
       sagan = insert(:author, name: "Carl Sagan")
@@ -439,7 +439,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       view |> form("#credit-work-0-identity") |> render_change()
 
       html = view |> element("#credit-work-0-resolver-input") |> render_focus()
-      assert html =~ "Existing"
+      assert html =~ "existing"
       assert has_element?(view, "#credit-work-0-resolver-option-#{sagan.id}")
       refute has_element?(view, "#credit-work-0-resolver-option-#{sanderson.id}")
     end


### PR DESCRIPTION
The operator red-lined screenshots of the import form and the left edge wandered in every one. The box-edge/text-rail system (design language §3) stays — this makes the implementation actually honor it, and amends the doc where the rules needed sharpening.

## The geometry pass

- **Bare prose joins the rail** everywhere a `pl-3` was forgotten (work/recording tick-prose, no-provider/no-match lines, series-link prose), with the `max-w-prose` its siblings already had.
- **Control text lands on the rail exactly**: borderless pills pad `px-3`; 1px-bordered boxes pad `px-[11px]` (the inputs' trick), with a transparent border on the ticked state so toggling doesn't shift the box; the record cards' leading checkbox sits on the rail itself. Near-misses of 2px are what "feels off" is made of.
- **Images are content, not containers** (new §3 rule): the cover preview and person photos sit on the rail like the words around them.
- **`<.disclosure>`** replaces every bare `<details>`: Firefox lays the native summary marker *inside* the padding (`list-style: disclosure-closed inside`), shoving the text off the rail — the component hides it and hangs a chevron in the gutter, swapping two icons on open because rotating a CSS-mask span rasterizes a grey sliver at its edge.
- **Credit and series rows join the decision-block anatomy**: the §2 state rail replaces the extra lime circle-check (the rail is the only settledness encoding — and the icon shifted the title sideways on approval), railed header row, labels above controls.
- **Header evidence card** railed: title cluster, tags fold, issue line.
- **Firefox date inputs** get a 2px compensation via `@supports (-moz-appearance:none)` — Firefox's internal date editor carries its own inset; no other browser matches the query.

## The resolver

The "Existing"/"Create" prefix was a status dressed as a control — an unclickable span in a 1px-outlined segment (the admin's last), pushing the resolver's text box 96px off the edge every other input sits on. The input now runs full width and the mode is a soft-tint suffix badge inside its right end: `existing` (lime) when a record is picked, `new` (zinc) while typing, nothing while empty. Dropdown loses its 1px outer border and its italics. Hidden inputs, hooks, and events untouched; the pure-picker mode is unaffected.

`mix check` green, 1239 tests green. More fixes from the same audit will land on this branch before merge.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx