### PR TITLE
Inbox fixes: baselines, resurrected icons, read-only imported items, imported/ignored rename

### DIFF
--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -102,6 +102,17 @@ shares the line or every chip gets its own. No flow mechanism expresses
 "stack only if they don't all fit", so the `fit-or-stack` hook measures the
 chips' natural widths and commits the row to one of the two modes.
 
+**The other axis: mixed text sizes on one line align by baseline, never by
+box centre.** A label row (label + badge + provenance), a microlabel grid
+(`Asked`, `Proposed`), the footer's buttons-plus-count: `items-baseline`
+(flex and grid both support it), never a `pt-*` nudge — near-misses read
+as badly on this axis as off the rail. What stays center- or top-aligned
+instead: rows of boxes (adjacent controls share exact height, §7),
+icon-only actions, image rows (a baseline puts the label on the first
+image's bottom edge), and any row whose first line truncates —
+`overflow: hidden` exports a synthesized baseline (the box bottom), worse
+than the centre it replaces.
+
 **Rhythm is 8 · 28 · 56** (`gap-2` / `gap-7` / `gap-14`): inside a field
 cluster / between blocks / between sections. Queue cards stack with
 `space-y-3`.

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -3,7 +3,7 @@ defmodule Ambry.Inbox do
   The curation queue every recording passes through before clients see it.
 
   **The inbox is the only road into the library.** Discovery finds candidates
-  and records what they are; approval is what creates real records and touches
+  and records what they are; import is what creates real records and touches
   files. Nothing here copies, links, moves, or organizes anything — an item
   references its files exactly where they landed.
 
@@ -29,15 +29,15 @@ defmodule Ambry.Inbox do
   use Boundary,
     deps: [Ambry, Ambry.Library, Ambry.Media],
     # The draft tree is exported because it IS the import form's data model —
-    # the form renders and edits it directly. Approval stays internal.
+    # the form renders and edits it directly. Import stays internal.
     exports: [InboxItem, {Draft, []}]
 
   import Ecto.Query
 
-  alias Ambry.Inbox.Approval
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Seed
+  alias Ambry.Inbox.Importer
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.Lookup
   alias Ambry.Inbox.Progress
@@ -112,7 +112,7 @@ defmodule Ambry.Inbox do
 
   Idempotent by design: an item's path is its identity, so rescanning updates
   the files of a known item rather than duplicating it, never resurrects a
-  dismissed one, and never re-offers files the library already has.
+  ignored one, and never re-offers files the library already has.
 
   A location that can't be read doesn't fail the run — one unmounted NAS
   shouldn't stop the others from being scanned — but it is counted, because
@@ -131,7 +131,7 @@ defmodule Ambry.Inbox do
   Scans one location, or one bare path.
 
   The bare-path form is for ad-hoc scans and for exercising the walk itself;
-  items it creates have no location, so approval can't know what custody they
+  items it creates have no location, so import can't know what custody they
   imply.
   """
   def discover(%Location{} = location) do
@@ -246,7 +246,7 @@ defmodule Ambry.Inbox do
   Refused once the item is in the library: the probe rebuilds an untouched
   draft, and an imported item's draft is the record of what was imported.
   """
-  def rescan_item_async(%InboxItem{status: :approved}), do: {:error, :already_approved}
+  def rescan_item_async(%InboxItem{status: :imported}), do: {:error, :already_imported}
 
   def rescan_item_async(%InboxItem{} = item) do
     %{inbox_item_id: item.id, refresh: true} |> RunProbe.new() |> Oban.insert()
@@ -356,7 +356,7 @@ defmodule Ambry.Inbox do
   Re-derives queued drafts that the library just moved under.
 
   **A draft is a snapshot of the library taken when the item was matched**, and
-  approval executes it exactly. So two queued items implying the same new
+  import executes it exactly. So two queued items implying the same new
   person, identity or series each created their own: measured on a real batch
   of seven, Em Grosland narrates both Monk & Robot books and arrived as two
   People and two Narrators, and "Monk and Robot" arrived as two Series. Books
@@ -368,15 +368,15 @@ defmodule Ambry.Inbox do
   series that meant to *create* something into a *link* when exactly one thing
   of that name now exists, and changes nothing else. The affected credit
   visibly becomes "link the existing Em Grosland" **before** the operator
-  approves it, so approval still executes only what the form showed.
+  imports it, so import still executes only what the form showed.
 
   Deliberately narrower than a re-seed, which would also re-open questions the
   operator had already answered — see `Seed.relink/2`.
   """
-  def refresh_siblings(%InboxItem{} = approved) do
-    case sibling_names(approved.draft) do
+  def refresh_siblings(%InboxItem{} = imported) do
+    case sibling_names(imported.draft) do
       [] -> :ok
-      names -> names |> siblings_of(approved) |> Enum.each(&refresh_draft/1)
+      names -> names |> siblings_of(imported) |> Enum.each(&refresh_draft/1)
     end
   end
 
@@ -403,7 +403,7 @@ defmodule Ambry.Inbox do
   # false positive costs an idempotent re-derivation that changes nothing,
   # while scanning every pending item would cost a full rebuild each on a
   # queue that is hundreds long during a cold start.
-  defp siblings_of(names, %InboxItem{} = approved) do
+  defp siblings_of(names, %InboxItem{} = imported) do
     condition =
       Enum.reduce(names, dynamic(false), fn name, acc ->
         dynamic(
@@ -413,7 +413,7 @@ defmodule Ambry.Inbox do
       end)
 
     InboxItem
-    |> where([i], i.status == :pending and i.id != ^approved.id and not is_nil(i.draft))
+    |> where([i], i.status == :pending and i.id != ^imported.id and not is_nil(i.draft))
     |> where(^condition)
     |> Repo.all()
   end
@@ -421,7 +421,7 @@ defmodule Ambry.Inbox do
   defp escape_like(value), do: String.replace(value, ~r/[\\%_]/, "\\\\\\0")
 
   # Never fatal: the import succeeded, and a sibling that won't re-derive is a
-  # stale proposal to fix on the form, not a reason to fail the approval that
+  # stale proposal to fix on the form, not a reason to fail the import that
   # already committed.
   defp refresh_draft(%InboxItem{} = item) do
     case update_draft(item, item.draft |> Seed.relink(item) |> dump()) do
@@ -463,7 +463,7 @@ defmodule Ambry.Inbox do
   Every save recomputes readiness, so the queue can never claim an item is
   importable when its draft says otherwise.
   """
-  def update_draft(%InboxItem{status: :approved}, _attrs), do: {:error, :already_approved}
+  def update_draft(%InboxItem{status: :imported}, _attrs), do: {:error, :already_imported}
 
   def update_draft(%InboxItem{} = item, attrs) do
     item
@@ -505,12 +505,12 @@ defmodule Ambry.Inbox do
   end
 
   @doc """
-  What approval will do with this item's bytes, decided before it's asked.
+  What import will do with this item's bytes, decided before it's asked.
 
   Placement can fail for reasons no amount of curation fixes — a downloads
   folder on a different NAS from its library root, a destination already
   occupied, no root registered at all. Those used to surface as an error at
-  the moment the operator clicked approve. Working them out up front is what
+  the moment the operator clicked import. Working them out up front is what
   lets the form refuse to offer a button that fails, and it tells the
   operator *where the file is going* before they commit to it.
 
@@ -615,8 +615,8 @@ defmodule Ambry.Inbox do
   the recording and its tracks — with the files referenced where they lie.
   Nothing is published: the recording is created `pending`.
   """
-  def approve_item(%InboxItem{} = item) do
-    case Approval.approve(item) do
+  def import_item(%InboxItem{} = item) do
+    case Importer.import_item(item) do
       {:ok, media} ->
         refresh_siblings(item)
         {:ok, media}
@@ -670,7 +670,7 @@ defmodule Ambry.Inbox do
       "Something is already at #{path}. Two recordings can't share one path."
     else
       "A file nothing in the library references is at #{path} — likely left " <>
-        "behind by an interrupted import. Delete it and approve again."
+        "behind by an interrupted import. Delete it and import again."
     end
   end
 
@@ -680,11 +680,11 @@ defmodule Ambry.Inbox do
   def describe_error(:ambiguous_library_root),
     do: "There's more than one library root — say which one this folder imports into."
 
-  def describe_error(:already_approved), do: "Already in the library — this item is read-only."
+  def describe_error(:already_imported), do: "Already in the library — this item is read-only."
 
   # The invariant, phrased for a human. It names the count rather than the
   # decisions because the form lists them properly — this is the flash you get
-  # if you somehow reached approval from the queue.
+  # if you somehow reached import from the queue.
   def describe_error({:unresolved, outstanding}) do
     count = length(outstanding)
 
@@ -713,7 +713,7 @@ defmodule Ambry.Inbox do
 
   Dismissals are remembered by path, so a rescan doesn't offer it again.
   """
-  def dismiss_item(%InboxItem{} = item), do: update_item(item, %{status: :dismissed})
+  def ignore_item(%InboxItem{} = item), do: update_item(item, %{status: :ignored})
 
   def restore_item(%InboxItem{} = item), do: update_item(item, %{status: :pending})
 
@@ -843,7 +843,7 @@ defmodule Ambry.Inbox do
   end
 
   # A known item's files can legitimately change (a torrent finished, a file
-  # was replaced). Its status is left alone: dismissed stays dismissed.
+  # was replaced). Its status is left alone: ignored stays ignored.
   #
   # An item found under a location adopts it if it had none — that's a fact
   # the scan just established, not a guess — but a location is never swapped

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -242,7 +242,12 @@ defmodule Ambry.Inbox do
 
   @doc """
   Re-reads and re-queries one item in the background.
+
+  Refused once the item is in the library: the probe rebuilds an untouched
+  draft, and an imported item's draft is the record of what was imported.
   """
+  def rescan_item_async(%InboxItem{status: :approved}), do: {:error, :already_approved}
+
   def rescan_item_async(%InboxItem{} = item) do
     %{inbox_item_id: item.id, refresh: true} |> RunProbe.new() |> Oban.insert()
   end
@@ -458,6 +463,8 @@ defmodule Ambry.Inbox do
   Every save recomputes readiness, so the queue can never claim an item is
   importable when its draft says otherwise.
   """
+  def update_draft(%InboxItem{status: :approved}, _attrs), do: {:error, :already_approved}
+
   def update_draft(%InboxItem{} = item, attrs) do
     item
     |> InboxItem.put_draft(attrs)
@@ -629,6 +636,7 @@ defmodule Ambry.Inbox do
   Shared between the flash shown at the time and the `issue` recorded on the
   item, so the row tomorrow says exactly what the toast said today.
   """
+
   def describe_error(:multi_file_unsupported),
     do:
       "Direct play handles single-file recordings for now — merge this one externally, or skip it."
@@ -672,7 +680,7 @@ defmodule Ambry.Inbox do
   def describe_error(:ambiguous_library_root),
     do: "There's more than one library root — say which one this folder imports into."
 
-  def describe_error(:already_approved), do: "Already in the library."
+  def describe_error(:already_approved), do: "Already in the library — this item is read-only."
 
   # The invariant, phrased for a human. It names the count rather than the
   # decisions because the form lists them properly — this is the flash you get

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -20,7 +20,7 @@ defmodule Ambry.Inbox.AutoMatch do
   record has been found there is no cast to ask about at all.
 
   Nothing is applied. This writes proposals onto the inbox item; the operator
-  approves, and approval is what creates records.
+  imports, and import is what creates records.
 
   ## Why the whole ranked list is kept
 

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -525,8 +525,12 @@ defmodule Ambry.Inbox.Importer do
   end
 
   defp link(item, media) do
+    # issue: nil — a failed attempt writes its reason onto the item so the
+    # row can explain itself tomorrow; succeeding is what resolves it. Left
+    # in place, "Couldn't add this to the library" sat in red on rows whose
+    # media was sitting right there in the library.
     item
-    |> InboxItem.changeset(%{status: :imported, media_id: media.id})
+    |> InboxItem.changeset(%{status: :imported, media_id: media.id, issue: nil})
     |> Repo.update()
   end
 end

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -1,12 +1,12 @@
-defmodule Ambry.Inbox.Approval do
+defmodule Ambry.Inbox.Importer do
   @moduledoc """
   Turns a fully-resolved staged import into real library records.
 
-  Approval is the only thing that creates records — discovery, matching and
+  Import is the only thing that creates records — discovery, matching and
   the form only ever propose. It covers the whole entity graph in one
   transaction: book, authors, narrators, series, the recording and its
   direct-play tracks. Either all of it lands or none of it does, so a
-  half-approved item can't exist.
+  half-imported item can't exist.
 
   ## It executes a draft; it does not decide anything
 
@@ -34,7 +34,7 @@ defmodule Ambry.Inbox.Approval do
       **external**. Ambry never moves, copies, renames or deletes it.
 
   A hardlink cannot cross a filesystem, and here the downloads folder and the
-  library can easily be on different NAS boxes. Approval **refuses** in that
+  library can easily be on different NAS boxes. Import **refuses** in that
   case rather than falling back to a copy: a silent copy is the storage
   doubling this whole phase exists to eliminate.
 
@@ -72,14 +72,14 @@ defmodule Ambry.Inbox.Approval do
   require Logger
 
   @doc """
-  Approves an item, creating everything its draft implies.
+  Imports an item, creating everything its draft implies.
 
   Returns `{:ok, media}`, or `{:error, reason}` — leaving the item untouched
   and the library unchanged.
   """
-  def approve(%InboxItem{status: :approved}), do: {:error, :already_approved}
+  def import_item(%InboxItem{status: :imported}), do: {:error, :already_imported}
 
-  def approve(%InboxItem{} = item) do
+  def import_item(%InboxItem{} = item) do
     item = Repo.preload(item, :location)
 
     # Facts about the files come first, then the draft, then placement. The
@@ -99,20 +99,20 @@ defmodule Ambry.Inbox.Approval do
     end
   end
 
-  # Approval is claimed under a row lock before anything is created or any
+  # Import is claimed under a row lock before anything is created or any
   # byte moves. The status check at the door reads the *caller's* copy of
-  # the item, so two concurrent approvals both walked through it — measured
+  # the item, so two concurrent imports both walked through it — measured
   # live: the loser's transaction rolled back AFTER its 834MB copy had
   # landed, and the orphan then refused the item forever with a message
-  # blaming a phantom second recording. Under the lock the second approval
+  # blaming a phantom second recording. Under the lock the second import
   # waits, sees the committed status, and refuses cleanly.
   defp claim(%InboxItem{id: id}) do
     import Ecto.Query, only: [from: 2]
 
     case Repo.one(from(i in InboxItem, where: i.id == ^id, lock: "FOR UPDATE")) do
       %InboxItem{status: :pending} = item -> {:ok, Repo.preload(item, :location)}
-      %InboxItem{} -> {:error, :already_approved}
-      nil -> {:error, :already_approved}
+      %InboxItem{} -> {:error, :already_imported}
+      nil -> {:error, :already_imported}
     end
   end
 
@@ -415,7 +415,7 @@ defmodule Ambry.Inbox.Approval do
 
   ## publishing
 
-  # An approved recording is finished, so it's published — unless the switch
+  # An imported recording is finished, so it's published — unless the switch
   # says the fleet can't play direct-play media yet, in which case it waits
   # in `pending` and is released when the switch is turned on.
   #
@@ -436,7 +436,7 @@ defmodule Ambry.Inbox.Approval do
 
   ## placement
 
-  # What approval should do with the bytes, decided by where the item came
+  # What import should do with the bytes, decided by where the item came
   # from. Only a downloads folder imports; an external collection is adopted
   # exactly where it lies (that is the entire promise of external custody).
   # Read off the draft rather than re-derived from the location: any input may
@@ -501,7 +501,7 @@ defmodule Ambry.Inbox.Approval do
 
   defp log_finalize({:error, reason}, item) do
     Logger.warning(fn ->
-      "Approved #{item.path} but couldn't remove the source: #{inspect(reason)}"
+      "Imported #{item.path} but couldn't remove the source: #{inspect(reason)}"
     end)
   end
 
@@ -515,7 +515,7 @@ defmodule Ambry.Inbox.Approval do
 
   # Re-probed rather than trusting what discovery recorded: it costs one
   # ffprobe and buys current track data, plus a file that vanished between
-  # discovery and approval failing the approval instead of creating a
+  # discovery and import failing the import instead of creating a
   # recording that points at nothing.
   defp probe(file) do
     case Scanner.probe_file(file, single_file: true) do
@@ -526,7 +526,7 @@ defmodule Ambry.Inbox.Approval do
 
   defp link(item, media) do
     item
-    |> InboxItem.changeset(%{status: :approved, media_id: media.id})
+    |> InboxItem.changeset(%{status: :imported, media_id: media.id})
     |> Repo.update()
   end
 end

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -3,9 +3,9 @@ defmodule Ambry.Inbox.InboxItem do
   One candidate recording waiting to be curated into the library.
 
   An item references files where they landed — nothing is copied, linked, or
-  organized until it's approved. `path` is the item's identity (the release
+  organized until it's imported. `path` is the item's identity (the release
   folder, or a loose file), which is what makes rescans idempotent and keeps
-  dismissed items dismissed.
+  ignored items ignored.
   """
 
   use Ecto.Schema
@@ -16,12 +16,12 @@ defmodule Ambry.Inbox.InboxItem do
   alias Ambry.Library.Location
   alias Ambry.Media.Media
 
-  @statuses [:pending, :dismissed, :approved]
+  @statuses [:pending, :ignored, :imported]
 
   schema "inbox_items" do
     belongs_to :media, Media
 
-    # Where this was found, which is what says whether approving it should
+    # Where this was found, which is what says whether importing it should
     # bring the files into a library root or adopt them where they lie.
     # Nullable: items from an ad-hoc scan have no location to speak for them.
     belongs_to :location, Location

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -63,10 +63,10 @@ defmodule AmbryWeb.Admin.Decisions do
     ~H"""
     <div
       :if={@outcomes != []}
-      class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3"
+      class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       data-role="provider-outcomes"
     >
-      <.microlabel class="pt-1">Asked</.microlabel>
+      <.microlabel>Asked</.microlabel>
 
       <div class="flex flex-wrap items-center gap-1.5">
         <%!-- A count is information, not an option — filled and quiet, so it
@@ -458,7 +458,7 @@ defmodule AmbryWeb.Admin.Decisions do
           INSIDE the control; only boxes touch the margin edge. See
           docs/admin-design-language.md §1. --%>
     <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", decision_rail(@field)]}>
-      <div class="flex items-center gap-2 pl-3">
+      <div class="flex items-baseline gap-2 pl-3">
         <.label>{@label}</.label>
 
         <.badge
@@ -544,11 +544,14 @@ defmodule AmbryWeb.Admin.Decisions do
       <%!-- The options row is a two-column grid — microlabel | chips — so a
             wrapping chip row stays in the chip column instead of falling
             back under the label, and every chip starts on one rail. --%>
+      <%!-- Text chips align to the microlabel by baseline; image chips
+          (cover previews) top-align instead — a baseline would put the
+          label on the first image's bottom edge. --%>
       <div
         :if={@field.candidates != []}
-        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3"
+        class={["grid-cols-[4.5rem_minmax(0,1fr)] grid gap-x-2 pl-3", (@preview && "items-start") || "items-baseline"]}
       >
-        <.microlabel class="pt-1.5">Proposed</.microlabel>
+        <.microlabel class={@preview && "pt-1.5"}>Proposed</.microlabel>
 
         <%!-- One line or a list, never a partial wrap — the hook measures
             whether every chip fits and commits to exactly one of the two. --%>
@@ -663,7 +666,7 @@ defmodule AmbryWeb.Admin.Decisions do
       (Credit.resolved?(@credit) && "border-brand-dark/60") || "border-amber-400/70"
     ]}>
       <div class="flex items-center justify-between gap-2 pl-3">
-        <div class="flex min-w-0 items-center gap-2">
+        <div class="flex min-w-0 items-baseline gap-2">
           <.label>{@verb}</.label>
 
           <.badge
@@ -707,7 +710,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <form
         id={"credit-#{@section}-#{@index}-identity"}
         phx-change="credit-change"
-        class="flex flex-wrap items-center gap-2"
+        class="flex flex-wrap items-baseline gap-2"
       >
         <input type="hidden" name="section" value={@section} />
         <input type="hidden" name="index" value={@index} />
@@ -1061,8 +1064,8 @@ defmodule AmbryWeb.Admin.Decisions do
           </div>
         </div>
 
-        <div :if={@bios != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
-          <.microlabel class="pt-1.5">Proposed</.microlabel>
+        <div :if={@bios != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3">
+          <.microlabel>Proposed</.microlabel>
 
           <div
             id={"person-bio-#{@at}-chips"}
@@ -1181,7 +1184,7 @@ defmodule AmbryWeb.Admin.Decisions do
       (SeriesLink.resolved?(@link) && "border-brand-dark/60") || "border-amber-400/70"
     ]}>
       <div class="flex items-center justify-between gap-2 pl-3">
-        <div class="flex min-w-0 items-center gap-2">
+        <div class="flex min-w-0 items-baseline gap-2">
           <.label>In series</.label>
 
           <.badge

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -189,7 +189,7 @@ defmodule AmbryWeb.CoreComponents do
         phx-connected={hide("#client-error")}
         hidden
       >
-        Attempting to reconnect <.icon name="fa-rotate" class="ml-1 inline h-3 w-3 animate-spin" />
+        Attempting to reconnect <.icon name="fa-rotate" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
 
       <.flash
@@ -200,7 +200,7 @@ defmodule AmbryWeb.CoreComponents do
         phx-connected={hide("#server-error")}
         hidden
       >
-        Hang in there while we get back on track <.icon name="fa-rotate" class="ml-1 inline h-3 w-3 animate-spin" />
+        Hang in there while we get back on track <.icon name="fa-rotate" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
     </div>
     """

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -46,7 +46,7 @@
       <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
         <div class="flex gap-4">
           <span :if={book.media > 0} title="# of audiobooks" data-role="book-media-count">
-            {book.media} <.icon name="fa-file-audio" class="inline h-4 w-4 text-current" />
+            {book.media} <.icon name="fa-file-audio" class="h-4 w-4 text-current" />
           </span>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -68,7 +68,23 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(searching_person: nil, photos_expanded: %{})
      |> assign(library_query: nil, library_results: [], ticking: false)
      |> attach_hook(:refuse_while_busy, :handle_event, &refuse_while_busy/3)
+     |> attach_hook(:refuse_when_imported, :handle_event, &refuse_when_imported/3)
      |> load(item)}
+  end
+
+  # An imported item's draft is the record of what was imported — the operator
+  # already created the library records from it, and an edit here would make
+  # the record lie. The banner and `inert` explain; this enforces, because
+  # markup is advisory and a stale tab can still send anything. The only
+  # events allowed through are pure view state.
+  @view_events ~w(toggle-photos toggle-people)
+
+  defp refuse_when_imported(event, _params, socket) do
+    if socket.assigns.read_only and event not in @view_events do
+      {:halt, put_flash(socket, :error, Inbox.describe_error(:already_approved))}
+    else
+      {:cont, socket}
+    end
   end
 
   # **The overlay explains; this enforces.** `inert` and a scrim are markup,
@@ -561,6 +577,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     assign(socket,
       item: item,
+      read_only: item.status == :approved,
       form: to_form(Inbox.change_draft(item)),
       unresolved: Draft.unresolved(item.draft),
       progress: Draft.progress(item.draft),

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -7,7 +7,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   possible iff every decision is resolved**. The button at the bottom reads
   `Draft.unresolved/1` and nothing else, which is what guarantees the form
   never offers an action that fails: everything that could go wrong at
-  approval was a visible decision before the button was pressed.
+  import was a visible decision before the button was pressed.
 
   ## Two kinds of interaction, deliberately
 
@@ -81,7 +81,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   defp refuse_when_imported(event, _params, socket) do
     if socket.assigns.read_only and event not in @view_events do
-      {:halt, put_flash(socket, :error, Inbox.describe_error(:already_approved))}
+      {:halt, put_flash(socket, :error, Inbox.describe_error(:already_imported))}
     else
       {:cont, socket}
     end
@@ -460,7 +460,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def handle_event("import", _params, socket) do
-    case Inbox.approve_item(socket.assigns.item) do
+    case Inbox.import_item(socket.assigns.item) do
       {:ok, _media} ->
         {:noreply,
          socket
@@ -475,12 +475,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
-  def handle_event("dismiss", _params, socket) do
-    {:ok, _item} = Inbox.dismiss_item(socket.assigns.item)
+  def handle_event("ignore", _params, socket) do
+    {:ok, _item} = Inbox.ignore_item(socket.assigns.item)
 
     {:noreply,
      socket
-     |> put_flash(:info, "Dismissed. Files untouched.")
+     |> put_flash(:info, "Ignored. Files untouched.")
      |> push_navigate(to: ~p"/admin/inbox")}
   end
 
@@ -577,7 +577,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     assign(socket,
       item: item,
-      read_only: item.status == :approved,
+      read_only: item.status == :imported,
       form: to_form(Inbox.change_draft(item)),
       unresolved: Draft.unresolved(item.draft),
       progress: Draft.progress(item.draft),

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -685,7 +685,7 @@
             Add to the library
           </.button>
 
-          <.button :if={!@read_only} type="button" color={:zinc} phx-click="dismiss">Dismiss</.button>
+          <.button :if={!@read_only} type="button" color={:zinc} phx-click="ignore">Ignore</.button>
 
           <p :if={@read_only} class="text-sm text-zinc-400">
             In the library — read-only.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -33,6 +33,7 @@
               <span class="font-bold">{@progress.resolved}</span> of {@progress.total} settled
             </p>
             <.button
+              :if={!@read_only}
               type="button"
               color={:zinc}
               class="mt-2"
@@ -76,6 +77,24 @@
         <p :if={@item.issue} class="flex items-baseline gap-1.5 pt-2 pl-3 text-sm text-red-400">
           <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
           {@item.issue}
+        </p>
+      </section>
+
+      <%!-- Once imported, the draft is the record of what was imported — the
+          library records were created FROM it, so an edit here would make
+          the record lie. The rail is lime because imported IS settled. --%>
+      <section
+        :if={@read_only}
+        class="border-brand-dark/60 rounded-lg border-l-4 bg-zinc-900 p-4"
+        data-role="imported-banner"
+      >
+        <p class="pl-3 font-bold">In the library</p>
+        <p class="max-w-prose pt-1 pl-3 text-sm text-zinc-400">
+          This one was imported, and everything below is the record of that import — it's
+          read-only now.
+          <.brand_link :if={@item.media_id} navigate={~p"/admin/media/#{@item.media_id}/edit"}>
+            Open the media record
+          </.brand_link>
         </p>
       </section>
 
@@ -123,7 +142,7 @@
       </section>
 
       <%!-- ==================== THE WORK ==================== --%>
-      <section id="work" class="space-y-7">
+      <section id="work" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
           The work — which book this is a recording of
         </h2>
@@ -394,7 +413,7 @@
       </section>
 
       <%!-- ==================== THE RECORDING ==================== --%>
-      <section id="recording" class="space-y-7">
+      <section id="recording" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
           The recording — which reading of it these files are
         </h2>
@@ -596,7 +615,7 @@
       </section>
 
       <%!-- ==================== FILES & DESTINATION ==================== --%>
-      <section id="destination" class="space-y-2">
+      <section id="destination" class="space-y-2" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
           Files &amp; destination
         </h2>
@@ -658,6 +677,7 @@
       <section class="shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900 p-4">
         <div class="flex flex-wrap items-baseline gap-x-4 gap-y-2">
           <.button
+            :if={!@read_only}
             phx-click="import"
             disabled={@unresolved != [] or @destination.blocker != nil}
             data-role="import"
@@ -665,7 +685,11 @@
             Add to the library
           </.button>
 
-          <.button type="button" color={:zinc} phx-click="dismiss">Dismiss</.button>
+          <.button :if={!@read_only} type="button" color={:zinc} phx-click="dismiss">Dismiss</.button>
+
+          <p :if={@read_only} class="text-sm text-zinc-400">
+            In the library — read-only.
+          </p>
 
           <.brand_link navigate={~p"/admin/inbox"} class="whitespace-nowrap">
             Back to the inbox

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -95,7 +95,7 @@
       >
         <p class="font-bold">Still to settle</p>
         <ul class="mt-2 space-y-1">
-          <li :for={decision <- @unresolved} class="flex items-center gap-2 text-sm">
+          <li :for={decision <- @unresolved} class="flex items-baseline gap-2 text-sm">
             <.badge color={elem(state_words(decision.state), 1)} class="text-xs">
               {elem(state_words(decision.state), 0)}
             </.badge>
@@ -139,7 +139,7 @@
           ]}
           data-role="local-books"
         >
-          <div class="flex items-center gap-2 pl-3">
+          <div class="flex items-baseline gap-2 pl-3">
             <.label>Is this a book you already have?</.label>
             <.badge
               :if={!@item.draft.work.approved}
@@ -217,7 +217,7 @@
         </div>
 
         <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
-          <div class="flex items-center gap-2 pl-3">
+          <div class="flex items-baseline gap-2 pl-3">
             <.label>
               {if @item.draft.work.mode == :link,
                 do: "Records that could fill blanks",
@@ -403,7 +403,7 @@
           "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
           (@item.draft.recording.approved && "border-brand-dark/60") || "border-amber-400/70"
         ]}>
-          <div class="flex items-center gap-2 pl-3">
+          <div class="flex items-baseline gap-2 pl-3">
             <.label>Records describing this recording</.label>
             <.badge
               :if={!@item.draft.recording.approved}
@@ -614,7 +614,7 @@
             (@item.draft.destination.approved && "border-brand-dark/60") || "border-amber-400/70"
           ]}
         >
-          <div class="flex items-center gap-2 pl-3">
+          <div class="flex items-baseline gap-2 pl-3">
             <.label>Library root</.label>
             <.badge
               :if={!@item.draft.destination.approved}
@@ -656,7 +656,7 @@
 
       <%!-- ==================== THE BUTTON ==================== --%>
       <section class="shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900 p-4">
-        <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <div class="flex flex-wrap items-baseline gap-x-4 gap-y-2">
           <.button
             phx-click="import"
             disabled={@unresolved != [] or @destination.blocker != nil}

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -83,14 +83,23 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # discards the job — so the old handlers matched `{:ok, _job}` and flashed
   # success for work that was never queued.
   def handle_event("rescan", %{"id" => id}, socket) do
-    {:ok, job} = id |> Inbox.get_item!() |> Inbox.rescan_item_async()
+    id
+    |> Inbox.get_item!()
+    |> Inbox.rescan_item_async()
+    |> case do
+      {:ok, job} ->
+        message =
+          if job.conflict?,
+            do: "Already re-reading this one.",
+            else:
+              "Re-reading the files and asking the providers again — this one is slow on purpose."
 
-    message =
-      if job.conflict?,
-        do: "Already re-reading this one.",
-        else: "Re-reading the files and asking the providers again — this one is slow on purpose."
+        {:noreply, put_flash(socket, :info, message)}
 
-    {:noreply, put_flash(socket, :info, message)}
+      # The button is gone from approved rows; this catches a stale tab.
+      {:error, :already_approved} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_approved))}
+    end
   end
 
   def handle_event("search", %{"search" => %{"query" => query}}, socket) do

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -149,8 +149,13 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       list_opts: list_opts,
       has_next: has_more?,
       has_prev: list_opts.page > 1,
-      next_page_path: ~p"/admin/inbox?#{patch_opts(next_opts(list_opts))}",
-      prev_page_path: ~p"/admin/inbox?#{patch_opts(prev_opts(list_opts))}"
+      # Built from the full query, not the shared filter+page helpers —
+      # those drop status and ready, so paging out of "Imported" silently
+      # landed back on the default view.
+      next_page_path:
+        ~p"/admin/inbox?#{page_query(list_opts, status, ready, list_opts.page + 1)}",
+      prev_page_path:
+        ~p"/admin/inbox?#{page_query(list_opts, status, ready, max(list_opts.page - 1, 1))}"
     )
     |> assign(:statuses, @statuses)
     |> schedule_tick()
@@ -210,6 +215,19 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       "status" => Keyword.get(overrides, :status, to_string(socket.assigns.status || "all")),
       "ready" =>
         Keyword.get(overrides, :ready, socket.assigns.ready && to_string(socket.assigns.ready))
+    }
+    |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+    |> Map.new()
+  end
+
+  # The same shape from locals rather than assigns — load_items runs before
+  # its assigns exist, so `patch/2` can't be used for the page links.
+  defp page_query(list_opts, status, ready, page) do
+    %{
+      "filter" => list_opts.filter,
+      "page" => to_string(page),
+      "status" => to_string(status || "all"),
+      "ready" => ready && to_string(ready)
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Map.new()

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   alias Ambry.Inbox.InboxItem
   alias Ambry.Library.Location
 
-  @statuses [:pending, :dismissed, :approved]
+  @statuses [:pending, :ignored, :imported]
 
   @impl Phoenix.LiveView
   def mount(params, _session, socket) do
@@ -50,10 +50,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     end
   end
 
-  def handle_event("dismiss", %{"id" => id}, socket) do
-    {:ok, _item} = id |> Inbox.get_item!() |> Inbox.dismiss_item()
+  def handle_event("ignore", %{"id" => id}, socket) do
+    {:ok, _item} = id |> Inbox.get_item!() |> Inbox.ignore_item()
 
-    {:noreply, socket |> put_flash(:info, "Dismissed. Files untouched.") |> reload()}
+    {:noreply, socket |> put_flash(:info, "Ignored. Files untouched.") |> reload()}
   end
 
   def handle_event("restore", %{"id" => id}, socket) do
@@ -62,10 +62,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     {:noreply, reload(socket)}
   end
 
-  def handle_event("approve", %{"id" => id}, socket) do
+  def handle_event("import", %{"id" => id}, socket) do
     id
     |> Inbox.get_item!()
-    |> Inbox.approve_item()
+    |> Inbox.import_item()
     |> case do
       {:ok, _media} ->
         {:noreply,
@@ -96,9 +96,9 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
         {:noreply, put_flash(socket, :info, message)}
 
-      # The button is gone from approved rows; this catches a stale tab.
-      {:error, :already_approved} ->
-        {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_approved))}
+      # The button is gone from imported rows; this catches a stale tab.
+      {:error, :already_imported} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_imported))}
     end
   end
 
@@ -215,7 +215,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     |> Map.new()
   end
 
-  defp parse_status(status) when status in ["pending", "dismissed", "approved"],
+  defp parse_status(status) when status in ["pending", "ignored", "imported"],
     do: String.to_existing_atom(status)
 
   # "all" is the explicit choice; the DEFAULT is pending — the inbox is a
@@ -240,8 +240,8 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   end
 
   defp segment_label(:pending), do: "Pending"
-  defp segment_label(:dismissed), do: "Dismissed"
-  defp segment_label(:approved), do: "Approved"
+  defp segment_label(:ignored), do: "Ignored"
+  defp segment_label(:imported), do: "Imported"
 
   # Pending work glows amber and settled-but-unimported glows lime — but only
   # while there IS any; a zero is just a zero.
@@ -276,24 +276,26 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   end
 
   defp status_color(:pending), do: :yellow
-  defp status_color(:approved), do: :brand
-  defp status_color(:dismissed), do: :gray
+  defp status_color(:imported), do: :brand
+  defp status_color(:ignored), do: :gray
 
   # The card's left edge carries the item's state — a 4px rail reads from
   # across the room and renders crisp at any DPI, unlike hairline borders.
   # Amber = needs the operator, lime = ready/done, dim = out of the queue.
   defp rail_class(%{status: :pending, ready: true}), do: "border-l-4 border-brand-dark"
   defp rail_class(%{status: :pending}), do: "border-l-4 border-amber-400"
-  defp rail_class(%{status: :approved}), do: "border-brand-dark/40 border-l-4"
+  defp rail_class(%{status: :imported}), do: "border-brand-dark/40 border-l-4"
   defp rail_class(_item), do: "border-l-4 border-zinc-700"
 
-  # Where an item came from is what decides its custody at approval — whether
+  # Where an item came from is what decides its custody at import — whether
   # the file gets brought into the library or referenced where it lies — so
   # it's worth reading off the row.
   defp location_label(%Location{name: name, kind: kind}), do: "#{name} · #{kind_word(kind)}"
   defp location_label(nil), do: "ad-hoc scan · adopted in place"
 
-  defp kind_word(:downloads), do: "imported"
+  # "imported" would now read as the item status; this is custody — what
+  # import will do with the bytes.
+  defp kind_word(:downloads), do: "brought in on import"
   defp kind_word(:external_collection), do: "adopted in place"
   defp kind_word(:library_root), do: "already in the library tree"
 

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -200,6 +200,7 @@
                 same question. Re-reads the folder, re-probes, and re-queries
                 every provider with the cache bypassed. --%>
             <span
+              :if={item.status != :approved}
               role="button"
               phx-click="rescan"
               phx-value-id={item.id}

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -98,14 +98,6 @@
           </div>
 
           <p
-            :if={item.issue}
-            class="mt-2 flex items-baseline gap-1.5 overflow-hidden text-ellipsis text-sm text-red-400"
-          >
-            <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
-            <span class="min-w-0">{item.issue}</span>
-          </p>
-
-          <p
             :if={progress_label(@progress[item.id])}
             class="text-xs text-zinc-400"
             data-role="item-progress"
@@ -125,6 +117,16 @@
               <span class="font-mono">{item.path}</span>
             </p>
           </div>
+
+          <%!-- The blocker reads last: it's the row's verdict, not one fact
+                among the others, and the eye leaves the card on it. --%>
+          <p
+            :if={item.issue}
+            class="mt-2 flex items-baseline gap-1.5 overflow-hidden text-ellipsis text-sm text-red-400"
+          >
+            <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
+            <span class="min-w-0">{item.issue}</span>
+          </p>
         </div>
       </div>
 
@@ -158,10 +160,10 @@
               <span class="font-bold text-zinc-300">{file_count(item)}</span> files
             </span>
             <span :if={item.tags && item.tags["asin"]} title={"ASIN #{item.tags["asin"]}"}>
-              <.icon name="fa-tag" class="inline h-3.5 w-3.5 text-current" />
+              <.icon name="fa-tag" class="h-3.5 w-3.5 text-current" />
             </span>
             <span :if={item.tags && item.tags["has_cover_art"]} title="Embedded cover art">
-              <.icon name="fa-image" class="inline h-3.5 w-3.5 text-current" />
+              <.icon name="fa-image" class="h-3.5 w-3.5 text-current" />
             </span>
           </div>
 
@@ -187,7 +189,9 @@
               title="Settle what's outstanding"
               class={action_class(:neutral)}
             >
-              <.icon name="fa-pen-to-square" class="h-3 w-3 text-current" /> Open
+              <%!-- fa-pencil, the app's edit glyph — pen-to-square isn't in
+                  the vendored set, and a missing name renders a blank mask. --%>
+              <.icon name="fa-pencil" class="h-3 w-3 text-current" /> Open
             </.link>
 
             <%!-- One action, because "re-read the files" and "look for matches

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -174,13 +174,13 @@
             <span
               :if={item.status == :pending and item.ready}
               role="button"
-              phx-click="approve"
+              phx-click="import"
               phx-value-id={item.id}
               title="Add to the library"
               data-confirm="Add this to the library?"
               class={action_class(:brand)}
             >
-              <.icon name="fa-check" class="h-3 w-3 text-current" /> Approve
+              <.icon name="fa-check" class="h-3 w-3 text-current" /> Import
             </span>
 
             <.link
@@ -200,7 +200,7 @@
                 same question. Re-reads the folder, re-probes, and re-queries
                 every provider with the cache bypassed. --%>
             <span
-              :if={item.status != :approved}
+              :if={item.status != :imported}
               role="button"
               phx-click="rescan"
               phx-value-id={item.id}
@@ -210,19 +210,22 @@
               <.icon name="fa-rotate" class="h-3 w-3 text-current" /> Re-match
             </span>
 
+            <%!-- Only a pending item can be ignored: an ignored one already
+                is, and ignoring an imported one is nonsense — it's in the
+                library. --%>
             <span
-              :if={item.status != :dismissed}
+              :if={item.status == :pending}
               role="button"
-              phx-click="dismiss"
+              phx-click="ignore"
               phx-value-id={item.id}
-              title="Dismiss (files are not touched)"
+              title="Ignore (files are not touched)"
               class={action_class(:danger)}
             >
-              <.icon name="fa-xmark" class="h-3 w-3 text-current" /> Dismiss
+              <.icon name="fa-xmark" class="h-3 w-3 text-current" /> Ignore
             </span>
 
             <span
-              :if={item.status == :dismissed}
+              :if={item.status == :ignored}
               role="button"
               phx-click="restore"
               phx-value-id={item.id}

--- a/lib/ambry_web/live/admin/location_live/form.html.heex
+++ b/lib/ambry_web/live/admin/location_live/form.html.heex
@@ -47,12 +47,12 @@
           <.input
             field={@form[:import_policy]}
             type="select"
-            label="On approval"
+            label="On import"
             options={policy_options()}
           />
           <p class="mt-2 text-sm text-zinc-400">
             Hardlinking only works within a single filesystem. If this folder and the library root
-            it imports into are on different disks, approval will say so rather than quietly
+            it imports into are on different disks, import will say so rather than quietly
             copying and doubling your storage.
           </p>
         </div>
@@ -71,7 +71,7 @@
           </p>
           <p :if={@root_options == []} class="mt-2 text-sm text-amber-400">
             There are no library roots yet, so nothing can be imported. Add a location of kind
-            "Library root" first — until then, approving an item from this folder will refuse.
+            "Library root" first — until then, importing an item from this folder will refuse.
           </p>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/location_live/index.ex
+++ b/lib/ambry_web/live/admin/location_live/index.ex
@@ -82,10 +82,10 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
   defp kind_label(:library_root), do: "Library root"
 
   defp kind_blurb(:downloads),
-    do: "Messy source. Approved imports are brought into a library root and become managed."
+    do: "Messy source. Imports are brought into a library root and become managed."
 
   defp kind_blurb(:external_collection),
-    do: "Organized elsewhere. Approved items are adopted in place and never written to."
+    do: "Organized elsewhere. Imported items are adopted in place and never written to."
 
   defp kind_blurb(:library_root),
     do: "Ambry's own tree, organized by the naming template. Watched for hand-placed files."

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -52,7 +52,7 @@
               title="Locations sharing this tag are on the same filesystem and can be hardlinked between"
               data-role="location-filesystem"
             >
-              <.icon name="fa-hard-drive" class="inline h-3 w-3 text-current" /> {fs}
+              <.icon name="fa-hard-drive" class="h-3 w-3 text-current" /> {fs}
             </span>
 
             <span

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -67,16 +67,16 @@
       <div class="hidden w-36 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
         <div class="flex gap-4">
           <span :if={!media.has_description} title="Missing description">
-            <.icon name="fa-paragraph" class="inline h-4 w-4 text-red-600" />
+            <.icon name="fa-paragraph" class="h-4 w-4 text-red-600" />
           </span>
           <span :if={media.abridged} title="Abridged">
-            <.icon name="fa-clock" class="inline h-4 w-4 text-current" />
+            <.icon name="fa-clock" class="h-4 w-4 text-current" />
           </span>
           <span :if={media.full_cast} title="Full cast">
-            <.icon name="fa-users" class="inline h-4 w-4 text-current" />
+            <.icon name="fa-users" class="h-4 w-4 text-current" />
           </span>
           <span :if={media.chapters > 0} title="# of chapters">
-            {media.chapters} <.icon name="fa-book-bookmark" class="inline h-4 w-4 text-current" />
+            {media.chapters} <.icon name="fa-book-bookmark" class="h-4 w-4 text-current" />
           </span>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/person_live/index.html.heex
+++ b/lib/ambry_web/live/admin/person_live/index.html.heex
@@ -44,13 +44,13 @@
       <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
         <div class="flex gap-4">
           <span :if={!person.has_description} title="Missing description" data-role="person-missing-description">
-            <.icon name="fa-paragraph" class="inline h-4 w-4 text-red-600" />
+            <.icon name="fa-paragraph" class="h-4 w-4 text-red-600" />
           </span>
           <span :if={person.authored_books > 0} title="# of authored books" data-role="person-authored-count">
-            {person.authored_books} <.icon name="fa-book" class="inline h-4 w-4 text-current" />
+            {person.authored_books} <.icon name="fa-book" class="h-4 w-4 text-current" />
           </span>
           <span :if={person.narrated_media > 0} title="# of narrated audiobooks" data-role="person-narrated-count">
-            {person.narrated_media} <.icon name="fa-microphone" class="inline h-4 w-4 text-current" />
+            {person.narrated_media} <.icon name="fa-microphone" class="h-4 w-4 text-current" />
           </span>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -41,7 +41,7 @@
       <div class="hidden w-12 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
         <div class="flex gap-4">
           <span title="# of books" data-role="series-book-count">
-            {series.books} <.icon name="fa-book" class="inline h-4 w-4 text-current" />
+            {series.books} <.icon name="fa-book" class="h-4 w-4 text-current" />
           </span>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/universe_live/index.html.heex
+++ b/lib/ambry_web/live/admin/universe_live/index.html.heex
@@ -37,7 +37,7 @@
       <div class="hidden w-12 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
         <div class="flex gap-4">
           <span title="# of books" data-role="universe-book-count">
-            {universe.books} <.icon name="fa-book" class="inline h-4 w-4 text-current" />
+            {universe.books} <.icon name="fa-book" class="h-4 w-4 text-current" />
           </span>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/user_devices_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_devices_live/index.html.heex
@@ -49,7 +49,7 @@
         <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
           <div class="flex gap-4">
             <span :if={device.event_count > 0} title="# of playback events">
-              {device.event_count} <.icon name="fa-bolt" class="inline h-4 w-4 text-current" />
+              {device.event_count} <.icon name="fa-bolt" class="h-4 w-4 text-current" />
             </span>
           </div>
         </div>

--- a/lib/ambry_web/live/admin/user_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_live/index.html.heex
@@ -38,7 +38,7 @@
       <div class="hidden w-44 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
         <div class="flex gap-4">
           <span :if={user.admin} title="Admin" data-role="is-admin">
-            <.icon name="fa-lock" class="inline h-4 w-4 text-current" />
+            <.icon name="fa-lock" class="h-4 w-4 text-current" />
           </span>
 
           <span
@@ -47,16 +47,16 @@
           >
             <.icon
               name={if user.confirmed, do: "fa-envelope-open", else: "fa-envelope"}
-              class="inline h-4 w-4 text-current"
+              class="h-4 w-4 text-current"
             />
           </span>
 
           <span :if={user.media_in_progress > 0} title="# of in-progress books" data-role="user-in-progress">
-            {user.media_in_progress} <.icon name="fa-book-bookmark" class="inline h-4 w-4 text-current" />
+            {user.media_in_progress} <.icon name="fa-book-bookmark" class="h-4 w-4 text-current" />
           </span>
 
           <span :if={user.media_finished > 0} title="# of finished books" data-role="user-finished">
-            {user.media_finished} <.icon name="fa-book" class="inline h-4 w-4 text-current" />
+            {user.media_finished} <.icon name="fa-book" class="h-4 w-4 text-current" />
           </span>
         </div>
       </div>

--- a/lib/ambry_web/live/first_time_setup/setup_live.ex
+++ b/lib/ambry_web/live/first_time_setup/setup_live.ex
@@ -67,7 +67,7 @@ defmodule AmbryWeb.FirstTimeSetup.SetupLive do
   defp restart_button(%{state: :admin_exists} = assigns) do
     ~H"""
     <.button class="w-full" phx-click="restart">
-      Restart <.icon name="fa-rotate" class="ml-2 inline h-4 w-4" aria-hidden="true" />
+      Restart <.icon name="fa-rotate" class="ml-2 h-4 w-4" aria-hidden="true" />
     </.button>
     """
   end
@@ -75,7 +75,7 @@ defmodule AmbryWeb.FirstTimeSetup.SetupLive do
   defp restart_button(%{state: :restarting} = assigns) do
     ~H"""
     <.button class="w-full" disabled>
-      Restarting... <.icon name="fa-rotate" class="ml-2 inline h-4 w-4 animate-spin" aria-hidden="true" />
+      Restarting... <.icon name="fa-rotate" class="ml-2 h-4 w-4 animate-spin" aria-hidden="true" />
     </.button>
     """
   end

--- a/priv/repo/migrations/20260810052514_rename_inbox_item_statuses.exs
+++ b/priv/repo/migrations/20260810052514_rename_inbox_item_statuses.exs
@@ -1,0 +1,20 @@
+defmodule Ambry.Repo.Migrations.RenameInboxItemStatuses do
+  use Ecto.Migration
+
+  @moduledoc """
+  The item statuses say what happened, in the operator's words: an item that
+  was approved *is in the library* — "imported" — and a dismissed one is
+  "ignored". "Approved" also collided with the drafts' per-decision approved
+  state, which is a genuinely different thing and keeps the name.
+  """
+
+  def up do
+    execute("UPDATE inbox_items SET status = 'imported' WHERE status = 'approved'")
+    execute("UPDATE inbox_items SET status = 'ignored' WHERE status = 'dismissed'")
+  end
+
+  def down do
+    execute("UPDATE inbox_items SET status = 'approved' WHERE status = 'imported'")
+    execute("UPDATE inbox_items SET status = 'dismissed' WHERE status = 'ignored'")
+  end
+end

--- a/priv/repo/migrations/20260810053427_clear_stale_issues_on_imported_items.exs
+++ b/priv/repo/migrations/20260810053427_clear_stale_issues_on_imported_items.exs
@@ -1,0 +1,18 @@
+defmodule Ambry.Repo.Migrations.ClearStaleIssuesOnImportedItems do
+  use Ecto.Migration
+
+  @moduledoc """
+  A failed import attempt writes its reason onto the item's `issue`, and
+  until now a later successful import didn't clear it — leaving "Couldn't
+  add this to the library" in red on rows whose media is in the library.
+  An imported item's issue is definitionally stale.
+  """
+
+  def up do
+    execute("UPDATE inbox_items SET issue = NULL WHERE status = 'imported'")
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -1,4 +1,4 @@
-defmodule Ambry.Inbox.ApprovalTest do
+defmodule Ambry.Inbox.ImporterTest do
   use Ambry.DataCase
   use Patch
 
@@ -15,7 +15,7 @@ defmodule Ambry.Inbox.ApprovalTest do
     test "creates the whole graph from a tagged file" do
       item = tagged_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       media = media.id |> Media.get_media!() |> Repo.preload(:narrators)
       book = Books.get_book!(media.book_id)
@@ -33,7 +33,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       [file] = item.files
       before = File.stat!(file)
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert media.custody == :external
       assert media.source_files == item.files
@@ -44,7 +44,7 @@ defmodule Ambry.Inbox.ApprovalTest do
     end
 
     test "does not publish" do
-      assert {:ok, media} = tagged_item() |> Inbox.approve_item()
+      assert {:ok, media} = tagged_item() |> Inbox.import_item()
 
       assert media.status == :pending
     end
@@ -52,18 +52,18 @@ defmodule Ambry.Inbox.ApprovalTest do
     test "marks the item approved and links it to what it became" do
       item = tagged_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       item = Inbox.get_item!(item.id)
-      assert item.status == :approved
+      assert item.status == :imported
       assert item.media_id == media.id
     end
 
     test "won't approve the same item twice" do
       item = tagged_item()
-      {:ok, _media} = Inbox.approve_item(item)
+      {:ok, _media} = Inbox.import_item(item)
 
-      assert {:error, :already_approved} = item.id |> Inbox.get_item!() |> Inbox.approve_item()
+      assert {:error, :already_imported} = item.id |> Inbox.get_item!() |> Inbox.import_item()
     end
 
     # The status check at the door reads the caller's copy of the item, so a
@@ -75,16 +75,16 @@ defmodule Ambry.Inbox.ApprovalTest do
       item = tagged_item()
       stale = item
 
-      {:ok, _media} = Inbox.approve_item(item)
+      {:ok, _media} = Inbox.import_item(item)
 
-      assert {:error, :already_approved} = Inbox.approve_item(stale)
+      assert {:error, :already_imported} = Inbox.import_item(stale)
     end
 
     # Occupied-by-a-recording and occupied-by-a-leftover need opposite
     # advice, and the old message sent the operator hunting for a second
     # recording that did not exist.
     test "an occupied destination says whether the occupant is an orphan" do
-      {:ok, media} = tagged_item() |> Inbox.approve_item()
+      {:ok, media} = tagged_item() |> Inbox.import_item()
       [track] = Media.get_media!(media.id).media_tracks
 
       assert Inbox.describe_error({:destination_exists, track.path}) =~
@@ -100,7 +100,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       existing = insert(:book, title: "The Way of Kings")
       item = tagged_item(work_match: {"local", existing.id})
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert media.book_id == existing.id
       assert Repo.aggregate(Book, :count) == 1
@@ -110,7 +110,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       person = insert(:person, name: "Brandon Sanderson")
       author = insert(:author, person: person, name: "Brandon Sanderson")
 
-      assert {:ok, media} = tagged_item() |> Inbox.approve_item()
+      assert {:ok, media} = tagged_item() |> Inbox.import_item()
 
       book = Books.get_book!(media.book_id)
       assert [%{id: author_id}] = book.authors
@@ -143,7 +143,7 @@ defmodule Ambry.Inbox.ApprovalTest do
 
       {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(item.draft))
 
-      assert {:ok, media} = item |> settle() |> Inbox.approve_item()
+      assert {:ok, media} = item |> settle() |> Inbox.import_item()
 
       book = media.book_id |> Books.get_book!() |> Repo.preload(authors: :people)
       assert [%{people: [person]}] = book.authors
@@ -159,7 +159,7 @@ defmodule Ambry.Inbox.ApprovalTest do
     end
 
     test "creates a person alongside a brand-new narrator credit" do
-      assert {:ok, media} = tagged_item() |> Inbox.approve_item()
+      assert {:ok, media} = tagged_item() |> Inbox.import_item()
 
       media = media.id |> Media.get_media!() |> Repo.preload(:narrators)
 
@@ -174,7 +174,7 @@ defmodule Ambry.Inbox.ApprovalTest do
     test "an author who narrates their own book is created once" do
       item = tagged_item(narrator: "Brandon Sanderson")
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert [person] = Repo.all(where(Person, name: "Brandon Sanderson"))
 
@@ -198,7 +198,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
       item = settle(item)
 
-      assert {:ok, _media} = Inbox.approve_item(item)
+      assert {:ok, _media} = Inbox.import_item(item)
 
       assert [_one, _other] = Repo.all(where(Person, name: "Brandon Sanderson"))
     end
@@ -221,7 +221,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       %{web_path: web_path} = Ambry.Factory.valid_image(:person)
       patch(Ambry.Images, :import_url, fn _url -> {:ok, web_path} end)
 
-      assert {:ok, _media} = Inbox.approve_item(item)
+      assert {:ok, _media} = Inbox.import_item(item)
 
       assert [person] = Repo.all(where(Person, name: "Brandon Sanderson"))
       assert person.image_path == web_path
@@ -249,7 +249,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       first = tagged_item(narrator: "Em Grosland")
       second = tagged_item(name: "Another Release", narrator: "Em Grosland")
 
-      assert {:ok, _media} = Inbox.approve_item(first)
+      assert {:ok, _media} = Inbox.import_item(first)
 
       # the refresh has re-derived the sibling: its narrator credit now points
       # at the identity that exists, and says so on the form
@@ -258,7 +258,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       assert credit.mode == :link
       assert credit.identity_id
 
-      assert {:ok, _media} = Inbox.approve_item(settle(second))
+      assert {:ok, _media} = Inbox.import_item(settle(second))
 
       assert [_only_one] = Repo.all(where(Person, name: "Em Grosland"))
       assert [_only_one] = Repo.all(where(Narrator, name: "Em Grosland"))
@@ -272,13 +272,13 @@ defmodule Ambry.Inbox.ApprovalTest do
       first = tagged_item(narrator: "Em Grosland")
       second = tagged_item(name: "A Better Rip", narrator: "Em Grosland")
 
-      assert {:ok, _media} = Inbox.approve_item(first)
+      assert {:ok, _media} = Inbox.import_item(first)
 
       second = Inbox.get_item!(second.id)
       assert second.draft.work.mode == :link
       assert second.draft.work.book_id
 
-      assert {:ok, _media} = Inbox.approve_item(settle(second))
+      assert {:ok, _media} = Inbox.import_item(settle(second))
       assert Repo.aggregate(Book, :count) == 1
     end
 
@@ -290,7 +290,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       draft = Draft.Edit.new_book(second.draft, second)
       {:ok, _} = Inbox.update_draft(second, Inbox.dump_draft(draft))
 
-      assert {:ok, _media} = Inbox.approve_item(first)
+      assert {:ok, _media} = Inbox.import_item(first)
 
       second = Inbox.get_item!(second.id)
       assert second.draft.work.mode == :create
@@ -306,7 +306,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       draft = Draft.Edit.approve_credit(second.draft, :recording, 0, true)
       {:ok, _} = Inbox.update_draft(second, Inbox.dump_draft(draft))
 
-      assert {:ok, _media} = Inbox.approve_item(first)
+      assert {:ok, _media} = Inbox.import_item(first)
 
       second = Inbox.get_item!(second.id)
       assert [credit] = second.draft.recording.narrators
@@ -321,7 +321,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       # release importable, so the operator must not be sent to the form.
       item = tagged_item(files: ["01.mp3", "02.mp3"], settle: false)
 
-      assert {:error, :multi_file_unsupported} = Inbox.approve_item(item)
+      assert {:error, :multi_file_unsupported} = Inbox.import_item(item)
       assert Repo.aggregate(Book, :count) == 0
     end
 
@@ -339,7 +339,7 @@ defmodule Ambry.Inbox.ApprovalTest do
 
       item = tagged_item(dated: false, work_match: selection)
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       book = Books.get_book!(media.book_id)
       assert book.published == ~D[2021-01-01]
@@ -353,7 +353,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       item = tagged_item(dated: false, settle: false)
       {:ok, item} = Inbox.prepare_draft(item)
 
-      assert {:error, {:unresolved, outstanding}} = Inbox.approve_item(item)
+      assert {:error, {:unresolved, outstanding}} = Inbox.import_item(item)
       assert Enum.any?(outstanding, &(&1.label == "First published" and &1.state == :missing))
       assert Repo.aggregate(Book, :count) == 0
     end
@@ -377,7 +377,7 @@ defmodule Ambry.Inbox.ApprovalTest do
       item = tagged_item()
       item.files |> hd() |> File.rm!()
 
-      assert {:error, {:unreadable, _reason}} = Inbox.approve_item(item)
+      assert {:error, {:unreadable, _reason}} = Inbox.import_item(item)
 
       # nothing half-created, and the item stays in the queue
       assert Repo.aggregate(Book, :count) == 0

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -1,4 +1,4 @@
-defmodule Ambry.Inbox.ManagedApprovalTest do
+defmodule Ambry.Inbox.ManagedImportTest do
   @moduledoc """
   Approving an item that came from a downloads folder, which is the first
   point where Ambry writes to the library rather than just reading it.
@@ -28,7 +28,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     test "hardlinks into the library under the naming template" do
       %{item: item, root: root, source: source} = downloads_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       media = Media.get_media!(media.id)
       assert media.custody == :managed
@@ -57,7 +57,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       {:ok, _setting} = Settings.set_library_naming_template("{author}/{year} - {title}")
       %{item: item, root: root} = downloads_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert [placed] = Media.get_media!(media.id).source_files
 
@@ -73,7 +73,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     test "moves instead, leaving the downloads folder clean" do
       %{item: item, source: source} = downloads_item(policy: :move)
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert [placed] = Media.get_media!(media.id).source_files
       assert File.exists?(placed)
@@ -84,7 +84,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     test "copies when asked to, duplicating deliberately" do
       %{item: item, source: source} = downloads_item(policy: :copy)
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert [placed] = Media.get_media!(media.id).source_files
       assert File.exists?(source)
@@ -94,10 +94,10 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     test "marks the item approved and links it to what it became" do
       %{item: item} = downloads_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       {[item], false} = Inbox.list_items()
-      assert item.status == :approved
+      assert item.status == :imported
       assert item.media_id == media.id
     end
   end
@@ -116,7 +116,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
 
         %{item: item, source: source} = downloads_item(root: root)
 
-        assert {:error, {:cross_filesystem, ^source, _destination}} = Inbox.approve_item(item)
+        assert {:error, {:cross_filesystem, ^source, _destination}} = Inbox.import_item(item)
 
         # library untouched, item still queued
         assert {[item], false} = Inbox.list_items()
@@ -131,7 +131,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
     test "refuses when there is no library root to import into" do
       %{item: item} = downloads_item(root: :none)
 
-      assert {:error, {:unresolved, outstanding}} = Inbox.approve_item(item)
+      assert {:error, {:unresolved, outstanding}} = Inbox.import_item(item)
       assert Enum.any?(outstanding, &(&1.section == :destination))
 
       {[item], false} = Inbox.list_items()
@@ -144,7 +144,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       insert(:location, kind: :library_root, import_policy: nil, path: new_dir("second-root"))
       %{item: item} = downloads_item()
 
-      assert {:error, {:unresolved, outstanding}} = Inbox.approve_item(item)
+      assert {:error, {:unresolved, outstanding}} = Inbox.import_item(item)
       assert Enum.any?(outstanding, &(&1.section == :destination))
     end
 
@@ -166,7 +166,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
           }
         })
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       assert [placed] = Media.get_media!(media.id).source_files
       assert String.starts_with?(placed, chosen.path)
@@ -201,7 +201,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       File.mkdir_p!(Path.dirname(occupied))
       File.write!(occupied, "already here")
 
-      assert {:error, {:destination_exists, ^occupied}} = Inbox.approve_item(item)
+      assert {:error, {:destination_exists, ^occupied}} = Inbox.import_item(item)
       assert File.read!(occupied) == "already here"
     end
   end
@@ -213,7 +213,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       {:ok, _setting} = Settings.set_direct_play_publishing(true)
       %{item: item} = downloads_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
       assert Media.get_media!(media.id).status == :ready
     end
 
@@ -223,14 +223,14 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       {:ok, _setting} = Settings.set_direct_play_publishing(false)
       %{item: item} = downloads_item()
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
       assert Media.get_media!(media.id).status == :pending
     end
 
     test "turning the switch on later releases what was waiting" do
       {:ok, _setting} = Settings.set_direct_play_publishing(false)
       %{item: item} = downloads_item()
-      {:ok, media} = Inbox.approve_item(item)
+      {:ok, media} = Inbox.import_item(item)
 
       {:ok, _setting} = Settings.set_direct_play_publishing(true)
       assert {:ok, %{published: 1}} = Media.publish_pending_direct_play()
@@ -244,7 +244,7 @@ defmodule Ambry.Inbox.ManagedApprovalTest do
       %{item: item, source: source} =
         downloads_item(kind: :external_collection, policy: nil)
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       media = Media.get_media!(media.id)
       assert media.custody == :external

--- a/test/ambry/inbox/progress_test.exs
+++ b/test/ambry/inbox/progress_test.exs
@@ -107,13 +107,13 @@ defmodule Ambry.Inbox.ProgressTest do
     end
   end
 
-  describe "approval failures" do
+  describe "import failures" do
     # A flash lasts one page load and a discarded job lasts a day; the
     # operator needs to know tomorrow.
     test "are written onto the item" do
       item = item(files: [], probe: %{"d" => 1})
 
-      assert {:error, :no_audio_files} = Inbox.approve_item(item)
+      assert {:error, :no_audio_files} = Inbox.import_item(item)
 
       assert Repo.reload(item).issue == "Couldn't add this to the library."
     end

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -183,18 +183,18 @@ defmodule Ambry.InboxTest do
       assert {[_one], false} = Inbox.list_items()
     end
 
-    test "never resurrects something dismissed" do
+    test "never resurrects something ignored" do
       root = watched_root()
       release_folder(root, "Not Wanted", ["book.m4b"])
       {:ok, _counts} = Inbox.discover(root)
 
       {[item], false} = Inbox.list_items()
-      {:ok, _item} = Inbox.dismiss_item(item)
+      {:ok, _item} = Inbox.ignore_item(item)
 
       assert {:ok, %{created: 0}} = Inbox.discover(root)
 
       assert {[item], false} = Inbox.list_items()
-      assert item.status == :dismissed
+      assert item.status == :ignored
     end
 
     test "picks up files that appeared after the first look" do
@@ -210,18 +210,18 @@ defmodule Ambry.InboxTest do
       assert length(item.files) == 2
     end
 
-    test "leaves a dismissed item dismissed even when its files change" do
+    test "leaves an ignored item ignored even when its files change" do
       root = watched_root()
       release = release_folder(root, "Growing Set", ["01.mp3"])
       {:ok, _counts} = Inbox.discover(root)
       {[item], false} = Inbox.list_items()
-      {:ok, _item} = Inbox.dismiss_item(item)
+      {:ok, _item} = Inbox.ignore_item(item)
 
       copy_audio(release, "02.mp3")
       {:ok, _counts} = Inbox.discover(root)
 
       assert {[item], false} = Inbox.list_items()
-      assert item.status == :dismissed
+      assert item.status == :ignored
       assert length(item.files) == 2
     end
   end
@@ -296,15 +296,15 @@ defmodule Ambry.InboxTest do
     end
   end
 
-  describe "dismiss_item/1 and restore_item/1" do
+  describe "ignore_item/1 and restore_item/1" do
     test "take an item out of the queue and back, without touching files" do
       root = watched_root()
       release = release_folder(root, "A Book", ["book.m4b"])
       {:ok, _counts} = Inbox.discover(root)
       {[item], false} = Inbox.list_items()
 
-      {:ok, item} = Inbox.dismiss_item(item)
-      assert item.status == :dismissed
+      {:ok, item} = Inbox.ignore_item(item)
+      assert item.status == :ignored
       assert File.exists?(Path.join(release, "book.m4b"))
 
       {:ok, item} = Inbox.restore_item(item)
@@ -321,7 +321,7 @@ defmodule Ambry.InboxTest do
 
       {items, false} = Inbox.list_items()
       reject = Enum.find(items, &(InboxItem.name(&1) == "Reject"))
-      {:ok, _item} = Inbox.dismiss_item(reject)
+      {:ok, _item} = Inbox.ignore_item(reject)
 
       assert {[item], false} = Inbox.list_items(status: :pending)
       assert InboxItem.name(item) == "Keeper"
@@ -329,7 +329,7 @@ defmodule Ambry.InboxTest do
       assert {[item], false} = Inbox.list_items(filter: "Reject")
       assert InboxItem.name(item) == "Reject"
 
-      assert %{pending: 1, dismissed: 1} = Inbox.count_by_status()
+      assert %{pending: 1, ignored: 1} = Inbox.count_by_status()
     end
   end
 

--- a/test/ambry_web/icons_test.exs
+++ b/test/ambry_web/icons_test.exs
@@ -1,0 +1,40 @@
+defmodule AmbryWeb.IconsTest do
+  @moduledoc """
+  Every icon name written in a template must exist in the vendored set.
+
+  The icon component renders `fa-<name>` as a CSS mask; a name with no
+  vendored SVG behind it renders a blank, correctly-sized-or-zero-width
+  nothing — no warning, no crash, just a missing glyph and mysterious
+  spacing. This has shipped twice. Dynamic names (`name={...}`) aren't
+  covered; string literals are the overwhelmingly common case.
+  """
+
+  use ExUnit.Case, async: true
+
+  @vendor Path.expand("../../assets/vendor/fontawesome", __DIR__)
+  @sources Path.expand("../../lib/ambry_web", __DIR__)
+
+  test "every fa- icon literal has a vendored SVG" do
+    used =
+      @sources
+      |> Path.join("**/*.{ex,heex}")
+      |> Path.wildcard()
+      |> Enum.flat_map(fn file ->
+        for [name] <-
+              Regex.scan(~r/name="fa-([a-z0-9-]+)"/, File.read!(file), capture: :all_but_first),
+            do: {name, Path.relative_to_cwd(file)}
+      end)
+
+    missing =
+      for {name, file} <- Enum.uniq(used),
+          path = vendored_path(name),
+          not File.exists?(Path.join(@vendor, path)),
+          do: "#{name} (#{file}) — expected assets/vendor/fontawesome/#{path}"
+
+    assert missing == [],
+           "icons referenced in templates but not vendored:\n  " <> Enum.join(missing, "\n  ")
+  end
+
+  defp vendored_path("brands-" <> name), do: "brands/#{name}.svg"
+  defp vendored_path(name), do: "solid/#{name}.svg"
+end

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -89,6 +89,19 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert html =~ "read-only"
     end
 
+    # A failed attempt writes its reason onto the item so the row explains
+    # itself tomorrow; succeeding is what resolves it. This one is from life:
+    # an imported item sat with "Couldn't add this to the library" in red
+    # while its media was in the library.
+    test "importing clears the issue a failed attempt left behind" do
+      item = probed_item() |> settle()
+      {:ok, item} = Inbox.update_item(item, %{issue: "Couldn't add this to the library."})
+
+      {:ok, _media} = Inbox.import_item(item)
+
+      assert Inbox.get_item!(item.id).issue == nil
+    end
+
     test "the context refuses a second import and any draft write" do
       item = probed_item() |> settle()
       {:ok, _media} = Inbox.import_item(item)

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -41,7 +41,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       view |> element("button[data-role='import']") |> render_click()
 
-      assert %{status: :approved, media_id: media_id} = Inbox.get_item!(item.id)
+      assert %{status: :imported, media_id: media_id} = Inbox.get_item!(item.id)
       assert media_id
     end
 
@@ -63,7 +63,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     # operator has done this by accident.
     test "reads as read-only: banner, no actions, inert sections", %{conn: conn} do
       item = probed_item() |> settle()
-      {:ok, _media} = Inbox.approve_item(item)
+      {:ok, _media} = Inbox.import_item(item)
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
@@ -78,7 +78,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
     test "refuses edits — markup is advisory, a stale tab can send anything", %{conn: conn} do
       item = probed_item() |> settle()
-      {:ok, _media} = Inbox.approve_item(item)
+      {:ok, _media} = Inbox.import_item(item)
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
       before = Inbox.get_item!(item.id).draft
@@ -91,12 +91,12 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
     test "the context refuses a second import and any draft write" do
       item = probed_item() |> settle()
-      {:ok, _media} = Inbox.approve_item(item)
+      {:ok, _media} = Inbox.import_item(item)
       item = Inbox.get_item!(item.id)
 
-      assert {:error, :already_approved} = Inbox.approve_item(item)
-      assert {:error, :already_approved} = Inbox.update_draft(item, %{})
-      assert {:error, :already_approved} = Inbox.rescan_item_async(item)
+      assert {:error, :already_imported} = Inbox.import_item(item)
+      assert {:error, :already_imported} = Inbox.update_draft(item, %{})
+      assert {:error, :already_imported} = Inbox.rescan_item_async(item)
     end
   end
 
@@ -279,7 +279,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
       item = settle(item)
 
-      assert {:ok, media} = Inbox.approve_item(item)
+      assert {:ok, media} = Inbox.import_item(item)
 
       book = media.book_id |> Ambry.Books.get_book!() |> Repo.preload(authors: :people)
       assert [author] = book.authors

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -57,6 +57,49 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "an imported item" do
+    # The draft is the record of what was imported — the library records were
+    # created from it, so editing it afterwards makes the record lie. The
+    # operator has done this by accident.
+    test "reads as read-only: banner, no actions, inert sections", %{conn: conn} do
+      item = probed_item() |> settle()
+      {:ok, _media} = Inbox.approve_item(item)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert has_element?(view, "[data-role='imported-banner']")
+      assert html =~ "In the library"
+      refute has_element?(view, "button[data-role='import']")
+      refute html =~ "Start over"
+      assert has_element?(view, "#work[inert]")
+      assert has_element?(view, "#recording[inert]")
+      assert has_element?(view, "#destination[inert]")
+    end
+
+    test "refuses edits — markup is advisory, a stale tab can send anything", %{conn: conn} do
+      item = probed_item() |> settle()
+      {:ok, _media} = Inbox.approve_item(item)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      before = Inbox.get_item!(item.id).draft
+
+      html = render_click(view, "new-book", %{})
+
+      assert Inbox.get_item!(item.id).draft == before
+      assert html =~ "read-only"
+    end
+
+    test "the context refuses a second import and any draft write" do
+      item = probed_item() |> settle()
+      {:ok, _media} = Inbox.approve_item(item)
+      item = Inbox.get_item!(item.id)
+
+      assert {:error, :already_approved} = Inbox.approve_item(item)
+      assert {:error, :already_approved} = Inbox.update_draft(item, %{})
+      assert {:error, :already_approved} = Inbox.rescan_item_async(item)
+    end
+  end
+
   describe "settling decisions" do
     test "take-the-top-suggestion settles everything that has one", %{conn: conn} do
       item = probed_item()

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -97,9 +97,9 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   # actions that write.
   test "an imported item's row offers no re-match", %{conn: conn} do
     item = probed_item() |> settle()
-    {:ok, _media} = Ambry.Inbox.approve_item(item)
+    {:ok, _media} = Ambry.Inbox.import_item(item)
 
-    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=approved")
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=imported")
 
     refute has_element?(view, "span[phx-click='rescan'][phx-value-id='#{item.id}']")
   end
@@ -138,40 +138,40 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert_enqueued(worker: RunDiscovery)
   end
 
-  test "dismisses and restores without touching files", %{conn: conn} do
+  test "ignores and restores without touching files", %{conn: conn} do
     item = probed_item()
     file = hd(item.files)
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
     html =
-      view |> element("span[phx-click='dismiss'][phx-value-id='#{item.id}']") |> render_click()
+      view |> element("span[phx-click='ignore'][phx-value-id='#{item.id}']") |> render_click()
 
     assert html =~ "Files untouched"
-    assert Inbox.get_item!(item.id).status == :dismissed
+    assert Inbox.get_item!(item.id).status == :ignored
     assert File.exists?(file)
 
-    # the default view is pending, so the dismissed item has left it
+    # the default view is pending, so the ignored item has left it
     refute has_element?(view, "span[phx-click='restore'][phx-value-id='#{item.id}']")
 
-    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=dismissed")
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=ignored")
 
     view |> element("span[phx-click='restore'][phx-value-id='#{item.id}']") |> render_click()
 
     assert Inbox.get_item!(item.id).status == :pending
   end
 
-  test "approves a settled item into the library, leaving files alone", %{conn: conn} do
+  test "imports a settled item into the library, leaving files alone", %{conn: conn} do
     item = probed_item() |> settle()
     file = hd(item.files)
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
     html =
-      view |> element("span[phx-click='approve'][phx-value-id='#{item.id}']") |> render_click()
+      view |> element("span[phx-click='import'][phx-value-id='#{item.id}']") |> render_click()
 
     assert html =~ "Files were left where they are"
-    assert %{status: :approved, media_id: media_id} = Inbox.get_item!(item.id)
+    assert %{status: :imported, media_id: media_id} = Inbox.get_item!(item.id)
     assert media_id
     assert File.exists?(file)
   end
@@ -183,7 +183,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
-    refute has_element?(view, "span[phx-click='approve'][phx-value-id='#{item.id}']")
+    refute has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
     assert has_element?(view, "a[href='/admin/inbox/#{item.id}']")
   end
 
@@ -193,7 +193,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     {:ok, view, html} = live(conn, ~p"/admin/inbox")
 
     assert html =~ "direct play handles single-file recordings"
-    refute has_element?(view, "span[phx-click='approve'][phx-value-id='#{item.id}']")
+    refute has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
     assert Inbox.get_item!(item.id).status == :pending
   end
 
@@ -216,7 +216,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   test "filters by status", %{conn: conn} do
     keeper = probed_item(name: "Keeper")
     reject = probed_item(name: "Reject")
-    {:ok, _item} = Inbox.dismiss_item(reject)
+    {:ok, _item} = Inbox.ignore_item(reject)
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -92,6 +92,18 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     )
   end
 
+  # An imported item's draft is the record of what was imported; re-matching
+  # would rebuild it. The row keeps Open-by-title for looking, loses the
+  # actions that write.
+  test "an imported item's row offers no re-match", %{conn: conn} do
+    item = probed_item() |> settle()
+    {:ok, _media} = Ambry.Inbox.approve_item(item)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=approved")
+
+    refute has_element?(view, "span[phx-click='rescan'][phx-value-id='#{item.id}']")
+  end
+
   # `RunMatch` is unique over a 60-second window and Oban answers a conflict
   # with `{:ok, %{job | conflict?: true}}` — an insert that looks successful
   # and drops the job. The old handler matched `{:ok, _job}` and flashed

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -92,6 +92,17 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     )
   end
 
+  # The page links used to be built from the shared filter+page helpers,
+  # which drop status and ready — so paging through "Imported" silently
+  # landed back on the default pending view.
+  test "the page links keep the status filter", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=ignored&page=2")
+
+    assert view
+           |> element("a[href*='status=ignored'][href*='page=1']")
+           |> has_element?()
+  end
+
   # An imported item's draft is the record of what was imported; re-matching
   # would rebuild it. The row keeps Open-by-title for looking, loses the
   # actions that write.

--- a/test/ambry_web/live/admin/location_live/form_test.exs
+++ b/test/ambry_web/live/admin/location_live/form_test.exs
@@ -28,14 +28,14 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
     test "shows the import policy only for downloads", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/admin/locations/new")
 
-      assert html =~ "On approval"
+      assert html =~ "On import"
 
       html =
         view
         |> form("#location-form", location: %{name: "L", path: "/data/l", kind: "library_root"})
         |> render_change()
 
-      refute html =~ "On approval"
+      refute html =~ "On import"
     end
 
     # Finding out that a path is wrong at save time is late; finding out at


### PR DESCRIPTION
A grab-bag continuation of the #1215 audit — the branch name predates the scope.

## Baselines (§3 grew "The other axis")

Mixed text sizes on one line align by baseline, never box centre: decision/credit/series headers, the Asked/Proposed microlabel grids (eyeballed `pt-*` nudges deleted), the credit identity row, the unresolved list, the form footer. Recorded exceptions: box rows, icon-only actions, image rows, truncating rows (`overflow: hidden` exports a synthesized baseline).

## The icons that were never there

Every icon carrying the `inline` utility was an invisible zero-width span (`.inline` is emitted after the FA plugin's `inline-block`; a `display: inline` span ignores `h-*`/`w-*`). ~20 icons across the admin index pages, betrayed by the phantom `gap-2` pushing the inbox "27 files" chip off the rail's right edge. Class removed everywhere. The inbox Open action was blank for the other reason — `fa-pen-to-square` was never vendored — and now wears `fa-pencil`. A new test scans every `fa-` literal against the vendored set, fencing both silent-vanish modes. The inbox issue line also moved to the card's bottom: it's the row's verdict.

## Imported items are read-only, in layers

The operator had accidentally edited already-imported items. Now: the context refuses draft writes and rescans on imported items; the form halts every non-view event via a second attach_hook (markup is advisory); the page shows a lime-railed "In the library" banner linking to the created media record, inert decision sections, and a footer without the import/ignore actions. The index drops Re-match from imported rows.

## Approved is imported, dismissed is ignored

"Approved" was doing double duty with the drafts' per-decision approved state (which is genuine approval and keeps the name). As an item status it was an alias for "the records exist", so the statuses now say what happened: **pending / ignored / imported**. `Ambry.Inbox.Approval` → `Importer`, `approve_item`/`dismiss_item` → `import_item`/`ignore_item`, queue segments/badges/actions follow, Locations custody copy says "On import", and a migration renames stored statuses both ways. Knock-ons: Ignore only offers itself on pending rows (ignoring an imported item is nonsense), and the downloads custody chip says "brought in on import" instead of colliding with the new status word.

## Pagination keeps the filter

The inbox page links were built from the shared filter+page helpers, which drop status/ready — paging through "Imported" landed back on the pending view. The links now carry the full query.

`mix check` green, full suite 1244 green.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx