### PR TITLE
Inbox grab bag: split mis-grouped items, tombstoned removals, ways back for every proposal, decision-state badges (+ Universes page fix)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,12 @@ import Config
 # at the `config/runtime.exs`.
 config :ambry, Ambry.Mailer, adapter: Swoosh.Adapters.Local
 
+# Postgres JIT prices a query by its *estimated* cost, and the flat views'
+# correlated subqueries estimate high enough to trip it — universes_flat spent
+# ~285ms compiling 43 JIT functions to return zero rows. Short OLTP queries
+# never win that trade.
+config :ambry, Ambry.Repo, parameters: [jit: "off"]
+
 # Configures the endpoint
 config :ambry, AmbryWeb.Endpoint,
   adapter: Bandit.PhoenixAdapter,
@@ -59,12 +65,6 @@ config :ambry,
   ecto_repos: [Ambry.Repo],
   generators: [timestamp_type: :utc_datetime],
   user_registration_enabled: true
-
-# Postgres JIT prices a query by its *estimated* cost, and the flat views'
-# correlated subqueries estimate high enough to trip it — universes_flat spent
-# ~285ms compiling 43 JIT functions to return zero rows. Short OLTP queries
-# never win that trade.
-config :ambry, Ambry.Repo, parameters: [jit: "off"]
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/config/config.exs
+++ b/config/config.exs
@@ -60,6 +60,12 @@ config :ambry,
   generators: [timestamp_type: :utc_datetime],
   user_registration_enabled: true
 
+# Postgres JIT prices a query by its *estimated* cost, and the flat views'
+# correlated subqueries estimate high enough to trip it — universes_flat spent
+# ~285ms compiling 43 JIT functions to return zero rows. Short OLTP queries
+# never win that trade.
+config :ambry, Ambry.Repo, parameters: [jit: "off"]
+
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.25.9",

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -168,7 +168,7 @@ defmodule Ambry.Inbox do
       results =
         root
         |> candidates()
-        |> Enum.map(&record_candidate(&1, known, imported, source))
+        |> Enum.flat_map(&List.wrap(record_candidate(&1, known, imported, source)))
 
       {:ok,
        %{
@@ -649,7 +649,8 @@ defmodule Ambry.Inbox do
 
   def describe_error(:multi_file_unsupported),
     do:
-      "Direct play handles single-file recordings for now — merge this one externally, or skip it."
+      "Direct play handles single-file recordings for now — merge this one externally if it's " <>
+        "one book, split it if it's several, or skip it."
 
   def describe_error(:no_published_date),
     do:
@@ -728,6 +729,55 @@ defmodule Ambry.Inbox do
   def restore_item(%InboxItem{} = item), do: update_item(item, %{status: :pending})
 
   def delete_item(%InboxItem{} = item), do: Repo.delete(item)
+
+  @doc """
+  Splits a multi-file item into one item per file.
+
+  The grouping heuristic is folder-based — a folder holding audio directly is
+  one release — and its known failure is two unrelated single-file books
+  sharing a folder. The operator is the one who can tell; this is how they
+  say so. Each file becomes its own item in the shape a loose file has always
+  had (`path` = the file), with a fresh probe (and the match that follows it)
+  queued, because the parent's probe, tags and matches described its first
+  file only.
+
+  A split survives rescans without any marker: discovery respects a finer
+  partition that already exists — see `record_candidate/4`.
+
+  Refused once imported (the item is the record of what was imported), and
+  meaningless below two files.
+  """
+  def split_item(%InboxItem{status: :imported}), do: {:error, :already_imported}
+  def split_item(%InboxItem{files: files}) when length(files) < 2, do: {:error, :not_multi_file}
+
+  def split_item(%InboxItem{} = item) do
+    Repo.transact(fn ->
+      with {:ok, _parent} <- Repo.delete(item),
+           {:ok, children} <- insert_children(item) do
+        # In the transaction on purpose: a job for a child that didn't get
+        # created must not exist either.
+        Enum.each(children, fn child -> {:ok, _job} = probe_item_async(child) end)
+        {:ok, children}
+      end
+    end)
+  end
+
+  defp insert_children(%InboxItem{} = item) do
+    item.files
+    |> Enum.reduce_while({:ok, []}, fn file, {:ok, acc} ->
+      %InboxItem{}
+      |> InboxItem.changeset(%{path: file, files: [file], source_id: item.source_id})
+      |> Repo.insert()
+      |> case do
+        {:ok, child} -> {:cont, {:ok, [child | acc]}}
+        {:error, changeset} -> {:halt, {:error, changeset}}
+      end
+    end)
+    |> case do
+      {:ok, children} -> {:ok, Enum.reverse(children)}
+      error -> error
+    end
+  end
 
   @doc """
   Runs discovery in the background.
@@ -847,6 +897,14 @@ defmodule Ambry.Inbox do
       item = Map.get(known, path) ->
         refresh_known(item, files, source)
 
+      # The operator split this folder: a finer partition already exists,
+      # keyed by file path. Respect it — re-recording the folder whole would
+      # re-merge what they just took apart, an hour later, silently. A file
+      # that has since appeared in the folder becomes its own item, which is
+      # the right default for a folder the operator declared "not one book".
+      Enum.any?(files, &Map.has_key?(known, &1)) ->
+        Enum.map(files, &record_candidate({&1, [&1]}, known, imported, source))
+
       true ->
         create_item(path, files, source)
     end
@@ -934,7 +992,7 @@ defmodule Ambry.Inbox do
 
   defp multi_file_issue(%InboxItem{files: files}) do
     "#{length(files)} audio files — direct play handles single-file recordings for now; " <>
-      "merge them externally or skip this one"
+      "merge them externally if this is one book, or split this item if they're separate books"
   end
 
   defp probe_map(probe) do

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -193,9 +193,18 @@ defmodule Ambry.Inbox do
   def probe_item(%InboxItem{} = item, opts \\ []) do
     attrs =
       case item.files do
-        [file] -> probe_single(file, single_file: true)
-        [] -> %{issue: "no audio files found"}
-        [file | _rest] -> file |> probe_single() |> Map.put(:issue, multi_file_issue(item))
+        [file] ->
+          probe_single(file, single_file: true)
+
+        [] ->
+          %{issue: "no audio files found"}
+
+        # A multi-file item the operator has already declared one recording
+        # in parts keeps that answer through re-probes; an undeclared one is
+        # stamped with the question.
+        [file | _rest] ->
+          attrs = probe_single(file)
+          if multi_part?(item), do: attrs, else: Map.put(attrs, :issue, multi_file_issue(item))
       end
 
     with {:ok, item} <- update_item(item, attrs) do
@@ -649,8 +658,8 @@ defmodule Ambry.Inbox do
 
   def describe_error(:multi_file_unsupported),
     do:
-      "Direct play handles single-file recordings for now — merge this one externally if it's " <>
-        "one book, split it if it's several, or skip it."
+      "Several audio files — say what they are first: mark it as one recording in parts, " <>
+        "or split it into separate recordings."
 
   def describe_error(:no_published_date),
     do:
@@ -729,6 +738,31 @@ defmodule Ambry.Inbox do
   def restore_item(%InboxItem{} = item), do: update_item(item, %{status: :pending})
 
   def delete_item(%InboxItem{} = item), do: Repo.delete(item)
+
+  @doc """
+  Records the operator's answer to "what are these files": one recording
+  split into parts, or not after all.
+
+  The other answer to the multi-file question (`split_item/1` being the
+  first). Import then creates one Media per file in one recording group —
+  see `Ambry.Inbox.Importer`. Always an operator call: no heuristic can tell
+  a two-part recording from two releases sharing a folder.
+
+  Declaring parts answers the multi-file question, so the item's standing
+  multi-file issue clears; undeclaring puts the question back.
+  """
+  def mark_multi_part(%InboxItem{draft: nil}, _multi_part?), do: {:error, :not_prepared}
+
+  def mark_multi_part(%InboxItem{} = item, multi_part?) do
+    draft = %{item.draft | recording: %{item.draft.recording | multi_part: multi_part?}}
+
+    with {:ok, item} <- update_draft(item, dump_draft(draft)) do
+      update_item(item, %{issue: if(!multi_part?, do: multi_file_issue(item))})
+    end
+  end
+
+  defp multi_part?(%InboxItem{draft: %Draft{recording: %{multi_part: true}}}), do: true
+  defp multi_part?(%InboxItem{}), do: false
 
   @doc """
   Splits a multi-file item into one item per file.
@@ -991,8 +1025,7 @@ defmodule Ambry.Inbox do
   end
 
   defp multi_file_issue(%InboxItem{files: files}) do
-    "#{length(files)} audio files — direct play handles single-file recordings for now; " <>
-      "merge them externally if this is one recording, or split this item if they're separate recordings"
+    "#{length(files)} audio files — one recording in parts, or separate recordings? Say which below."
   end
 
   defp probe_map(probe) do

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -199,12 +199,8 @@ defmodule Ambry.Inbox do
         [] ->
           %{issue: "no audio files found"}
 
-        # A multi-file item the operator has already declared one recording
-        # in parts keeps that answer through re-probes; an undeclared one is
-        # stamped with the question.
         [file | _rest] ->
-          attrs = probe_single(file)
-          if multi_part?(item), do: attrs, else: Map.put(attrs, :issue, multi_file_issue(item))
+          file |> probe_single() |> Map.put(:issue, multi_file_issue(item))
       end
 
     with {:ok, item} <- update_item(item, attrs) do
@@ -657,9 +653,7 @@ defmodule Ambry.Inbox do
   """
 
   def describe_error(:multi_file_unsupported),
-    do:
-      "Several audio files — say what they are first: mark it as one recording in parts, " <>
-        "or split it into separate recordings."
+    do: "Several audio files — an import is one file, so split this into one item per file first."
 
   def describe_error(:no_published_date),
     do:
@@ -738,31 +732,6 @@ defmodule Ambry.Inbox do
   def restore_item(%InboxItem{} = item), do: update_item(item, %{status: :pending})
 
   def delete_item(%InboxItem{} = item), do: Repo.delete(item)
-
-  @doc """
-  Records the operator's answer to "what are these files": one recording
-  split into parts, or not after all.
-
-  The other answer to the multi-file question (`split_item/1` being the
-  first). Import then creates one Media per file in one recording group —
-  see `Ambry.Inbox.Importer`. Always an operator call: no heuristic can tell
-  a two-part recording from two releases sharing a folder.
-
-  Declaring parts answers the multi-file question, so the item's standing
-  multi-file issue clears; undeclaring puts the question back.
-  """
-  def mark_multi_part(%InboxItem{draft: nil}, _multi_part?), do: {:error, :not_prepared}
-
-  def mark_multi_part(%InboxItem{} = item, multi_part?) do
-    draft = %{item.draft | recording: %{item.draft.recording | multi_part: multi_part?}}
-
-    with {:ok, item} <- update_draft(item, dump_draft(draft)) do
-      update_item(item, %{issue: if(!multi_part?, do: multi_file_issue(item))})
-    end
-  end
-
-  defp multi_part?(%InboxItem{draft: %Draft{recording: %{multi_part: true}}}), do: true
-  defp multi_part?(%InboxItem{}), do: false
 
   @doc """
   Splits a multi-file item into one item per file.
@@ -1025,7 +994,7 @@ defmodule Ambry.Inbox do
   end
 
   defp multi_file_issue(%InboxItem{files: files}) do
-    "#{length(files)} audio files — one recording in parts, or separate recordings? Say which below."
+    "#{length(files)} audio files — an import is one file; split this into one item per file below"
   end
 
   defp probe_map(probe) do

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -992,7 +992,7 @@ defmodule Ambry.Inbox do
 
   defp multi_file_issue(%InboxItem{files: files}) do
     "#{length(files)} audio files — direct play handles single-file recordings for now; " <>
-      "merge them externally if this is one book, or split this item if they're separate books"
+      "merge them externally if this is one recording, or split this item if they're separate recordings"
   end
 
   defp probe_map(probe) do

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -205,6 +205,39 @@ defmodule Ambry.Inbox.Draft do
   end
 
   @doc """
+  How settled a level's identity question is, as one badge-sized fact.
+
+  This replaces showing the match confidence forever: confidence is how sure
+  the *machine* was at match time, and it never moved again — an operator
+  could pick the right work and the badge still said "unsure", with no way
+  to say "you were right". But they do say it: ticking records, linking a
+  book, settling uncatalogued all clear the level's doubt. The badge now
+  listens to the same signals as the rest of the form.
+
+    * `:confirmed` — a human answered (ticked records, answered identity)
+    * `:trusted` — the machine believed its match and nobody has had to touch it
+    * `:unsure` — doubt outstanding; the doubt banner carries the numbers
+    * `:no_match` — nothing was found (which is an answer, not a failure)
+  """
+  def level_state(%Work{} = work) do
+    cond do
+      work.curated or work.evidence_curated -> :confirmed
+      work.doubt == :nothing_found -> :no_match
+      work.doubt in [nil, :none] -> :trusted
+      true -> :unsure
+    end
+  end
+
+  def level_state(%Recording{} = recording) do
+    cond do
+      recording.evidence_curated -> :confirmed
+      recording.doubt == :nothing_found -> :no_match
+      recording.doubt in [nil, :none] -> :trusted
+      true -> :unsure
+    end
+  end
+
+  @doc """
   Whether a human has answered anything in this draft yet.
 
   What tells "matched but untouched" from "the operator has been working on

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -252,13 +252,15 @@ defmodule Ambry.Inbox.Draft do
   def curated?(%__MODULE__{} = draft) do
     # Answering the identity question and ticking records are curation too.
     # Both were missed here, so a draft whose only human input was either
-    # one was rebuilt wholesale by the next background re-match.
+    # one was rebuilt wholesale by the next background re-match. So is
+    # declaring the files one multi-part recording.
     Enum.any?(fields(draft), &(&1 && &1.curated)) or
       Enum.any?(credits(draft), fn {_kind, _section, _index, credit} -> credit.curated end) or
       Enum.any?((draft.work && draft.work.series) || [], & &1.curated) or
       Enum.any?(draft.people, & &1.curated) or
       (draft.work && (draft.work.curated or draft.work.evidence_curated)) == true or
-      (draft.recording && draft.recording.evidence_curated) == true
+      (draft.recording &&
+         (draft.recording.evidence_curated or draft.recording.multi_part)) == true
   end
 
   defp fields(%__MODULE__{work: work, recording: recording}) do

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -216,7 +216,12 @@ defmodule Ambry.Inbox.Draft do
     Enum.any?(fields(draft), &(&1 && &1.curated)) or
       Enum.any?(credits(draft), fn {_kind, _section, _index, credit} -> credit.curated end) or
       Enum.any?((draft.work && draft.work.series) || [], & &1.curated) or
-      Enum.any?(draft.people, & &1.curated)
+      Enum.any?(draft.people, & &1.curated) or
+      # Answering the identity question and ticking records are curation too.
+      # Both were missed here, so a draft whose only human input was either
+      # one was rebuilt wholesale by the next background re-match.
+      (draft.work && (draft.work.curated or draft.work.evidence_curated)) == true or
+      (draft.recording && draft.recording.evidence_curated) == true
   end
 
   defp fields(%__MODULE__{work: work, recording: recording}) do

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -252,15 +252,17 @@ defmodule Ambry.Inbox.Draft do
   def curated?(%__MODULE__{} = draft) do
     # Answering the identity question and ticking records are curation too.
     # Both were missed here, so a draft whose only human input was either
-    # one was rebuilt wholesale by the next background re-match. So is
-    # declaring the files one multi-part recording.
+    # one was rebuilt wholesale by the next background re-match. So are the
+    # typed part-of-a-set numbers — nothing proposes those, so a rebuild
+    # could never get them back.
     Enum.any?(fields(draft), &(&1 && &1.curated)) or
       Enum.any?(credits(draft), fn {_kind, _section, _index, credit} -> credit.curated end) or
       Enum.any?((draft.work && draft.work.series) || [], & &1.curated) or
       Enum.any?(draft.people, & &1.curated) or
       (draft.work && (draft.work.curated or draft.work.evidence_curated)) == true or
       (draft.recording &&
-         (draft.recording.evidence_curated or draft.recording.multi_part)) == true
+         (draft.recording.evidence_curated or draft.recording.part_number != nil or
+            draft.recording.parts_total != nil)) == true
   end
 
   defp fields(%__MODULE__{work: work, recording: recording}) do

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -166,6 +166,7 @@ defmodule Ambry.Inbox.Draft do
   def appearances(%__MODULE__{} = draft) do
     for {kind, section, index, credit} <- credits(draft),
         credit.mode == :create,
+        not credit.removed,
         key <- credit.person_keys,
         reduce: %{} do
       acc ->
@@ -195,6 +196,9 @@ defmodule Ambry.Inbox.Draft do
   def referenced_keys(%__MODULE__{} = draft) do
     for {_kind, _section, _index, credit} <- credits(draft),
         credit.mode == :create,
+        # A removed credit holds its person_keys for its possible restore,
+        # but a person only a tombstone references is nobody's decision.
+        not credit.removed,
         key <- credit.person_keys,
         uniq: true,
         do: key
@@ -266,12 +270,15 @@ defmodule Ambry.Inbox.Draft do
 
   defp work_total(nil), do: 1
 
-  defp work_total(%Work{mode: :link} = work), do: 1 + length(work.series)
+  defp work_total(%Work{mode: :link} = work), do: 1 + live_count(work.series)
 
   defp work_total(%Work{} = work) do
-    1 + 3 + length(work.authors) + length(work.series)
+    1 + 3 + live_count(work.authors) + live_count(work.series)
   end
 
   defp recording_total(nil), do: 1
-  defp recording_total(%Recording{} = recording), do: 1 + 5 + length(recording.narrators)
+  defp recording_total(%Recording{} = recording), do: 1 + 5 + live_count(recording.narrators)
+
+  # Tombstoned rows are answered questions; they neither count nor resolve.
+  defp live_count(rows), do: Enum.count(rows, &(not &1.removed))
 end

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -250,13 +250,13 @@ defmodule Ambry.Inbox.Draft do
   def curated?(nil), do: false
 
   def curated?(%__MODULE__{} = draft) do
+    # Answering the identity question and ticking records are curation too.
+    # Both were missed here, so a draft whose only human input was either
+    # one was rebuilt wholesale by the next background re-match.
     Enum.any?(fields(draft), &(&1 && &1.curated)) or
       Enum.any?(credits(draft), fn {_kind, _section, _index, credit} -> credit.curated end) or
       Enum.any?((draft.work && draft.work.series) || [], & &1.curated) or
       Enum.any?(draft.people, & &1.curated) or
-      # Answering the identity question and ticking records are curation too.
-      # Both were missed here, so a draft whose only human input was either
-      # one was rebuilt wholesale by the next background re-match.
       (draft.work && (draft.work.curated or draft.work.evidence_curated)) == true or
       (draft.recording && draft.recording.evidence_curated) == true
   end

--- a/lib/ambry/inbox/draft/credit.ex
+++ b/lib/ambry/inbox/draft/credit.ex
@@ -50,6 +50,12 @@ defmodule Ambry.Inbox.Draft.Credit do
     field :name, :string
     field :kind, Ecto.Enum, values: [:author, :narrator]
 
+    # What the evidence called them, frozen at seed time — the way back after
+    # a rename or an accidental clear. The scalar fields keep their proposals
+    # as candidates; a credit's name had no equivalent, so a cleared box lost
+    # the provider's spelling with nothing on screen holding it.
+    field :proposed_name, :string
+
     field :mode, Ecto.Enum, values: [:link, :create], default: :create
     # when linking: the Author or Narrator id, never a Person id
     field :identity_id, :id
@@ -113,6 +119,7 @@ defmodule Ambry.Inbox.Draft.Credit do
     credit
     |> cast(attrs, [
       :name,
+      :proposed_name,
       :kind,
       :mode,
       :identity_id,

--- a/lib/ambry/inbox/draft/credit.ex
+++ b/lib/ambry/inbox/draft/credit.ex
@@ -64,6 +64,14 @@ defmodule Ambry.Inbox.Draft.Credit do
     # record was ticked.
     field :curated, :boolean, default: false
 
+    # Removal is a decision, so it's a tombstone, not a deletion. A deleted
+    # row left nothing curated behind, so `Seed.keep_curated/2` re-appended
+    # the same proposal on the very next reseed — and there was no way back
+    # for the operator who removed it on purpose. A removed credit stays out
+    # of resolution, approval and person references, and renders as a ghost
+    # with a restore.
+    field :removed, :boolean, default: false
+
     # candidate identities that matched the name, so the operator can choose
     # rather than retype
     embeds_many :candidates, __MODULE__.Match, on_replace: :delete
@@ -111,6 +119,7 @@ defmodule Ambry.Inbox.Draft.Credit do
       :source,
       :approved,
       :curated,
+      :removed,
       :person_keys
     ])
     |> validate_required([:kind])

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -90,7 +90,7 @@ defmodule Ambry.Inbox.Draft.Edit do
           decision.sources ++ [SourceRef.of(record)]
         end
 
-      settle(%{decision | sources: sources}, level)
+      settle(%{decision | sources: sources, evidence_curated: true}, level)
     end)
     |> follow_work(item, level, record)
     |> reseed(item, scope(level, record))
@@ -134,7 +134,7 @@ defmodule Ambry.Inbox.Draft.Edit do
   def uncatalogued(draft, %InboxItem{} = item) do
     draft
     |> update_in([Access.key(:recording)], fn recording ->
-      %{recording | sources: [], approved: true, doubt: :none, doubt_detail: nil}
+      %{recording | sources: [], approved: true, evidence_curated: true, doubt: :none, doubt_detail: nil}
     end)
     |> reseed(item, :recording)
   end

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -461,11 +461,30 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   @doc """
-  Drops a proposed credit entirely — the source suggested somebody this
-  recording isn't actually by.
+  Drops a proposed credit — the source suggested somebody this recording
+  isn't actually by.
+
+  A tombstone, not a deletion. Deleting the row left nothing curated behind,
+  so `Seed.keep_curated/2` re-appended the same proposal on the next reseed —
+  removal was the one edit that didn't stick — and it was also the one edit
+  with no way back. The reseed drops the people only this credit referenced,
+  which used to be skipped outright: the orphaned `PersonDecision` stayed in
+  `draft.people`, where `unresolved/1` counted it as a decision the operator
+  could neither see nor settle.
   """
-  def remove_credit(draft, section, index) do
-    update_credits(draft, section, &List.delete_at(&1, index))
+  def remove_credit(draft, %InboxItem{} = item, section, index) do
+    draft
+    |> update_credit(section, index, &%{&1 | removed: true, curated: true})
+    |> Seed.reseed_people(item)
+  end
+
+  @doc """
+  Brings back a removed credit, exactly as it was when it was removed.
+  """
+  def restore_credit(draft, %InboxItem{} = item, section, index) do
+    draft
+    |> update_credit(section, index, &%{&1 | removed: false})
+    |> Seed.reseed_people(item)
   end
 
   ## series
@@ -486,8 +505,14 @@ defmodule Ambry.Inbox.Draft.Edit do
     update_series(draft, index, &%{&1 | mode: :create, series_id: nil, curated: true})
   end
 
+  # The same tombstone as `remove_credit/4`; a series references no people,
+  # so there is nothing to reconcile.
   def remove_series(draft, index) do
-    update_in(draft.work.series, &List.delete_at(&1, index))
+    update_series(draft, index, &%{&1 | removed: true, curated: true})
+  end
+
+  def restore_series(draft, index) do
+    update_series(draft, index, &%{&1 | removed: false})
   end
 
   ## the identity decisions
@@ -570,6 +595,10 @@ defmodule Ambry.Inbox.Draft.Edit do
   defp settle_if_possible(%Field{required: false} = field), do: %{field | approved: true}
   defp settle_if_possible(field), do: field
 
+  # A removed row is already answered; approving everything must not quietly
+  # re-arm it.
+  defp settle_credit(%Credit{removed: true} = credit), do: credit
+
   defp settle_credit(%Credit{} = credit) do
     cond do
       Credit.resolved?(credit) -> credit
@@ -581,6 +610,7 @@ defmodule Ambry.Inbox.Draft.Edit do
 
   # A number nobody supplied stays a question — this is the one thing the
   # approve-everything button must not paper over.
+  defp settle_series(%SeriesLink{removed: true} = link), do: link
   defp settle_series(%SeriesLink{number: nil} = link), do: link
   defp settle_series(%SeriesLink{} = link), do: %{link | approved: true}
 

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -258,10 +258,25 @@ defmodule Ambry.Inbox.Draft.Edit do
       # Clearing the box un-confirms: a credit cannot stay settled with
       # nothing to create. Any other rename keeps the confirmation, so fixing
       # a typo doesn't cost a second click.
-      %{credit | name: name, curated: true, approved: credit.approved and not blank?(name)}
+      %{
+        credit
+        | name: name,
+          curated: true,
+          approved: credit.approved and not blank?(name),
+          # An added row starts with nobody behind it; the first real name
+          # mints its person. Once minted, keys are stored, never re-derived
+          # — later renames follow via `follow_credit_name/3`.
+          person_keys: mint_keys(credit, name)
+      }
     end)
     |> follow_credit_name(was, name)
   end
+
+  defp mint_keys(%Credit{mode: :create, person_keys: []}, name) do
+    if blank?(name), do: [], else: Credit.new_person_default(name)
+  end
+
+  defp mint_keys(credit, _name), do: credit.person_keys
 
   # A person still called what the credit called them is still tracking it, so
   # they follow the rename. One the operator has already named is theirs and
@@ -273,12 +288,18 @@ defmodule Ambry.Inbox.Draft.Edit do
   defp follow_credit_name(draft, %Credit{} = was, name) do
     Enum.reduce(was.person_keys, draft, fn key, draft ->
       update_person(draft, key, fn person ->
-        if person.mode == :create and Field.value(person.name) == was.name,
+        if person.mode == :create and tracking?(Field.value(person.name), was.name),
           do: %{person | name: Field.edit(person.name, name)},
           else: person
       end)
     end)
   end
+
+  # A cleared box is a blank in both places — nil in the person's field, ""
+  # in the credit — and a bare == between them broke tracking exactly at the
+  # clear-to-retype moment, leaving the person nameless while the credit got
+  # its new name.
+  defp tracking?(person_name, credit_name), do: presence(person_name) == presence(credit_name)
 
   defp blank?(nil), do: true
   defp blank?(name) when is_binary(name), do: String.trim(name) == ""
@@ -292,6 +313,30 @@ defmodule Ambry.Inbox.Draft.Edit do
       index,
       &%{&1 | name: name, curated: true, approved: &1.approved and not blank?(name)}
     )
+  end
+
+  @doc """
+  Puts the evidence's spelling back in a renamed credit.
+
+  The way back the scalar fields have always had through their chips — a
+  cleared or mistyped name is recoverable by click, not by remembering what
+  the provider said.
+  """
+  def reset_credit_name(draft, section, index) do
+    case Enum.at(credits_in(draft, section), index) do
+      %Credit{proposed_name: name} when is_binary(name) -> rename_credit(draft, section, index, name)
+      _no_proposal -> draft
+    end
+  end
+
+  @doc """
+  Puts the evidence's spelling back in a renamed series.
+  """
+  def reset_series_name(draft, index) do
+    case Enum.at(draft.work.series, index) do
+      %SeriesLink{proposed_name: name} when is_binary(name) -> rename_series(draft, index, name)
+      _no_proposal -> draft
+    end
   end
 
   @doc """
@@ -486,6 +531,43 @@ defmodule Ambry.Inbox.Draft.Edit do
     |> update_credit(section, index, &%{&1 | removed: false})
     |> Seed.reseed_people(item)
   end
+
+  @doc """
+  Adds a credit the sources didn't propose.
+
+  The row starts blank and unconfirmed — the operator is about to type the
+  name — and curated from birth, so no reseed sweeps it away. Its person is
+  minted by the first real name (see `rename_credit/4`).
+  """
+  def add_credit(draft, section) do
+    credit = %Credit{
+      kind: kind_of(section),
+      name: "",
+      source: "manual",
+      mode: :create,
+      curated: true
+    }
+
+    update_credits(draft, section, &(&1 ++ [credit]))
+  end
+
+  defp kind_of(:work), do: :author
+  defp kind_of(:recording), do: :narrator
+
+  @doc """
+  Adds a series membership the sources didn't propose.
+  """
+  def add_series(draft) do
+    link = %SeriesLink{name: "", source: "manual", mode: :create, curated: true}
+    update_in(draft.work.series, &(&1 ++ [link]))
+  end
+
+  @doc """
+  Brings the draft's people into line with the credits, for callers outside
+  this module — the form calls it after name edits, because a person named
+  for the first time needs their decision minted before approval can read it.
+  """
+  def sync_people(draft, %InboxItem{} = item), do: Seed.reseed_people(draft, item)
 
   ## series
 

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -134,7 +134,14 @@ defmodule Ambry.Inbox.Draft.Edit do
   def uncatalogued(draft, %InboxItem{} = item) do
     draft
     |> update_in([Access.key(:recording)], fn recording ->
-      %{recording | sources: [], approved: true, evidence_curated: true, doubt: :none, doubt_detail: nil}
+      %{
+        recording
+        | sources: [],
+          approved: true,
+          evidence_curated: true,
+          doubt: :none,
+          doubt_detail: nil
+      }
     end)
     |> reseed(item, :recording)
   end
@@ -324,8 +331,11 @@ defmodule Ambry.Inbox.Draft.Edit do
   """
   def reset_credit_name(draft, section, index) do
     case Enum.at(credits_in(draft, section), index) do
-      %Credit{proposed_name: name} when is_binary(name) -> rename_credit(draft, section, index, name)
-      _no_proposal -> draft
+      %Credit{proposed_name: name} when is_binary(name) ->
+        rename_credit(draft, section, index, name)
+
+      _no_proposal ->
+        draft
     end
   end
 

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -526,11 +526,23 @@ defmodule Ambry.Inbox.Draft.Edit do
   which used to be skipped outright: the orphaned `PersonDecision` stayed in
   `draft.people`, where `unresolved/1` counted it as a decision the operator
   could neither see nor settle.
+
+  A row the operator added themselves really is deleted: no evidence proposed
+  it, so there is nothing for a reseed to resurrect and nothing a ghost would
+  be holding for them.
   """
   def remove_credit(draft, %InboxItem{} = item, section, index) do
-    draft
-    |> update_credit(section, index, &%{&1 | removed: true, curated: true})
-    |> Seed.reseed_people(item)
+    case Enum.at(credits_in(draft, section), index) do
+      %Credit{source: "manual"} ->
+        draft
+        |> update_credits(section, &List.delete_at(&1, index))
+        |> Seed.reseed_people(item)
+
+      _proposed ->
+        draft
+        |> update_credit(section, index, &%{&1 | removed: true, curated: true})
+        |> Seed.reseed_people(item)
+    end
   end
 
   @doc """
@@ -598,9 +610,16 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   # The same tombstone as `remove_credit/4`; a series references no people,
-  # so there is nothing to reconcile.
+  # so there is nothing to reconcile. Operator-added rows really delete,
+  # same as credits — no evidence proposed them.
   def remove_series(draft, index) do
-    update_series(draft, index, &%{&1 | removed: true, curated: true})
+    case Enum.at(draft.work.series, index) do
+      %SeriesLink{source: "manual"} ->
+        update_in(draft.work.series, &List.delete_at(&1, index))
+
+      _proposed ->
+        update_series(draft, index, &%{&1 | removed: true, curated: true})
+    end
   end
 
   def restore_series(draft, index) do
@@ -608,6 +627,26 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   ## the identity decisions
+
+  @doc """
+  Approves the machine's ticks exactly as they are — "yes, you were right."
+
+  Ticking a record settles a level, but a level the seeder already ticked had
+  no one-click way to be human-confirmed: clicking the ticked record unticks
+  it, so confirming took an untick and a re-tick, churning a reseed each way.
+  This is the missing single click. It changes no sources — it only records
+  that a human looked.
+  """
+  def confirm_level(draft, :work) do
+    update_in(draft.work, &%{&1 | evidence_curated: true, doubt: :none, doubt_detail: nil})
+  end
+
+  def confirm_level(draft, :recording) do
+    update_in(
+      draft.recording,
+      &%{&1 | approved: true, evidence_curated: true, doubt: :none, doubt_detail: nil}
+    )
+  end
 
   def approve_work(draft, approved?), do: update_in(draft.work.approved, fn _ -> approved? end)
 

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -30,12 +30,14 @@ defmodule Ambry.Inbox.Draft.Recording do
     # `PersonDecision.evidence_curated`.
     field :evidence_curated, :boolean, default: false
 
-    # The operator's answer to "what are these files": one recording split
-    # into parts (GraphicAudio's "Part 1 of 2"). Import then creates one
-    # Media per file in one RecordingGroup, part numbers following file
-    # order. Always an operator call — no heuristic can tell a two-part
-    # recording from two releases sharing a folder.
-    field :multi_part, :boolean, default: false
+    # The optional part-of-a-set facts Media carries ("Part 1 of 2" —
+    # GraphicAudio's shape). Plain values, deliberately not Fields: the
+    # operator types them, nothing proposes them. A part-release is an
+    # ordinary separate recording (its own cover, date, narrators, sometimes
+    # sold separately) that happens to want this label; grouping parts into
+    # a set stays on the media form.
+    field :part_number, :integer
+    field :parts_total, :integer
 
     # Which records describe this recording. Hardcover, rreading-glasses and
     # Audible will all have a record of a popular reading — and the databases
@@ -77,10 +79,13 @@ defmodule Ambry.Inbox.Draft.Recording do
       :query_fields,
       :approved,
       :evidence_curated,
-      :multi_part,
+      :part_number,
+      :parts_total,
       :doubt,
       :doubt_detail
     ])
+    |> validate_number(:part_number, greater_than_or_equal_to: 1)
+    |> validate_number(:parts_total, greater_than_or_equal_to: 1)
     |> cast_embed(:sources)
     |> cast_embed(:title)
     |> cast_embed(:published)

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -158,8 +158,7 @@ defmodule Ambry.Inbox.Draft.Recording do
   defp credits(narrators) do
     narrators
     # a tombstoned row is an answered question, not an outstanding one
-    |> Enum.reject(& &1.removed)
-    |> Enum.reject(&Credit.resolved?/1)
+    |> Enum.reject(&(&1.removed or Credit.resolved?(&1)))
     |> Enum.map(&%{section: :recording, label: "Narrator: #{&1.name}", state: Credit.state(&1)})
   end
 end

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -24,6 +24,12 @@ defmodule Ambry.Inbox.Draft.Recording do
     field :query_fields, :map, default: %{}
     field :approved, :boolean, default: false
 
+    # Whether a human has ticked/unticked records at this level — the seeder
+    # also writes `sources` and `approved`, so neither can carry the
+    # distinction `Draft.curated?/1` needs. Same name and reason as
+    # `PersonDecision.evidence_curated`.
+    field :evidence_curated, :boolean, default: false
+
     # Which records describe this recording. Hardcover, rreading-glasses and
     # Audible will all have a record of a popular reading — and the databases
     # keep out-of-print editions the storefront has scrubbed — so more than
@@ -58,7 +64,15 @@ defmodule Ambry.Inbox.Draft.Recording do
   @doc false
   def changeset(recording, attrs) do
     recording
-    |> cast(attrs, [:confidence, :query, :query_fields, :approved, :doubt, :doubt_detail])
+    |> cast(attrs, [
+      :confidence,
+      :query,
+      :query_fields,
+      :approved,
+      :evidence_curated,
+      :doubt,
+      :doubt_detail
+    ])
     |> cast_embed(:sources)
     |> cast_embed(:title)
     |> cast_embed(:published)

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -157,6 +157,8 @@ defmodule Ambry.Inbox.Draft.Recording do
 
   defp credits(narrators) do
     narrators
+    # a tombstoned row is an answered question, not an outstanding one
+    |> Enum.reject(& &1.removed)
     |> Enum.reject(&Credit.resolved?/1)
     |> Enum.map(&%{section: :recording, label: "Narrator: #{&1.name}", state: Credit.state(&1)})
   end

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -30,6 +30,13 @@ defmodule Ambry.Inbox.Draft.Recording do
     # `PersonDecision.evidence_curated`.
     field :evidence_curated, :boolean, default: false
 
+    # The operator's answer to "what are these files": one recording split
+    # into parts (GraphicAudio's "Part 1 of 2"). Import then creates one
+    # Media per file in one RecordingGroup, part numbers following file
+    # order. Always an operator call — no heuristic can tell a two-part
+    # recording from two releases sharing a folder.
+    field :multi_part, :boolean, default: false
+
     # Which records describe this recording. Hardcover, rreading-glasses and
     # Audible will all have a record of a popular reading — and the databases
     # keep out-of-print editions the storefront has scrubbed — so more than
@@ -70,6 +77,7 @@ defmodule Ambry.Inbox.Draft.Recording do
       :query_fields,
       :approved,
       :evidence_curated,
+      :multi_part,
       :doubt,
       :doubt_detail
     ])

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -335,7 +335,14 @@ defmodule Ambry.Inbox.Draft.Seed do
   # A field the operator typed is theirs; re-seeding from another candidate
   # must not quietly undo a correction. Everything else is provider data being
   # replaced by other provider data, which is exactly what was asked for.
-  defp keep_manual(%Field{source: "manual"} = existing, _fresh), do: existing
+  #
+  # The *candidates* still follow the fresh derivation: curation protects
+  # decisions, not evidence. Freezing the whole struct meant a manually
+  # edited field stopped collecting chips — newly ticked records had nothing
+  # to offer it, and the way back to a proposal was gone the moment the
+  # proposal predated the edit.
+  defp keep_manual(%Field{source: "manual"} = existing, fresh),
+    do: %{existing | candidates: fresh.candidates}
 
   # A chip the operator picked stays picked while its proposal is still on
   # offer — re-deriving because some other record was ticked must not quietly
@@ -1324,7 +1331,7 @@ defmodule Ambry.Inbox.Draft.Seed do
     matches = identity_matches(name, kind)
     people = person_matches(name)
 
-    base = %Credit{name: name, kind: kind, source: source, candidates: matches}
+    base = %Credit{name: name, proposed_name: name, kind: kind, source: source, candidates: matches}
     # Who is behind the credit is a reference now, not an embed — the human
     # themselves is decided once, in `draft.people`.
     keys = Credit.new_person_default(name)
@@ -1589,7 +1596,13 @@ defmodule Ambry.Inbox.Draft.Seed do
       |> matching_series()
       |> Enum.map(&%SeriesLink.Match{series_id: &1.id, name: &1.name, exact: true})
 
-    base = %SeriesLink{name: name, number: presence(number), source: source, candidates: matches}
+    base = %SeriesLink{
+      name: name,
+      proposed_name: name,
+      number: presence(number),
+      source: source,
+      candidates: matches
+    }
 
     case matches do
       # A number nobody supplied is a question, not a default. Getting this

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -1331,7 +1331,14 @@ defmodule Ambry.Inbox.Draft.Seed do
     matches = identity_matches(name, kind)
     people = person_matches(name)
 
-    base = %Credit{name: name, proposed_name: name, kind: kind, source: source, candidates: matches}
+    base = %Credit{
+      name: name,
+      proposed_name: name,
+      kind: kind,
+      source: source,
+      candidates: matches
+    }
+
     # Who is behind the credit is a reference now, not an embed — the human
     # themselves is decided once, in `draft.people`.
     keys = Credit.new_person_default(name)

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -34,6 +34,11 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
     # or pointed elsewhere. Survives re-derivation.
     field :curated, :boolean, default: false
 
+    # Same tombstone as `Credit.removed`: removal is a decision that has to
+    # survive reseeds (a bare delete resurrected the proposal) and be
+    # reversible.
+    field :removed, :boolean, default: false
+
     embeds_many :candidates, __MODULE__.Match, on_replace: :delete
   end
 
@@ -59,7 +64,7 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
   @doc false
   def changeset(series_link, attrs) do
     series_link
-    |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved, :curated])
+    |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved, :curated, :removed])
     |> cast_embed(:candidates)
     |> validate_number()
     |> validate_link()

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -23,6 +23,11 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
 
   embedded_schema do
     field :name, :string
+
+    # What the evidence called it, frozen at seed time — the way back after a
+    # rename or an accidental clear (same as `Credit.proposed_name`).
+    field :proposed_name, :string
+
     field :mode, Ecto.Enum, values: [:link, :create], default: :create
     field :series_id, :id
 
@@ -64,7 +69,17 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
   @doc false
   def changeset(series_link, attrs) do
     series_link
-    |> cast(attrs, [:name, :mode, :series_id, :number, :source, :approved, :curated, :removed])
+    |> cast(attrs, [
+      :name,
+      :proposed_name,
+      :mode,
+      :series_id,
+      :number,
+      :source,
+      :approved,
+      :curated,
+      :removed
+    ])
     |> cast_embed(:candidates)
     |> validate_number()
     |> validate_link()

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -44,6 +44,13 @@ defmodule Ambry.Inbox.Draft.Work do
     field :doubt, Ecto.Enum, values: [:none, :nothing_found, :low_confidence]
     field :doubt_detail, :string
 
+    # Whether a human has ticked/unticked records at this level, as opposed to
+    # the seeder ticking the top group. `sources` and `approved` can't carry
+    # the distinction — the seeder writes both — and `Draft.curated?/1` needs
+    # it, or a re-match rebuilds a draft whose only curation was the ticking.
+    # Same name and reason as `PersonDecision.evidence_curated`.
+    field :evidence_curated, :boolean, default: false
+
     # Which provider records describe this book. The records live on the
     # item's `matches` because they're evidence; which of them count is a
     # decision, so it lives here.
@@ -65,6 +72,7 @@ defmodule Ambry.Inbox.Draft.Work do
       :book_id,
       :approved,
       :curated,
+      :evidence_curated,
       :confidence,
       :query,
       :query_fields,

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -178,8 +178,7 @@ defmodule Ambry.Inbox.Draft.Work do
   defp unresolved_in(items, resolved?, label) do
     items
     # a tombstoned row is an answered question, not an outstanding one
-    |> Enum.reject(& &1.removed)
-    |> Enum.reject(resolved?)
+    |> Enum.reject(&(&1.removed or resolved?.(&1)))
     |> Enum.map(&%{section: :work, label: "#{label}: #{&1.name}", state: state_of(&1)})
   end
 

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -177,6 +177,8 @@ defmodule Ambry.Inbox.Draft.Work do
 
   defp unresolved_in(items, resolved?, label) do
     items
+    # a tombstoned row is an answered question, not an outstanding one
+    |> Enum.reject(& &1.removed)
     |> Enum.reject(resolved?)
     |> Enum.map(&%{section: :work, label: "#{label}: #{&1.name}", state: state_of(&1)})
   end

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -62,7 +62,6 @@ defmodule Ambry.Inbox.Importer do
   alias Ambry.Library.Placement
   alias Ambry.Library.Root
   alias Ambry.Media
-  alias Ambry.Media.RecordingGroup
   alias Ambry.Media.Scanner
   alias Ambry.People
   alias Ambry.People.Author
@@ -76,14 +75,8 @@ defmodule Ambry.Inbox.Importer do
   @doc """
   Imports an item, creating everything its draft implies.
 
-  One file is one recording; several files the operator has declared one
-  multi-part recording become one Media per file in one `RecordingGroup`,
-  part numbers following file order. Several files with no declaration are
-  refused — no heuristic can tell a two-part recording from two releases
-  sharing a folder.
-
-  Returns `{:ok, media}` (the first part, for a multi-part set), or
-  `{:error, reason}` — leaving the item untouched and the library unchanged.
+  Returns `{:ok, media}`, or `{:error, reason}` — leaving the item untouched
+  and the library unchanged.
   """
   def import_item(%InboxItem{status: :imported}), do: {:error, :already_imported}
 
@@ -91,18 +84,18 @@ defmodule Ambry.Inbox.Importer do
     item = Repo.preload(item, :source)
 
     # Facts about the files come first, then the draft, then placement. The
-    # order is the order the operator can act on them: an undeclared
-    # multi-file release or a vanished file is not something any amount of
-    # curation fixes, so reporting an unresolved decision on one would send
-    # them to the form to fix something the form can't fix.
-    with {:ok, files} <- importable_files(item),
-         {:ok, parts} <- probe_all(files),
+    # order is the order the operator can act on them: a multi-file release or
+    # a vanished file is not something any amount of curation fixes, so
+    # reporting an unresolved decision on one would send them to the form to
+    # fix something the form can't fix.
+    with {:ok, file} <- single_file(item),
+         {:ok, probe} <- probe(file),
          :ok <- resolved(item),
          {:ok, destination} <- destination(item),
-         {:ok, {media, placements}} <- create(item, parts, destination) do
+         {:ok, {media, placement}} <- create(item, file, probe, destination) do
       # Only now, with the records committed, is it safe to remove a moved
       # file's source.
-      Enum.each(placements, &log_finalize(Placement.finalize(&1), item))
+      log_finalize(Placement.finalize(placement), item)
       {:ok, media}
     end
   end
@@ -138,14 +131,7 @@ defmodule Ambry.Inbox.Importer do
   # fail at the commit and the worst case is a stray file in the library,
   # which the audit tooling surfaces — never a file whose source was already
   # deleted and whose record didn't survive.
-  #
-  # `parts` is `[{file, probe}]` in part order. Everything book-shaped
-  # happens once; everything recording-shaped loops. The single-file case is
-  # a one-element loop with no group and no part numbers — exactly what it
-  # created before parts existed.
-  defp create(item, parts, destination) do
-    total = length(parts)
-
+  defp create(item, file, probe, destination) do
     Repo.transact(fn ->
       # People first, and for the whole draft at once: the same human can be
       # behind two credits, and each credit creating its own left a
@@ -153,62 +139,13 @@ defmodule Ambry.Inbox.Importer do
       with {:ok, item} <- claim(item),
            {:ok, people} <- resolve_people(item.draft),
            {:ok, book} <- resolve_book(item.draft.work, people),
-           {:ok, group_id} <- recording_group(total),
-           {:ok, placed} <- create_parts(item, book, people, parts, group_id, destination),
-           {:ok, [media | _rest]} <- publish_all(placed),
-           # The item records the first part: `media_id` is singular, and the
-           # first part is the group's representative everywhere else too.
-           {:ok, _item} <- link(item, media) do
-        {:ok, {media, Enum.map(placed, fn {_media, placement} -> placement end)}}
+           {:ok, media} <- create_media(item, book, probe, people),
+           {:ok, _item} <- link(item, media),
+           {:ok, media, placement} <- place(destination, book, media, file),
+           {:ok, media} <- publish(media) do
+        {:ok, {media, placement}}
       end
     end)
-  end
-
-  # The group exists only to tie parts together, so a single-file import
-  # never creates one. Nothing but defaults on it: the name is an optional
-  # admin label, and the tile logic renders an unnamed group as "N parts".
-  defp recording_group(1), do: {:ok, nil}
-
-  defp recording_group(_several) do
-    with {:ok, group} <- Repo.insert(%RecordingGroup{}), do: {:ok, group.id}
-  end
-
-  defp create_parts(item, book, people, parts, group_id, destination) do
-    total = length(parts)
-
-    parts
-    |> Enum.with_index(1)
-    |> Enum.reduce_while({:ok, []}, fn {{file, probe}, number}, {:ok, acc} ->
-      part = part_of(number, total, group_id)
-
-      with {:ok, media} <- create_media(item, book, probe, people, part),
-           {:ok, media, placement} <- place(destination, book, media, file, part) do
-        {:cont, {:ok, [{media, placement} | acc]}}
-      else
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-    |> case do
-      {:ok, placed} -> {:ok, Enum.reverse(placed)}
-      error -> error
-    end
-  end
-
-  defp part_of(_number, 1, nil), do: nil
-  defp part_of(number, total, group_id), do: %{number: number, total: total, group_id: group_id}
-
-  defp publish_all(placed) do
-    placed
-    |> Enum.reduce_while({:ok, []}, fn {media, _placement}, {:ok, acc} ->
-      case publish(media) do
-        {:ok, media} -> {:cont, {:ok, [media | acc]}}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-    |> case do
-      {:ok, medias} -> {:ok, Enum.reverse(medias)}
-      error -> error
-    end
   end
 
   ## the work
@@ -384,7 +321,7 @@ defmodule Ambry.Inbox.Importer do
 
   ## the recording
 
-  defp create_media(item, book, probe, people, part) do
+  defp create_media(item, book, probe, people) do
     recording = item.draft.recording
 
     Media.create_media(
@@ -394,14 +331,13 @@ defmodule Ambry.Inbox.Importer do
         # repointed to its library copy below
         custody: :external,
         source_path: item.path,
-        # A part claims only its own file — its sibling's bytes are not this
-        # media's to list (or, on deletion, to remove). A single-file import
-        # keeps the item's whole list, exactly as before.
-        source_files: (part && [probe.path]) || item.files,
+        source_files: item.files,
         status: :pending,
-        recording_group_id: part && part.group_id,
-        part_number: part && part.number,
-        parts_total: part && part.total,
+        # The optional part-of-a-set label ("Part 1 of 2"), typed by the
+        # operator. Grouping the parts into one set is the media form's job,
+        # after each part is imported.
+        part_number: recording.part_number,
+        parts_total: recording.parts_total,
         duration: probe.duration,
         chapters: probe.chapters,
         media_narrators: narrator_params(recording.narrators, people),
@@ -529,9 +465,9 @@ defmodule Ambry.Inbox.Importer do
 
   defp destination(%InboxItem{}), do: {:ok, :adopt}
 
-  defp place(:adopt, _book, media, _file, _part), do: {:ok, media, nil}
+  defp place(:adopt, _book, media, _file), do: {:ok, media, nil}
 
-  defp place({root, policy}, book, media, file, part) do
+  defp place({root, policy}, book, media, file) do
     # Forced: a freshly-created book carries its `book_authors` as insert
     # results with the nested `author` unloaded, and a reused one carries
     # nothing at all. Without this every folder silently loses its author
@@ -543,7 +479,7 @@ defmodule Ambry.Inbox.Importer do
     values = Books.naming_values(book, media)
 
     with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
-         {:ok, filename} <- NamingTemplate.filename(values, file, filename_part(part)),
+         {:ok, filename} <- NamingTemplate.filename(values, file, filename_part(media)),
          path = Path.join([root.path, folder, filename]),
          {:ok, placement} <- Placement.place(file, path, policy),
          {:ok, media} <- adopt_managed(media, path) do
@@ -551,11 +487,11 @@ defmodule Ambry.Inbox.Importer do
     end
   end
 
-  # Parts share the book folder, so the filename has to keep them apart —
-  # without the suffix every part renders to one identical path and the
-  # second placement dies on destination_exists.
-  defp filename_part(nil), do: nil
-  defp filename_part(%{number: number, total: total}), do: {number, total}
+  # Two parts of one set are two separate imports into the same book folder;
+  # the suffix is what keeps "The Way of Kings.m4b" from colliding with
+  # itself when part 2 arrives.
+  defp filename_part(%{part_number: nil}), do: nil
+  defp filename_part(%{part_number: number, parts_total: total}), do: {number, total}
 
   # The recording now points at the library copy and Ambry owns those bytes.
   defp adopt_managed(media, path) do
@@ -589,31 +525,12 @@ defmodule Ambry.Inbox.Importer do
 
   ## files
 
-  # One file imports as it always has. Several import only once the operator
-  # has declared them one recording in parts — an undeclared multi-file item
-  # stays refused, because half-importing it or guessing wrong both write
-  # confident nonsense into the library.
-  defp importable_files(%InboxItem{files: []}), do: {:error, :no_audio_files}
-  defp importable_files(%InboxItem{files: [file]}), do: {:ok, [file]}
-
-  defp importable_files(%InboxItem{files: files, draft: %Draft{recording: %{multi_part: true}}}),
-    do: {:ok, files}
-
-  defp importable_files(%InboxItem{}), do: {:error, :multi_file_unsupported}
-
-  defp probe_all(files) do
-    files
-    |> Enum.reduce_while({:ok, []}, fn file, {:ok, acc} ->
-      case probe(file) do
-        {:ok, probe} -> {:cont, {:ok, [{file, probe} | acc]}}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-    |> case do
-      {:ok, parts} -> {:ok, Enum.reverse(parts)}
-      error -> error
-    end
-  end
+  # An import is one file — a recording whose tracks can't be described has
+  # no business in the library, and a multi-file item is split into one item
+  # per file first.
+  defp single_file(%InboxItem{files: [file]}), do: {:ok, file}
+  defp single_file(%InboxItem{files: []}), do: {:error, :no_audio_files}
+  defp single_file(%InboxItem{}), do: {:error, :multi_file_unsupported}
 
   # Re-probed rather than trusting what discovery recorded: it costs one
   # ffprobe and buys current track data, plus a file that vanished between

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -62,6 +62,7 @@ defmodule Ambry.Inbox.Importer do
   alias Ambry.Library.Placement
   alias Ambry.Library.Root
   alias Ambry.Media
+  alias Ambry.Media.RecordingGroup
   alias Ambry.Media.Scanner
   alias Ambry.People
   alias Ambry.People.Author
@@ -75,8 +76,14 @@ defmodule Ambry.Inbox.Importer do
   @doc """
   Imports an item, creating everything its draft implies.
 
-  Returns `{:ok, media}`, or `{:error, reason}` — leaving the item untouched
-  and the library unchanged.
+  One file is one recording; several files the operator has declared one
+  multi-part recording become one Media per file in one `RecordingGroup`,
+  part numbers following file order. Several files with no declaration are
+  refused — no heuristic can tell a two-part recording from two releases
+  sharing a folder.
+
+  Returns `{:ok, media}` (the first part, for a multi-part set), or
+  `{:error, reason}` — leaving the item untouched and the library unchanged.
   """
   def import_item(%InboxItem{status: :imported}), do: {:error, :already_imported}
 
@@ -84,18 +91,18 @@ defmodule Ambry.Inbox.Importer do
     item = Repo.preload(item, :source)
 
     # Facts about the files come first, then the draft, then placement. The
-    # order is the order the operator can act on them: a multi-file release or
-    # a vanished file is not something any amount of curation fixes, so
-    # reporting an unresolved decision on one would send them to the form to
-    # fix something the form can't fix.
-    with {:ok, file} <- single_file(item),
-         {:ok, probe} <- probe(file),
+    # order is the order the operator can act on them: an undeclared
+    # multi-file release or a vanished file is not something any amount of
+    # curation fixes, so reporting an unresolved decision on one would send
+    # them to the form to fix something the form can't fix.
+    with {:ok, files} <- importable_files(item),
+         {:ok, parts} <- probe_all(files),
          :ok <- resolved(item),
          {:ok, destination} <- destination(item),
-         {:ok, {media, placement}} <- create(item, file, probe, destination) do
+         {:ok, {media, placements}} <- create(item, parts, destination) do
       # Only now, with the records committed, is it safe to remove a moved
       # file's source.
-      log_finalize(Placement.finalize(placement), item)
+      Enum.each(placements, &log_finalize(Placement.finalize(&1), item))
       {:ok, media}
     end
   end
@@ -131,7 +138,14 @@ defmodule Ambry.Inbox.Importer do
   # fail at the commit and the worst case is a stray file in the library,
   # which the audit tooling surfaces — never a file whose source was already
   # deleted and whose record didn't survive.
-  defp create(item, file, probe, destination) do
+  #
+  # `parts` is `[{file, probe}]` in part order. Everything book-shaped
+  # happens once; everything recording-shaped loops. The single-file case is
+  # a one-element loop with no group and no part numbers — exactly what it
+  # created before parts existed.
+  defp create(item, parts, destination) do
+    total = length(parts)
+
     Repo.transact(fn ->
       # People first, and for the whole draft at once: the same human can be
       # behind two credits, and each credit creating its own left a
@@ -139,13 +153,62 @@ defmodule Ambry.Inbox.Importer do
       with {:ok, item} <- claim(item),
            {:ok, people} <- resolve_people(item.draft),
            {:ok, book} <- resolve_book(item.draft.work, people),
-           {:ok, media} <- create_media(item, book, probe, people),
-           {:ok, _item} <- link(item, media),
-           {:ok, media, placement} <- place(destination, book, media, file),
-           {:ok, media} <- publish(media) do
-        {:ok, {media, placement}}
+           {:ok, group_id} <- recording_group(total),
+           {:ok, placed} <- create_parts(item, book, people, parts, group_id, destination),
+           {:ok, [media | _rest]} <- publish_all(placed),
+           # The item records the first part: `media_id` is singular, and the
+           # first part is the group's representative everywhere else too.
+           {:ok, _item} <- link(item, media) do
+        {:ok, {media, Enum.map(placed, fn {_media, placement} -> placement end)}}
       end
     end)
+  end
+
+  # The group exists only to tie parts together, so a single-file import
+  # never creates one. Nothing but defaults on it: the name is an optional
+  # admin label, and the tile logic renders an unnamed group as "N parts".
+  defp recording_group(1), do: {:ok, nil}
+
+  defp recording_group(_several) do
+    with {:ok, group} <- Repo.insert(%RecordingGroup{}), do: {:ok, group.id}
+  end
+
+  defp create_parts(item, book, people, parts, group_id, destination) do
+    total = length(parts)
+
+    parts
+    |> Enum.with_index(1)
+    |> Enum.reduce_while({:ok, []}, fn {{file, probe}, number}, {:ok, acc} ->
+      part = part_of(number, total, group_id)
+
+      with {:ok, media} <- create_media(item, book, probe, people, part),
+           {:ok, media, placement} <- place(destination, book, media, file, part) do
+        {:cont, {:ok, [{media, placement} | acc]}}
+      else
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, placed} -> {:ok, Enum.reverse(placed)}
+      error -> error
+    end
+  end
+
+  defp part_of(_number, 1, nil), do: nil
+  defp part_of(number, total, group_id), do: %{number: number, total: total, group_id: group_id}
+
+  defp publish_all(placed) do
+    placed
+    |> Enum.reduce_while({:ok, []}, fn {media, _placement}, {:ok, acc} ->
+      case publish(media) do
+        {:ok, media} -> {:cont, {:ok, [media | acc]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, medias} -> {:ok, Enum.reverse(medias)}
+      error -> error
+    end
   end
 
   ## the work
@@ -321,7 +384,7 @@ defmodule Ambry.Inbox.Importer do
 
   ## the recording
 
-  defp create_media(item, book, probe, people) do
+  defp create_media(item, book, probe, people, part) do
     recording = item.draft.recording
 
     Media.create_media(
@@ -331,8 +394,14 @@ defmodule Ambry.Inbox.Importer do
         # repointed to its library copy below
         custody: :external,
         source_path: item.path,
-        source_files: item.files,
+        # A part claims only its own file — its sibling's bytes are not this
+        # media's to list (or, on deletion, to remove). A single-file import
+        # keeps the item's whole list, exactly as before.
+        source_files: (part && [probe.path]) || item.files,
         status: :pending,
+        recording_group_id: part && part.group_id,
+        part_number: part && part.number,
+        parts_total: part && part.total,
         duration: probe.duration,
         chapters: probe.chapters,
         media_narrators: narrator_params(recording.narrators, people),
@@ -460,9 +529,9 @@ defmodule Ambry.Inbox.Importer do
 
   defp destination(%InboxItem{}), do: {:ok, :adopt}
 
-  defp place(:adopt, _book, media, _file), do: {:ok, media, nil}
+  defp place(:adopt, _book, media, _file, _part), do: {:ok, media, nil}
 
-  defp place({root, policy}, book, media, file) do
+  defp place({root, policy}, book, media, file, part) do
     # Forced: a freshly-created book carries its `book_authors` as insert
     # results with the nested `author` unloaded, and a reused one carries
     # nothing at all. Without this every folder silently loses its author
@@ -474,13 +543,19 @@ defmodule Ambry.Inbox.Importer do
     values = Books.naming_values(book, media)
 
     with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
-         {:ok, filename} <- NamingTemplate.filename(values, file),
+         {:ok, filename} <- NamingTemplate.filename(values, file, filename_part(part)),
          path = Path.join([root.path, folder, filename]),
          {:ok, placement} <- Placement.place(file, path, policy),
          {:ok, media} <- adopt_managed(media, path) do
       {:ok, media, placement}
     end
   end
+
+  # Parts share the book folder, so the filename has to keep them apart —
+  # without the suffix every part renders to one identical path and the
+  # second placement dies on destination_exists.
+  defp filename_part(nil), do: nil
+  defp filename_part(%{number: number, total: total}), do: {number, total}
 
   # The recording now points at the library copy and Ambry owns those bytes.
   defp adopt_managed(media, path) do
@@ -514,11 +589,31 @@ defmodule Ambry.Inbox.Importer do
 
   ## files
 
-  # Direct-play v1 is single-file, and a recording whose tracks can't be
-  # described has no business in the library.
-  defp single_file(%InboxItem{files: [file]}), do: {:ok, file}
-  defp single_file(%InboxItem{files: []}), do: {:error, :no_audio_files}
-  defp single_file(%InboxItem{}), do: {:error, :multi_file_unsupported}
+  # One file imports as it always has. Several import only once the operator
+  # has declared them one recording in parts — an undeclared multi-file item
+  # stays refused, because half-importing it or guessing wrong both write
+  # confident nonsense into the library.
+  defp importable_files(%InboxItem{files: []}), do: {:error, :no_audio_files}
+  defp importable_files(%InboxItem{files: [file]}), do: {:ok, [file]}
+
+  defp importable_files(%InboxItem{files: files, draft: %Draft{recording: %{multi_part: true}}}),
+    do: {:ok, files}
+
+  defp importable_files(%InboxItem{}), do: {:error, :multi_file_unsupported}
+
+  defp probe_all(files) do
+    files
+    |> Enum.reduce_while({:ok, []}, fn file, {:ok, acc} ->
+      case probe(file) do
+        {:ok, probe} -> {:cont, {:ok, [{file, probe} | acc]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, parts} -> {:ok, Enum.reverse(parts)}
+      error -> error
+    end
+  end
 
   # Re-probed rather than trusting what discovery recorded: it costs one
   # ffprobe and buys current track data, plus a file that vanished between

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -153,7 +153,7 @@ defmodule Ambry.Inbox.Importer do
   defp resolve_book(%{mode: :link, book_id: book_id} = work, _people) do
     case Repo.get(Book, book_id) do
       nil -> {:error, :book_not_found}
-      book -> add_series(book, work.series)
+      book -> add_series(book, Enum.reject(work.series, & &1.removed))
     end
   end
 
@@ -192,8 +192,11 @@ defmodule Ambry.Inbox.Importer do
     end
   end
 
+  # Tombstoned rows are the operator saying "not this one" — they stay on the
+  # draft for their possible restore and must never reach the library.
   defp author_params(credits, people) do
     credits
+    |> Enum.reject(& &1.removed)
     |> Enum.map(fn credit ->
       {:ok, author} = resolve_identity(credit, people)
       %{author_id: author.id}
@@ -201,7 +204,9 @@ defmodule Ambry.Inbox.Importer do
   end
 
   defp series_params(links) do
-    Enum.map(links, fn link ->
+    links
+    |> Enum.reject(& &1.removed)
+    |> Enum.map(fn link ->
       {:ok, series} = resolve_series(link)
       %{series_id: series.id, book_number: SeriesLink.decimal(link)}
     end)
@@ -352,7 +357,9 @@ defmodule Ambry.Inbox.Importer do
   end
 
   defp narrator_params(credits, people) do
-    Enum.map(credits, fn credit ->
+    credits
+    |> Enum.reject(& &1.removed)
+    |> Enum.map(fn credit ->
       {:ok, narrator} = resolve_identity(credit, people)
       %{narrator_id: narrator.id}
     end)

--- a/lib/ambry/library/naming_template.ex
+++ b/lib/ambry/library/naming_template.ex
@@ -68,11 +68,11 @@ defmodule Ambry.Library.NamingTemplate do
   @doc """
   The filename for a recording's file, keeping the source's extension.
 
-  A part of a multi-part recording passes `{number, total}` and gets a
-  " - Part N of M" suffix — every part of a recording lands in the same book
-  folder, and without the suffix they'd render to one identical path. (A
-  proper `{part}` template token is future work; this keeps the parts apart
-  until then.)
+  A recording carrying part-of-a-set numbers passes `{number, total}` (total
+  may be nil) and gets a " - Part N of M" suffix — parts of one set are
+  separate imports into the same book folder, and without the suffix they'd
+  render to one identical path. (A proper `{part}` template token is future
+  work; this keeps the parts apart until then.)
   """
   def filename(values, source_path, part \\ nil) do
     values = stringify(values)
@@ -84,6 +84,7 @@ defmodule Ambry.Library.NamingTemplate do
   end
 
   defp part_suffix(nil), do: ""
+  defp part_suffix({number, nil}), do: " - Part #{number}"
   defp part_suffix({number, total}), do: " - Part #{number} of #{total}"
 
   @doc """

--- a/lib/ambry/library/naming_template.ex
+++ b/lib/ambry/library/naming_template.ex
@@ -67,15 +67,24 @@ defmodule Ambry.Library.NamingTemplate do
 
   @doc """
   The filename for a recording's file, keeping the source's extension.
+
+  A part of a multi-part recording passes `{number, total}` and gets a
+  " - Part N of M" suffix — every part of a recording lands in the same book
+  folder, and without the suffix they'd render to one identical path. (A
+  proper `{part}` template token is future work; this keeps the parts apart
+  until then.)
   """
-  def filename(values, source_path) do
+  def filename(values, source_path, part \\ nil) do
     values = stringify(values)
 
     case sanitize(to_string(values["title"] || "")) do
       "" -> {:error, :no_title}
-      name -> {:ok, name <> String.downcase(Path.extname(source_path))}
+      name -> {:ok, name <> part_suffix(part) <> String.downcase(Path.extname(source_path))}
     end
   end
+
+  defp part_suffix(nil), do: ""
+  defp part_suffix({number, total}), do: " - Part #{number} of #{total}"
 
   @doc """
   Checks a template without needing anything to render it against.

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -371,9 +371,9 @@ defmodule Ambry.Media do
   end
 
   defp delete_all_files_async(%Media{} = media) do
-    folders = source_folders(media)
+    {folders, own_files} = source_deletions(media)
 
-    try_delete_files_async(all_file_paths(media), folders,
+    try_delete_files_async(all_file_paths(media) ++ own_files, folders,
       prune_until: if(folders != [], do: library_root_paths())
     )
   end
@@ -401,10 +401,23 @@ defmodule Ambry.Media do
   #
   # Transcoded outputs, images and thumbnails are always Ambry's own, under
   # the uploads path, so they're removed regardless of custody.
-  defp source_folders(%Media{custody: :managed, source_path: path}) when is_binary(path),
-    do: [path]
+  # A folder shared with a sibling is not this media's to remove: a
+  # multi-part recording places every part in one book folder, so deleting
+  # part 1 with an rm_rf of `source_path` would take part 2's file with it.
+  # A shared folder yields only the media's own files; the folder itself
+  # goes with its last part.
+  defp source_deletions(%Media{custody: :managed, source_path: path} = media)
+       when is_binary(path) do
+    if shared_source_path?(media),
+      do: {[], media.source_files || []},
+      else: {[path], []}
+  end
 
-  defp source_folders(%Media{}), do: []
+  defp source_deletions(%Media{}), do: {[], []}
+
+  defp shared_source_path?(%Media{id: id, source_path: path}) do
+    Repo.exists?(from(m in Media, where: m.source_path == ^path and m.id != ^id))
+  end
 
   defp all_file_paths(%Media{} = media) do
     %Media{

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -656,6 +656,34 @@ defmodule AmbryWeb.Admin.Decisions do
   generalized fix for the pen-name bug where matching found a Person and
   linked its first identity.
   """
+  # Removed is a tombstone the operator can take back — a ghost row (dashed,
+  # like every escape hatch) holding the name and a restore, out of the
+  # decision queue. It renders instead of vanishing so removal is never a
+  # one-way door.
+  def credit_row(%{credit: %Credit{removed: true}} = assigns) do
+    ~H"""
+    <div
+      class="rounded-lg border border-dashed border-zinc-700 p-4"
+      data-role="removed-credit"
+    >
+      <div class="flex items-center justify-between gap-2 pl-3">
+        <p class="min-w-0 truncate text-sm text-zinc-500">
+          {@verb} <span class="line-through">{@credit.name}</span> — removed
+        </p>
+        <button
+          type="button"
+          phx-click="restore-credit"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          class="bg-white/5 flex-none rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
+        >
+          Restore
+        </button>
+      </div>
+    </div>
+    """
+  end
+
   def credit_row(assigns) do
     ~H"""
     <%!-- A decision block, so it wears the state rail like every other one —
@@ -1173,6 +1201,30 @@ defmodule AmbryWeb.Admin.Decisions do
   defaulted — a series proposal with no number stays outstanding, because
   inventing "book 1" writes confident nonsense into a curated field.
   """
+  # The same ghost as a removed credit: dashed, named, restorable.
+  def series_row(%{link: %SeriesLink{removed: true}} = assigns) do
+    ~H"""
+    <div
+      class="rounded-lg border border-dashed border-zinc-700 p-4"
+      data-role="removed-series"
+    >
+      <div class="flex items-center justify-between gap-2 pl-3">
+        <p class="min-w-0 truncate text-sm text-zinc-500">
+          In series <span class="line-through">{@link.name}</span> — removed
+        </p>
+        <button
+          type="button"
+          phx-click="restore-series"
+          phx-value-index={@index}
+          class="bg-white/5 flex-none rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
+        >
+          Restore
+        </button>
+      </div>
+    </div>
+    """
+  end
+
   def series_row(assigns) do
     ~H"""
     <%!-- The same anatomy as every other decision block: railed header row

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -1383,6 +1383,20 @@ defmodule AmbryWeb.Admin.Decisions do
   def state_words(_other), do: {"needs confirming", :yellow}
 
   @doc """
+  A level's identity state as a badge — `Ambry.Inbox.Draft.level_state/1`'s
+  words. One vocabulary for the queue and the form, or they drift.
+
+  "confirmed" is the operator's; "trusted" is the machine's. The distinction
+  is the point: the old badge showed match-time confidence forever, so a
+  human's answer could never update it — and a correct "unsure" match could
+  never be told "you were right" except by this.
+  """
+  def level_state_words(:confirmed), do: {"confirmed", :brand}
+  def level_state_words(:trusted), do: {"trusted", :blue}
+  def level_state_words(:unsure), do: {"unsure", :yellow}
+  def level_state_words(:no_match), do: {"no match", :gray}
+
+  @doc """
   Where a cover value can actually be looked at.
 
   A provider URL goes through the admin proxy, because tracking protection

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -768,6 +768,32 @@ defmodule AmbryWeb.Admin.Decisions do
         </span>
       </form>
 
+      <%!-- The way back after a rename or a clear — the same chip the scalar
+            fields have always had. Only speaks while the box disagrees with
+            the evidence; a linked identity has the library's own name. --%>
+      <div
+        :if={
+          @credit.mode == :create && @credit.proposed_name &&
+            @credit.proposed_name != @credit.name
+        }
+        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+      >
+        <.microlabel>Proposed</.microlabel>
+        <div class="flex flex-wrap items-center gap-1.5">
+          <.proposal_chip
+            chosen={false}
+            event="reset-credit-name"
+            values={%{section: @section, index: @index}}
+            title="go back to what the records proposed"
+          >
+            <span class="text-[10px] flex-none uppercase tracking-wide text-zinc-500">
+              {source_words(@credit.source)}
+            </span>
+            {@credit.proposed_name}
+          </.proposal_chip>
+        </div>
+      </div>
+
       <%!-- The photo and bio belong to the credit itself while there is one
             implied person behind it, which is nearly always. Putting them
             inside the pen-name fold hid them behind a control nobody would
@@ -1304,6 +1330,28 @@ defmodule AmbryWeb.Admin.Decisions do
             class={input_classes("w-16")}
           />
         </form>
+      </div>
+
+      <%!-- Same restore chip as a credit's name: the evidence's spelling
+            stays reachable after a rename or a clear. --%>
+      <div
+        :if={@link.mode == :create && @link.proposed_name && @link.proposed_name != @link.name}
+        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+      >
+        <.microlabel>Proposed</.microlabel>
+        <div class="flex flex-wrap items-center gap-1.5">
+          <.proposal_chip
+            chosen={false}
+            event="reset-series-name"
+            values={%{index: @index}}
+            title="go back to what the records proposed"
+          >
+            <span class="text-[10px] flex-none uppercase tracking-wide text-zinc-500">
+              {source_words(@link.source)}
+            </span>
+            {@link.proposed_name}
+          </.proposal_chip>
+        </div>
       </div>
     </div>
     """

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -273,6 +273,19 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      end)}
   end
 
+  def handle_event("split", _params, socket) do
+    case Inbox.split_item(socket.assigns.item) do
+      {:ok, children} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Split into #{length(children)} items — scanning each fresh now.")
+         |> push_navigate(to: ~p"/admin/inbox")}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Couldn't split this item.")}
+    end
+  end
+
   def handle_event("add-credit", %{"section" => s}, socket) do
     {:noreply, edit(socket, &Draft.Edit.add_credit(&1, atom(s)))}
   end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -401,7 +401,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def handle_event("remove-credit", %{"section" => s, "index" => i}, socket) do
-    {:noreply, edit(socket, &Draft.Edit.remove_credit(&1, atom(s), to_int(i)))}
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.remove_credit(&1, item, atom(s), to_int(i)))}
+  end
+
+  def handle_event("restore-credit", %{"section" => s, "index" => i}, socket) do
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.restore_credit(&1, item, atom(s), to_int(i)))}
   end
 
   def handle_event("set-series-number", %{"index" => i, "number" => number}, socket) do
@@ -431,6 +437,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def handle_event("remove-series", %{"index" => i}, socket) do
     {:noreply, edit(socket, &Draft.Edit.remove_series(&1, to_int(i)))}
+  end
+
+  def handle_event("restore-series", %{"index" => i}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.restore_series(&1, to_int(i)))}
   end
 
   def handle_event("approve-work", params, socket) do

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -255,6 +255,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     section = atom(section)
     index = to_int(i)
     id = to_int(params["identity_id"])
+    item = socket.assigns.item
 
     {:noreply,
      edit(socket, fn draft ->
@@ -264,8 +265,35 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
          draft
          |> Draft.Edit.create_credit(section, index)
          |> Draft.Edit.rename_credit(section, index, params["name"] || "")
+         # A person named for the first time (an added row's first real name
+         # mints their key) needs their decision minted before approval can
+         # resolve it.
+         |> Draft.Edit.sync_people(item)
        end
      end)}
+  end
+
+  def handle_event("add-credit", %{"section" => s}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.add_credit(&1, atom(s)))}
+  end
+
+  def handle_event("add-series", _params, socket) do
+    {:noreply, edit(socket, &Draft.Edit.add_series(&1))}
+  end
+
+  def handle_event("reset-credit-name", %{"section" => s, "index" => i}, socket) do
+    item = socket.assigns.item
+
+    {:noreply,
+     edit(socket, fn draft ->
+       draft
+       |> Draft.Edit.reset_credit_name(atom(s), to_int(i))
+       |> Draft.Edit.sync_people(item)
+     end)}
+  end
+
+  def handle_event("reset-series-name", %{"index" => i}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.reset_series_name(&1, to_int(i)))}
   end
 
   # Whether the person layer is unfolded is view state, not a decision — it

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -273,15 +273,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      end)}
   end
 
-  def handle_event("multi-part", _params, socket) do
-    item = socket.assigns.item
-
-    case Inbox.mark_multi_part(item, !multi_part?(item)) do
-      {:ok, item} -> {:noreply, load(socket, item)}
-      {:error, _reason} -> {:noreply, put_flash(socket, :error, "Couldn't update this item.")}
-    end
-  end
-
   def handle_event("split", _params, socket) do
     case Inbox.split_item(socket.assigns.item) do
       {:ok, children} ->
@@ -890,12 +881,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   @doc "Existing Books this release might be another edition of."
   defdelegate local_records(item, level), to: Seed
-
-  @doc """
-  Whether the operator has declared this item one recording in parts.
-  """
-  def multi_part?(%InboxItem{draft: %Draft{recording: %{multi_part: true}}}), do: true
-  def multi_part?(%InboxItem{}), do: false
 
   @doc """
   How many decisions the bulk button would settle, so its label can say.

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -291,7 +291,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def handle_event("add-series", _params, socket) do
-    {:noreply, edit(socket, &Draft.Edit.add_series(&1))}
+    {:noreply, edit(socket, &Draft.Edit.add_series/1)}
   end
 
   def handle_event("reset-credit-name", %{"section" => s, "index" => i}, socket) do
@@ -887,5 +887,4 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def settleable(unresolved) do
     Enum.count(unresolved, &(&1.state != :missing))
   end
-
 end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -273,6 +273,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      end)}
   end
 
+  def handle_event("multi-part", _params, socket) do
+    item = socket.assigns.item
+
+    case Inbox.mark_multi_part(item, !multi_part?(item)) do
+      {:ok, item} -> {:noreply, load(socket, item)}
+      {:error, _reason} -> {:noreply, put_flash(socket, :error, "Couldn't update this item.")}
+    end
+  end
+
   def handle_event("split", _params, socket) do
     case Inbox.split_item(socket.assigns.item) do
       {:ok, children} ->
@@ -881,6 +890,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   @doc "Existing Books this release might be another edition of."
   defdelegate local_records(item, level), to: Seed
+
+  @doc """
+  Whether the operator has declared this item one recording in parts.
+  """
+  def multi_part?(%InboxItem{draft: %Draft{recording: %{multi_part: true}}}), do: true
+  def multi_part?(%InboxItem{}), do: false
 
   @doc """
   How many decisions the bulk button would settle, so its label can say.

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -888,9 +888,4 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     Enum.count(unresolved, &(&1.state != :missing))
   end
 
-  def confidence_label(nil), do: {"no match", :gray}
-  def confidence_label(confidence) when confidence >= 0.85, do: {"near-certain", :brand}
-  def confidence_label(confidence) when confidence >= 0.6, do: {"likely", :blue}
-  def confidence_label(confidence) when confidence > 0.0, do: {"unsure", :yellow}
-  def confidence_label(_confidence), do: {"no match", :gray}
 end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -488,6 +488,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.approve_work(&1, params["approved"] == "true"))}
   end
 
+  def handle_event("confirm-level", %{"section" => s}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.confirm_level(&1, atom(s)))}
+  end
+
   def handle_event("choose-root", %{"root_id" => root_id}, socket) do
     id = to_int(root_id)
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -80,8 +80,10 @@
         </p>
 
         <%!-- The grouping heuristic is folder-based and its known failure is
-            unrelated single-file books sharing a folder. Only the operator
-            can tell — this is how they say so. --%>
+            unrelated single-file recordings sharing a folder. Only the
+            operator can tell — this is how they say so. "Recordings", not
+            "books": the split items are separate imports, and each may still
+            link to the same book (two novellas, or two editions). --%>
         <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
           <button
             type="button"
@@ -90,7 +92,7 @@
             data-role="split"
             class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
           >
-            These are separate books — split into {length(@item.files)} items
+            These are separate recordings — split into {length(@item.files)} items
           </button>
         </div>
       </section>
@@ -267,6 +269,20 @@
             >
               {elem(level_state_words(Draft.level_state(@item.draft.work)), 0)}
             </.badge>
+
+            <%!-- "Yes, you were right" in one click. Clicking the ticked
+                record would untick it — confirming as-is must not cost an
+                untick and a re-tick. --%>
+            <button
+              :if={Draft.level_state(@item.draft.work) == :trusted}
+              type="button"
+              phx-click="confirm-level"
+              phx-value-section="work"
+              data-role="confirm-work"
+              class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
+            >
+              Confirm
+            </button>
           </div>
 
           <%!-- Same as the recording level: a doubted match adopts nothing, and
@@ -467,6 +483,17 @@
             >
               {elem(level_state_words(Draft.level_state(@item.draft.recording)), 0)}
             </.badge>
+
+            <button
+              :if={Draft.level_state(@item.draft.recording) == :trusted}
+              type="button"
+              phx-click="confirm-level"
+              phx-value-section="recording"
+              data-role="confirm-recording"
+              class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
+            >
+              Confirm
+            </button>
           </div>
 
           <%!-- A doubted match used to be indistinguishable from no match at

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -257,13 +257,15 @@
                 do: "Records that could fill blanks",
                 else: "Records describing this book"}
             </.label>
+            <%!-- Decision state, not match history: confidence was frozen at
+                match time, so the badge kept saying "unsure" after the
+                operator had answered. The raw score stays in the tooltip. --%>
             <.badge
-              :if={@item.draft.work.confidence}
-              color={elem(confidence_label(@item.draft.work.confidence), 1)}
+              color={elem(level_state_words(Draft.level_state(@item.draft.work)), 1)}
               class="text-xs"
-              title={"score #{@item.draft.work.confidence}"}
+              title={@item.draft.work.confidence && "match score #{@item.draft.work.confidence}"}
             >
-              {elem(confidence_label(@item.draft.work.confidence), 0)}
+              {elem(level_state_words(Draft.level_state(@item.draft.work)), 0)}
             </.badge>
           </div>
 
@@ -452,20 +454,18 @@
         ]}>
           <div class="flex items-baseline gap-2 pl-3">
             <.label>Records describing this recording</.label>
+            <%!-- One badge, not two: "needs confirming" and a frozen
+                confidence said less together than the decision state says
+                alone — and the old pair could contradict each other. --%>
             <.badge
-              :if={!@item.draft.recording.approved}
-              color={elem(state_words(:unconfirmed), 1)}
+              color={elem(level_state_words(Draft.level_state(@item.draft.recording)), 1)}
               class="text-xs"
+              title={
+                @item.draft.recording.confidence &&
+                  "match score #{@item.draft.recording.confidence}"
+              }
             >
-              {elem(state_words(:unconfirmed), 0)}
-            </.badge>
-            <.badge
-              :if={@item.draft.recording.confidence}
-              color={elem(confidence_label(@item.draft.recording.confidence), 1)}
-              class="text-xs"
-              title={"score #{@item.draft.recording.confidence}"}
-            >
-              {elem(confidence_label(@item.draft.recording.confidence), 0)}
+              {elem(level_state_words(Draft.level_state(@item.draft.recording)), 0)}
             </.badge>
           </div>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -79,26 +79,11 @@
           {@item.issue}
         </p>
 
-        <%!-- The multi-file question, and both of its answers. Only the
-            operator can tell a two-part recording from two releases sharing
-            a folder — no heuristic can. "Recordings", not "books": split
-            items are separate imports, and each may still link to the same
-            book (two novellas, or two editions). --%>
-        <div :if={length(@item.files) > 1 and !@read_only} class="flex flex-wrap gap-2 pt-2 pl-3">
-          <button
-            type="button"
-            phx-click="multi-part"
-            data-role="multi-part"
-            class={[
-              "rounded-sm px-2 py-1 text-xs",
-              multi_part?(@item) && "bg-brand-dark/15 ring-brand-dark/50 text-zinc-100 ring-2 ring-inset",
-              !multi_part?(@item) && "bg-white/5 text-zinc-300 hover:bg-white/10"
-            ]}
-          >
-            <.icon :if={multi_part?(@item)} name="fa-check" class="text-brand-dark mr-1 h-3 w-3" />
-            One recording in {length(@item.files)} parts
-          </button>
-
+        <%!-- One button, no judgment on why: an import is one file, and only
+            the operator knows what these files are to each other. Each split
+            item is its own import — link them to one book, give them part
+            numbers, whatever the release calls for. --%>
+        <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
           <button
             type="button"
             phx-click="split"
@@ -106,7 +91,7 @@
             data-role="split"
             class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
           >
-            Separate recordings — split into {length(@item.files)} items
+            Split into {length(@item.files)} items — one per file
           </button>
         </div>
       </section>
@@ -638,6 +623,41 @@
                 type="textarea"
                 field={@item.draft.recording.description}
               />
+
+              <%!-- Plain values, deliberately not a decision row: nothing
+                  proposes these, the operator just knows. Optional — most
+                  recordings aren't part of a set. --%>
+              <div class="space-y-2 rounded-lg border-l-4 border-zinc-700 bg-zinc-900 p-4">
+                <div class="pl-3">
+                  <.label>Part of a set</.label>
+                </div>
+                <p class="max-w-prose pl-3 text-sm text-zinc-400">
+                  Optional — for releases sold as "Part 1 of 2". Each part is its own
+                  recording; tying the set together happens on the media page once the
+                  parts are in.
+                </p>
+                <div class="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min="1"
+                    name={recording[:part_number].name}
+                    value={recording[:part_number].value}
+                    placeholder="—"
+                    data-role="part-number"
+                    class={input_classes("w-20")}
+                  />
+                  <span class="text-sm text-zinc-400">of</span>
+                  <input
+                    type="number"
+                    min="1"
+                    name={recording[:parts_total].name}
+                    value={recording[:parts_total].value}
+                    placeholder="—"
+                    data-role="parts-total"
+                    class={input_classes("w-20")}
+                  />
+                </div>
+              </div>
             </.inputs_for>
           </.inputs_for>
         </.simple_form>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -79,12 +79,26 @@
           {@item.issue}
         </p>
 
-        <%!-- The grouping heuristic is folder-based and its known failure is
-            unrelated single-file recordings sharing a folder. Only the
-            operator can tell — this is how they say so. "Recordings", not
-            "books": the split items are separate imports, and each may still
-            link to the same book (two novellas, or two editions). --%>
-        <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
+        <%!-- The multi-file question, and both of its answers. Only the
+            operator can tell a two-part recording from two releases sharing
+            a folder — no heuristic can. "Recordings", not "books": split
+            items are separate imports, and each may still link to the same
+            book (two novellas, or two editions). --%>
+        <div :if={length(@item.files) > 1 and !@read_only} class="flex flex-wrap gap-2 pt-2 pl-3">
+          <button
+            type="button"
+            phx-click="multi-part"
+            data-role="multi-part"
+            class={[
+              "rounded-sm px-2 py-1 text-xs",
+              multi_part?(@item) && "bg-brand-dark/15 ring-brand-dark/50 text-zinc-100 ring-2 ring-inset",
+              !multi_part?(@item) && "bg-white/5 text-zinc-300 hover:bg-white/10"
+            ]}
+          >
+            <.icon :if={multi_part?(@item)} name="fa-check" class="text-brand-dark mr-1 h-3 w-3" />
+            One recording in {length(@item.files)} parts
+          </button>
+
           <button
             type="button"
             phx-click="split"
@@ -92,7 +106,7 @@
             data-role="split"
             class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
           >
-            These are separate recordings — split into {length(@item.files)} items
+            Separate recordings — split into {length(@item.files)} items
           </button>
         </div>
       </section>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -78,6 +78,21 @@
           <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
           {@item.issue}
         </p>
+
+        <%!-- The grouping heuristic is folder-based and its known failure is
+            unrelated single-file books sharing a folder. Only the operator
+            can tell — this is how they say so. --%>
+        <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
+          <button
+            type="button"
+            phx-click="split"
+            data-confirm={"Split into #{length(@item.files)} separate items? Each file becomes its own inbox item and is scanned fresh."}
+            data-role="split"
+            class="bg-white/5 rounded-sm px-2 py-1 text-xs text-zinc-300 hover:bg-white/10"
+          >
+            These are separate books — split into {length(@item.files)} items
+          </button>
+        </div>
       </section>
 
       <%!-- Once imported, the draft is the record of what was imported — the

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -383,6 +383,15 @@
             searching_person={@searching_person}
             photos_expanded={@photos_expanded}
           />
+
+          <button
+            type="button"
+            phx-click="add-credit"
+            phx-value-section="work"
+            class="pl-3 text-xs text-zinc-400 underline"
+          >
+            Add an author
+          </button>
         </div>
 
         <%!-- each series is its own decision, number included --%>
@@ -409,6 +418,10 @@
             index={index}
             options={@series}
           />
+
+          <button type="button" phx-click="add-series" class="pl-3 text-xs text-zinc-400 underline">
+            Add a series
+          </button>
         </div>
       </section>
 
@@ -599,6 +612,15 @@
             searching_person={@searching_person}
             photos_expanded={@photos_expanded}
           />
+
+          <button
+            type="button"
+            phx-click="add-credit"
+            phx-value-section="recording"
+            class="pl-3 text-xs text-zinc-400 underline"
+          >
+            Add a narrator
+          </button>
         </div>
       </section>
 

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -435,5 +435,4 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
   def candidate_origin(%{"source" => "provider:" <> id}), do: id
   def candidate_origin(_candidate), do: nil
-
 end

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -9,10 +9,12 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   use AmbryWeb, :admin_live_view
 
+  import AmbryWeb.Admin.Decisions, only: [level_state_words: 1]
   import AmbryWeb.Admin.PaginationHelpers
   import AmbryWeb.TimeUtils
 
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
   alias Ambry.Inbox.InboxItem
   alias Ambry.Library.Source
 
@@ -381,7 +383,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   Both are shown even when one is missing: knowing that nothing matched at
   the recording level is itself the useful thing.
   """
-  def match_summary(%InboxItem{matches: matches}) when is_map(matches) do
+  def match_summary(%InboxItem{matches: matches} = item) when is_map(matches) do
     Enum.map(["work", "recording"], fn level ->
       # `|| []` on both lines: a level present without candidates used to
       # crash `List.first/1` here, taking the whole page down over one
@@ -392,13 +394,33 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
         level: level,
         best: List.first(candidates),
         alternatives: max(length(candidates) - 1, 0),
-        confidence: get_in(matches, [level, "confidence"]) || 0.0,
+        state: level_state(item, level),
+        confidence: get_in(matches, [level, "confidence"]),
         query: get_in(matches, [level, "query"])
       }
     end)
   end
 
   def match_summary(_item), do: []
+
+  # The draft is the live truth: its state moves when the operator decides,
+  # where `matches[level]["confidence"]` was frozen at match time — so the
+  # queue used to keep calling an item "unsure" after a human had settled it,
+  # and could disagree with the form after a background re-match. The
+  # fallback covers the moment between matching and the draft existing.
+  defp level_state(%InboxItem{draft: %Draft{work: %{} = work}}, "work"),
+    do: Draft.level_state(work)
+
+  defp level_state(%InboxItem{draft: %Draft{recording: %{} = recording}}, "recording"),
+    do: Draft.level_state(recording)
+
+  defp level_state(%InboxItem{matches: matches}, level) do
+    case get_in(matches, [level, "confidence"]) || 0.0 do
+      sure when sure >= 0.6 -> :trusted
+      some when some > 0.0 -> :unsure
+      _nothing -> :no_match
+    end
+  end
 
   def candidate_label(nil), do: "no match"
 
@@ -414,12 +436,4 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   def candidate_origin(%{"source" => "provider:" <> id}), do: id
   def candidate_origin(_candidate), do: nil
 
-  @doc """
-  Confidence as a word. A number invites false precision; what the operator
-  needs is whether this one can be waved through.
-  """
-  def confidence_label(confidence) when confidence >= 0.85, do: {"near-certain", :brand}
-  def confidence_label(confidence) when confidence >= 0.6, do: {"likely", :blue}
-  def confidence_label(confidence) when confidence > 0.0, do: {"unsure", :yellow}
-  def confidence_label(_confidence), do: {"no match", :gray}
 end

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -79,8 +79,12 @@
           >
             <span class="text-xs text-zinc-400">{match.level}</span>
             <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-              <.badge color={elem(confidence_label(match.confidence), 1)} class="text-xs">
-                {elem(confidence_label(match.confidence), 0)}
+              <.badge
+                color={elem(level_state_words(match.state), 1)}
+                class="text-xs"
+                title={match.confidence && "match score #{match.confidence}"}
+              >
+                {elem(level_state_words(match.state), 0)}
               </.badge>
               <%!-- basis-48 + grow keeps the title from being shrunk out of
                     existence (meta wraps down instead); max-w-fit stops the grow

--- a/priv/repo/migrations/20260810201551_add_media_book_id_index.exs
+++ b/priv/repo/migrations/20260810201551_add_media_book_id_index.exs
@@ -1,0 +1,11 @@
+defmodule Ambry.Repo.Migrations.AddMediaBookIdIndex do
+  use Ecto.Migration
+
+  def change do
+    # media has always been joined through book_id (flat views, editions,
+    # imported-file lookups) but never had an index on it; the planner priced
+    # those lookups as full scans, which pushed the universes_flat estimate
+    # past Postgres's JIT thresholds.
+    create index(:media, [:book_id])
+  end
+end

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1356,6 +1356,93 @@ defmodule Ambry.Inbox.DraftTest do
     end
   end
 
+  # Proposals must always be recoverable: the scalar fields keep theirs as
+  # candidates, but a credit's or series' name was a plain string — cleared
+  # once, the provider's spelling was gone with nothing on screen holding it.
+  describe "the evidence's spelling stays reachable" do
+    test "a renamed series can be reset to what the records proposed" do
+      item = series_item()
+
+      draft =
+        item.draft
+        |> Draft.Edit.rename_series(0, "The Expans")
+        |> Draft.Edit.reset_series_name(0)
+
+      assert [%{name: "The Expanse", curated: true}] = draft.work.series
+    end
+
+    test "a renamed credit can be reset, and its tracking person follows" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        item.draft
+        |> Draft.Edit.rename_credit(:work, 0, "")
+        |> Draft.Edit.reset_credit_name(:work, 0)
+
+      assert [%{name: "James S.A. Corey", proposed_name: "James S.A. Corey"}] =
+               draft.work.authors
+
+      assert [person] = draft.people
+      assert Field.value(person.name) == "James S.A. Corey"
+    end
+
+    test "a manually edited scalar keeps collecting fresh candidates" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      # type over the title — the field is the operator's now
+      edited = update_in(item.draft.work.title, &Field.edit(&1, "My Own Title")).draft
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(edited))
+
+      reseeded = Draft.Edit.resettle(item.draft, item)
+
+      # the value is pinned, but the evidence still flows: the proposal
+      # remains on offer as a chip instead of being frozen out forever
+      assert Field.value(reseeded.work.title) == "My Own Title"
+      assert Enum.any?(reseeded.work.title.candidates, &(&1.value == "Leviathan Wakes"))
+    end
+  end
+
+  describe "rows the sources didn't propose" do
+    test "an added author mints its person once it is named" do
+      item = item(%{matches: matches([]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      assert item.draft.work.authors == []
+
+      draft = Draft.Edit.add_credit(item.draft, :work)
+
+      assert [%{name: "", curated: true, approved: false, person_keys: []}] =
+               draft.work.authors
+
+      draft =
+        draft
+        |> Draft.Edit.rename_credit(:work, 0, "Martha Wells")
+        |> Draft.Edit.sync_people(item)
+
+      assert [%{name: "Martha Wells", person_keys: [key]}] = draft.work.authors
+      assert [%{key: ^key} = person] = draft.people
+      assert Field.value(person.name) == "Martha Wells"
+    end
+
+    test "an added series survives reseeds like any curated row" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        item.draft
+        |> Draft.Edit.add_series()
+        |> Draft.Edit.rename_series(0, "The Murderbot Diaries")
+        |> Draft.Edit.set_series_number(0, "1")
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      reseeded = Draft.Edit.resettle(item.draft, item)
+
+      assert Enum.any?(reseeded.work.series, &(&1.name == "The Murderbot Diaries"))
+    end
+  end
+
   # The reported flow: the operator reveals a pen name, renames the person
   # behind it (which marks them curated), and clicks "look again". The results
   # land in `matches` — and a reseed that skipped curated people wholesale

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1208,6 +1208,75 @@ defmodule Ambry.Inbox.DraftTest do
     end
   end
 
+  # `Draft.curated?/1` decides whether a re-match rebuilds the draft or
+  # re-derives around the operator. It only looked at fields, credits, series
+  # and people — so a draft whose only human input was ticking records or
+  # answering the identity question was rebuilt wholesale, discarding exactly
+  # the decisions the tick and the answer were.
+  describe "ticking records and answering identity count as curation" do
+    test "a freshly seeded draft is not curated" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      refute Draft.curated?(item.draft)
+    end
+
+    test "ticking a work record marks the draft curated" do
+      record = provider_candidate(%{"score" => 0.5})
+      item = item(%{matches: matches([record], confidence: 0.3), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      refute Draft.curated?(item.draft)
+
+      draft = Draft.Edit.toggle_source(item.draft, item, :work, record)
+
+      assert Draft.curated?(draft)
+    end
+
+    test "ticking a recording record marks the draft curated" do
+      record = recording_record(%{"score" => 0.5})
+
+      item =
+        item(%{
+          matches: matches([], recording: [record], recording_confidence: 0.3),
+          tags: %{}
+        })
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      refute Draft.curated?(item.draft)
+
+      draft = Draft.Edit.toggle_source(item.draft, item, :recording, record)
+
+      assert Draft.curated?(draft)
+    end
+
+    test "answering the identity question marks the draft curated" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      refute Draft.curated?(item.draft)
+
+      assert Draft.curated?(Draft.Edit.new_book(item.draft, item))
+    end
+
+    test "settling the recording as uncatalogued marks the draft curated" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      refute Draft.curated?(item.draft)
+
+      assert Draft.curated?(Draft.Edit.uncatalogued(item.draft, item))
+    end
+
+    test "the tick survives the reseed it triggers" do
+      record = provider_candidate(%{"score" => 0.5})
+      item = item(%{matches: matches([record], confidence: 0.3), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.toggle_source(item.draft, item, :work, record)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      assert Draft.curated?(Draft.Edit.resettle(item.draft, item))
+    end
+  end
+
   # The reported flow: the operator reveals a pen name, renames the person
   # behind it (which marks them curated), and clicks "look again". The results
   # land in `matches` — and a reseed that skipped curated people wholesale

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1265,6 +1265,26 @@ defmodule Ambry.Inbox.DraftTest do
       assert Draft.curated?(Draft.Edit.uncatalogued(item.draft, item))
     end
 
+    test "the badge state follows decisions, not match history" do
+      record = provider_candidate(%{"score" => 0.5})
+      item = item(%{matches: matches([record], confidence: 0.3), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert Draft.level_state(item.draft.work) == :unsure
+      assert Draft.level_state(item.draft.recording) == :no_match
+
+      # ticking the doubted record is "yes, you were right"
+      draft = Draft.Edit.toggle_source(item.draft, item, :work, record)
+      assert Draft.level_state(draft.work) == :confirmed
+    end
+
+    test "a believed match reads trusted until a human touches it" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert Draft.level_state(item.draft.work) == :trusted
+    end
+
     test "the tick survives the reseed it triggers" do
       record = provider_candidate(%{"score" => 0.5})
       item = item(%{matches: matches([record], confidence: 0.3), tags: %{}})

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1285,6 +1285,20 @@ defmodule Ambry.Inbox.DraftTest do
       assert Draft.level_state(item.draft.work) == :trusted
     end
 
+    # Clicking the already-ticked record UNTICKS it, so "yes, you were right"
+    # used to cost an untick and a re-tick with a reseed churning each way.
+    test "confirm approves the machine's ticks without moving them" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      ticked = item.draft.work.sources
+
+      draft = Draft.Edit.confirm_level(item.draft, :work)
+
+      assert Draft.level_state(draft.work) == :confirmed
+      assert draft.work.sources == ticked
+      assert Draft.curated?(draft)
+    end
+
     test "the tick survives the reseed it triggers" do
       record = provider_candidate(%{"score" => 0.5})
       item = item(%{matches: matches([record], confidence: 0.3), tags: %{}})
@@ -1443,6 +1457,30 @@ defmodule Ambry.Inbox.DraftTest do
       assert [%{name: "Martha Wells", person_keys: [key]}] = draft.work.authors
       assert [%{key: ^key} = person] = draft.people
       assert Field.value(person.name) == "Martha Wells"
+    end
+
+    test "a manually added row really deletes — nothing proposed it" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        item.draft
+        |> Draft.Edit.add_series()
+        |> Draft.Edit.rename_series(0, "Not A Real Series")
+        |> Draft.Edit.remove_series(0)
+
+      assert draft.work.series == []
+
+      draft =
+        draft
+        |> Draft.Edit.add_credit(:work)
+        |> Draft.Edit.rename_credit(:work, 1, "Nobody Real")
+        |> Draft.Edit.sync_people(item)
+        |> Draft.Edit.remove_credit(item, :work, 1)
+
+      # gone entirely, and the person it minted goes with it
+      assert [%{source: "provider:hardcover"}] = draft.work.authors
+      refute Enum.any?(draft.people, &(Field.value(&1.name) == "Nobody Real"))
     end
 
     test "an added series survives reseeds like any curated row" do

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1277,6 +1277,85 @@ defmodule Ambry.Inbox.DraftTest do
     end
   end
 
+  # Removal used to be a bare List.delete_at — the one edit that didn't
+  # stick (keep_curated re-appended the fresh proposal on the next reseed)
+  # and the one with no way back. It is a tombstone now.
+  describe "removing a row is a decision" do
+    defp series_item do
+      candidates = [
+        provider_candidate(%{
+          "series" => [%{"name" => "The Expanse", "number" => "1"}]
+        })
+      ]
+
+      item = item(%{matches: matches(candidates), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+      item
+    end
+
+    test "a removed series does not resurrect on reseed" do
+      item = series_item()
+      assert [%{name: "The Expanse"}] = item.draft.work.series
+
+      draft = Draft.Edit.remove_series(item.draft, 0)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      reseeded = Draft.Edit.resettle(item.draft, item)
+
+      assert [%{name: "The Expanse", removed: true}] = reseeded.work.series
+    end
+
+    test "a removed series stops blocking the import" do
+      item = series_item()
+
+      draft = Draft.Edit.remove_series(item.draft, 0)
+
+      refute Enum.any?(Draft.unresolved(draft), &(&1.label =~ "Series"))
+    end
+
+    test "restore brings the series back exactly as it was" do
+      item = series_item()
+
+      draft =
+        item.draft
+        |> Draft.Edit.remove_series(0)
+        |> Draft.Edit.restore_series(0)
+
+      assert [%{name: "The Expanse", number: "1", removed: false}] = draft.work.series
+    end
+
+    test "a removed credit drops its person and restore re-mints them" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert [%{name: "James S.A. Corey"}] = item.draft.work.authors
+      assert [_person] = item.draft.people
+
+      removed = Draft.Edit.remove_credit(item.draft, item, :work, 0)
+
+      # the person only this credit referenced is nobody's decision now —
+      # it used to linger and block the import invisibly
+      assert removed.people == []
+      refute Enum.any?(Draft.unresolved(removed), &(&1.label =~ "Person"))
+
+      restored = Draft.Edit.restore_credit(removed, item, :work, 0)
+
+      assert [%{name: "James S.A. Corey", removed: false}] = restored.work.authors
+      assert [_person] = restored.people
+    end
+
+    test "a removed credit never reaches approval params" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft = Draft.Edit.remove_credit(item.draft, item, :work, 0)
+
+      # approve-all must not quietly re-arm the tombstone
+      approved = Draft.Edit.approve_all(draft)
+      assert [%{removed: true}] = approved.work.authors
+    end
+  end
+
   # The reported flow: the operator reveals a pen name, renames the person
   # behind it (which marks them curated), and clicks "look again". The results
   # land in `matches` — and a reseed that skipped curated people wholesale

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -315,10 +315,68 @@ defmodule Ambry.Inbox.ImporterTest do
     end
   end
 
+  describe "multi-part recordings" do
+    # GraphicAudio's shape: one book, one recording, "Part 1 of 2" and
+    # "Part 2 of 2" — each part a normal single-file media, tied together by
+    # a recording group. The whole rendering/sync model shipped with the
+    # Edition work; import was the missing piece.
+    test "a declared parts item imports as one recording group" do
+      item = parts_item()
+
+      assert {:ok, media} = Inbox.import_item(item)
+
+      assert [part1, part2] =
+               Repo.all(from(m in Media.Media, order_by: m.part_number))
+
+      assert part1.part_number == 1
+      assert part2.part_number == 2
+      assert part1.parts_total == 2
+      assert part1.recording_group_id
+      assert part1.recording_group_id == part2.recording_group_id
+
+      # the item records the representative: the first part
+      assert media.id == part1.id
+      item = Inbox.get_item!(item.id)
+      assert item.status == :imported
+      assert item.media_id == part1.id
+
+      # one book, one author graph — only the recording looped
+      assert Repo.aggregate(Book, :count) == 1
+
+      # each part is independently playable: its own track, its own file
+      assert [%{path: file1}] = Media.get_media!(part1.id).media_tracks
+      assert [%{path: file2}] = Media.get_media!(part2.id).media_tracks
+      assert file1 != file2
+
+      # and claims only its own file
+      assert part1.source_files == [file1]
+      assert part2.source_files == [file2]
+    end
+
+    test "the declaration survives a re-probe instead of re-raising the issue" do
+      item = parts_item()
+      assert item.issue == nil
+
+      {:ok, item} = Inbox.probe_item(item)
+
+      assert item.issue == nil
+    end
+
+    test "undeclaring puts the multi-file question back" do
+      item = parts_item()
+
+      {:ok, item} = Inbox.mark_multi_part(item, false)
+
+      assert item.issue =~ "2 audio files"
+      assert {:error, :multi_file_unsupported} = Inbox.import_item(item)
+    end
+  end
+
   describe "approve/1 refusals" do
     test "refuses a multi-file release rather than importing half of it" do
-      # Checked before the draft: no amount of curation makes a multi-file
-      # release importable, so the operator must not be sent to the form.
+      # Checked before the draft: an *undeclared* multi-file release is not
+      # importable by curation alone — the operator has to say what the files
+      # are (one recording in parts, or separate recordings to split) first.
       item = tagged_item(files: ["01.mp3", "02.mp3"], settle: false)
 
       assert {:error, :multi_file_unsupported} = Inbox.import_item(item)
@@ -383,6 +441,24 @@ defmodule Ambry.Inbox.ImporterTest do
       assert Repo.aggregate(Book, :count) == 0
       assert Inbox.get_item!(item.id).status == :pending
     end
+  end
+
+  # A two-part release, discovered, settled, and declared one recording in
+  # parts — the state the form leaves the GraphicAudio case in.
+  defp parts_item do
+    root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
+    release = Path.join(root, "The Way of Kings [GraphicAudio]")
+    File.mkdir_p!(release)
+    fixture = tagged_fixture(true, nil)
+    File.cp!(fixture, Path.join(release, "Part 1 of 2.m4b"))
+    File.cp!(fixture, Path.join(release, "Part 2 of 2.m4b"))
+
+    {:ok, _counts} = Inbox.discover(root)
+    {[item], false} = Inbox.list_items(filter: "GraphicAudio")
+    {:ok, item} = Inbox.probe_item(item)
+    item = settle(item)
+    {:ok, item} = Inbox.mark_multi_part(item, true)
+    item
   end
 
   # A real tagged file discovered the way discovery would find it.

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -315,68 +315,48 @@ defmodule Ambry.Inbox.ImporterTest do
     end
   end
 
-  describe "multi-part recordings" do
-    # GraphicAudio's shape: one book, one recording, "Part 1 of 2" and
-    # "Part 2 of 2" — each part a normal single-file media, tied together by
-    # a recording group. The whole rendering/sync model shipped with the
-    # Edition work; import was the missing piece.
-    test "a declared parts item imports as one recording group" do
-      item = parts_item()
+  describe "part-of-a-set numbers" do
+    # A part-release (GraphicAudio's "Part 1 of 2") is an ordinary separate
+    # recording — its own cover, date, narrators, sometimes sold separately —
+    # that happens to carry the optional part label. The operator types the
+    # numbers; nothing proposes them, and grouping the parts into one set
+    # stays on the media form.
+    test "typed part numbers reach the imported media" do
+      item = tagged_item()
+
+      draft = %{
+        item.draft
+        | recording: %{item.draft.recording | part_number: 1, parts_total: 2}
+      }
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
 
       assert {:ok, media} = Inbox.import_item(item)
 
-      assert [part1, part2] =
-               Repo.all(from(m in Media.Media, order_by: m.part_number))
-
-      assert part1.part_number == 1
-      assert part2.part_number == 2
-      assert part1.parts_total == 2
-      assert part1.recording_group_id
-      assert part1.recording_group_id == part2.recording_group_id
-
-      # the item records the representative: the first part
-      assert media.id == part1.id
-      item = Inbox.get_item!(item.id)
-      assert item.status == :imported
-      assert item.media_id == part1.id
-
-      # one book, one author graph — only the recording looped
-      assert Repo.aggregate(Book, :count) == 1
-
-      # each part is independently playable: its own track, its own file
-      assert [%{path: file1}] = Media.get_media!(part1.id).media_tracks
-      assert [%{path: file2}] = Media.get_media!(part2.id).media_tracks
-      assert file1 != file2
-
-      # and claims only its own file
-      assert part1.source_files == [file1]
-      assert part2.source_files == [file2]
+      media = Media.get_media!(media.id)
+      assert media.part_number == 1
+      assert media.parts_total == 2
+      # no group is invented — tying the set together is the media form's job
+      assert media.recording_group_id == nil
     end
 
-    test "the declaration survives a re-probe instead of re-raising the issue" do
-      item = parts_item()
-      assert item.issue == nil
+    test "the numbers count as curation, so a re-match can't discard them" do
+      item = tagged_item(settle: false)
+      {:ok, item} = Inbox.prepare_draft(item)
 
-      {:ok, item} = Inbox.probe_item(item)
+      draft = %{
+        item.draft
+        | recording: %{item.draft.recording | part_number: 1, parts_total: 2}
+      }
 
-      assert item.issue == nil
-    end
-
-    test "undeclaring puts the multi-file question back" do
-      item = parts_item()
-
-      {:ok, item} = Inbox.mark_multi_part(item, false)
-
-      assert item.issue =~ "2 audio files"
-      assert {:error, :multi_file_unsupported} = Inbox.import_item(item)
+      assert Draft.curated?(draft)
     end
   end
 
   describe "approve/1 refusals" do
     test "refuses a multi-file release rather than importing half of it" do
-      # Checked before the draft: an *undeclared* multi-file release is not
-      # importable by curation alone — the operator has to say what the files
-      # are (one recording in parts, or separate recordings to split) first.
+      # Checked before the draft: no amount of curation makes a multi-file
+      # release importable — the operator splits it into one item per file.
       item = tagged_item(files: ["01.mp3", "02.mp3"], settle: false)
 
       assert {:error, :multi_file_unsupported} = Inbox.import_item(item)
@@ -441,24 +421,6 @@ defmodule Ambry.Inbox.ImporterTest do
       assert Repo.aggregate(Book, :count) == 0
       assert Inbox.get_item!(item.id).status == :pending
     end
-  end
-
-  # A two-part release, discovered, settled, and declared one recording in
-  # parts — the state the form leaves the GraphicAudio case in.
-  defp parts_item do
-    root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
-    release = Path.join(root, "The Way of Kings [GraphicAudio]")
-    File.mkdir_p!(release)
-    fixture = tagged_fixture(true, nil)
-    File.cp!(fixture, Path.join(release, "Part 1 of 2.m4b"))
-    File.cp!(fixture, Path.join(release, "Part 2 of 2.m4b"))
-
-    {:ok, _counts} = Inbox.discover(root)
-    {[item], false} = Inbox.list_items(filter: "GraphicAudio")
-    {:ok, item} = Inbox.probe_item(item)
-    item = settle(item)
-    {:ok, item} = Inbox.mark_multi_part(item, true)
-    item
   end
 
   # A real tagged file discovered the way discovery would find it.

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -102,16 +102,17 @@ defmodule Ambry.Inbox.ManagedImportTest do
     end
   end
 
-  describe "multi-part placement" do
-    test "parts land in one book folder with distinct filenames" do
-      %{item: item, root: root} = parts_downloads_item()
-
-      assert {:ok, _media} = Inbox.import_item(item)
+  describe "part-of-a-set placement" do
+    # Two parts of one set are two ordinary separate imports that land in the
+    # same book folder — the part suffix is what keeps the second placement
+    # from colliding with the first.
+    test "two part imports share the folder with distinct filenames" do
+      %{media1: media1, media2: media2, root: root} = two_part_imports()
 
       folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
 
-      assert [placed1] = part(1).source_files
-      assert [placed2] = part(2).source_files
+      assert [placed1] = Media.get_media!(media1.id).source_files
+      assert [placed2] = Media.get_media!(media2.id).source_files
       assert placed1 == Path.join(folder, "The Way of Kings - Part 1 of 2.m4b")
       assert placed2 == Path.join(folder, "The Way of Kings - Part 2 of 2.m4b")
       assert File.exists?(placed1)
@@ -121,33 +122,30 @@ defmodule Ambry.Inbox.ManagedImportTest do
     # The deletion worker rm_rfs a managed media's source folder. Parts share
     # theirs, so deleting part 1 that way would take part 2's file with it.
     test "deleting one part leaves its sibling's file alone" do
-      %{item: item} = parts_downloads_item()
-      {:ok, _media} = Inbox.import_item(item)
+      %{media1: media1, media2: media2} = two_part_imports()
 
-      part1 = part(1)
-      [placed2] = part(2).source_files
+      [placed1] = Media.get_media!(media1.id).source_files
+      [placed2] = Media.get_media!(media2.id).source_files
 
-      assert {:ok, _deleted} = Media.delete_media(Media.get_media!(part1.id))
+      assert {:ok, _deleted} = Media.delete_media(Media.get_media!(media1.id))
       # file deletion happens in a background job on the default queue
       assert %{success: _some, failure: 0} = Oban.drain_queue(queue: :default)
 
-      refute File.exists?(hd(part1.source_files))
+      refute File.exists?(placed1)
       assert File.exists?(placed2)
     end
 
-    defp part(number) do
-      Repo.one!(from(m in Media.Media, where: m.part_number == ^number))
-    end
-
-    defp parts_downloads_item do
+    defp two_part_imports do
       root = new_dir("root")
       insert(:root, path: root, name: "Library")
 
       downloads = new_dir("downloads")
-      release = Path.join(downloads, "The Way of Kings [GraphicAudio]")
-      File.mkdir_p!(release)
-      File.cp!(tagged_audio(), Path.join(release, "Part 1 of 2.m4b"))
-      File.cp!(tagged_audio(), Path.join(release, "Part 2 of 2.m4b"))
+
+      for n <- 1..2 do
+        release = Path.join(downloads, "The Way of Kings Part #{n}")
+        File.mkdir_p!(release)
+        File.cp!(tagged_audio(), Path.join(release, "book.m4b"))
+      end
 
       watched =
         insert(:source,
@@ -158,12 +156,45 @@ defmodule Ambry.Inbox.ManagedImportTest do
         )
 
       {:ok, _counts} = Inbox.discover(watched)
-      {[item], false} = Inbox.list_items()
-      {:ok, item} = Inbox.probe_item(item)
-      item = settle(item)
-      {:ok, item} = Inbox.mark_multi_part(item, true)
+      {items, false} = Inbox.list_items()
+      [first, second] = Enum.sort_by(items, & &1.path)
 
-      %{item: item, root: root}
+      {:ok, first} = Inbox.probe_item(first)
+      first = first |> settle() |> with_parts(1, 2)
+      {:ok, media1} = Inbox.import_item(first)
+
+      # the second part is the same book — a strong local hit links it the
+      # way matching would once the library holds part 1
+      {:ok, second} = Inbox.probe_item(second)
+      book_id = Media.get_media!(media1.id).book_id
+
+      {:ok, second} =
+        Inbox.update_item(second, %{
+          matches: %{
+            "work" => %{
+              "candidates" => [],
+              "local" => [%{"id" => book_id, "score" => 1.0}],
+              "confidence" => 1.0
+            },
+            "recording" => %{"candidates" => []},
+            "people" => %{}
+          }
+        })
+
+      second = second |> settle() |> with_parts(2, 2)
+      {:ok, media2} = Inbox.import_item(second)
+
+      %{media1: media1, media2: media2, root: root}
+    end
+
+    defp with_parts(item, number, total) do
+      draft = %{
+        item.draft
+        | recording: %{item.draft.recording | part_number: number, parts_total: total}
+      }
+
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+      item
     end
   end
 

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -102,6 +102,71 @@ defmodule Ambry.Inbox.ManagedImportTest do
     end
   end
 
+  describe "multi-part placement" do
+    test "parts land in one book folder with distinct filenames" do
+      %{item: item, root: root} = parts_downloads_item()
+
+      assert {:ok, _media} = Inbox.import_item(item)
+
+      folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
+
+      assert [placed1] = part(1).source_files
+      assert [placed2] = part(2).source_files
+      assert placed1 == Path.join(folder, "The Way of Kings - Part 1 of 2.m4b")
+      assert placed2 == Path.join(folder, "The Way of Kings - Part 2 of 2.m4b")
+      assert File.exists?(placed1)
+      assert File.exists?(placed2)
+    end
+
+    # The deletion worker rm_rfs a managed media's source folder. Parts share
+    # theirs, so deleting part 1 that way would take part 2's file with it.
+    test "deleting one part leaves its sibling's file alone" do
+      %{item: item} = parts_downloads_item()
+      {:ok, _media} = Inbox.import_item(item)
+
+      part1 = part(1)
+      [placed2] = part(2).source_files
+
+      assert {:ok, _deleted} = Media.delete_media(Media.get_media!(part1.id))
+      # file deletion happens in a background job on the default queue
+      assert %{success: _some, failure: 0} = Oban.drain_queue(queue: :default)
+
+      refute File.exists?(hd(part1.source_files))
+      assert File.exists?(placed2)
+    end
+
+    defp part(number) do
+      Repo.one!(from(m in Media.Media, where: m.part_number == ^number))
+    end
+
+    defp parts_downloads_item do
+      root = new_dir("root")
+      insert(:root, path: root, name: "Library")
+
+      downloads = new_dir("downloads")
+      release = Path.join(downloads, "The Way of Kings [GraphicAudio]")
+      File.mkdir_p!(release)
+      File.cp!(tagged_audio(), Path.join(release, "Part 1 of 2.m4b"))
+      File.cp!(tagged_audio(), Path.join(release, "Part 2 of 2.m4b"))
+
+      watched =
+        insert(:source,
+          on_import: :bring_in,
+          import_policy: :copy,
+          path: downloads,
+          name: "Downloads #{Ecto.UUID.generate()}"
+        )
+
+      {:ok, _counts} = Inbox.discover(watched)
+      {[item], false} = Inbox.list_items()
+      {:ok, item} = Inbox.probe_item(item)
+      item = settle(item)
+      {:ok, item} = Inbox.mark_multi_part(item, true)
+
+      %{item: item, root: root}
+    end
+  end
+
   describe "refusals" do
     # Silently copying instead is the storage doubling this entire phase
     # exists to eliminate, and the operator would never know it happened.

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -400,6 +400,75 @@ defmodule Ambry.InboxTest do
     end
   end
 
+  # The grouping heuristic's known failure: two unrelated single-file books
+  # sharing a folder become one 2-file item, which multi-file support being
+  # deferred makes unimportable. Split is the operator's correction, and it
+  # has to survive the hourly rescan or it silently un-happens.
+  describe "split_item/1" do
+    test "splits a folder of separate books into one item per file" do
+      root = watched_root()
+      release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
+      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      {[item], false} = Inbox.list_items()
+
+      assert {:ok, children} = Inbox.split_item(item)
+
+      assert Enum.sort(Enum.map(children, & &1.path)) ==
+               Enum.sort([Path.join(release, "one.m4b"), Path.join(release, "two.m4b")])
+
+      assert Enum.all?(children, &(&1.files == [&1.path]))
+      refute Repo.get(InboxItem, item.id)
+
+      # each child probes (and then matches) fresh — the parent's probe and
+      # tags described its first file only
+      for child <- children do
+        assert_enqueued(worker: Ambry.Inbox.RunProbe, args: %{inbox_item_id: child.id})
+      end
+    end
+
+    test "a rescan respects the split instead of re-merging the folder" do
+      root = watched_root()
+      release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], false} = Inbox.list_items()
+      {:ok, _children} = Inbox.split_item(item)
+
+      assert {:ok, %{created: 0}} = Inbox.discover(root)
+
+      {items, false} = Inbox.list_items()
+      assert length(items) == 2
+      assert Enum.all?(items, &(length(&1.files) == 1))
+    end
+
+    test "a file that appears in a split folder becomes its own item" do
+      root = watched_root()
+      release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], false} = Inbox.list_items()
+      {:ok, _children} = Inbox.split_item(item)
+
+      copy_audio(release, "three.m4b")
+
+      assert {:ok, %{created: 1}} = Inbox.discover(root)
+
+      {items, false} = Inbox.list_items()
+      assert length(items) == 3
+      assert Enum.any?(items, &(&1.path == Path.join(release, "three.m4b")))
+    end
+
+    test "refuses an imported item and a single-file item" do
+      imported = raw_item(%{path: "/two", files: ["/a.m4b", "/b.m4b"], status: :imported})
+      assert {:error, :already_imported} = Inbox.split_item(imported)
+
+      single = raw_item(%{path: "/only.m4b", files: ["/only.m4b"]})
+      assert {:error, :not_multi_file} = Inbox.split_item(single)
+    end
+  end
+
+  defp raw_item(attrs) do
+    %InboxItem{} |> InboxItem.changeset(attrs) |> Repo.insert!()
+  end
+
   # Nothing in the inbox may modify what it finds, so every test works
   # against a real throwaway tree of real audio files.
   defp watched_root do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -906,6 +906,34 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "splitting a mis-grouped item" do
+    # The folder heuristic's known failure: two separate single-file books in
+    # one folder become one 2-file item. The correction has to be reachable
+    # from the form's default state.
+    test "the split button breaks the item into one per file", %{conn: conn} do
+      root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
+      release = Path.join(root, "Two Novellas")
+      File.mkdir_p!(release)
+      File.cp!(tagged_fixture(true, false, nil), Path.join(release, "one.m4b"))
+      File.cp!(tagged_fixture(true, false, nil), Path.join(release, "two.m4b"))
+
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], _more} = Inbox.list_items(filter: "Two Novellas")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      assert html =~ "split into 2 items"
+
+      view |> element("button[data-role='split']") |> render_click()
+      assert_redirect(view, ~p"/admin/inbox")
+
+      {items, _more} = Inbox.list_items(filter: "Two Novellas")
+      assert length(items) == 2
+      assert Enum.all?(items, &(length(&1.files) == 1))
+    end
+  end
+
   describe "destination" do
     test "says where the file is going before anything is committed", %{conn: conn} do
       item = probed_item() |> settle()

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -906,37 +906,26 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
-  describe "declaring a multi-part recording" do
-    # The other answer to the multi-file question (split being the first),
-    # reachable from the form's default state.
-    test "the toggle clears the question and puts it back", %{conn: conn} do
-      root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
-      release = Path.join(root, "Two Part Set")
-      File.mkdir_p!(release)
-      File.cp!(tagged_fixture(true, false, nil), Path.join(release, "Part 1 of 2.m4b"))
-      File.cp!(tagged_fixture(true, false, nil), Path.join(release, "Part 2 of 2.m4b"))
-
-      {:ok, _counts} = Inbox.discover(root)
-      {[item], _more} = Inbox.list_items(filter: "Two Part Set")
-      {:ok, item} = Inbox.probe_item(item)
-      Repo.delete_all(Oban.Job)
+  describe "part-of-a-set numbers" do
+    # Plain optional inputs, reachable from the default state — nothing
+    # proposes these, the operator just knows.
+    test "typing the numbers saves them to the draft", %{conn: conn} do
+      item = probed_item()
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
-      assert html =~ "One recording in 2 parts"
-      assert html =~ "2 audio files"
+      assert html =~ "Part of a set"
 
-      html = view |> element("button[data-role='multi-part']") |> render_click()
-
-      item = Inbox.get_item!(item.id)
-      assert item.draft.recording.multi_part
-      assert item.issue == nil
-      refute html =~ "2 audio files"
-
-      view |> element("button[data-role='multi-part']") |> render_click()
+      view
+      |> form("#recording-form", %{
+        "inbox_item" => %{
+          "draft" => %{"recording" => %{"part_number" => "1", "parts_total" => "2"}}
+        }
+      })
+      |> render_change()
 
       item = Inbox.get_item!(item.id)
-      refute item.draft.recording.multi_part
-      assert item.issue =~ "2 audio files"
+      assert item.draft.recording.part_number == 1
+      assert item.draft.recording.parts_total == 2
     end
   end
 
@@ -957,7 +946,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       Repo.delete_all(Oban.Job)
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
-      assert html =~ "split into 2 items"
+      assert html =~ "Split into 2 items"
 
       view |> element("button[data-role='split']") |> render_click()
       assert_redirect(view, ~p"/admin/inbox")

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -183,15 +183,28 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
-      before = length(Inbox.get_item!(item.id).draft.recording.narrators)
 
-      view
-      |> element(
-        "button[phx-click='remove-credit'][phx-value-section='recording'][phx-value-index='0']"
-      )
-      |> render_click()
+      html =
+        view
+        |> element(
+          "button[phx-click='remove-credit'][phx-value-section='recording'][phx-value-index='0']"
+        )
+        |> render_click()
 
-      assert length(Inbox.get_item!(item.id).draft.recording.narrators) == before - 1
+      # a tombstone, not a deletion: the row stays, out of the decision
+      # queue, rendered as a ghost the operator can take back
+      assert [%{removed: true} | _rest] = Inbox.get_item!(item.id).draft.recording.narrators
+      assert html =~ "data-role=\"removed-credit\""
+
+      html =
+        view
+        |> element(
+          "button[phx-click='restore-credit'][phx-value-section='recording'][phx-value-index='0']"
+        )
+        |> render_click()
+
+      assert [%{removed: false} | _rest] = Inbox.get_item!(item.id).draft.recording.narrators
+      refute html =~ "data-role=\"removed-credit\""
     end
   end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -906,6 +906,40 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "declaring a multi-part recording" do
+    # The other answer to the multi-file question (split being the first),
+    # reachable from the form's default state.
+    test "the toggle clears the question and puts it back", %{conn: conn} do
+      root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
+      release = Path.join(root, "Two Part Set")
+      File.mkdir_p!(release)
+      File.cp!(tagged_fixture(true, false, nil), Path.join(release, "Part 1 of 2.m4b"))
+      File.cp!(tagged_fixture(true, false, nil), Path.join(release, "Part 2 of 2.m4b"))
+
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], _more} = Inbox.list_items(filter: "Two Part Set")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      assert html =~ "One recording in 2 parts"
+      assert html =~ "2 audio files"
+
+      html = view |> element("button[data-role='multi-part']") |> render_click()
+
+      item = Inbox.get_item!(item.id)
+      assert item.draft.recording.multi_part
+      assert item.issue == nil
+      refute html =~ "2 audio files"
+
+      view |> element("button[data-role='multi-part']") |> render_click()
+
+      item = Inbox.get_item!(item.id)
+      refute item.draft.recording.multi_part
+      assert item.issue =~ "2 audio files"
+    end
+  end
+
   describe "splitting a mis-grouped item" do
     # The folder heuristic's known failure: two separate single-file books in
     # one folder become one 2-file item. The correction has to be reachable

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -241,7 +241,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
     {:ok, view, html} = live(conn, ~p"/admin/inbox")
 
-    assert html =~ "one recording in parts, or separate recordings"
+    assert html =~ "split this into one item per file"
     refute has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
     assert Inbox.get_item!(item.id).status == :pending
   end

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -62,12 +62,50 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
     {:ok, _view, html} = live(conn, ~p"/admin/inbox")
 
-    assert html =~ "near-certain"
+    # no draft yet, so the badge falls back to the match-time confidence
+    assert html =~ "trusted"
     assert html =~ "The Way of Kings"
     assert html =~ "already in library"
     assert html =~ "+1 other"
     # the recording level says so rather than going silent
     assert html =~ "no match"
+  end
+
+  # The badge is decision state, not match history: confidence was frozen at
+  # match time, so the queue kept calling an item "unsure" after the operator
+  # had answered — and there was no way to tell a correct-but-doubted match
+  # "you were right" except by deciding, which is exactly what now flips it.
+  test "a level the operator settled reads confirmed", %{conn: conn} do
+    record = %{
+      "title" => "The Way of Kings",
+      "authors" => ["Brandon Sanderson"],
+      "source" => "provider:hardcover",
+      "id" => "hc-1",
+      "score" => 0.5
+    }
+
+    item = probed_item()
+
+    {:ok, item} =
+      Inbox.update_item(item, %{
+        matches: %{
+          "work" => %{"confidence" => 0.3, "query" => "q", "candidates" => [record]},
+          "recording" => %{"confidence" => 0.0, "query" => nil, "candidates" => []},
+          "people" => %{}
+        }
+      })
+
+    {:ok, item} = Inbox.prepare_draft(item)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+    assert html =~ "unsure"
+
+    draft = Ambry.Inbox.Draft.Edit.toggle_source(item.draft, item, :work, record)
+    {:ok, _item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+    assert html =~ "confirmed"
+    refute html =~ ">unsure<"
   end
 
   # One button, because the two it replaced were never separable: matching

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -241,7 +241,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
     {:ok, view, html} = live(conn, ~p"/admin/inbox")
 
-    assert html =~ "direct play handles single-file recordings"
+    assert html =~ "one recording in parts, or separate recordings"
     refute has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
     assert Inbox.get_item!(item.id).status == :pending
   end


### PR DESCRIPTION
Four operator observations from live curation, one branch — plus two feedback rounds. Full write-ups in ROADMAP 3e ("The operator's grab bag" and "Parts are ordinary metadata", 2026-08-10).

## 1. Universes admin page was ~40× slower than the other lists
Postgres JIT, not data: `media.book_id` was never indexed, so the planner priced `universes_flat`'s per-book thumbnail lateral as a full media scan, and the 4.68M cost estimate tripped JIT — ~285ms compiling 43 functions to return zero rows, twice per page load. Fixed with the missing `media(book_id)` index and `jit: "off"` on the Repo's connections (every flat view sits near that cost cliff; short OLTP queries never win the JIT trade). Measured: ~300ms → ~15ms with the index alone, sub-ms once JIT-off applies.

## 2. Split, and part-of-a-set metadata
An import is one file, so a multi-file item gets **one judgment-free split button**: "Split into N items — one per file". Each split item is its own import — link them to one book, give them part numbers, whatever the release calls for. Discovery respects the finer partition, so the hourly rescan won't re-merge a split, and a file that later lands in a split folder becomes its own item.

A part-release ("Part 1 of 2", GraphicAudio's shape) is an ordinary separate recording — its own cover, description, date, narrator cast, sometimes sold separately — that carries the optional part label Media has had since the Edition work. The import form now exposes **`part_number`/`parts_total` as plain optional inputs** ("Part of a set"): typed values, deliberately no candidate/matching machinery; typing them counts as curation. Grouping parts into a `RecordingGroup` stays on the media form after import. Two supporting fixes with tests: managed placement suffixes filenames from the part fields (part 2 lands in part 1's book folder and would otherwise collide on an identical path), and deleting a managed media no longer `rm_rf`s a source folder another media claims (deleting part 1 must not take part 2's file).

## 3. Every erased proposal has a way back, every missing row a way in
- Removal is a decision: tombstones (`removed` + `curated`) instead of bare deletes, which both resurrected on the next reseed **and** were unrecoverable. Ghost rows with Restore; excluded from resolution, approve-all, approval params, and person references (fixing an orphaned PersonDecision that could block the import button invisibly). Rows the operator added themselves (`source: "manual"`) really delete — nothing proposed them, so there is nothing to restore.
- `Credit`/`SeriesLink` gain `proposed_name` (frozen at seed) with a "Proposed" restore chip — the name equivalent of a scalar's candidate chips.
- `keep_manual` pins a manually edited field's value but lets fresh candidates keep flowing — curation protects decisions, not evidence.
- "Add an author / narrator / series" buttons; `rename_credit` mints the person on the first real name; `credit-change` syncs people so the minted decision exists before approval reads it.
- Found along the way: `follow_credit_name`'s bare `==` broke person tracking at exactly the clear-to-retype moment (nil vs "").

## 4. Badges show decision state, not frozen match confidence
Confidence was written once at match time and never again — the queue kept calling an item "unsure" after the operator had answered. Both surfaces now wear `Draft.level_state/1`: **confirmed** / **trusted** / **unsure** / **no match**, raw score in the tooltip. A **Confirm** button beside a `trusted` badge makes "yes, you were right" one click (clicking the ticked record would untick it). Underneath, Work and Recording gain `evidence_curated`, which also closes a real `Draft.curated?/1` hole: a draft whose only curation was ticking records or answering the identity question was rebuilt wholesale by the next background re-match.

## Verification
- 1285 tests pass; `mix check` green end to end, dialyzer included. Rebased onto main after the phoenix_live_view CVE bump (#1221), so Check Dependencies passes.
- Dead-rendered the live dev form and queue throughout; the ACOTAR two-part item is left pending on the dev server — the intended flow is now: split it, link both halves to one book, give them part numbers 1/2 and 2/2, import, then group them on the media page.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx