### PR TITLE
The group edit page stops blanking its member typeaheads on every keystroke

### DIFF
--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -53,9 +53,15 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     {:noreply,
      socket
      |> assign_form(changeset)
-     # member options follow the chosen book — the set can only hold its
-     # book's recordings
-     |> assign(media_options: Media.media_for_select(group_params["book_id"]))}
+     # Member options follow the chosen book — the set can only hold its
+     # book's recordings. On the edit page with members the book renders as
+     # static text and posts nothing, so fall back to the group's own book:
+     # without it, any keystroke emptied the options and every member
+     # typeahead displayed blank (label lookup by id found nothing).
+     |> assign(
+       media_options:
+         Media.media_for_select(group_params["book_id"] || socket.assigns.group.book_id)
+     )}
   end
 
   def handle_event("submit", %{"recording_group_form" => group_params}, socket) do

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -87,6 +87,29 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
              |> Floki.attribute("value") == [to_string(media.id)]
     end
 
+    # Regression: validate re-derives member options from the posted book_id,
+    # but the edit page renders the book as static text (posts nothing) — so
+    # any keystroke in any field emptied the options, and every member
+    # typeahead displayed blank (its label lookup by id found nothing).
+    test "editing another field leaves the member typeaheads displaying their picks", %{
+      conn: conn
+    } do
+      book = insert(:book, title: "A Court of Thorns and Roses")
+      group = insert(:recording_group, name: "Graphic Audio", book: book)
+      insert(:media, book: book, part_number: 1, recording_group: group)
+
+      {:ok, view, html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+
+      assert resolver_display(html) == "A Court of Thorns and Roses"
+
+      html =
+        view
+        |> form("#group-form")
+        |> render_change(%{recording_group_form: %{name: "Renamed"}})
+
+      assert resolver_display(html) == "A Court of Thorns and Roses"
+    end
+
     test "saving edits facts and the member list together", %{conn: conn} do
       book = insert(:book)
       group = insert(:recording_group, name: "Before", book: book)
@@ -116,5 +139,13 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       assert dropped.recording_group_id == nil
       assert dropped.part_number == nil
     end
+  end
+
+  defp resolver_display(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(~s{input[name="resolver[recording_group_form_members_0_media_id]"]})
+    |> Floki.attribute("value")
+    |> List.first()
   end
 end


### PR DESCRIPTION
Operator-reported: on /admin/groups/:id/edit, editing any field cleared every recordings typeahead's displayed value. validate re-derives member options from the posted `book_id`, but the edit page renders the book as static text once members exist — nothing posts, options emptied, and the resolvers' label lookups found nothing (the underlying ids were intact; only the display blanked). Fixed by falling back to the group's own book; regression test drives the exact reported flow.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx