### PR TITLE
Ask the file who read it: the provider audit, and matching backwards

### DIFF
--- a/lib/ambry/images.ex
+++ b/lib/ambry/images.ex
@@ -84,9 +84,8 @@ defmodule Ambry.Images do
 
     try do
       with {_output, 0} <- ffmpeg(audio_path, destination, ["-f", "image2"]),
-           {:ok, binary} <- File.read(destination),
-           {:ok, mime} <- sniff(binary) do
-        {:ok, binary, mime}
+           {:ok, binary} <- File.read(destination) do
+        browser_safe(binary)
       else
         _no_image -> {:error, :no_embedded_image}
       end
@@ -95,10 +94,43 @@ defmodule Ambry.Images do
     end
   end
 
-  # The attached picture keeps its original encoding under `-c:v copy`, so the
-  # bytes say what it is and the filename can't.
+  @doc """
+  Image bytes a browser will actually render, and the mime type to serve them
+  under.
+
+  The attached picture keeps its original encoding under `-c:v copy`, so the
+  bytes say what it is and the filename can't. What they say is not
+  necessarily what the *container* says: the operator's Martian declares a PNG
+  stream and carries a big-endian TIFF (`4D 4D 00 2A`), which ffprobe itself
+  complains about ("Invalid PNG signature"). The picture extracted fine,
+  failed the sniff, and the preview 404'd into a broken image sitting next to
+  a chip offering it — for the one decision where seeing the art is the entire
+  point.
+
+  So anything libvips can read becomes a JPEG rather than a 404. Passing
+  unrecognized bytes straight through would only move the broken image: a
+  browser can't show a TIFF either.
+  """
+  def browser_safe(binary) do
+    case sniff(binary) do
+      {:ok, mime} -> {:ok, binary, mime}
+      :error -> transcode(binary)
+    end
+  end
+
+  defp transcode(binary) do
+    with {:ok, image} <- Image.from_binary(binary),
+         {:ok, jpeg} <- Image.write(image, :memory, suffix: ".jpg", quality: 90) do
+      {:ok, jpeg, "image/jpeg"}
+    else
+      _unreadable -> {:error, :no_embedded_image}
+    end
+  end
+
   defp sniff(<<0xFF, 0xD8, _rest::binary>>), do: {:ok, "image/jpeg"}
   defp sniff(<<0x89, "PNG\r\n", 0x1A, "\n", _rest::binary>>), do: {:ok, "image/png"}
+  defp sniff("GIF8" <> _rest), do: {:ok, "image/gif"}
+  defp sniff(<<"RIFF", _size::binary-4, "WEBP", _rest::binary>>), do: {:ok, "image/webp"}
   defp sniff(_other), do: :error
 
   defp ffmpeg(source, destination, extra \\ []) do

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -642,9 +642,32 @@ defmodule Ambry.Inbox.AutoMatch do
       # the operator's library, the two disagree on 105 of 198 releases, and
       # neither is reliably the better one. `title` is what gets searched and
       # scored; this is what gets proposed.
-      release_title: parsed.title
+      release_title: parsed.title,
+      # Everything the item says about itself, **unparsed**. The fields above
+      # are what gets searched; this is what a candidate gets checked back
+      # against, and it exists because parsing is precisely what fails in the
+      # cases that matter. `Weir Andy - The Martian (R.C. Bray) - 2013` names
+      # its narrator in a shape no field captures — `extract_narrator/1` only
+      # knows "(read by X)" — so `narrator` comes out nil, the narrator scorer
+      # no-ops, and Wil Wheaton's edition takes the item at 1.0.
+      raw: raw_text(item)
     }
   end
+
+  # Basenames only: the parent directories are the source root, which is the
+  # operator's filesystem layout and says nothing about this release.
+  defp raw_text(%InboxItem{} = item) do
+    [Path.basename(item.path || "")]
+    |> Enum.concat(Enum.map(item.files || [], &Path.basename/1))
+    |> Enum.concat(tag_text(item.tags))
+    |> Enum.join(" ")
+  end
+
+  defp tag_text(tags) when is_map(tags) do
+    tags |> Map.values() |> List.flatten() |> Enum.filter(&is_binary/1)
+  end
+
+  defp tag_text(_tags), do: []
 
   # Local Books are kept in their own list, not ranked among the provider
   # records. Reusing a Book you already have and importing one you don't are
@@ -752,7 +775,12 @@ defmodule Ambry.Inbox.AutoMatch do
     {candidates, outcomes} = provider_books(:recording, query, hints, opts)
     {editions, edition_outcomes} = editions_for(top_group(work["candidates"]), hints, opts)
 
-    level_result(query, candidates ++ editions, outcomes ++ edition_outcomes, hints.author)
+    level_result(
+      query,
+      candidates |> Kernel.++(editions) |> dedupe_records() |> apply_narrator_evidence(hints),
+      outcomes ++ edition_outcomes,
+      hints.author
+    )
   end
 
   # Structured, not concatenated. Audible's catalog matches `title` against
@@ -770,7 +798,180 @@ defmodule Ambry.Inbox.AutoMatch do
     {candidates, outcomes} = provider_books(:recording, query, hints, opts)
     {editions, edition_outcomes} = editions_for(top_group(work["candidates"]), hints, opts)
 
-    level_result(query, candidates ++ editions, outcomes ++ edition_outcomes, hints.author)
+    level_result(
+      query,
+      candidates |> Kernel.++(editions) |> dedupe_records() |> apply_narrator_evidence(hints),
+      outcomes ++ edition_outcomes,
+      hints.author
+    )
+  end
+
+  @doc """
+  Collapses records **one provider** returned more than once.
+
+  Not the same thing as fusing two providers' records, which this module
+  refuses to do and should keep refusing: those are two databases describing
+  one book, each knowing something the other doesn't. This is one database
+  holding the same edition four times. Measured on The Martian, Hardcover
+  returns R.C. Bray's recording on four rows and Wil Wheaton's on four more,
+  differing only in which fields are filled — and with `@candidate_limit` at
+  #{@candidate_limit}, those eight rows crowd genuine alternatives (the German
+  and Swedish recordings) off the list entirely.
+
+  Two rules keep it from doing harm:
+
+    * **Merge, don't drop.** The duplicates are not identical — of Wheaton's
+      four rows only one carries an ASIN — so the survivor takes the union,
+      filling its blanks from the rows it absorbs. Picking a winner and
+      discarding the rest threw away the ASIN roughly three times in four.
+    * **First occurrence keeps the identity.** A record is referred to by
+      `{source, id}`, and the draft points at records by that ref. Records
+      already on the item come before newly-found ones, so the ref a re-search
+      might have collapsed is the one that survives — and anything the
+      operator has actually ticked is pinned outright.
+
+  Deliberately strict about what counts as the same record: same provider,
+  same normalized title, the *same* set of narrators, and no disagreement on
+  ASIN or publisher (one side being blank is not a disagreement). Two Audible
+  ASINs for one Wheaton recording are a US and a UK edition, not a duplicate,
+  and an edition crediting nobody is not evidence that it is some other
+  edition's recording.
+  """
+  def dedupe_records(records, pinned \\ MapSet.new()) do
+    Enum.reduce(records, [], fn record, kept ->
+      case duplicate_index(kept, record, pinned) do
+        nil -> kept ++ [record]
+        index -> List.update_at(kept, index, &absorb(&1, record))
+      end
+    end)
+  end
+
+  defp duplicate_index(kept, record, pinned) do
+    if !MapSet.member?(pinned, ref(record)) do
+      Enum.find_index(kept, &duplicate?(&1, record))
+    end
+  end
+
+  defp duplicate?(kept, record) do
+    kept["source"] == record["source"] and
+      normalize(kept["title"] || "") == normalize(record["title"] || "") and
+      narrator_key(kept) == narrator_key(record) and
+      agreeable?(kept["asin"], record["asin"]) and
+      agreeable?(kept["publisher"], record["publisher"])
+  end
+
+  defp narrator_key(record) do
+    record["narrators"] |> List.wrap() |> Enum.map(&normalize/1) |> Enum.sort()
+  end
+
+  defp agreeable?(nil, _other), do: true
+  defp agreeable?(_value, nil), do: true
+  defp agreeable?(value, other), do: value == other
+
+  # The survivor keeps everything it had and gains everything it lacked. The
+  # count rides along because a provider holding four rows for one recording
+  # is a fact about the provider worth being able to see, and silently tidying
+  # it away is how a data-quality problem becomes invisible.
+  defp absorb(kept, record) do
+    record
+    |> Map.merge(kept, fn _key, incoming, held ->
+      if held in [nil, "", []], do: incoming, else: held
+    end)
+    |> Map.put("duplicates", (kept["duplicates"] || 1) + 1)
+  end
+
+  @doc """
+  Re-scores recordings by what the file *says*, not by what the parser could
+  get out of it.
+
+  Everything else here runs forwards: read the item, build a query, score what
+  comes back. This runs **backwards** — take each candidate's narrators and go
+  looking for them in the item's own raw text. It exists because the forward
+  path has a silent hole: `hints.narrator` is nil whenever the parser couldn't
+  find a credit, and `apply_narrator/3` then does nothing at all, so a
+  recording by the wrong reader keeps a perfect title-and-author score.
+  Measured on The Martian — tags carrying no narrator, "(R.C. Bray)" sitting in
+  the filename — the item proposed **Wil Wheaton at 1.0**, unopposed.
+
+  Three-valued, like every "didn't say" in this module, and the middle value is
+  the one that matters:
+
+    * **supported** — a candidate's reader is named in the file. Corroboration.
+    * **unstated** — *no* candidate's reader is named anywhere. The file has
+      said nothing about who read it, which is the ordinary case, so nothing
+      is adjusted. Getting this wrong would penalise every correct match in
+      the library.
+    * **contradicted** — this candidate's reader is absent *while a rival's is
+      present*. Only then has the file spoken: it named a reader, just not
+      through any field we parse, and it isn't this one.
+
+  Candidates carrying no narrator at all are never touched — a record that
+  doesn't say who read it isn't contradicted by one that does.
+
+  Only fires when `hints.narrator` is nil, so exactly one narrator mechanism is
+  ever active: the stated credit when there is one, this when there isn't.
+  Full-cast releases land here too — "Full Cast" is a placeholder, not a
+  person, so `stated_narrator/1` rejects it and the forward path has nothing.
+  """
+  def apply_narrator_evidence(candidates, hints)
+
+  def apply_narrator_evidence(candidates, %{narrator: narrator, raw: raw})
+      when is_binary(raw) and is_nil(narrator) do
+    haystack = tokens(raw)
+    supported = Map.new(candidates, &{ref(&1), named_in?(&1["narrators"], haystack)})
+
+    if Enum.any?(supported, fn {_ref, yes?} -> yes? end) do
+      candidates |> Enum.map(&verdict(&1, supported[ref(&1)])) |> order_candidates()
+    else
+      candidates
+    end
+  end
+
+  def apply_narrator_evidence(candidates, _hints), do: candidates
+
+  # A record with no narrators is silent, not wrong.
+  defp verdict(%{"narrators" => narrators} = record, _supported?) when narrators in [nil, []],
+    do: record
+
+  defp verdict(record, supported?) do
+    # Re-derived from the untouched base every time rather than multiplied into
+    # the running score: re-searching an item runs this again over records that
+    # already carry a verdict, and a factor applied twice would sink a
+    # candidate a little further on every visit.
+    base = record["base_score"] || record["score"] || 0.0
+    factor = if supported?, do: 1.05, else: @narrator_mismatch
+
+    record
+    |> Map.put("base_score", base)
+    |> Map.put("score", base |> Kernel.*(factor) |> min(1.0) |> Float.round(3))
+    |> Map.put("narrator_evidence", if(supported?, do: "supported", else: "contradicted"))
+  end
+
+  # Any one reader is enough: a full-cast release names a handful of its
+  # fifteen actors at most, and one of them appearing IS the corroboration.
+  defp named_in?(narrators, haystack) do
+    Enum.any?(List.wrap(narrators), fn name ->
+      tokens(name)
+      |> MapSet.to_list()
+      |> Enum.filter(&(String.length(&1) >= 3))
+      |> case do
+        # Initials and mononyms carry too little to search for: "R.C." against
+        # a filename would match anything with an "r" in it. "Bray" is the
+        # part that identifies, and a name reduced to nothing identifies
+        # nobody — so it abstains rather than guessing.
+        [] -> false
+        parts -> Enum.all?(parts, &MapSet.member?(haystack, &1))
+      end
+    end)
+  end
+
+  defp tokens(nil), do: MapSet.new()
+
+  defp tokens(string) do
+    string
+    |> String.downcase()
+    |> String.split(~r/[^\p{L}\p{N}]+/u, trim: true)
+    |> MapSet.new()
   end
 
   @doc """
@@ -779,10 +980,16 @@ defmodule Ambry.Inbox.AutoMatch do
   This is what finds an edition a storefront has erased: Audible's catalog API
   is a storefront, not a bibliography — when rights lapse and a title is
   pulled, it vanishes from search *and* from direct ASIN lookup, with no record
-  that it ever existed. Hardcover and rreading-glasses are databases of
-  editions rather than shops, so they still have it. Measured for Neuromancer:
-  Audible 1 audio edition, Hardcover 7 — including a narrator Audible doesn't
-  list at all.
+  that it ever existed. Hardcover is a database of editions rather than a shop,
+  so it still has it. Measured for Neuromancer: Audible 1 audio edition,
+  Hardcover 7 — including a narrator Audible doesn't list at all. Measured for
+  The Martian: Audible has only Wil Wheaton's re-recording, Hardcover still has
+  R.C. Bray's Podium original with its ASIN.
+
+  **Not rreading-glasses**, whatever older notes here said: its edition list
+  never carries a narrator, because the Goodreads query it issues omits
+  secondary contributors. At this level that makes it silent on the only
+  question being asked.
 
   **Every capable record is asked**, not the first one. This used to be an
   `Enum.find_value` that stopped at the first editions-capable provider even
@@ -894,10 +1101,27 @@ defmodule Ambry.Inbox.AutoMatch do
   loser's payload and made the list look like a set of rival identities.
   """
   def rank(candidates) do
-    candidates
-    |> Enum.sort_by(& &1["score"], :desc)
-    |> Enum.take(@candidate_limit)
+    candidates |> order_candidates() |> Enum.take(@candidate_limit)
   end
+
+  @doc """
+  Best first: by score, and among equal scores by what the file corroborated.
+
+  The tie-break is not decoration. A supported candidate cannot out-*score* a
+  silent one that was already at 1.0 — the boost is capped there — so The
+  Martian ends with R.C. Bray's corroborated recording and an Audible edition
+  crediting nobody both sitting at exactly 1.000. Inventing a score gap to
+  separate them would be dishonest about how sure we are; ordering the
+  corroborated one first is simply saying which of two equals the file
+  actually spoke about.
+  """
+  def order_candidates(candidates) do
+    Enum.sort_by(candidates, &{&1["score"] || 0.0, corroboration(&1)}, :desc)
+  end
+
+  defp corroboration(%{"narrator_evidence" => "supported"}), do: 2
+  defp corroboration(%{"narrator_evidence" => "contradicted"}), do: 0
+  defp corroboration(_record), do: 1
 
   defp query_fields(nil), do: %{}
 
@@ -1419,7 +1643,10 @@ defmodule Ambry.Inbox.AutoMatch do
       part_number: nil,
       parts_total: nil,
       asin: nil,
-      release_title: nil
+      release_title: nil,
+      # No files behind a form: the operator typed these fields, and a typed
+      # narrator is a *stated* one, which the forward scorer already handles.
+      raw: nil
     }
   end
 
@@ -1722,7 +1949,16 @@ defmodule Ambry.Inbox.AutoMatch do
   end
 
   defp author_similarity(_authors, nil), do: nil
-  defp author_similarity([], _author), do: 0.0
+
+  # "Didn't say" is not "said no" — the same rule the clause above already
+  # applies to a file that names no author, applied to a record that names
+  # none. Scoring an authorless record as a wrong-author match cost it a flat
+  # quarter of its score, which is not a judgement about the book: it is a
+  # judgement about how complete the provider's row is. Edition records are
+  # the ones that pay it, because an edition lists its narrator where the work
+  # lists its author — so the recordings that only a bibliography still has
+  # were docked 25% against the storefront hits they exist to compete with.
+  defp author_similarity([], _author), do: nil
 
   defp author_similarity(authors, author) do
     authors |> Enum.map(&similarity(&1, author)) |> Enum.max(fn -> 0.0 end)

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -1170,9 +1170,24 @@ defmodule Ambry.Inbox.AutoMatch do
   """
   def agrees?(one, other) do
     same_stated_title?(one["title"] || "", other["title"] || "") and
+      companion?(one["title"]) == companion?(other["title"]) and
       compatible?(one["narrators"], other["narrators"]) and
       compatible?(one["authors"], other["authors"])
   end
+
+  # A study guide agrees with its subject on every other test, and that is not
+  # a near miss — it is the three tests lining up. Its title's *head* is the
+  # book's title exactly, because a companion work is named
+  # "<The Book>: <something>" by construction, and head containment was built
+  # for genuine subtitles. It credits no narrator and, very often, no author.
+  # So all three read "didn't say", and "The Martian: A Novel by Andy Weir |
+  # Unofficial Summary & Analysis" was pre-ticked onto the operator's Martian
+  # while showing a score of 0.25 — the scorer knew, and nothing asked it.
+  #
+  # The sharpest part: the two rival companion works, which name a *different*
+  # author, were correctly excluded. Only the one carrying no author data at
+  # all got through, so the record with the worst data earned the most trust.
+  defp companion?(title), do: companion_penalty(title || "") != 1.0
 
   # A title and that same title carrying its subtitle are one answer written
   # two ways: rreading-glasses says "Cast Under an Alien Sun" where Hardcover

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -90,6 +90,10 @@ defmodule Ambry.Inbox.AutoMatch do
   @narrator_match 0.85
   @narrator_mismatch 0.5
 
+  # What it costs to be by somebody else. Decisive rather than blended, for
+  # exactly the reason the narrator is — see `author_agreement/2`.
+  @author_mismatch 0.5
+
   # What it costs to sit at a different number in the series the label named.
   @series_mismatch 0.5
 
@@ -550,6 +554,33 @@ defmodule Ambry.Inbox.AutoMatch do
     candidates
     |> Enum.filter(&agrees?(&1, best))
     |> Enum.take(@group_limit)
+  end
+
+  @doc """
+  The records worth *pre-ticking* — narrower than `top_group/1` once the file
+  has said who read it.
+
+  Ticking a record says "this describes my file", and a record naming no
+  narrator cannot support that claim at the recording level. It stays in the
+  group for every other purpose — it may well be the operator's edition, and
+  `apply_narrator_evidence/2` deliberately never penalises it — but adopting
+  its fields is a guess.
+
+  Measured: The Martian's `B082BHWQCJ` is Wil Wheaton's edition with the role
+  string missing upstream. Silent, so unpenalised, so still at 1.000, so
+  ticked — and it handed the operator's 2013 R.C. Bray recording Wheaton's
+  2020 release date as a conflict.
+
+  Only bites when some record IS corroborated. With nothing to go on — the
+  ordinary case across most of a library — this is `top_group/1` exactly.
+  """
+  def settled_group(records) do
+    group = top_group(records)
+
+    case Enum.filter(group, &(&1["narrator_evidence"] == "supported")) do
+      [] -> group
+      corroborated -> corroborated
+    end
   end
 
   @doc """
@@ -1347,9 +1378,13 @@ defmodule Ambry.Inbox.AutoMatch do
   # doubted too, which is what the cross-similarity floor is for.
   @distinct_author 0.7
 
+  # Guarded on `:match` rather than on a similarity crossing a threshold: with
+  # `author_similarity/2` returning nil for a record naming nobody, `nil >=
+  # 0.85` is *true* in Elixir's term order (atoms sort above numbers), so an
+  # authorless candidate silently adjudicated every tie it was in.
   defp author_adjudicated?(best, second, author) do
     is_binary(author) and
-      author_similarity(best["authors"] || [], author) >= @narrator_match and
+      author_agreement(best["authors"] || [], author) == :match and
       cross_author_similarity(best, second) < @distinct_author
   end
 
@@ -1742,9 +1777,10 @@ defmodule Ambry.Inbox.AutoMatch do
       end
 
     base =
-      case author_similarity(authors, hints.author) do
-        nil -> title_similarity
-        author_score -> title_similarity * 0.75 + author_score * 0.25
+      case author_agreement(authors, hints.author) do
+        :match -> min(title_similarity * 1.05, 1.0)
+        :conflict -> title_similarity * @author_mismatch
+        :unstated -> title_similarity
       end
 
     # The narrator only speaks when both sides have one. Recording-level hits
@@ -1963,20 +1999,42 @@ defmodule Ambry.Inbox.AutoMatch do
     end
   end
 
-  defp author_similarity(_authors, nil), do: nil
+  @doc """
+  Whether a candidate's authors and the file's answer each other.
 
-  # "Didn't say" is not "said no" — the same rule the clause above already
-  # applies to a file that names no author, applied to a record that names
-  # none. Scoring an authorless record as a wrong-author match cost it a flat
-  # quarter of its score, which is not a judgement about the book: it is a
-  # judgement about how complete the provider's row is. Edition records are
-  # the ones that pay it, because an edition lists its narrator where the work
-  # lists its author — so the recordings that only a bibliography still has
-  # were docked 25% against the storefront hits they exist to compete with.
-  defp author_similarity([], _author), do: nil
+  Three-valued for the usual reason, and **by shared name token, not by jaro**.
+  Jaro cannot tell a name variant from a different human — measured on the
+  operator's own Martian import:
 
-  defp author_similarity(authors, author) do
-    authors |> Enum.map(&similarity(&1, author)) |> Enum.max(fn -> 0.0 end)
+      "J.R.R. Tolkien" vs "John Ronald Reuel Tolkien"   0.573   same person
+      "Daily  Books"   vs "Andy Weir"                   0.519   unrelated
+
+  Five hundredths apart. Blended in at a quarter share, that noise put "The
+  Martian: A Novel By Andy Weir | Conversation Starters" — a companion work by
+  a content farm — at **0.88** against the operator's file, because a
+  head-matched title scores 1.0 and even a completely wrong author adds 0.13
+  on top of 0.75 of it. Sharing a name token separates the two rows above
+  perfectly, and it is the same test `Ambry.Metadata.PersonSearch` already
+  applies for the same reason.
+
+  `:unstated` covers both sides being silent *and* a name that reduces to
+  nothing comparable ("J.R.R."), which abstains rather than guessing.
+  """
+  def author_agreement(authors, author) do
+    wanted = name_tokens(author)
+    stated = authors |> List.wrap() |> Enum.map(&name_tokens/1) |> Enum.reject(&Enum.empty?/1)
+
+    cond do
+      Enum.empty?(wanted) or stated == [] -> :unstated
+      Enum.any?(stated, &(not MapSet.disjoint?(&1, wanted))) -> :match
+      true -> :conflict
+    end
+  end
+
+  # Single letters are dropped: initials match everything, so "J. Smith" and
+  # "J. Jones" would agree on "j".
+  defp name_tokens(name) do
+    name |> tokens() |> Enum.reject(&(String.length(&1) < 2)) |> MapSet.new()
   end
 
   defp similarity(nil, _other), do: 0.0

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -749,7 +749,12 @@ defmodule Ambry.Inbox.Draft.Seed do
       query_fields: Map.get(level, "query_fields") || %{},
       doubt: doubt,
       doubt_detail: detail,
-      sources: if(best, do: Enum.map(AutoMatch.top_group(records), &SourceRef.of/1), else: []),
+      # `settled_group/1`, not `top_group/1`: once the file has named its
+      # reader, a record that names none is still a fine candidate and still
+      # a poor thing to adopt fields from. Same principle as the paragraph
+      # above, one level finer.
+      sources:
+        if(best, do: Enum.map(AutoMatch.settled_group(records), &SourceRef.of/1), else: []),
       # Settled when we actually know which recording this is — a trusted
       # match — or when there was nothing to choose between. A doubted record
       # leaves the question open rather than being adopted quietly; that

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -23,6 +23,7 @@ defmodule Ambry.Inbox.Lookup do
   (scoring), and writing evidence into `inbox_items.matches`.
   """
   alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.Draft
   alias Ambry.Inbox.InboxItem
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Registry
@@ -54,8 +55,14 @@ defmodule Ambry.Inbox.Lookup do
 
   This is the route to an edition no storefront will admit exists. Audible's
   catalog is a shop: when rights lapse the title vanishes from search and from
-  ASIN lookup alike. Hardcover and rreading-glasses are databases of editions
-  and keep it.
+  ASIN lookup alike. Hardcover is a database of editions and keeps it —
+  measured, R.C. Bray's delisted Martian is there with its ASIN and Audible
+  has only the Wil Wheaton re-recording.
+
+  **Hardcover, and only Hardcover.** rreading-glasses is named here in older
+  notes and does not belong: its edition list never carries a narrator (the
+  Goodreads query it issues omits secondary contributors entirely), which
+  makes it useless at the level where the narrator is the whole question.
   """
   def editions(%InboxItem{} = item, work_refs) do
     records =
@@ -63,10 +70,11 @@ defmodule Ambry.Inbox.Lookup do
       |> records("work")
       |> Enum.filter(&(AutoMatch.ref(&1) in work_refs))
 
-    {found, outcomes} = AutoMatch.editions_for(records, AutoMatch.hints(item))
+    hints = AutoMatch.hints(item)
+    {found, outcomes} = AutoMatch.editions_for(records, hints)
 
     item
-    |> update_records("recording", &add(&1, found))
+    |> update_records("recording", &(&1 |> add(found) |> refine(item, "recording", hints)))
     |> update_outcomes("recording", outcomes)
   end
 
@@ -84,10 +92,11 @@ defmodule Ambry.Inbox.Lookup do
     if Provider.Query.blank?(query) do
       {:ok, item}
     else
-      {found, outcomes} = search(level, query, AutoMatch.hints(item))
+      hints = AutoMatch.hints(item)
+      {found, outcomes} = search(level, query, hints)
 
       item
-      |> update_records(level, &add(&1, found))
+      |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
       |> update_outcomes(level, outcomes)
       |> remember_query(level, query)
     end
@@ -108,9 +117,10 @@ defmodule Ambry.Inbox.Lookup do
     case Registry.fetch(provider_id) do
       {:ok, entry} ->
         {books, outcome} = Search.books_one(entry, query)
+        found = AutoMatch.records_from(books, entry, hints)
 
         item
-        |> update_records(level, &add(&1, AutoMatch.records_from(books, entry, hints)))
+        |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
         |> update_outcomes(level, [outcome])
 
       {:error, _reason} ->
@@ -191,15 +201,50 @@ defmodule Ambry.Inbox.Lookup do
     {records, outcomes}
   end
 
+  # Both passes are facts about the *whole* list rather than about one record
+  # — it takes a rival naming somebody the file mentions to make a candidate's
+  # silence damning, and it takes another row to make a row a duplicate — so
+  # they re-run over the merged list, not over the records this search
+  # happened to add. Otherwise a re-search that finally turned up the right
+  # reader would leave the wrong one sitting at the top on its original score.
+  #
+  # Order matters: collapse first, so the evidence pass scores each recording
+  # once, then sort, because both passes move records around.
+  defp refine(records, item, level, hints) do
+    records
+    |> dedupe(item, level)
+    |> reweigh(level, hints)
+    |> AutoMatch.order_candidates()
+  end
+
+  defp dedupe(records, item, "recording"),
+    do: AutoMatch.dedupe_records(records, ticked(item, :recording, records))
+
+  defp dedupe(records, _item, _level), do: records
+
+  defp reweigh(records, "recording", hints), do: AutoMatch.apply_narrator_evidence(records, hints)
+
+  defp reweigh(records, _level, _hints), do: records
+
+  # A record the operator has ticked keeps its identity no matter what: the
+  # draft points at it by ref, and collapsing it into a look-alike would break
+  # that pointer — the one thing evidence-writing must never do.
+  defp ticked(%InboxItem{draft: nil}, _level, _records), do: MapSet.new()
+
+  defp ticked(%InboxItem{draft: draft}, level, records) do
+    records
+    |> Enum.filter(&Draft.Edit.uses?(draft, level, &1))
+    |> MapSet.new(&AutoMatch.ref/1)
+  end
+
   # New records join the list; ones already there keep their place and their
-  # payload. Replacing them would un-tick the operator's choices, which is the
-  # one thing evidence-writing must never do.
+  # payload. Replacing them would un-tick the operator's choices, and keeping
+  # them *first* is what lets `dedupe_records/2` collapse a look-alike into
+  # the record already on the item rather than the other way round.
   defp add(existing, found) do
     known = MapSet.new(existing, &AutoMatch.ref/1)
 
-    existing
-    |> Kernel.++(Enum.reject(found, &MapSet.member?(known, AutoMatch.ref(&1))))
-    |> Enum.sort_by(&(&1["score"] || 0.0), :desc)
+    existing ++ Enum.reject(found, &MapSet.member?(known, AutoMatch.ref(&1)))
   end
 
   defp update_records(item, level, fun) do

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -117,9 +117,50 @@ defmodule Ambry.Metadata.Providers.Hardcover do
     end
   end
 
+  # Hardcover's `contribution` is free text and the narrator credit is written
+  # at least five ways. Measured across 400 audiobook editions: "Narrator" 286,
+  # "Reading" 9, "Reader" 7, "narrator" 7, "Read by" 5. Matching the one
+  # spelling dropped a tenth of all narrator credits, and on The Martian it
+  # dropped R.C. Bray's recording — the delisted one this whole capability
+  # exists to recover — while keeping every Wil Wheaton record.
+  @narrator_roles ["narrator", "reader", "reading", "read by"]
+
+  # The same set in the casings seen upstream: the server's `_in` is
+  # case-sensitive, and `_ilike`/`_iregex` are refused outright (403 "ilike and
+  # related operations are not permitted on this server"). Recall only — the
+  # authoritative, case-insensitive test is `narrator_role?/1` below.
+  @narrator_roles_upstream [
+    "Narrator",
+    "narrator",
+    "Reader",
+    "reader",
+    "Reading",
+    "reading",
+    "Read by",
+    "read by"
+  ]
+
+  @audiobook_format 2
+
+  # The audio filter belongs in the WHERE clause, not in Elixir. Fetching an
+  # arbitrary unordered page and filtering it here silently capped coverage at
+  # whichever editions the server happened to return first: The Martian has
+  # **150** editions, so `limit: 60` decided by nothing at all which ones we
+  # got, and the audiobooks were not among them. Filtering upstream, the same
+  # book yields 13 rows — the entire audio set, comfortably inside the limit.
   @editions_query """
-  query AudioEditions($id: Int!) {
-    editions(where: {book_id: {_eq: $id}}, limit: 60) {
+  query AudioEditions($id: Int!, $roles: [String!]) {
+    editions(
+      where: {
+        book_id: {_eq: $id},
+        _or: [
+          {reading_format_id: {_eq: #{@audiobook_format}}},
+          {audio_seconds: {_is_null: false}},
+          {contributions: {contribution: {_in: $roles}}}
+        ]
+      },
+      limit: 60
+    ) {
       id
       title
       release_date
@@ -146,7 +187,7 @@ defmodule Ambry.Metadata.Providers.Hardcover do
   def editions(work_id, config) do
     with {:ok, id} <- parse_id(work_id),
          {:ok, %{"editions" => editions}} <-
-           Client.query(config, @editions_query, %{id: id}) do
+           Client.query(config, @editions_query, %{id: id, roles: @narrator_roles_upstream}) do
       {:ok, editions |> Enum.filter(&audio_edition?/1) |> Enum.map(&edition_to_book/1)}
     else
       {:ok, _other} -> {:error, :not_found}
@@ -154,22 +195,30 @@ defmodule Ambry.Metadata.Providers.Hardcover do
     end
   end
 
-  # NOT `reading_format_id`: it is unreliable in exactly the cases that matter
-  # — several Neuromancer editions with explicit Narrator credits and audio
-  # publishers are stored as format 1 ("Read"). An explicit Narrator
-  # contribution is the honest signal that this is a recording, and an
-  # audio_seconds runtime corroborates it.
+  # `reading_format_id` is unreliable as a *negative* — several Neuromancer
+  # editions with explicit Narrator credits and audio publishers are stored as
+  # format 1 ("Read"), which is why it can't be the filter. As a positive it is
+  # perfectly good evidence, so it joins the other two tells rather than
+  # replacing them: a narrator credit under any of its spellings, a runtime, or
+  # the format saying audiobook.
   defp audio_edition?(edition) do
-    narrators(edition) != [] or not is_nil(edition["audio_seconds"])
+    narrators(edition) != [] or not is_nil(edition["audio_seconds"]) or
+      edition["reading_format_id"] == @audiobook_format
   end
 
   defp narrators(edition) do
     edition["contributions"]
     |> List.wrap()
-    |> Enum.filter(&(&1["contribution"] == "Narrator"))
+    |> Enum.filter(&narrator_role?(&1["contribution"]))
     |> Enum.map(& &1["author"])
     |> Enum.reject(&is_nil/1)
   end
+
+  # A nil contribution is NOT admitted, tempting as it is: nil is also how
+  # Hardcover credits the author (Andy Weir is nil on every Martian edition),
+  # so reading it as a narrator would credit authors as their own readers.
+  defp narrator_role?(role) when is_binary(role), do: String.downcase(role) in @narrator_roles
+  defp narrator_role?(_role), do: false
 
   defp edition_to_book(edition) do
     %Provider.Book{
@@ -177,6 +226,13 @@ defmodule Ambry.Metadata.Providers.Hardcover do
       id: to_string(edition["id"]),
       asin: presence(edition["asin"]),
       title: edition["title"],
+      # An edition record that names nobody as its author is scored as though
+      # it named the WRONG one, so every edition arrived a flat quarter behind
+      # the storefront's search hits — enough, measured on The Martian, for
+      # Audible's Wil Wheaton to outrank the recording actually in hand. The
+      # author is right here in the same contributions list, under the nil
+      # role Hardcover credits authors with.
+      authors: contributions_to_authors(edition["contributions"]),
       cover_url: get_in(edition, ["image", "url"]),
       publisher: get_in(edition, ["publisher", "name"]),
       # Old editions frequently carry the *work's* date rather than their own

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -170,6 +170,7 @@ defmodule Ambry.Metadata.Providers.Hardcover do
       publisher { name }
       image { url }
       contributions { contribution author { id name } }
+      book { contributions { contribution author { id name } } }
     }
   }
   """
@@ -226,13 +227,19 @@ defmodule Ambry.Metadata.Providers.Hardcover do
       id: to_string(edition["id"]),
       asin: presence(edition["asin"]),
       title: edition["title"],
-      # An edition record that names nobody as its author is scored as though
-      # it named the WRONG one, so every edition arrived a flat quarter behind
-      # the storefront's search hits — enough, measured on The Martian, for
-      # Audible's Wil Wheaton to outrank the recording actually in hand. The
-      # author is right here in the same contributions list, under the nil
-      # role Hardcover credits authors with.
-      authors: contributions_to_authors(edition["contributions"]),
+      # From the WORK's contributions, not the edition's own. An edition of a
+      # book has that book's author by definition, and reading the edition's
+      # list instead promotes whoever upstream filed under the nil role —
+      # which on The Martian's B082BHWQCJ is Wil Wheaton, its *narrator*. That
+      # record then arrived crediting Wheaton as an author of the novel, and
+      # was pre-ticked for it, because naming a superset of the right authors
+      # reads as corroboration. The work's own list can't be wrong that way.
+      #
+      # Editions need an author at all because a record naming none used to be
+      # scored as naming the WRONG one — a flat quarter off, enough on The
+      # Martian for Audible's Wheaton edition to outrank the recording
+      # actually in hand.
+      authors: contributions_to_authors(get_in(edition, ["book", "contributions"])),
       cover_url: get_in(edition, ["image", "url"]),
       publisher: get_in(edition, ["publisher", "name"]),
       # Old editions frequently carry the *work's* date rather than their own

--- a/lib/ambry_web/components/admin/curation.ex
+++ b/lib/ambry_web/components/admin/curation.ex
@@ -24,6 +24,7 @@ defmodule AmbryWeb.Admin.Curation do
     only: [
       provider_outcomes_row: 1,
       proposal_chip: 1,
+      record_list: 1,
       record_row: 1,
       research_form: 1,
       source_words: 1
@@ -76,14 +77,17 @@ defmodule AmbryWeb.Admin.Curation do
       </p>
 
       <div class="mt-2 space-y-2 rounded-lg bg-zinc-900 p-4">
-        <.record_row
-          :for={record <- @evidence.records}
-          record={record}
-          used={Evidence.used?(@evidence, record)}
-          level={@level}
-          event="toggle-evidence"
-          note={Evidence.note(@evidence, record)}
-        />
+        <.record_list records={@evidence.records} used={&Evidence.used?(@evidence, &1)}>
+          <:row :let={record}>
+            <.record_row
+              record={record}
+              used={Evidence.used?(@evidence, record)}
+              level={@level}
+              event="toggle-evidence"
+              note={Evidence.note(@evidence, record)}
+            />
+          </:row>
+        </.record_list>
 
         <p
           :if={@evidence.searched? and not @evidence.running? and @evidence.records == []}

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -131,6 +131,67 @@ defmodule AmbryWeb.Admin.Decisions do
         do: {key, value}
   end
 
+  # Where a candidate stops being an alternative and starts being noise. Sits
+  # deliberately at the boundary rather than below it: on the operator's
+  # Martian the contradicted Wil Wheaton editions score exactly 0.5, and they
+  # are the *other real recording* of that book — precisely what somebody
+  # opens this list to find. One constant, tune it here.
+  @worth_showing 0.5
+
+  attr :records, :list, required: true
+  attr :used, :any, required: true, doc: "fn record -> boolean, the ticked test"
+  slot :row, required: true, doc: "renders one record; receives the record"
+
+  @doc """
+  A level's records, with the junk folded away.
+
+  Eight rows all wearing the same weight is how a 6% study guide got read as
+  an alternative worth considering. Below `#{@worth_showing}` a record is not
+  a rival reading of the book, it is a search result that happened to share a
+  word — so it goes behind a link and stops competing for the eye.
+
+  **A ticked record is never hidden**, whatever it scores. Folding away
+  something the operator has chosen would leave the form showing a decision
+  with no visible cause, and a low score is exactly why somebody would have
+  gone looking for it by hand.
+  """
+  def record_list(assigns) do
+    {shown, folded} = Enum.split_with(assigns.records, &worth_showing?(&1, assigns.used))
+
+    assigns = assign(assigns, shown: shown, folded: folded)
+
+    ~H"""
+    <%= for record <- @shown do %>
+      {render_slot(@row, record)}
+    <% end %>
+
+    <.disclosure
+      :if={@folded != []}
+      summary={worse_matches_label(@folded)}
+      container_class="space-y-2"
+      data-role="worse-matches"
+    >
+      <div class="space-y-2 pt-2">
+        <%= for record <- @folded do %>
+          {render_slot(@row, record)}
+        <% end %>
+      </div>
+    </.disclosure>
+    """
+  end
+
+  # An *unscored* record is not a weak one — person records carry no score at
+  # all, and reading a missing score as zero would fold every one of them away.
+  defp worth_showing?(record, used) do
+    case record["score"] do
+      score when is_number(score) -> score >= @worth_showing or used.(record)
+      _unscored -> true
+    end
+  end
+
+  defp worse_matches_label([_one]), do: "Show 1 worse match"
+  defp worse_matches_label(folded), do: "Show #{length(folded)} worse matches"
+
   attr :record, :map, required: true
   attr :used, :boolean, required: true
   attr :level, :string, default: nil
@@ -175,10 +236,31 @@ defmodule AmbryWeb.Admin.Decisions do
       />
       <%!-- Identification, not selection: the cover or face that tells this
           record apart, visible BEFORE ticking — the chips below remain the
-          place a photo is chosen. --%>
-      <span :if={thumb = record_thumb(@record)} class="group/zoom relative -my-0.5 flex-none">
-        <img src={thumb} class="h-12 w-12 rounded-sm object-cover" loading="lazy" />
+          place a photo is chosen.
+
+          The box is always 48×48 and the image is `object-contain` inside it.
+          Cropping to fill turned every portrait jacket into a square, which
+          is the one thing an operator is looking at these for — square art is
+          the audiobook and a portrait is the print cover, and `object-cover`
+          made those two indistinguishable. The box is rendered even with
+          nothing to put in it, so the titles down the list stay on one rail
+          instead of stepping left whenever a record has no art. --%>
+      <span class="group/zoom relative -my-0.5 h-12 w-12 flex-none">
+        <img
+          :if={thumb = record_thumb(@record)}
+          src={thumb}
+          class="h-full w-full rounded-sm object-contain"
+          loading="lazy"
+        />
         <span
+          :if={!record_thumb(@record)}
+          class="bg-zinc-800/80 flex h-full w-full items-center justify-center rounded-sm"
+          title="No image"
+        >
+          <.icon name="fa-image" class="h-4 w-4 text-zinc-600" />
+        </span>
+        <span
+          :if={thumb = record_thumb(@record)}
           data-zoomable
           data-full={thumb}
           title="View full size"

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -279,13 +279,19 @@
             No provider had a record of this. The fields below come from the file's own tags.
           </p>
 
-          <.record_row
-            :for={record <- records(@item, "work")}
-            record={record}
-            level="work"
-            used={Work.uses?(@item.draft.work, record)}
-            working={@enriching == record_ref(record)}
-          />
+          <.record_list
+            records={records(@item, "work")}
+            used={&Work.uses?(@item.draft.work, &1)}
+          >
+            <:row :let={record}>
+              <.record_row
+                record={record}
+                level="work"
+                used={Work.uses?(@item.draft.work, record)}
+                working={@enriching == record_ref(record)}
+              />
+            </:row>
+          </.record_list>
 
           <.provider_outcomes_row
             outcomes={provider_outcomes(@item, "work")}
@@ -469,13 +475,19 @@
             delisted, which is often the only place an older reading still exists.
           </p>
 
-          <.record_row
-            :for={record <- records(@item, "recording")}
-            record={record}
-            level="recording"
-            used={Recording.uses?(@item.draft.recording, record)}
-            working={@enriching == record_ref(record)}
-          />
+          <.record_list
+            records={records(@item, "recording")}
+            used={&Recording.uses?(@item.draft.recording, &1)}
+          >
+            <:row :let={record}>
+              <.record_row
+                record={record}
+                level="recording"
+                used={Recording.uses?(@item.draft.recording, record)}
+                working={@enriching == record_ref(record)}
+              />
+            </:row>
+          </.record_list>
 
           <.provider_outcomes_row
             outcomes={provider_outcomes(@item, "recording")}

--- a/test/ambry/images_test.exs
+++ b/test/ambry/images_test.exs
@@ -1,0 +1,38 @@
+defmodule Ambry.ImagesTest do
+  use ExUnit.Case, async: true
+
+  alias Ambry.Images
+
+  describe "browser_safe/1" do
+    test "JPEG and PNG pass through untouched" do
+      jpeg = encoded(".jpg")
+      png = encoded(".png")
+
+      assert {:ok, ^jpeg, "image/jpeg"} = Images.browser_safe(jpeg)
+      assert {:ok, ^png, "image/png"} = Images.browser_safe(png)
+    end
+
+    # The operator's Martian: a picture stream the container calls PNG,
+    # carrying a big-endian TIFF. It extracted fine and the preview 404'd,
+    # leaving a broken image beside a chip offering the art.
+    test "a TIFF becomes a JPEG rather than a 404" do
+      tiff = encoded(".tif")
+
+      # Either byte order is a TIFF — the operator's file is big-endian
+      # ("MM"), libvips writes little-endian ("II"), and a browser shows
+      # neither.
+      assert binary_part(tiff, 0, 2) in ["MM", "II"]
+      assert {:ok, <<0xFF, 0xD8, 0xFF, _rest::binary>>, "image/jpeg"} = Images.browser_safe(tiff)
+    end
+
+    test "bytes that are not an image at all are still an error" do
+      assert {:error, :no_embedded_image} = Images.browser_safe("not an image")
+    end
+
+    defp encoded(suffix) do
+      {:ok, image} = Image.new(8, 8, color: :red)
+      {:ok, binary} = Image.write(image, :memory, suffix: suffix)
+      binary
+    end
+  end
+end

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -73,6 +73,30 @@ defmodule Ambry.Inbox.AutoMatchTest do
     end
   end
 
+  describe "agrees?/2" do
+    defp work_record(title, authors) do
+      %{"source" => "provider:hardcover", "id" => title, "title" => title, "authors" => authors}
+    end
+
+    # Pre-ticking is `top_group/1`, which is `agrees?/2` with no score floor at
+    # all — so this record, scored 0.25 by the companion penalty, was ticked
+    # onto the operator's Martian anyway.
+    test "a companion work never agrees with the book it is about" do
+      book = work_record("The Martian", ["Andy Weir"])
+      guide = work_record("The Martian: A Novel by Andy Weir | Unofficial Summary & Analysis", [])
+
+      refute AutoMatch.agrees?(guide, book)
+    end
+
+    # The rule it rides in on, which has to keep working: a genuine subtitle.
+    test "a subtitled edition still agrees with its bare title" do
+      bare = work_record("Cast Under an Alien Sun", ["Olan Thorensen"])
+      subtitled = work_record("Cast Under an Alien Sun: Destiny's Crucible, Book 1", [])
+
+      assert AutoMatch.agrees?(subtitled, bare)
+    end
+  end
+
   describe "dedupe_records/2" do
     defp row(attrs) do
       Map.merge(

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -73,6 +73,104 @@ defmodule Ambry.Inbox.AutoMatchTest do
     end
   end
 
+  describe "author_agreement/2" do
+    # Jaro puts these five hundredths apart, in the wrong order for any
+    # threshold: the same person scores 0.573 and two unrelated names 0.519.
+    test "a shared name token separates a variant from a different human" do
+      assert :match = AutoMatch.author_agreement(["J.R.R. Tolkien"], "John Ronald Reuel Tolkien")
+      assert :conflict = AutoMatch.author_agreement(["Daily  Books"], "Andy Weir")
+      assert :conflict = AutoMatch.author_agreement(["Scott M. Williams"], "Andy Weir")
+    end
+
+    test "any one of several authors agreeing is agreement" do
+      assert :match = AutoMatch.author_agreement(["Andy Weir", "Chris Hadfield"], "Andy Weir")
+    end
+
+    test "silence on either side, or a name with nothing comparable, abstains" do
+      assert :unstated = AutoMatch.author_agreement([], "Andy Weir")
+      assert :unstated = AutoMatch.author_agreement(["Andy Weir"], nil)
+      assert :unstated = AutoMatch.author_agreement(["J.R.R."], "Andy Weir")
+    end
+
+    # Initials match everything.
+    test "single letters are not tokens" do
+      assert :conflict = AutoMatch.author_agreement(["J. Smith"], "J. Jones")
+    end
+  end
+
+  describe "scoring an author who is not the author" do
+    defp scored(title, authors, wanted_author) do
+      entry = %Registry.Entry{id: "hardcover", display_name: "Hardcover"}
+      book = %Provider.Book{id: "1", title: title, authors: contributors(authors)}
+
+      hints =
+        AutoMatch.hints(%InboxItem{
+          path: "/d/The Martian",
+          tags: %{"book_title" => "The Martian", "authors" => [wanted_author]}
+        })
+
+      [record] = AutoMatch.records_from([book], entry, hints)
+      record["score"]
+    end
+
+    defp contributors(names) do
+      Enum.map(names, &%Provider.Contributor{name: &1, role: "author"})
+    end
+
+    # Measured at 0.88 on the operator's Martian import: a head-matched title
+    # scores a full 1.0, and a completely wrong author still added 0.13 on top
+    # of three quarters of it. "Conversation Starters" is in no marker list
+    # and never will be — the author is what says this isn't the book.
+    test "a companion work by a content farm is decisively marked down" do
+      assert scored(
+               "The Martian: A Novel By Andy Weir | Conversation Starters",
+               ["Daily  Books"],
+               "Andy Weir"
+             ) == 0.5
+    end
+
+    test "the book itself is unharmed" do
+      assert scored("The Martian", ["Andy Weir"], "Andy Weir") == 1.0
+    end
+
+    test "a record naming no author is neither credited nor punished" do
+      assert scored("The Martian", [], "Andy Weir") == 1.0
+    end
+  end
+
+  describe "settled_group/1" do
+    defp reading(id, narrators, score, evidence) do
+      %{
+        "source" => "provider:hardcover",
+        "id" => id,
+        "title" => "The Martian",
+        "narrators" => narrators,
+        "score" => score,
+        "narrator_evidence" => evidence
+      }
+    end
+
+    # B082BHWQCJ is Wil Wheaton's edition with the role string missing
+    # upstream: silent, so unpenalised, so still at 1.000, so ticked — and it
+    # handed a 2013 R.C. Bray recording Wheaton's 2020 release date.
+    test "a silent record is not pre-ticked once the file has named a reader" do
+      records = [
+        reading("bray", ["R.C. Bray"], 1.0, "supported"),
+        reading("silent", [], 1.0, nil)
+      ]
+
+      assert [%{"id" => "bray"}] = AutoMatch.settled_group(records)
+    end
+
+    # The ordinary case across most of a library.
+    test "with nothing corroborated it is top_group exactly" do
+      records = [reading("a", ["Someone"], 1.0, nil), reading("b", [], 1.0, nil)]
+
+      assert AutoMatch.settled_group(records) == AutoMatch.top_group(records)
+      assert length(AutoMatch.settled_group(records)) == 2
+    end
+  end
+
   describe "agrees?/2" do
     defp work_record(title, authors) do
       %{"source" => "provider:hardcover", "id" => title, "title" => title, "authors" => authors}

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -57,6 +57,250 @@ defmodule Ambry.Inbox.AutoMatchTest do
       assert %{asin: "B003ZWFO7E"} =
                AutoMatch.hints(%InboxItem{path: "/d/Whatever", tags: %{"asin" => "B003ZWFO7E"}})
     end
+
+    test "carries the item's raw text, basenames only" do
+      item = %InboxItem{
+        path: "/home/someone/downloads/Weir Andy - The Martian (R.C. Bray) - 2013",
+        files: ["/home/someone/downloads/Weir Andy - The Martian (R.C. Bray) - 2013/part1.mp3"],
+        tags: %{"book_title" => "The Martian (Unabridged)", "authors" => ["Andy Weir"]}
+      }
+
+      assert %{raw: raw} = AutoMatch.hints(item)
+      assert raw =~ "R.C. Bray"
+      assert raw =~ "part1.mp3"
+      assert raw =~ "Andy Weir"
+      refute raw =~ "someone"
+    end
+  end
+
+  describe "dedupe_records/2" do
+    defp row(attrs) do
+      Map.merge(
+        %{
+          "source" => "provider:hardcover",
+          "id" => "1",
+          "title" => "The Martian",
+          "narrators" => ["R.C. Bray"],
+          "asin" => nil,
+          "publisher" => nil,
+          "score" => 0.75
+        },
+        attrs
+      )
+    end
+
+    # Of Hardcover's four Wil Wheaton rows for The Martian, exactly one
+    # carries an ASIN. Picking a winner and dropping the rest threw it away
+    # three times in four.
+    test "the survivor takes the union of the rows it absorbs" do
+      records = [
+        row(%{"id" => "a"}),
+        row(%{"id" => "b", "asin" => "B00B5HZGUG"}),
+        row(%{"id" => "c", "publisher" => "Podium Publishing"})
+      ]
+
+      assert [merged] = AutoMatch.dedupe_records(records)
+      assert merged["id"] == "a"
+      assert merged["asin"] == "B00B5HZGUG"
+      assert merged["publisher"] == "Podium Publishing"
+      assert merged["duplicates"] == 3
+    end
+
+    test "two readers of one book are not duplicates" do
+      records = [
+        row(%{"id" => "bray"}),
+        row(%{"id" => "wheaton", "narrators" => ["Wil Wheaton"]})
+      ]
+
+      assert length(AutoMatch.dedupe_records(records)) == 2
+    end
+
+    # Two Audible ASINs for one Wheaton recording are a US and a UK edition —
+    # and the operator's file matches one of them.
+    test "records disagreeing on ASIN or publisher stay apart" do
+      records = [
+        row(%{"id" => "us", "asin" => "B082BHJMFF"}),
+        row(%{"id" => "uk", "asin" => "B082BHWQCJ"})
+      ]
+
+      assert length(AutoMatch.dedupe_records(records)) == 2
+
+      publishers = [
+        row(%{"id" => "podium", "publisher" => "Podium Publishing"}),
+        row(%{"id" => "brilliance", "publisher" => "Brilliance Audio"})
+      ]
+
+      assert length(AutoMatch.dedupe_records(publishers)) == 2
+    end
+
+    # Two databases describing one book is the case this module refuses to
+    # fuse — each knows something the other doesn't.
+    test "never merges across providers" do
+      records = [row(%{"id" => "1"}), row(%{"id" => "1", "source" => "provider:audible"})]
+
+      assert length(AutoMatch.dedupe_records(records)) == 2
+    end
+
+    # An edition crediting nobody is not evidence that it is some other
+    # edition's recording.
+    test "a record naming no narrator does not merge into one that does" do
+      records = [row(%{"id" => "named"}), row(%{"id" => "silent", "narrators" => []})]
+
+      assert length(AutoMatch.dedupe_records(records)) == 2
+    end
+
+    # The draft points at records by ref. Collapsing a ticked record into a
+    # look-alike would break that pointer and silently un-tick the operator's
+    # choice.
+    test "a pinned record keeps its identity" do
+      records = [row(%{"id" => "a"}), row(%{"id" => "ticked"})]
+      pinned = MapSet.new([{"provider:hardcover", "ticked"}])
+
+      assert [_a, ticked] = AutoMatch.dedupe_records(records, pinned)
+      assert ticked["id"] == "ticked"
+    end
+
+    test "first occurrence keeps the identity" do
+      records = [row(%{"id" => "already-on-the-item"}), row(%{"id" => "newly-found"})]
+
+      assert [merged] = AutoMatch.dedupe_records(records)
+      assert merged["id"] == "already-on-the-item"
+    end
+  end
+
+  describe "apply_narrator_evidence/2" do
+    # The Martian, measured: tags carry no narrator at all, "(R.C. Bray)" sits
+    # in the filename in a shape `extract_narrator/1` doesn't know, so the
+    # forward scorer no-ops and Audible's Wil Wheaton edition took the item at
+    # a perfect 1.0.
+    defp martian_hints do
+      AutoMatch.hints(%InboxItem{
+        path: "/d/Weir Andy - The Martian (R.C. Bray) - 2013 (320 kbp)",
+        tags: %{"book_title" => "The Martian (Unabridged)", "authors" => ["Andy Weir"]}
+      })
+    end
+
+    defp candidate(id, narrators, score) do
+      %{
+        "source" => "provider:hardcover",
+        "id" => id,
+        "title" => "The Martian",
+        "narrators" => narrators,
+        "score" => score
+      }
+    end
+
+    test "demotes a reader the file never mentions, in favour of one it does" do
+      candidates = [
+        candidate("wheaton", ["Wil Wheaton"], 1.0),
+        candidate("bray", ["R.C. Bray"], 0.75)
+      ]
+
+      assert [bray, wheaton] = AutoMatch.apply_narrator_evidence(candidates, martian_hints())
+
+      assert bray["id"] == "bray"
+      assert bray["narrator_evidence"] == "supported"
+      assert bray["score"] > wheaton["score"]
+
+      assert wheaton["narrator_evidence"] == "contradicted"
+      assert wheaton["score"] == 0.5
+    end
+
+    # The ordinary case, and the one this must not break: most files say
+    # nothing about who read them, and a check that punished every candidate
+    # for that would sink every correct match in the library.
+    test "changes nothing when the file names no reader at all" do
+      candidates = [
+        candidate("wheaton", ["Wil Wheaton"], 1.0),
+        candidate("dean", ["Robertson Dean"], 0.75)
+      ]
+
+      hints =
+        AutoMatch.hints(%InboxItem{
+          path: "/d/The Martian",
+          tags: %{"book_title" => "The Martian"}
+        })
+
+      assert ^candidates = AutoMatch.apply_narrator_evidence(candidates, hints)
+    end
+
+    test "leaves a record that names no reader alone" do
+      candidates = [candidate("bray", ["R.C. Bray"], 0.75), candidate("silent", [], 0.9)]
+
+      assert [silent, _bray] = AutoMatch.apply_narrator_evidence(candidates, martian_hints())
+      assert silent["id"] == "silent"
+      assert silent["score"] == 0.9
+      refute Map.has_key?(silent, "narrator_evidence")
+    end
+
+    # A re-search runs this again over records that already carry a verdict.
+    # Multiplying into the running score would sink the same candidate a
+    # little further on every visit.
+    test "is idempotent" do
+      candidates = [
+        candidate("wheaton", ["Wil Wheaton"], 1.0),
+        candidate("bray", ["R.C. Bray"], 0.75)
+      ]
+
+      once = AutoMatch.apply_narrator_evidence(candidates, martian_hints())
+      assert ^once = AutoMatch.apply_narrator_evidence(once, martian_hints())
+    end
+
+    # The stated credit is the stronger signal and the forward scorer already
+    # has it; leaving both live would apply two narrator factors at once.
+    test "stands down when the file states a narrator outright" do
+      candidates = [candidate("bray", ["R.C. Bray"], 0.75)]
+
+      hints =
+        AutoMatch.hints(%InboxItem{
+          path: "/d/The Martian (R.C. Bray)",
+          tags: %{"book_title" => "The Martian", "narrators" => ["R.C. Bray"]}
+        })
+
+      assert ^candidates = AutoMatch.apply_narrator_evidence(candidates, hints)
+    end
+
+    # "Full Cast" is a label for a cast, not a person, so `stated_narrator/1`
+    # rejects it and the forward path has nothing to work with — which is
+    # exactly when this has to step in.
+    test "still runs for a full-cast release, on any one of the cast" do
+      hints =
+        AutoMatch.hints(%InboxItem{
+          path: "/d/Harry Potter and the Philosopher's Stone (Full Cast)",
+          files: ["/d/HP1/Hugh Laurie, Matthew Macfadyen - part 1.mp3"],
+          tags: %{"book_title" => "Harry Potter", "narrators" => ["Full Cast"]}
+        })
+
+      candidates = [
+        candidate("solo", ["Stephen Fry"], 1.0),
+        candidate("cast", ["Hugh Laurie", "Matthew Macfadyen", "Fifteen Others"], 0.8)
+      ]
+
+      assert [cast, solo] = AutoMatch.apply_narrator_evidence(candidates, hints)
+      assert cast["id"] == "cast"
+      assert solo["narrator_evidence"] == "contradicted"
+    end
+
+    # The boost is capped at 1.0, so a corroborated candidate cannot out-score
+    # a silent one already sitting there — which is exactly what The Martian
+    # produces. The tie-break is what puts the file's own reader on top.
+    test "a corroborated candidate outranks a silent one it cannot out-score" do
+      candidates = [candidate("silent", [], 1.0), candidate("bray", ["R.C. Bray"], 1.0)]
+
+      assert [bray, silent] = AutoMatch.apply_narrator_evidence(candidates, martian_hints())
+      assert bray["id"] == "bray"
+      assert bray["score"] == silent["score"]
+    end
+
+    # "R.C." reduces to nothing searchable — one- and two-letter tokens match
+    # almost any filename — so a name with no substantial part abstains
+    # instead of guessing.
+    test "abstains on a name with nothing substantial to match" do
+      candidates = [candidate("initials", ["R.C."], 0.9), candidate("bray", ["R.C. Bray"], 0.75)]
+
+      assert [_bray, initials] = AutoMatch.apply_narrator_evidence(candidates, martian_hints())
+      assert initials["narrator_evidence"] == "contradicted"
+    end
   end
 
   describe "match/1" do

--- a/test/ambry/metadata/providers/hardcover_test.exs
+++ b/test/ambry/metadata/providers/hardcover_test.exs
@@ -200,6 +200,110 @@ defmodule Ambry.Metadata.Providers.HardcoverTest do
     end
   end
 
+  describe "editions/2" do
+    defp edition(attrs) do
+      Map.merge(
+        %{
+          "id" => 1,
+          "title" => "The Martian",
+          "asin" => nil,
+          "audio_seconds" => nil,
+          "reading_format_id" => 1,
+          "release_date" => nil,
+          "publisher" => nil,
+          "image" => nil,
+          "contributions" => []
+        },
+        attrs
+      )
+    end
+
+    defp narrated_by(name, role) do
+      [%{"contribution" => role, "author" => %{"id" => 250_358, "name" => name}}]
+    end
+
+    # The Martian has 150 editions on Hardcover, so a `limit` over an
+    # unfiltered set decided by nothing at all which ones came back — and
+    # R.C. Bray's delisted recording, the exact case `:editions` exists for,
+    # was not among them.
+    test "asks the server for audio editions rather than filtering a page here" do
+      patch(Client, :query, fn _config, query, vars ->
+        assert query =~ "reading_format_id: {_eq: 2}"
+        assert query =~ "audio_seconds: {_is_null: false}"
+        assert query =~ "contribution: {_in: $roles}"
+        assert "Narrator" in vars.roles
+        {:ok, %{"editions" => []}}
+      end)
+
+      assert {:ok, []} = Hardcover.editions("292354", %{})
+    end
+
+    # Measured across 400 audiobook editions: "Narrator" 286, "Reading" 9,
+    # "Reader" 7, "narrator" 7, "Read by" 5. R.C. Bray is credited on The
+    # Martian under four of the five.
+    test "recognizes every spelling of the narrator credit" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:ok,
+         %{
+           "editions" =>
+             for {role, id} <- Enum.with_index(["Narrator", "Reader", "Reading", "read by"]) do
+               edition(%{"id" => id, "contributions" => narrated_by("R.C. Bray", role)})
+             end
+         }}
+      end)
+
+      assert {:ok, books} = Hardcover.editions("292354", %{})
+      assert length(books) == 4
+      assert Enum.all?(books, &match?([%Provider.Contributor{name: "R.C. Bray"}], &1.narrators))
+    end
+
+    # nil is how Hardcover credits the *author* — Andy Weir is nil on every
+    # Martian edition — so reading it as a narrator credits authors as their
+    # own readers.
+    test "does not read a nil contribution as a narrator credit" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:ok,
+         %{
+           "editions" => [
+             edition(%{
+               "reading_format_id" => 2,
+               "contributions" => narrated_by("Andy Weir", nil)
+             })
+           ]
+         }}
+      end)
+
+      assert {:ok, [book]} = Hardcover.editions("292354", %{})
+      assert book.narrators == []
+    end
+
+    # Unreliable as a negative (audio editions are stored as format 1), which
+    # is why it can't be the filter — but as a positive it is good evidence.
+    test "keeps an audiobook-format edition that names no narrator" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:ok, %{"editions" => [edition(%{"reading_format_id" => 2})]}}
+      end)
+
+      assert {:ok, [%Provider.Book{narrators: []}]} = Hardcover.editions("292354", %{})
+    end
+
+    test "drops a print edition the recall filter swept in" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:ok,
+         %{
+           "editions" => [
+             edition(%{
+               "reading_format_id" => 1,
+               "contributions" => narrated_by("Some Translator", "Translator")
+             })
+           ]
+         }}
+      end)
+
+      assert {:ok, []} = Hardcover.editions("292354", %{})
+    end
+  end
+
   describe "token_expiry/1" do
     test "decodes the exp claim" do
       assert {:ok, %DateTime{year: 2027}} =

--- a/test/ambry/metadata/providers/hardcover_test.exs
+++ b/test/ambry/metadata/providers/hardcover_test.exs
@@ -222,6 +222,32 @@ defmodule Ambry.Metadata.Providers.HardcoverTest do
       [%{"contribution" => role, "author" => %{"id" => 250_358, "name" => name}}]
     end
 
+    defp by_author(name) do
+      %{"contributions" => [%{"contribution" => nil, "author" => %{"id" => 1, "name" => name}}]}
+    end
+
+    # Hardcover files authors under a nil contribution — and on The Martian's
+    # B082BHWQCJ the nil-role contributor is Wil Wheaton, its *narrator*. Read
+    # off the edition, that record credited Wheaton as an author of the novel.
+    # An edition of a book has that book's author by definition.
+    test "authors come from the work, not from the edition's own contributions" do
+      patch(Client, :query, fn _config, _query, _vars ->
+        {:ok,
+         %{
+           "editions" => [
+             edition(%{
+               "reading_format_id" => 2,
+               "contributions" => narrated_by("Wil Wheaton", nil),
+               "book" => by_author("Andy Weir")
+             })
+           ]
+         }}
+      end)
+
+      assert {:ok, [book]} = Hardcover.editions("292354", %{})
+      assert [%Provider.Contributor{name: "Andy Weir", role: "author"}] = book.authors
+    end
+
     # The Martian has 150 editions on Hardcover, so a `limit` over an
     # unfiltered set decided by nothing at all which ones came back — and
     # R.C. Bray's delisted recording, the exact case `:editions` exists for,

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -572,6 +572,63 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert work.book_id == book.id
     end
 
+    # Eight rows all wearing the same weight is how a 6% study guide got read
+    # as an alternative worth considering.
+    test "a junk record is folded away behind a link", %{conn: conn} do
+      item = probed_item() |> with_work_records(scores: %{"hc-2" => 0.12})
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Show 1 worse match"
+      assert folded_records(html) == ["hc-2"]
+    end
+
+    test "nothing is folded when every record is worth showing", %{conn: conn} do
+      item = probed_item() |> with_work_records()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute html =~ "worse match"
+      assert folded_records(html) == []
+    end
+
+    # A low score is exactly why somebody would have gone looking for it by
+    # hand; folding it away afterwards would show a decision with no cause.
+    test "a ticked record is never folded, whatever it scores", %{conn: conn} do
+      item = probed_item() |> with_work_records(scores: %{"hc-2" => 0.12})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("input[phx-click='toggle-source'][phx-value-id='hc-2']")
+        |> render_click()
+
+      assert folded_records(html) == []
+      assert html =~ "hc-2"
+    end
+
+    # Square art is the audiobook and a portrait is the print cover, and
+    # cropping to fill made those two indistinguishable. The box is reserved
+    # either way so the titles stay on one rail.
+    test "a cover keeps its shape, and a record without one still reserves the space",
+         %{conn: conn} do
+      item =
+        probed_item()
+        |> with_work_records(covers: %{"hc-1" => "https://example.test/cover.jpg"})
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      rows = html |> Floki.parse_document!() |> Floki.find("[data-role='record']")
+
+      assert [with_cover, without] = rows
+      assert [class] = with_cover |> Floki.find("img") |> Floki.attribute("class")
+      assert class =~ "object-contain"
+      refute class =~ "object-cover"
+
+      assert without |> Floki.find("[title='No image']") != []
+      assert without |> Floki.find("img") == []
+    end
+
     test "the search that produced the records can be re-run", %{conn: conn} do
       item = probed_item() |> with_work_records()
 
@@ -1022,7 +1079,8 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
         "authors" => ["Brandon Sanderson"],
         "published" => published,
         "published_format" => "full",
-        "score" => if(id == "hc-1", do: 0.95, else: 0.6)
+        "cover_url" => Keyword.get(opts, :covers, %{})[id],
+        "score" => Keyword.get(opts, :scores, %{})[id] || if(id == "hc-1", do: 0.95, else: 0.6)
       }
     end
 
@@ -1107,6 +1165,13 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
     {:ok, item} = Inbox.rebuild_draft(item)
     item
+  end
+
+  defp folded_records(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("[data-role='worse-matches'] [data-role='record'] input[type='checkbox']")
+    |> Enum.flat_map(&Floki.attribute([&1], "phx-value-id"))
   end
 
   defp used_records(html) do


### PR DESCRIPTION
The operator's own R.C. Bray recording of The Martian was matched to Wil
Wheaton's, at a perfect 1.0, unopposed. Unpicking that took four bugs, a new
matching rule, and an audit of which providers we ask what.

Test bed: **inbox item 103**, the real file, symlinked into the dev downloads
fixture. Its tags carry a title, an author, a year, and **no narrator at
all** — the only place "R.C. Bray" appears is the filename.

| | before | after |
|---|---|---|
| top recording | Wil Wheaton, 1.000 | **R.C. Bray, 1.000, with ASIN `B00B5HZGUG`** |
| Wheaton's edition | 1.000, pre-ticked | 0.500, `contradicted` |
| Hardcover audio editions found | 2 (both German) | 13 |
| study guide at 0.25 | pre-ticked | not ticked, folded away |
| release date | conflicted (2013 vs 2020) | no conflict |

## The bugs

**Hardcover's editions query took an arbitrary 60 rows of 150.** No ordering,
no server-side filter, so nothing decided which 60 — and the audiobooks
weren't among them. Neuromancer only ever worked because it is a smaller
book. Filtering upstream returns the whole audio set.

**The narrator credit is spelled five ways.** Measured across 400 audiobook
editions: `Narrator` 286, `Reading` 9, `Reader` 7, `narrator` 7, `Read by` 5.
Bray is credited under four of them. A `nil` contribution stays excluded —
that is how Hardcover credits the author.

**"Didn't say" was scored as "said no", twice.** A record naming no author
was scored as naming the *wrong* one, costing a flat 25% — and editions pay
that, since an edition lists its narrator where the work lists its author. A
companion work naming no author was also read as *agreeing* with the book, so
"The Martian: … | Unofficial Summary & Analysis" was pre-ticked at 0.25.
Sharpest part: the two companion works naming a *different* author were
correctly excluded, so the record with the worst data earned the most trust.

**Jaro cannot judge a name.** `"J.R.R. Tolkien"` vs `"John Ronald Reuel
Tolkien"` scores 0.573; `"Daily  Books"` vs `"Andy Weir"` scores 0.519. Five
hundredths apart, in the wrong order for any threshold — which is how a
content farm's "Conversation Starters" reached 0.88. The author is now
near-binary and tested by shared name token, exactly as this module already
does for narrators and as `PersonSearch` already does for people.

## The new rule: matching backwards

Everything else runs forwards — read the item, build a query, score what
comes back. `apply_narrator_evidence/2` runs the other way: take each
candidate's narrators and look for them in the item's raw, unparsed text.
Three-valued, and the middle value carries it:

- **supported** — a candidate's reader is named in the file
- **unstated** — *no* candidate's reader is named anywhere; nothing is
  adjusted, which is the ordinary case and must stay a no-op
- **contradicted** — this candidate's reader is absent while a rival's is
  present. Only then has the file spoken

Full-cast releases land here by construction: "Full Cast" is a placeholder
the forward path discards.

Ticking is held to a higher bar than ranking — `settled_group/1` pre-ticks
only corroborated records once the file has named a reader, because a record
naming nobody cannot support the claim "this describes my file". That is what
was handing a 2013 recording a 2020 release date.

## Also

- **Within-provider dedup**, merge-don't-drop: Hardcover returns one
  recording on four rows and of Wheaton's four only one carries an ASIN. The
  first occurrence keeps the identity (the draft points at records by ref)
  and anything ticked is pinned.
- **Junk folded** behind "Show N worse matches" below 0.5. Ticked and
  unscored records are never folded.
- **Covers keep their aspect ratio** — `object-cover` cropped every portrait
  jacket square, erasing the one distinction (square = audiobook, portrait =
  print) an operator scans these for. Records with no art reserve the box so
  titles stay on one rail.
- **The embedded-cover preview 404'd into a broken image.** The file declares
  a PNG picture stream and carries a big-endian TIFF; ffprobe says so itself.
  libvips reads it, so anything it can read is served as JPEG. No new
  dependencies — `:image` was already in the tree and vix bundles libvips.

## Audit findings left open

Written up in ROADMAP under 3e: `retry_plainer` only fires for background
matching, so every *manual* search misses the subtitle-stripping retry; the
media edit form discards its work-search outcomes; chapters bypass the
registry entirely; and rreading-glasses is documented as an editions source
it has never been (its Goodreads query omits secondary contributors, so its
editions carry no narrator at all — `:editions` for it was considered and
rejected).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx