### PR TITLE
A recording can be more than one file (2f)

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -193,14 +193,8 @@ defmodule Ambry.Inbox do
   def probe_item(%InboxItem{} = item, opts \\ []) do
     attrs =
       case item.files do
-        [file] ->
-          probe_single(file, single_file: true)
-
-        [] ->
-          %{issue: "no audio files found"}
-
-        [file | _rest] ->
-          file |> probe_single() |> Map.put(:issue, multi_file_issue(item))
+        [] -> %{issue: "no audio files found"}
+        files -> probe_recording(files)
       end
 
     with {:ok, item} <- update_item(item, attrs) do
@@ -671,9 +665,6 @@ defmodule Ambry.Inbox do
   item, so the row tomorrow says exactly what the toast said today.
   """
 
-  def describe_error(:multi_file_unsupported),
-    do: "Several audio files — an import is one file, so split this into one item per file first."
-
   def describe_error(:no_published_date),
     do:
       "No publication date, and one can't be invented. Match a work, or tag the file with a date."
@@ -1002,31 +993,41 @@ defmodule Ambry.Inbox do
     MapSet.new(track_paths ++ source_files)
   end
 
-  defp probe_single(file, opts \\ []) do
-    case Scanner.probe_file(file, opts) do
-      {:ok, probe} ->
-        %{probe: probe_map(probe), tags: tags_map(probe.tags), issue: nil}
+  # The whole release, measured as the one recording it will become: the
+  # durations add up into a single book timeline, and the tags are read off
+  # the first file the way playback will encounter it.
+  #
+  # This costs no more than a single-file release of the same book — the
+  # expensive part is decode-counting VBR mp3s, and forty files hold the same
+  # fourteen hours of audio one file would.
+  defp probe_recording(files) do
+    case Scanner.probe_all(files) do
+      {:ok, [first | _rest] = probes} ->
+        %{probe: probe_map(probes), tags: tags_map(first.tags), issue: nil}
 
       {:error, reason} ->
         %{issue: "couldn't read the file: #{inspect(reason)}"}
     end
   end
 
-  defp multi_file_issue(%InboxItem{files: files}) do
-    "#{length(files)} audio files — an import is one file; split this into one item per file below"
+  defp probe_map([first | _rest] = probes) do
+    %{
+      "path" => first.path,
+      "files" => length(probes),
+      "size" => Enum.reduce(probes, 0, &(&1.size + &2)),
+      "format" => first.format,
+      "codec" => first.codec,
+      "mime" => first.mime,
+      "duration" => probes |> Scanner.total_duration() |> Decimal.to_string(),
+      # The worst of them, not the first: one file that can't be seeked
+      # accurately makes every seek past it inaccurate too.
+      "seek_accuracy" => probes |> Enum.map(& &1.seek_accuracy) |> seek_accuracy(),
+      "chapters" => length(Scanner.embedded_chapters(probes))
+    }
   end
 
-  defp probe_map(probe) do
-    %{
-      "path" => probe.path,
-      "size" => probe.size,
-      "format" => probe.format,
-      "codec" => probe.codec,
-      "mime" => probe.mime,
-      "duration" => probe.duration && Decimal.to_string(probe.duration),
-      "seek_accuracy" => to_string(probe.seek_accuracy),
-      "chapters" => length(probe.chapters)
-    }
+  defp seek_accuracy(accuracies) do
+    if Enum.any?(accuracies, &(&1 == :approximate)), do: "approximate", else: "exact"
   end
 
   defp tags_map(tags) do

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -86,18 +86,18 @@ defmodule Ambry.Inbox.Importer do
     item = Repo.preload(item, :source)
 
     # Facts about the files come first, then the draft, then placement. The
-    # order is the order the operator can act on them: a multi-file release or
-    # a vanished file is not something any amount of curation fixes, so
-    # reporting an unresolved decision on one would send them to the form to
-    # fix something the form can't fix.
-    with {:ok, file} <- single_file(item),
-         {:ok, probe} <- probe(file),
+    # order is the order the operator can act on them: a vanished file is not
+    # something any amount of curation fixes, so reporting an unresolved
+    # decision on one would send them to the form to fix something the form
+    # can't fix.
+    with {:ok, files} <- audio_files(item),
+         {:ok, probes} <- probe_all(files),
          :ok <- resolved(item),
          {:ok, destination} <- destination(item),
-         {:ok, {media, placement}} <- create(item, file, probe, destination) do
+         {:ok, {media, placements}} <- create(item, files, probes, destination) do
       # Only now, with the records committed, is it safe to remove a moved
       # file's source.
-      log_finalize(Placement.finalize(placement), item)
+      log_finalize(Placement.finalize(placements), item)
       {:ok, media}
     end
   end
@@ -133,7 +133,7 @@ defmodule Ambry.Inbox.Importer do
   # fail at the commit and the worst case is a stray file in the library,
   # which the audit tooling surfaces — never a file whose source was already
   # deleted and whose record didn't survive.
-  defp create(item, file, probe, destination) do
+  defp create(item, files, probes, destination) do
     Repo.transact(fn ->
       # People first, and for the whole draft at once: the same human can be
       # behind two credits, and each credit creating its own left a
@@ -141,11 +141,11 @@ defmodule Ambry.Inbox.Importer do
       with {:ok, item} <- claim(item),
            {:ok, people} <- resolve_people(item.draft),
            {:ok, book} <- resolve_book(item.draft.work, people),
-           {:ok, media} <- create_media(item, book, probe, people),
+           {:ok, media} <- create_media(item, book, probes, people),
            {:ok, _item} <- link(item, media),
-           {:ok, media, placement} <- place(destination, book, media, file),
+           {:ok, media, placements} <- place(destination, book, media, files),
            {:ok, media} <- publish(media) do
-        {:ok, {media, placement}}
+        {:ok, {media, placements}}
       end
     end)
   end
@@ -326,11 +326,11 @@ defmodule Ambry.Inbox.Importer do
 
   ## the recording
 
-  defp create_media(item, book, probe, people) do
+  defp create_media(item, book, probes, people) do
     recording = item.draft.recording
 
     with {:ok, group} <- resolve_group(recording.recording_group, book) do
-      do_create_media(item, book, probe, people, recording, group)
+      do_create_media(item, book, probes, people, recording, group)
     end
   end
 
@@ -352,7 +352,7 @@ defmodule Ambry.Inbox.Importer do
         parts_total: link.parts_total
       })
 
-  defp do_create_media(item, book, probe, people, recording, group) do
+  defp do_create_media(item, book, probes, people, recording, group) do
     Media.create_media(
       %{
         book_id: book.id,
@@ -365,10 +365,10 @@ defmodule Ambry.Inbox.Importer do
         # The recording's settled place in its part set, if any.
         part_number: part_number(recording.recording_group),
         recording_group_id: group && group.id,
-        duration: probe.duration,
-        chapters: probe.chapters,
+        duration: Scanner.total_duration(probes),
+        chapters: Scanner.embedded_chapters(probes),
         media_narrators: narrator_params(recording.narrators, people),
-        media_tracks: [track_params(probe)],
+        media_tracks: Scanner.track_attrs(probes),
         title: Field.value(recording.title),
         published: Field.date(recording.published),
         published_format: Field.format_atom(recording.published, :full),
@@ -421,20 +421,6 @@ defmodule Ambry.Inbox.Importer do
   defp log_cover(source, reason) do
     Logger.warning(fn -> "Couldn't bring in the cover from #{source}: #{inspect(reason)}" end)
     nil
-  end
-
-  defp track_params(probe) do
-    %{
-      index: 0,
-      path: probe.path,
-      size: probe.size,
-      mime: probe.mime,
-      format: probe.format,
-      codec: probe.codec,
-      duration: probe.duration,
-      start_offset: 0,
-      seek_accuracy: probe.seek_accuracy
-    }
   end
 
   ## provenance
@@ -521,9 +507,9 @@ defmodule Ambry.Inbox.Importer do
 
   defp destination(%InboxItem{}), do: {:ok, :adopt}
 
-  defp place(:adopt, _book, media, _file), do: {:ok, media, nil}
+  defp place(:adopt, _book, media, _files), do: {:ok, media, []}
 
-  defp place({root, policy}, book, media, file) do
+  defp place({root, policy}, book, media, files) do
     # Forced: a freshly-created book carries its `book_authors` as insert
     # results with the nested `author` unloaded, and a reused one carries
     # nothing at all. Without this every folder silently loses its author
@@ -535,11 +521,11 @@ defmodule Ambry.Inbox.Importer do
     values = Books.naming_values(book, media)
 
     with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
-         {:ok, filename} <- NamingTemplate.filename(values, file, filename_part(media)),
-         path = Path.join([root.path, folder, filename]),
-         {:ok, placement} <- Placement.place(file, path, policy),
-         {:ok, media} <- adopt_managed(media, path) do
-      {:ok, media, placement}
+         {:ok, filenames} <- NamingTemplate.filenames(values, files, filename_part(media)),
+         paths = Enum.map(filenames, &Path.join([root.path, folder, &1])),
+         {:ok, placements} <- Placement.place_all(Enum.zip(files, paths), policy),
+         {:ok, media} <- adopt_managed(media, paths) do
+      {:ok, media, placements}
     end
   end
 
@@ -556,24 +542,41 @@ defmodule Ambry.Inbox.Importer do
   defp part_number(%GroupLink{removed: false, part_number: number}), do: number
   defp part_number(_absent_or_removed), do: nil
 
-  # The recording now points at the library copy and Ambry owns those bytes.
-  defp adopt_managed(media, path) do
-    with {:ok, _track} <- repoint_track(media, path) do
+  # The recording now points at the library copies and Ambry owns those
+  # bytes. `source_path` is the folder those copies share, which for a
+  # multi-file recording is the subfolder of its own that placement gave it,
+  # not the book folder it sits in.
+  defp adopt_managed(media, paths) do
+    with {:ok, _tracks} <- repoint_tracks(media, paths) do
       media
       |> Ecto.Changeset.change(%{
         custody: :managed,
-        source_path: Path.dirname(path),
-        source_files: [path]
+        source_path: paths |> hd() |> Path.dirname(),
+        source_files: paths
       })
       |> Repo.update()
     end
   end
 
-  defp repoint_track(%{media_tracks: [track | _rest]}, path) do
-    track |> Ecto.Changeset.change(%{path: path}) |> Repo.update()
+  # Zipped by position, and the positions are the same order everywhere: the
+  # probes were taken in it, the tracks were written in it, and the
+  # destination names were rendered from it.
+  defp repoint_tracks(%{media_tracks: [_ | _] = tracks}, paths) do
+    tracks
+    |> Enum.sort_by(& &1.index)
+    |> Enum.zip(paths)
+    |> Enum.reduce_while({:ok, []}, fn {track, path}, {:ok, acc} ->
+      track
+      |> Ecto.Changeset.change(%{path: path})
+      |> Repo.update()
+      |> case do
+        {:ok, track} -> {:cont, {:ok, [track | acc]}}
+        {:error, changeset} -> {:halt, {:error, changeset}}
+      end
+    end)
   end
 
-  defp repoint_track(_no_tracks, _path), do: {:error, :no_tracks}
+  defp repoint_tracks(_no_tracks, _paths), do: {:error, :no_tracks}
 
   # A source that couldn't be removed is untidy, not broken: the library copy
   # exists and is recorded. Failing the import here would be worse than
@@ -588,20 +591,20 @@ defmodule Ambry.Inbox.Importer do
 
   ## files
 
-  # An import is one file — a recording whose tracks can't be described has
-  # no business in the library, and a multi-file item is split into one item
-  # per file first.
-  defp single_file(%InboxItem{files: [file]}), do: {:ok, file}
-  defp single_file(%InboxItem{files: []}), do: {:error, :no_audio_files}
-  defp single_file(%InboxItem{}), do: {:error, :multi_file_unsupported}
+  # An item's files, in the order discovery recorded them — which is natural
+  # sort, and therefore the play order the operator saw listed on the form.
+  # A release the operator has decided is really two books is split into
+  # separate items first; this is the one they've said is one recording.
+  defp audio_files(%InboxItem{files: []}), do: {:error, :no_audio_files}
+  defp audio_files(%InboxItem{files: files}), do: {:ok, files}
 
   # Re-probed rather than trusting what discovery recorded: it costs one
-  # ffprobe and buys current track data, plus a file that vanished between
-  # discovery and import failing the import instead of creating a
+  # ffprobe per file and buys current track data, plus a file that vanished
+  # between discovery and import failing the import instead of creating a
   # recording that points at nothing.
-  defp probe(file) do
-    case Scanner.probe_file(file, single_file: true) do
-      {:ok, probe} -> {:ok, probe}
+  defp probe_all(files) do
+    case Scanner.probe_all(files) do
+      {:ok, probes} -> {:ok, probes}
       {:error, reason} -> {:error, {:unreadable, reason}}
     end
   end

--- a/lib/ambry/library/naming_template.ex
+++ b/lib/ambry/library/naming_template.ex
@@ -76,13 +76,66 @@ defmodule Ambry.Library.NamingTemplate do
   then.)
   """
   def filename(values, source_path, part \\ nil) do
+    with {:ok, [name]} <- filenames(values, [source_path], part), do: {:ok, name}
+  end
+
+  @doc """
+  The names for every file of a recording, relative to its book folder.
+
+  A single-file recording is one name sitting directly in the folder, exactly
+  as before. A multi-file one gets a **subfolder of its own**, with its files
+  renamed to a zero-padded index:
+
+      1 - Words of Radiance (2014)/
+        Words of Radiance/
+          Words of Radiance - 001.mp3
+          Words of Radiance - 002.mp3
+
+  Two things make the subfolder non-negotiable. Forty files loose in the book
+  folder would sit alongside the *other* recordings of that book — the folder
+  is shared by every part of a set and by a second reading of the same work —
+  and pruning or deleting one of them could then no longer tell whose files
+  were whose. And the index has to be rendered rather than inherited: play
+  order is the order these names are generated in, so it must be legible on
+  disk instead of depending on how the release happened to name things.
+
+  Renaming loses nothing that isn't already captured. Chapter titles are read
+  off the source filenames at import (the roadmap's 1h), and a hardlinked
+  source keeps its own name regardless — the library copy is a second name for
+  the same bytes, not a replacement.
+  """
+  def filenames(values, source_paths, part \\ nil)
+
+  def filenames(_values, [], _part), do: {:ok, []}
+
+  def filenames(values, source_paths, part) do
     values = stringify(values)
 
     case sanitize(to_string(values["title"] || "")) do
       "" -> {:error, :no_title}
-      name -> {:ok, name <> part_suffix(part) <> String.downcase(Path.extname(source_path))}
+      name -> {:ok, build_filenames(name <> part_suffix(part), source_paths)}
     end
   end
+
+  defp build_filenames(name, [source_path]), do: [name <> extname(source_path)]
+
+  defp build_filenames(name, source_paths) do
+    width = index_width(length(source_paths))
+
+    source_paths
+    |> Enum.with_index(1)
+    |> Enum.map(fn {source_path, index} ->
+      padded = index |> to_string() |> String.pad_leading(width, "0")
+      Path.join(name, "#{name} - #{padded}#{extname(source_path)}")
+    end)
+  end
+
+  # Three digits unless there are genuinely more files than that, so a
+  # forty-file book reads 001..040 and never gets re-padded by a later
+  # re-organize.
+  defp index_width(count), do: max(3, count |> to_string() |> String.length())
+
+  defp extname(source_path), do: source_path |> Path.extname() |> String.downcase()
 
   defp part_suffix(nil), do: ""
 

--- a/lib/ambry/library/placement.ex
+++ b/lib/ambry/library/placement.ex
@@ -53,10 +53,50 @@ defmodule Ambry.Library.Placement do
   end
 
   @doc """
+  Places every file of a multi-file recording, or none of them.
+
+  Takes `{source, destination}` pairs in play order and returns the
+  placements in the same order. A recording is one thing: thirty-nine linked
+  files and a fortieth that hit a full disk is not a partial success, it's a
+  book that plays up to chapter 39 and then stops. So the first failure
+  undoes everything already placed and reports why — the same all-or-nothing
+  the surrounding transaction gives the database records.
+  """
+  def place_all(pairs, policy) do
+    Enum.reduce_while(pairs, {:ok, []}, fn {source, destination}, {:ok, placed} ->
+      case place(source, destination, policy) do
+        {:ok, placement} ->
+          {:cont, {:ok, [placement | placed]}}
+
+        {:error, reason} ->
+          undo(placed)
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, placed} -> {:ok, Enum.reverse(placed)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
   Completes a placement once the database work has committed.
 
   Only `:move` has anything left to do.
   """
+  def finalize(placements) when is_list(placements) do
+    placements
+    |> Enum.map(&finalize/1)
+    |> Enum.reject(&(&1 == :ok))
+    |> case do
+      [] -> :ok
+      # One source that wouldn't go away is reported, not accumulated: the
+      # caller logs this and carries on either way, and the first reason is
+      # the one worth reading.
+      [error | _rest] -> error
+    end
+  end
+
   def finalize(%__MODULE__{policy: :move} = placement) do
     case File.rm(placement.source) do
       :ok -> :ok
@@ -78,6 +118,11 @@ defmodule Ambry.Library.Placement do
   Never touches the source — for every policy the source is still the only
   copy at this point.
   """
+  def undo(placements) when is_list(placements) do
+    Enum.each(placements, &undo/1)
+    :ok
+  end
+
   def undo(%__MODULE__{destination: destination}) do
     File.rm(destination)
     prune_empty_parents(Path.dirname(destination))

--- a/lib/ambry/media/organization.ex
+++ b/lib/ambry/media/organization.ex
@@ -55,9 +55,11 @@ defmodule Ambry.Media.Organization do
       ])
 
     with {:ok, root} <- root_for(media),
-         {:ok, file} <- single_file(media),
-         {:ok, destination} <- destination(media, root, file) do
-      if destination == file, do: {:ok, :noop}, else: move(media, file, destination)
+         {:ok, files} <- current_files(media),
+         {:ok, destinations} <- destinations(media, root, files) do
+      if destinations == files,
+        do: {:ok, :noop},
+        else: move(media, Enum.zip(files, destinations))
     else
       :noop -> {:ok, :noop}
       {:error, reason} -> {:error, reason}
@@ -117,18 +119,22 @@ defmodule Ambry.Media.Organization do
     String.starts_with?(path, root_path <> "/")
   end
 
-  # Direct-play v1 is single-file. A recording with several tracks would need
-  # every one moved and re-pointed, which isn't reachable yet and shouldn't
-  # be guessed at.
-  defp single_file(%Media{media_tracks: [%{path: path}]}), do: {:ok, path}
-  defp single_file(%Media{}), do: :noop
+  # Where the recording's files are now, in play order. Track order is the
+  # order the destination names are rendered in, so a multi-file recording's
+  # file 003 stays file 003 across a rename.
+  defp current_files(%Media{media_tracks: [_ | _] = tracks}) do
+    {:ok, tracks |> Enum.sort_by(& &1.index) |> Enum.map(& &1.path)}
+  end
 
-  defp destination(media, root, current_file) do
+  defp current_files(%Media{}), do: :noop
+
+  defp destinations(media, root, current_files) do
     values = Books.naming_values(media.book, media)
 
     with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
-         {:ok, filename} <- NamingTemplate.filename(values, current_file, filename_part(media)) do
-      {:ok, Path.join([root.path, folder, filename])}
+         {:ok, filenames} <-
+           NamingTemplate.filenames(values, current_files, filename_part(media)) do
+      {:ok, Enum.map(filenames, &Path.join([root.path, folder, &1]))}
     end
   end
 
@@ -141,61 +147,99 @@ defmodule Ambry.Media.Organization do
     %{number: number, total: group && group.parts_total, word: group && group.part_word}
   end
 
-  defp move(media, from, to) do
-    cond do
-      not File.regular?(from) ->
-        # Reconciliation's job to notice and record, not this one's to guess
-        # at. Moving a file that isn't there would only turn one problem into
-        # two.
-        {:error, {:source_missing, from}}
+  # A file already sitting at its destination is skipped, not refused. Adding
+  # one file to a forty-file recording renames only the forty-first: the rest
+  # map to themselves, and treating "it's already there" as a collision would
+  # fail every such re-organize.
+  defp move(media, pairs) do
+    pairs = Enum.reject(pairs, fn {from, to} -> from == to end)
 
-      File.exists?(to) ->
-        {:error, {:destination_exists, to}}
-
-      true ->
-        do_move(media, from, to)
+    case Enum.find_value(pairs, &blocker/1) do
+      nil -> do_move(media, pairs)
+      reason -> {:error, reason}
     end
   end
 
-  defp do_move(media, from, to) do
-    with :ok <- File.mkdir_p(Path.dirname(to)),
-         :ok <- File.rename(from, to),
-         {:ok, _media} <- repoint(media, from, to) do
-      prune(from)
+  # Checked for every file before any of them moves. Half a renamed recording
+  # is worse than an unrenamed one — the tracks would point at two different
+  # folders — and the cheap checks are the ones that catch it.
+  defp blocker({from, to}) do
+    cond do
+      # Reconciliation's job to notice and record, not this one's to guess
+      # at. Moving a file that isn't there would only turn one problem into
+      # two.
+      not File.regular?(from) -> {:source_missing, from}
+      File.exists?(to) -> {:destination_exists, to}
+      true -> nil
+    end
+  end
+
+  defp do_move(media, pairs) do
+    with :ok <- rename_all(pairs),
+         {:ok, _media} <- repoint(media, pairs) do
+      pairs |> Enum.map(&elem(&1, 0)) |> prune()
       {:ok, :moved}
     else
       {:error, reason} -> {:error, {:move_failed, reason}}
     end
   end
 
-  defp repoint(media, from, to) do
+  defp rename_all(pairs) do
+    Enum.reduce_while(pairs, :ok, fn {from, to}, :ok ->
+      with :ok <- File.mkdir_p(Path.dirname(to)),
+           :ok <- File.rename(from, to) do
+        {:cont, :ok}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp repoint(media, pairs) do
+    moved = Map.new(pairs)
+
     Repo.transact(fn ->
-      with {:ok, _track} <- repoint_track(media, to) do
+      with {:ok, _tracks} <- repoint_tracks(media, moved) do
         media
         |> Ecto.Changeset.change(%{
-          source_path: Path.dirname(to),
-          source_files: replace_path(media.source_files, from, to)
+          source_path: pairs |> List.last() |> elem(1) |> Path.dirname(),
+          source_files: replace_paths(media.source_files, moved, media.media_tracks)
         })
         |> Repo.update()
       end
     end)
   end
 
-  defp repoint_track(%Media{media_tracks: [track]}, to) do
-    track |> Ecto.Changeset.change(%{path: to}) |> Repo.update()
+  defp repoint_tracks(%Media{media_tracks: tracks}, moved) do
+    tracks
+    |> Enum.filter(&Map.has_key?(moved, &1.path))
+    |> Enum.reduce_while({:ok, []}, fn track, {:ok, acc} ->
+      track
+      |> Ecto.Changeset.change(%{path: moved[track.path]})
+      |> Repo.update()
+      |> case do
+        {:ok, track} -> {:cont, {:ok, [track | acc]}}
+        {:error, changeset} -> {:halt, {:error, changeset}}
+      end
+    end)
   end
 
-  defp replace_path(source_files, from, to) when is_list(source_files) do
-    Enum.map(source_files, fn path -> if path == from, do: to, else: path end)
+  defp replace_paths(source_files, moved, _tracks) when is_list(source_files) do
+    Enum.map(source_files, fn path -> Map.get(moved, path, path) end)
   end
 
-  defp replace_path(_source_files, _from, to), do: [to]
+  # A recording old enough to have no `source_files` gets the one thing that
+  # is certainly true afterwards: where its tracks are now.
+  defp replace_paths(_source_files, moved, tracks) do
+    tracks |> Enum.sort_by(& &1.index) |> Enum.map(&Map.get(moved, &1.path, &1.path))
+  end
 
-  # The folder the file just left, and any parent left empty by it. Passing
-  # the old *file* path is what makes the pruning start at its folder rather
-  # than at the folder's parent. Stops at any registered location — a root's
-  # existence is configuration, not a consequence of holding a book.
-  defp prune(from) do
-    Utils.try_prune_empty_parents([from], Library.registered_paths())
+  # The folders the files just left, and any parent left empty by them.
+  # Passing the old *file* paths is what makes the pruning start at their
+  # folders rather than at the folders' parents. Stops at any registered
+  # location — a root's existence is configuration, not a consequence of
+  # holding a book.
+  defp prune(from_paths) do
+    Utils.try_prune_empty_parents(from_paths, Library.registered_paths())
   end
 end

--- a/lib/ambry/media/scanner.ex
+++ b/lib/ambry/media/scanner.ex
@@ -11,10 +11,27 @@ defmodule Ambry.Media.Scanner do
   this can run over the existing library without changing what clients see.
   Only the inbox approval flow (Phase 3) makes a direct-play media `ready`.
 
-  Direct-play v1 handles single-file recordings only. A folder of 40 mp3s is
-  reported as `{:error, :multi_file_unsupported}` rather than silently
-  concatenated — the tracks model is ready for it, the player isn't (see the
-  roadmap's 2f).
+  ## Multi-file recordings
+
+  A folder of 40 mp3s is 40 tracks laid end to end on one continuous book
+  timeline, not a concat job: each file keeps its own bytes and its own
+  `start_offset`, and everything downstream — progress, chapters, sync —
+  already speaks absolute book-seconds. Nothing is decoded or rewritten here
+  either way.
+
+  Order is the order `Media.files/2` yields, natural-sorted: `Disc 2` after
+  `Disc 1`, `track10.mp3` after `track2.mp3`. That is the same order
+  discovery recorded the files in, so an inbox import re-derives exactly what
+  the operator was shown. Embedded track-number tags are deliberately *not*
+  consulted — a visible filename the operator can check beats a tag they
+  can't, and the ordering has to be one they can predict from the folder.
+
+  ## Tags describe the release, not each file
+
+  A multi-file release's title lives in `album`; `title` is the individual
+  file's own name ("Chapter 3"). So tags are read from the first file with
+  `single_file: false`, which is what makes `album` win — see the measured
+  finding in the roadmap's 1b.
   """
 
   alias Ambry.Media, as: MediaContext
@@ -29,9 +46,9 @@ defmodule Ambry.Media.Scanner do
   Returns `{:ok, media}` with the updated media, or `{:error, reason}`.
   """
   def scan(%Media{} = media) do
-    with {:ok, path} <- single_file(media),
-         {:ok, probe} <- Probe.run(path, single_file: true) do
-      write_tracks(media, probe)
+    with {:ok, paths} <- audio_files(media),
+         {:ok, probes} <- probe_all(paths) do
+      write_tracks(media, probes)
     end
   end
 
@@ -45,8 +62,8 @@ defmodule Ambry.Media.Scanner do
   Returns `{:ok, %Tags{}}` or `{:error, reason}`.
   """
   def tags(%Media{} = media) do
-    with {:ok, path} <- single_file(media),
-         {:ok, probe} <- Probe.run(path, single_file: true) do
+    with {:ok, [first | rest]} <- audio_files(media),
+         {:ok, probe} <- Probe.run(first, single_file: rest == []) do
       {:ok, probe.tags}
     end
   end
@@ -64,59 +81,126 @@ defmodule Ambry.Media.Scanner do
   """
   def extensions, do: @extensions
 
-  # v1 is single-file; the tracks model is multi-file-shaped for later.
-  defp single_file(media) do
+  @doc """
+  The audio files a media is made of, in play order.
+
+  Public because placement and organization have to move the same files in
+  the same order this writes tracks in.
+  """
+  def audio_files(%Media{} = media) do
     case files(media) do
-      [file] -> {:ok, file}
       [] -> {:error, :no_audio_files}
-      [_ | _] -> {:error, :multi_file_unsupported}
+      files -> {:ok, files}
     end
   end
 
   # `Media.files/2` yields names relative to the source folder for media that
   # recorded `source_files`, and absolute paths for the older ones that
-  # didn't.
+  # didn't. The sort matters for the second kind: `File.ls/1` returns
+  # whatever order the filesystem felt like, which for a 40-file book is a
+  # shuffled audiobook.
   defp files(media) do
     media
     |> Media.files(@extensions)
     |> Enum.map(fn file ->
       if Path.type(file) == :absolute, do: file, else: Media.source_path(media, file)
     end)
+    |> Enum.sort(NaturalOrder)
   end
 
-  defp write_tracks(media, %Probe{} = probe) do
+  @doc """
+  Probes every file of a recording, in play order.
+
+  All of them or none: one unreadable file in forty means every track after
+  it sits at the wrong offset, so this fails rather than quietly producing a
+  book that is short by a chapter.
+  """
+  def probe_all(paths) do
+    single_file = match?([_only], paths)
+
+    Enum.reduce_while(paths, {:ok, []}, fn path, {:ok, acc} ->
+      case Probe.run(path, single_file: single_file) do
+        {:ok, probe} -> {:cont, {:ok, [probe | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, probes} -> {:ok, Enum.reverse(probes)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp write_tracks(media, probes) do
     attrs =
       %{
-        media_tracks: [track_attrs(probe)],
-        duration: probe.duration
+        media_tracks: track_attrs(probes),
+        duration: total_duration(probes)
       }
-      |> maybe_put_chapters(media, probe)
+      |> maybe_put_chapters(media, probes)
 
     MediaContext.update_media(media, attrs)
   end
 
-  defp track_attrs(%Probe{} = probe) do
-    %{
-      index: 0,
-      path: probe.path,
-      size: probe.size,
-      mime: probe.mime,
-      format: probe.format,
-      codec: probe.codec,
-      duration: probe.duration,
-      # single-track v1: the file *is* the whole book timeline
-      start_offset: 0,
-      seek_accuracy: probe.seek_accuracy
-    }
+  @doc """
+  Track attributes for a list of probes, in play order.
+
+  Tracks are laid end to end: each one starts where the previous ended, so
+  the book timeline is continuous and absolute book-seconds mean the same
+  thing to a one-file m4b and a forty-file mp3 rip.
+
+  Public because the inbox importer writes a recording's first tracks
+  straight from its own probes, and two hand-rolled versions of this
+  arithmetic is exactly one too many.
+  """
+  def track_attrs(probes) do
+    probes
+    |> Enum.with_index()
+    |> Enum.map_reduce(Decimal.new(0), fn {probe, index}, offset ->
+      attrs = %{
+        index: index,
+        path: probe.path,
+        size: probe.size,
+        mime: probe.mime,
+        format: probe.format,
+        codec: probe.codec,
+        duration: probe.duration,
+        start_offset: offset,
+        seek_accuracy: probe.seek_accuracy
+      }
+
+      {attrs, Decimal.add(offset, probe.duration)}
+    end)
+    |> elem(0)
+  end
+
+  @doc """
+  The chapter markers a set of probes offers, if any.
+
+  A single file's embedded markers come in with it. A multi-file recording's
+  markers are its file boundaries, which is the chapter work's job to write
+  with a title source attached (the roadmap's 1h) rather than something to
+  take from whichever file happened to be first.
+  """
+  def embedded_chapters([%Probe{chapters: chapters}]), do: chapters
+  def embedded_chapters(_multi_file), do: []
+
+  @doc """
+  The whole book's duration: every track's, added up.
+  """
+  def total_duration(probes) do
+    Enum.reduce(probes, Decimal.new(0), &Decimal.add(&2, &1.duration))
   end
 
   # Embedded markers are only offered to a media that has none. Chapters are
   # curated data, and the merge that pours provider titles onto file-derived
   # markers is its own piece of work (the roadmap's 1h) — until it exists,
   # scanning must never overwrite what an operator has already confirmed.
-  defp maybe_put_chapters(attrs, %Media{chapters: []}, %Probe{chapters: [_ | _] = chapters}) do
-    Map.put(attrs, :chapters, chapters)
+  defp maybe_put_chapters(attrs, %Media{chapters: []}, probes) do
+    case embedded_chapters(probes) do
+      [] -> attrs
+      chapters -> Map.put(attrs, :chapters, chapters)
+    end
   end
 
-  defp maybe_put_chapters(attrs, _media, _probe), do: attrs
+  defp maybe_put_chapters(attrs, _media, _probes), do: attrs
 end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -750,6 +750,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def evidence(%InboxItem{probe: probe}) when is_map(probe) do
     [
       probe["duration"] && format_timecode(Decimal.new(probe["duration"])),
+      file_count(probe),
       probe["codec"],
       probe["chapters"] && probe["chapters"] > 0 && "#{probe["chapters"]} chapters",
       probe["seek_accuracy"] == "approximate" && "inexact seeking"
@@ -759,6 +760,11 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def evidence(_item), do: "not read yet"
+
+  # A one-file recording says nothing; a forty-file one is the single most
+  # useful fact about it, because it's what the timeline is built out of.
+  defp file_count(%{"files" => count}) when count > 1, do: "#{count} files"
+  defp file_count(_probe), do: nil
 
   @doc """
   How many chapters the file carries, and where they came from.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -79,11 +79,15 @@
           {@item.issue}
         </p>
 
-        <%!-- One button, no judgment on why: an import is one file, and only
-            the operator knows what these files are to each other. Each split
-            item is its own import — link them to one book, give them part
-            numbers, whatever the release calls for. --%>
+        <%!-- These files are one recording unless the operator says
+            otherwise — a folder of forty mp3s is one book in forty pieces far
+            more often than it is forty books. Splitting is the escape hatch
+            for when it genuinely isn't: each split item becomes its own
+            import, to link to its own book or take a part number. --%>
         <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
+          <p class="text-sm text-zinc-400">
+            These {length(@item.files)} files import as one recording, played in this order.
+          </p>
           <button
             type="button"
             phx-click="split"
@@ -91,7 +95,7 @@
             data-role="split"
             class={action_classes()}
           >
-            Split into {length(@item.files)} items — one per file
+            Not one recording — split into {length(@item.files)} items
           </button>
         </div>
       </section>

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -480,12 +480,13 @@ defmodule Ambry.Inbox.ImporterTest do
   end
 
   describe "approve/1 refusals" do
-    test "refuses a multi-file release rather than importing half of it" do
-      # Checked before the draft: no amount of curation makes a multi-file
-      # release importable — the operator splits it into one item per file.
-      item = tagged_item(files: ["01.mp3", "02.mp3"], settle: false)
+    test "refuses a release with no audio in it at all" do
+      # Checked before the draft: no amount of curation makes an empty
+      # release importable.
+      item = tagged_item(settle: false)
+      {:ok, item} = item |> Ecto.Changeset.change(%{files: []}) |> Repo.update()
 
-      assert {:error, :multi_file_unsupported} = Inbox.import_item(item)
+      assert {:error, :no_audio_files} = Inbox.import_item(item)
       assert Repo.aggregate(Book, :count) == 0
     end
 

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -53,6 +53,76 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert media.source_path == Path.dirname(placed)
     end
 
+    test "gives a multi-file recording a subfolder of its own, with indexed names" do
+      %{item: item, root: root, sources: sources} =
+        downloads_item(files: ["02.m4b", "01.m4b", "10.m4b"])
+
+      assert {:ok, media} = Inbox.import_item(item)
+      media = Media.get_media!(media.id)
+
+      book_folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
+
+      # A subfolder, because the book folder is shared with every other
+      # recording of the same work — and indexed names, because play order
+      # has to be legible on disk rather than inherited from whatever the
+      # release called things.
+      assert media.source_files == [
+               Path.join([book_folder, "The Way of Kings", "The Way of Kings - 001.m4b"]),
+               Path.join([book_folder, "The Way of Kings", "The Way of Kings - 002.m4b"]),
+               Path.join([book_folder, "The Way of Kings", "The Way of Kings - 003.m4b"])
+             ]
+
+      assert Enum.all?(media.source_files, &File.exists?/1)
+      assert media.source_path == Path.join(book_folder, "The Way of Kings")
+
+      # 01 before 02 before 10: the order the operator saw, not the order the
+      # filenames sort as strings.
+      assert media.media_tracks
+             |> Enum.sort_by(& &1.index)
+             |> Enum.map(& &1.path) == media.source_files
+
+      # Every one hardlinked, and every source still seeding.
+      assert Enum.all?(media.source_files, &match?({:ok, %{links: 2}}, File.stat(&1)))
+      assert Enum.all?(sources, &File.exists?/1)
+    end
+
+    test "lays a multi-file recording's tracks end to end" do
+      %{item: item} = downloads_item(files: ["01.m4b", "02.m4b"])
+
+      assert {:ok, media} = Inbox.import_item(item)
+      media = Media.get_media!(media.id)
+
+      assert [first, second] = Enum.sort_by(media.media_tracks, & &1.index)
+      assert Decimal.equal?(first.start_offset, 0)
+      assert Decimal.equal?(second.start_offset, first.duration)
+
+      assert Decimal.equal?(media.duration, Decimal.add(first.duration, second.duration))
+    end
+
+    test "places every file of a recording or none of them" do
+      %{item: item, root: root} = downloads_item(files: ["01.m4b", "02.m4b", "03.m4b"])
+
+      # Something is already sitting where the third file has to go. Two
+      # thirds of a book in the library is not a partial success.
+      occupied =
+        Path.join([
+          root,
+          "Brandon Sanderson",
+          "The Way of Kings (2010)",
+          "The Way of Kings",
+          "The Way of Kings - 003.m4b"
+        ])
+
+      File.mkdir_p!(Path.dirname(occupied))
+      File.write!(occupied, "not ours")
+
+      assert {:error, {:destination_exists, ^occupied}} = Inbox.import_item(item)
+
+      assert File.ls!(Path.dirname(occupied)) == ["The Way of Kings - 003.m4b"]
+      assert File.read!(occupied) == "not ours"
+      assert Repo.aggregate(Media.Media, :count) == 0
+    end
+
     test "renders the folder from the operator's template" do
       {:ok, _setting} = Settings.set_library_naming_template("{author}/{year} - {title}")
       %{item: item, root: root} = downloads_item()
@@ -373,8 +443,17 @@ defmodule Ambry.Inbox.ManagedImportTest do
     downloads = new_dir("downloads")
     release = Path.join(downloads, "The Way of Kings [M4B]")
     File.mkdir_p!(release)
-    source = Path.join(release, "book.m4b")
-    File.cp!(tagged_audio(), source)
+
+    sources =
+      opts
+      |> Keyword.get(:files, ["book.m4b"])
+      |> Enum.map(fn name ->
+        path = Path.join(release, name)
+        File.cp!(tagged_audio(), path)
+        path
+      end)
+
+    source = hd(sources)
 
     watched =
       insert(:source,
@@ -393,7 +472,14 @@ defmodule Ambry.Inbox.ManagedImportTest do
     # happens to the bytes afterwards.
     item = settle(item)
 
-    %{item: item, root: root, source: source, watched: watched, downloads: downloads}
+    %{
+      item: item,
+      root: root,
+      source: source,
+      sources: sources,
+      watched: watched,
+      downloads: downloads
+    }
   end
 
   defp new_dir(prefix) do

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -3,6 +3,7 @@ defmodule Ambry.InboxTest do
 
   alias Ambry.Inbox
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Media.Scanner
 
   describe "discover/1" do
     test "offers each release folder as one candidate" do
@@ -266,7 +267,7 @@ defmodule Ambry.InboxTest do
       assert is_map(item.tags)
     end
 
-    test "flags a multi-file release instead of hiding it" do
+    test "measures a multi-file release as the one recording it will become" do
       root = watched_root()
       release_folder(root, "Chaptered Book", ["01.mp3", "02.mp3"])
       {:ok, _counts} = Inbox.discover(root)
@@ -274,10 +275,15 @@ defmodule Ambry.InboxTest do
 
       assert {:ok, item} = Inbox.probe_item(item)
 
-      assert item.issue =~ "2 audio files"
-      assert item.status == :pending
-      # still probed, so the operator has something to look at
+      refute item.issue
+      assert item.probe["files"] == 2
       assert item.probe["codec"] == "mp3"
+
+      # The whole book, not the first file: the durations add up into one
+      # timeline, and so do the bytes.
+      {:ok, one} = Scanner.probe_file(Path.join(item.path, "01.mp3"))
+      assert Decimal.equal?(Decimal.new(item.probe["duration"]), Decimal.mult(one.duration, 2))
+      assert item.probe["size"] == one.size * 2
     end
 
     @tag :capture_log

--- a/test/ambry/library/naming_template_test.exs
+++ b/test/ambry/library/naming_template_test.exs
@@ -149,6 +149,61 @@ defmodule Ambry.Library.NamingTemplateTest do
     end
   end
 
+  describe "filenames/3" do
+    test "a single file sits directly in the book folder, exactly as before" do
+      assert {:ok, ["The Way of Kings.m4b"]} =
+               NamingTemplate.filenames(@book, ["/downloads/x/book.m4b"])
+    end
+
+    test "a multi-file recording gets a subfolder of its own and indexed names" do
+      sources = for i <- 1..3, do: "/downloads/x/track#{i}.mp3"
+
+      assert {:ok, names} = NamingTemplate.filenames(@book, sources)
+
+      assert names == [
+               "The Way of Kings/The Way of Kings - 001.mp3",
+               "The Way of Kings/The Way of Kings - 002.mp3",
+               "The Way of Kings/The Way of Kings - 003.mp3"
+             ]
+    end
+
+    test "the index is wide enough for the recording it numbers" do
+      sources = for i <- 1..1200, do: "/downloads/x/#{i}.mp3"
+
+      assert {:ok, names} = NamingTemplate.filenames(@book, sources)
+
+      assert List.first(names) =~ "- 0001.mp3"
+      assert List.last(names) =~ "- 1200.mp3"
+    end
+
+    test "keeps each file's own extension" do
+      assert {:ok, [first, second]} =
+               NamingTemplate.filenames(@book, ["/x/a.MP3", "/x/b.m4a"])
+
+      assert first =~ ".mp3"
+      assert second =~ ".m4a"
+    end
+
+    test "a part of a set takes its suffix into the subfolder name too" do
+      assert {:ok, names} =
+               NamingTemplate.filenames(@book, ["/x/a.mp3", "/x/b.mp3"], %{
+                 number: 2,
+                 total: 3,
+                 word: nil
+               })
+
+      assert names == [
+               "The Way of Kings - Part 2 of 3/The Way of Kings - Part 2 of 3 - 001.mp3",
+               "The Way of Kings - Part 2 of 3/The Way of Kings - Part 2 of 3 - 002.mp3"
+             ]
+    end
+
+    test "refuses without a title" do
+      assert {:error, :no_title} =
+               NamingTemplate.filenames(%{@book | title: nil}, ["a.mp3", "b.mp3"])
+    end
+  end
+
   describe "validate/1" do
     test "accepts the default" do
       assert :ok = NamingTemplate.validate(NamingTemplate.default_template())

--- a/test/ambry/library/placement_test.exs
+++ b/test/ambry/library/placement_test.exs
@@ -153,6 +153,61 @@ defmodule Ambry.Library.PlacementTest do
     end
   end
 
+  describe "place_all/2" do
+    setup %{source: source} do
+      dir = Path.dirname(source)
+
+      sources =
+        for index <- 1..3 do
+          path = Path.join(dir, "track#{index}.mp3")
+          File.write!(path, "audio bytes #{index}")
+          path
+        end
+
+      %{sources: sources}
+    end
+
+    test "places every file in order", %{root: root, sources: sources} do
+      pairs = Enum.map(sources, &{&1, Path.join([root, "Book", Path.basename(&1)])})
+
+      assert {:ok, placements} = Placement.place_all(pairs, :hardlink)
+
+      assert Enum.map(placements, & &1.source) == sources
+      assert Enum.all?(placements, &File.exists?(&1.destination))
+    end
+
+    # Thirty-nine linked files and a fortieth that failed is not a partial
+    # success — it's a book that plays up to chapter 39 and then stops.
+    test "undoes everything already placed when one file fails", %{root: root, sources: sources} do
+      occupied = Path.join([root, "Book", "track3.mp3"])
+      File.mkdir_p!(Path.dirname(occupied))
+      File.write!(occupied, "somebody else's")
+
+      pairs = Enum.map(sources, &{&1, Path.join([root, "Book", Path.basename(&1)])})
+
+      assert {:error, {:destination_exists, ^occupied}} = Placement.place_all(pairs, :hardlink)
+
+      assert File.ls!(Path.join(root, "Book")) == ["track3.mp3"]
+      assert File.read!(occupied) == "somebody else's"
+      # Never the sources: at this point they're still the only copy.
+      assert Enum.all?(sources, &File.exists?/1)
+    end
+
+    test "a moved set removes its sources only once the caller confirms", %{
+      root: root,
+      sources: sources
+    } do
+      pairs = Enum.map(sources, &{&1, Path.join([root, "Book", Path.basename(&1)])})
+
+      assert {:ok, placements} = Placement.place_all(pairs, :move)
+      assert Enum.all?(sources, &File.exists?/1)
+
+      assert :ok = Placement.finalize(placements)
+      refute Enum.any?(sources, &File.exists?/1)
+      assert Enum.all?(placements, &File.exists?(&1.destination))
+    end
+  end
+
   describe "undo/1" do
     test "removes the file and the folders it created", %{root: root, source: source} do
       destination = Path.join([root, "Author", "Series", "Title.m4b"])

--- a/test/ambry/media/organization_test.exs
+++ b/test/ambry/media/organization_test.exs
@@ -155,6 +155,106 @@ defmodule Ambry.Media.OrganizationTest do
     end
   end
 
+  describe "organize/1 with a multi-file recording" do
+    test "moves every file and repoints every track" do
+      %{media: media, root: root, files: files} = organized_multi_file_media()
+
+      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
+
+      assert {:ok, :moved} = Organization.organize(reload(media))
+
+      subfolder = Path.join([root, "Brandon Sanderson", "Oathbringer (2010)", "Oathbringer"])
+
+      moved = [
+        Path.join(subfolder, "Oathbringer - 001.mp3"),
+        Path.join(subfolder, "Oathbringer - 002.mp3"),
+        Path.join(subfolder, "Oathbringer - 003.mp3")
+      ]
+
+      # The order survives the rename: file 2 is still the second thing
+      # played, whatever it is now called.
+      assert Enum.map(moved, &File.read!/1) == ["audio 1", "audio 2", "audio 3"]
+      refute Enum.any?(files, &File.exists?/1)
+
+      media = reload(media)
+      assert media.source_files == moved
+      assert media.source_path == subfolder
+      assert media.media_tracks |> Enum.sort_by(& &1.index) |> Enum.map(& &1.path) == moved
+    end
+
+    test "does nothing when the files are already where they belong" do
+      %{media: media, files: files} = organized_multi_file_media()
+
+      assert {:ok, :noop} = Organization.organize(reload(media))
+      assert Enum.all?(files, &File.exists?/1)
+    end
+
+    # A file that maps to itself is skipped, not refused. Otherwise adding
+    # one file to a forty-file recording would fail on the other thirty-nine.
+    test "renames only the files whose names actually changed" do
+      %{media: media, root: root, files: files} = organized_multi_file_media()
+      subfolder = Path.dirname(hd(files))
+
+      # A fourth file arrives under the release's own name and is scanned in.
+      # The first three are already at their destinations; only the new one
+      # has anywhere to go.
+      arrived = Path.join(subfolder, "bonus-epilogue.mp3")
+      File.write!(arrived, "audio 4")
+
+      insert(:media_track, media: media, path: arrived, index: 3)
+
+      {:ok, _media} =
+        media
+        |> Ecto.Changeset.change(%{source_files: files ++ [arrived]})
+        |> Repo.update()
+
+      assert {:ok, :moved} = Organization.organize(reload(media))
+
+      renamed = Path.join(subfolder, "The Way of Kings - 004.mp3")
+      assert File.read!(renamed) == "audio 4"
+      refute File.exists?(arrived)
+
+      # The three that were already right were left alone, not moved out and
+      # back — a re-organize of a forty-file book must not touch thirty-nine
+      # files to rename one.
+      assert Enum.map(files, &File.read!/1) == ["audio 1", "audio 2", "audio 3"]
+
+      media = reload(media)
+      assert media.source_files == files ++ [renamed]
+      assert File.dir?(Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"]))
+    end
+  end
+
+  defp organized_multi_file_media do
+    %{media: media, root: root, folder: folder, file: file, book: book} = organized_media()
+
+    File.rm!(file)
+    subfolder = Path.join(folder, "The Way of Kings")
+    File.mkdir_p!(subfolder)
+
+    files =
+      for index <- 1..3 do
+        path = Path.join(subfolder, "The Way of Kings - 00#{index}.mp3")
+        File.write!(path, "audio #{index}")
+        path
+      end
+
+    Repo.delete_all(Ecto.assoc(media, :media_tracks))
+
+    files
+    |> Enum.with_index()
+    |> Enum.each(fn {path, index} ->
+      insert(:media_track, media: media, path: path, index: index)
+    end)
+
+    {:ok, media} =
+      media
+      |> Ecto.Changeset.change(%{source_path: subfolder, source_files: files})
+      |> Repo.update()
+
+    %{media: reload(media), root: root, files: files, folder: folder, book: book}
+  end
+
   defp organized_media(opts \\ []) do
     root = new_dir("root")
 

--- a/test/ambry/media/scanner_test.exs
+++ b/test/ambry/media/scanner_test.exs
@@ -83,11 +83,56 @@ defmodule Ambry.Media.ScannerTest do
       assert media.status == :pending
     end
 
-    test "refuses a multi-file recording rather than guessing" do
+    test "lays a multi-file recording end to end on one timeline" do
       media = scannable_media(:mp3, 3)
 
-      assert {:error, :multi_file_unsupported} = Scanner.scan(media)
-      assert Media.get_media!(media.id).media_tracks == []
+      assert {:ok, media} = Scanner.scan(media)
+
+      tracks =
+        media.id
+        |> Media.get_media!()
+        |> Map.fetch!(:media_tracks)
+        |> Enum.sort_by(& &1.index)
+
+      assert [%MediaTrack{index: 0}, %MediaTrack{index: 1}, %MediaTrack{index: 2}] = tracks
+
+      # Each track starts where the previous one ended, with no gap and no
+      # overlap, and the book is as long as all of them together.
+      Enum.reduce(tracks, Decimal.new(0), fn track, expected_offset ->
+        assert Decimal.equal?(track.start_offset, expected_offset)
+        Decimal.add(expected_offset, track.duration)
+      end)
+
+      assert Decimal.equal?(
+               media.duration,
+               Enum.reduce(tracks, Decimal.new(0), &Decimal.add(&2, &1.duration))
+             )
+    end
+
+    test "plays a multi-file recording in natural order, whatever order the files were recorded in" do
+      media = scannable_media(:mp3, 12)
+
+      # `File.ls/1` gives no order at all, and a recording old enough to
+      # predate `source_files` is read straight off the filesystem. A plain
+      # string sort would put "10-sample" before "2-sample" and shuffle the
+      # book.
+      {:ok, media} =
+        media
+        |> Ecto.Changeset.change(%{source_files: Enum.shuffle(media.source_files)})
+        |> Repo.update()
+
+      assert {:ok, _media} = Scanner.scan(media)
+
+      names =
+        media.id
+        |> Media.get_media!()
+        |> Map.fetch!(:media_tracks)
+        |> Enum.sort_by(& &1.index)
+        |> Enum.map(&Path.basename(&1.path))
+
+      assert names == Enum.sort(names, NaturalOrder)
+      assert hd(names) == "1-sample.mp3"
+      assert names |> Enum.at(1) == "2-sample.mp3"
     end
 
     test "reports a media with nothing to scan" do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1045,7 +1045,11 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       Repo.delete_all(Oban.Job)
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
-      assert html =~ "Split into 2 items"
+
+      # Two files are one recording by default — the button is the way to
+      # say they aren't, not a precondition for importing them.
+      assert html =~ "import as one recording"
+      assert html =~ "split into 2 items"
 
       view |> element("button[data-role='split']") |> render_click()
       assert_redirect(view, ~p"/admin/inbox")

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -29,13 +29,23 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert html =~ "pending"
   end
 
+  @tag :capture_log
   test "surfaces an issue rather than hiding the item", %{conn: conn} do
-    item = probed_item(files: ["01.mp3", "02.mp3"])
+    item = probed_item(files: ["book.m4b"], unreadable: true)
 
     {:ok, _view, html} = live(conn, ~p"/admin/inbox")
 
-    assert html =~ "2 audio files"
+    assert html =~ "couldn&#39;t read the file"
     assert html =~ item.path
+  end
+
+  test "counts a multi-file release's files on the row", %{conn: conn} do
+    _item = probed_item(files: ["01.mp3", "02.mp3"])
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+    assert html =~ "files"
+    assert html =~ ">2</span> files"
   end
 
   test "shows both matches with how sure each one is", %{conn: conn} do
@@ -252,12 +262,13 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert has_element?(view, "a[href='/admin/inbox/#{item.id}']")
   end
 
+  @tag :capture_log
   test "a refusal no curation can fix is visible before anything is clicked", %{conn: conn} do
-    item = probed_item(files: ["01.mp3", "02.mp3"])
+    item = probed_item(unreadable: true)
 
     {:ok, view, html} = live(conn, ~p"/admin/inbox")
 
-    assert html =~ "split this into one item per file"
+    assert html =~ "couldn&#39;t read the file"
     refute has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
     assert Inbox.get_item!(item.id).status == :pending
   end
@@ -339,8 +350,16 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     File.mkdir_p!(release)
 
     Enum.each(files, fn filename ->
-      fixture = if Path.extname(filename) == ".mp3", do: valid_audio(:mp3), else: tagged_fixture()
-      File.cp!(fixture, Path.join(release, filename))
+      path = Path.join(release, filename)
+
+      if Keyword.get(opts, :unreadable, false) do
+        File.write!(path, "this is not audio")
+      else
+        fixture =
+          if Path.extname(filename) == ".mp3", do: valid_audio(:mp3), else: tagged_fixture()
+
+        File.cp!(fixture, path)
+      end
     end)
 
     {:ok, _counts} = Inbox.discover(root)


### PR DESCRIPTION
Direct-play v1 refused a folder of 40 mp3s. The tracks model has been multi-file-shaped since 2a — ordered files with per-track `start_offset` against one continuous book timeline — but the scanner, the importer and the organizer each carried their own single-file guard, and the inbox told the operator to split the release into 40 separate books.

This removes all three guards. No migration, no schema change, no sync-table checklist: the design safety recorded in 2a paid off exactly as intended.

## What changed

- **`Scanner`** writes N tracks with cumulative offsets and a summed duration. `probe_all/1` is all-or-nothing — one unreadable file in forty means every track after it sits at the wrong offset.
- **`Importer`** places N files and records all of them. `Scanner.track_attrs/1` and `total_duration/1` are now public and shared; the importer had its own copy of the offset arithmetic.
- **`Organization`** moves and repoints every track, and *skips* a file already at its destination instead of refusing it — otherwise adding one file to a forty-file recording would fail on the other thirty-nine.
- **`Placement.place_all/2`** is all-or-nothing. Thirty-nine linked files and a fortieth that hit a full disk is a book that plays to chapter 39 and stops.
- **`NamingTemplate.filenames/3`** gives a multi-file recording a subfolder of its own with zero-padded indexed names. Single-file recordings are untouched, so no existing library churns.

## Two decisions worth reading

**Order is natural sort of the discovered paths, and nothing cleverer.** Discovery already sorted that way, so play order is the order the operator saw on the form. Embedded track-number tags are deliberately not consulted: a visible filename they can check beats a tag they can't.

**A subfolder is non-negotiable.** The book folder is shared — by every part of a set, and by a second recording of the same work — so forty loose files in it would mean deletion and pruning could no longer tell whose files were whose. Renaming loses nothing: chapter titles come off the source names at import (1h), and a hardlinked source keeps its own name anyway.

Split stays, reworded: it is now the escape hatch for a folder that really is two books, not a precondition for importing one.

## Verified on the real library

"This Is How You Lose the Time War" — 28 mp3s, 131MB — copied out of the real downloads folder and run end to end on the dev server:

- probed in 7s; 4.27h total; all tracks `exact` seek; `album` won over `title` for the book name, as 1b measured it should
- imported in 7s → `managed`, `:ready`, 28 tracks laid end to end, all 28 files placed under `…/This Is How You Lose the Time War (2019)/This Is How You Lose the Time War/… - 001.mp3`
- `organize` → `{:ok, :noop}`, `reconcile` → `{:ok, :unchanged}`
- GraphQL returned all 28 tracks in index order with correct offsets
- first and last tracks both served **206 Partial Content** on a range request

1393 tests green, `mix check` clean.

## Not done

**Mobile cannot play any of it** — `buildStreamingTrackAdd` has no track queue. That is 2c, which was already the critical path and gates the release. The server side is backwards compatible: a single-file recording produces the byte-identical tree and the one-element track list it did before.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx