### PR TITLE
Three things found by importing one real book

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -55,7 +55,8 @@ defmodule Ambry.Inbox do
   require Logger
 
   @doc """
-  Lists inbox items, newest first.
+  Lists inbox items, most recent first — of whatever "recent" means for the
+  view being asked for.
 
   Options: `:status`, `:filter` (matches the path), `:offset`, `:limit`.
   """
@@ -68,7 +69,7 @@ defmodule Ambry.Inbox do
       |> filter_by_status(opts[:status])
       |> filter_by_ready(opts[:ready])
       |> filter_by_path(opts[:filter])
-      |> order_by([i], desc: i.inserted_at, desc: i.id)
+      |> order_by(^newest_first(opts[:status]))
       |> offset(^Keyword.get(opts, :offset, 0))
       |> limit(^over_limit)
       |> preload(:source)
@@ -78,6 +79,23 @@ defmodule Ambry.Inbox do
 
     {items_to_return, items != items_to_return}
   end
+
+  # The queue and the history are sorted by two different clocks, and using
+  # one for both is what put a release imported this morning below one
+  # imported last week.
+  #
+  # A **pending** item is waiting to be looked at, so the interesting moment
+  # is when it was found: newest discoveries first.
+  #
+  # An **imported or ignored** item is a record of something the operator
+  # did, so the interesting moment is when they did it — `updated_at`, which
+  # is stamped by the status change itself. Discovery can't muddy it:
+  # `record_candidate/4` skips a folder whose files are already imported, and
+  # nothing else touches a settled row.
+  defp newest_first(status) when status in [:imported, :ignored],
+    do: [desc: :updated_at, desc: :id]
+
+  defp newest_first(_pending_or_all), do: [desc: :inserted_at, desc: :id]
 
   @doc """
   Counts items per status, for at-a-glance badges.

--- a/lib/ambry/media/scanner/tags.ex
+++ b/lib/ambry/media/scanner/tags.ex
@@ -141,6 +141,25 @@ defmodule Ambry.Media.Scanner.Tags do
   # these are proposals, the operator confirms them, and `raw` keeps the
   # original string for a consumer that wants to try a whole-string match
   # first.
+  #
+  # **The slash is a separator too**, and leaving it out was expensive out of
+  # all proportion to how rare it is. Measured across all 295 releases of the
+  # operator's library: 4 credit values carry a slash, in 3 releases, and it
+  # is the ONLY separator character in the whole library this doesn't handle
+  # (no `|`, `+`, `·`, `•` anywhere). A person whose name contains a slash
+  # does not appear at all.
+  #
+  # What one unsplit value cost, on "This Is How You Lose the Time War"
+  # (`composer=Cynthia Farrell/Emily Woo Zeller`): the recording search
+  # carried the joined string as a query token; every correct candidate —
+  # Audible's and Hardcover's, all of which listed the two readers properly —
+  # then failed `apply_narrator/3`, because no single name is 0.85-similar to
+  # both names glued together, and took the decisive `@narrator_mismatch`
+  # penalty meant for *the wrong reader's edition*. Four right answers at
+  # 0.50, nothing confident enough to adopt, and the fallback wrote the
+  # joined string into the library as one person's name.
+  @separators ~r{\s*[;,&/]\s*|\s+(?:and|feat\.?|with)\s+}i
+
   defp get_list(tags, keys) do
     case get(tags, keys) do
       nil ->
@@ -148,7 +167,7 @@ defmodule Ambry.Media.Scanner.Tags do
 
       value ->
         value
-        |> String.split(~r/\s*[;,&]\s*|\s+(?:and|feat\.?|with)\s+/i)
+        |> String.split(@separators)
         |> Enum.map(&String.trim/1)
         |> Enum.reject(&(&1 == ""))
         |> Enum.uniq()

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -68,6 +68,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      # themselves are evidence and live on the item.
      |> assign(searching_person: nil, photos_expanded: %{})
      |> assign(library_query: nil, library_results: [], ticking: false)
+     # An import the operator started, as opposed to a job that found the
+     # item on its own. Both own the form; only this one is theirs.
+     |> assign(importing: false)
      |> attach_hook(:refuse_while_busy, :handle_event, &refuse_while_busy/3)
      |> attach_hook(:refuse_when_imported, :handle_event, &refuse_when_imported/3)
      |> load(item)}
@@ -94,13 +97,24 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # provider finally answers, so an edit accepted here would be thrown away by
   # work the operator couldn't see.
   defp refuse_while_busy(event, _params, socket) do
-    if socket.assigns.busy do
+    if busy?(socket) do
       Logger.debug(fn -> "Inbox form: refusing #{event} while a job owns item" end)
       {:halt, socket}
     else
       {:cont, socket}
     end
   end
+
+  @doc """
+  Whether anything owns this form right now — a matching job, or the
+  operator's own import.
+
+  One predicate for both, because the form's answer is the same either way:
+  the overlay, the `inert`, and the refusal are about "not yours to edit",
+  not about who took it.
+  """
+  def busy?(%{assigns: assigns}), do: busy?(assigns)
+  def busy?(%{busy: busy, importing: importing}), do: busy or importing
 
   # How often a busy form looks again. Only ticks while a job is actually on
   # this item, so an idle form costs nothing.
@@ -128,10 +142,20 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   @doc """
   What the job on this item is doing, in the words the overlay uses.
   """
-  def busy_label(:working), do: "Matching…"
-  def busy_label(:retrying), do: "A provider couldn't be reached — waiting to try again…"
-  def busy_label(:queued), do: "Queued for matching…"
-  def busy_label(_idle), do: "Working…"
+  def busy_label(_job, importing \\ false)
+
+  # Naming the slow part, because it is the part that makes the operator
+  # wonder whether the click landed: a multi-file release is re-probed file
+  # by file and then every one of them is placed.
+  def busy_label(_job, true), do: "Adding to the library — reading the files and placing them…"
+
+  def busy_label(:working, _importing), do: "Matching…"
+
+  def busy_label(:retrying, _importing),
+    do: "A provider couldn't be reached — waiting to try again…"
+
+  def busy_label(:queued, _importing), do: "Queued for matching…"
+  def busy_label(_idle, _importing), do: "Working…"
 
   @doc """
   Whether a credit's person layer should be showing.
@@ -558,20 +582,23 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> load(item)}
   end
 
+  # Off the LiveView process, because it is not quick and it used to look
+  # broken: importing re-probes every file and then moves the bytes, which
+  # for a 28-file release measured seven seconds of ffprobe plus a 131MB
+  # copy — all of it inside `handle_event`, where the process cannot render.
+  # The operator got a button that did nothing until the page changed under
+  # them, so of course they clicked it again.
+  #
+  # The form already knows how to say "something owns this item and you can't
+  # edit it": same overlay, same `inert`, same event refusal as a matching
+  # job. This just makes an import one of the things that can own it.
   def handle_event("import", _params, socket) do
-    case Inbox.import_item(socket.assigns.item) do
-      {:ok, _media} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Added to the library.")
-         |> push_navigate(to: ~p"/admin/inbox")}
+    item = socket.assigns.item
 
-      {:error, reason} ->
-        {:noreply,
-         socket
-         |> put_flash(:error, Inbox.describe_error(reason))
-         |> load(Inbox.get_item!(socket.assigns.item.id))}
-    end
+    {:noreply,
+     socket
+     |> assign(importing: true)
+     |> start_async(:import, fn -> Inbox.import_item(item) end)}
   end
 
   def handle_event("ignore", _params, socket) do
@@ -584,6 +611,34 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   @impl Phoenix.LiveView
+  def handle_async(:import, {:ok, {:ok, _media}}, socket) do
+    {:noreply,
+     socket
+     |> put_flash(:info, "Added to the library.")
+     |> push_navigate(to: ~p"/admin/inbox")}
+  end
+
+  def handle_async(:import, {:ok, {:error, reason}}, socket) do
+    {:noreply,
+     socket
+     |> assign(importing: false)
+     |> put_flash(:error, Inbox.describe_error(reason))
+     |> load(Inbox.get_item!(socket.assigns.item.id))}
+  end
+
+  # A crash mid-import is the one case where the form must not stay locked:
+  # the transaction rolled back, so the item is exactly as it was and the
+  # operator can try again once they know.
+  def handle_async(:import, {:exit, reason}, socket) do
+    Logger.error(fn -> "Inbox form: import crashed: #{inspect(reason)}" end)
+
+    {:noreply,
+     socket
+     |> assign(importing: false)
+     |> put_flash(:error, "Adding to the library failed unexpectedly. Nothing was changed.")
+     |> load(Inbox.get_item!(socket.assigns.item.id))}
+  end
+
   def handle_async({:person_search, _key}, {:ok, {:ok, item}}, socket) do
     {:noreply, socket |> assign(searching_person: nil) |> load(item) |> resettle()}
   end

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -4,9 +4,13 @@
           rebuilds an untouched draft when one finally comes back — so a form
           with a job on it is not the operator's to edit yet, and says so
           over the whole thing rather than in a badge. --%>
-    <.busy_overlay busy={@busy} label={busy_label(@job)} class="sticky top-0 h-screen" />
+    <.busy_overlay
+      busy={busy?(assigns)}
+      label={busy_label(@job, @importing)}
+      class="sticky top-0 h-screen"
+    />
 
-    <div class="-mb-4 max-w-4xl space-y-14" inert={@busy}>
+    <div class="-mb-4 max-w-4xl space-y-14" inert={busy?(assigns)}>
       <%!-- the evidence: what was found, before anybody interpreted it --%>
       <section class="space-y-1 rounded-lg bg-zinc-900 p-4">
         <div class="flex items-start justify-between gap-4">

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -337,6 +337,42 @@ defmodule Ambry.InboxTest do
 
       assert %{pending: 1, ignored: 1} = Inbox.count_by_status()
     end
+
+    test "the queue is newest-found first" do
+      root = watched_root()
+      release_folder(root, "Found first", ["book.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+      release_folder(root, "Found second", ["book.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+
+      assert {items, false} = Inbox.list_items(status: :pending)
+      assert Enum.map(items, &InboxItem.name/1) == ["Found second", "Found first"]
+    end
+
+    # The queue and the history run on two different clocks. Sorting the
+    # history by discovery time is what buried a release imported this
+    # morning under one imported last week.
+    test "the history is most-recently-acted-on first, not newest-found" do
+      root = watched_root()
+      release_folder(root, "Found first", ["book.m4b"])
+      release_folder(root, "Found second", ["book.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+
+      {items, false} = Inbox.list_items()
+      first = Enum.find(items, &(InboxItem.name(&1) == "Found first"))
+      second = Enum.find(items, &(InboxItem.name(&1) == "Found second"))
+
+      # Acted on in the opposite order to the one they were found in.
+      {:ok, _item} = Inbox.ignore_item(second)
+      # `updated_at` has second resolution, so without this both rows carry
+      # the same timestamp and the tie-break decides — which would pass for
+      # the wrong reason.
+      Process.sleep(1100)
+      {:ok, _item} = Inbox.ignore_item(first)
+
+      assert {items, false} = Inbox.list_items(status: :ignored)
+      assert Enum.map(items, &InboxItem.name/1) == ["Found first", "Found second"]
+    end
   end
 
   describe "discover/0 across registered sources" do

--- a/test/ambry/media/scanner/tags_test.exs
+++ b/test/ambry/media/scanner/tags_test.exs
@@ -173,7 +173,29 @@ defmodule Ambry.Media.Scanner.TagsTest do
       assert Tags.parse(%{"artist" => "A; B"}).authors == ["A", "B"]
       assert Tags.parse(%{"artist" => "A & B"}).authors == ["A", "B"]
       assert Tags.parse(%{"artist" => "A and B"}).authors == ["A", "B"]
+      assert Tags.parse(%{"artist" => "A/B"}).authors == ["A", "B"]
       assert Tags.parse(%{"composer" => "A, B, C"}).narrators == ["A", "B", "C"]
+    end
+
+    # Rare — 4 values in 295 real releases — and expensive out of all
+    # proportion: the joined string is not 0.85-similar to either real name,
+    # so every correct candidate took the "wrong reader" penalty and the
+    # library got a person called "Cynthia Farrell/Emily Woo Zeller".
+    test "splits the slash, measured on the release that needed it" do
+      tags =
+        Tags.parse(%{
+          "artist" => "Amal El-Mohtar/Max Gladstone",
+          "composer" => "Cynthia Farrell/Emily Woo Zeller"
+        })
+
+      assert tags.authors == ["Amal El-Mohtar", "Max Gladstone"]
+      assert tags.narrators == ["Cynthia Farrell", "Emily Woo Zeller"]
+    end
+
+    test "tolerates the spacing a real tagger leaves around a slash" do
+      # "Peter  Brown/Kate Atwater", the library's other slash-carrying credit
+      assert Tags.parse(%{"artist" => "Peter Brown / Kate Atwater"}).authors ==
+               ["Peter Brown", "Kate Atwater"]
     end
 
     test "doesn't repeat a name listed twice" do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -39,10 +39,33 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      view |> element("button[data-role='import']") |> render_click()
+      # The click only *starts* the import — it runs off the LiveView process
+      # so the form can say it's working — so the assertion has to wait for
+      # the redirect that means it landed.
+      html = view |> element("button[data-role='import']") |> render_click()
+      assert html =~ "Adding to the library"
+
+      assert_redirect(view, ~p"/admin/inbox")
 
       assert %{status: :imported, media_id: media_id} = Inbox.get_item!(item.id)
       assert media_id
+    end
+
+    # The whole point of moving it off the process: a click that appears to do
+    # nothing is a click the operator makes again.
+    test "the form says it is working while the import runs", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html = view |> element("button[data-role='import']") |> render_click()
+
+      assert html =~ "reading the files and placing them"
+      assert has_element?(view, "[data-role='busy-overlay']")
+
+      # Waits for the import to land rather than leaving it running into the
+      # next test's sandbox.
+      assert_redirect(view, ~p"/admin/inbox")
     end
 
     test "each outstanding decision is named, not just counted", %{conn: conn} do

--- a/test/ambry_web/live/admin/media_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_test.exs
@@ -218,7 +218,10 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/chapters?import=source")
 
-      html = render_async(view)
+      # Generous, because this one genuinely goes to disk: it ffprobes the
+      # real fixture, and the default 100ms is a coin flip under a loaded
+      # suite.
+      html = render_async(view, 5_000)
       # The fixture is one plain file with no chapter marks of its own.
       assert html =~ "no chapter marks"
       refute has_element?(view, "button[phx-click='import-all']")


### PR DESCRIPTION
> **Stacked on #1229, which is stacked on #1228.** Retarget both children to `main` *before* merging anything — GitHub closes a child PR when its base branch is deleted on merge, and a closed PR can't be reopened.

Three unrelated bugs you hit exercising the two feature branches.

## 1. "Add to the library" appeared to hang

`handle_event("import", …)` ran `Inbox.import_item/1` inline, and a LiveView process cannot render while it is doing that. For a 28-file release that is ~7s of re-probing plus a 131MB copy during which the button is visibly dead — so of course it gets clicked again.

It runs through `start_async` now and drives the overlay, `inert` and event-refusal machinery a matching job already had. The label names the slow part — "Adding to the library — reading the files and placing them…" — because that is what you're actually waiting on.

## 2. The inbox history was sorted by the wrong clock

`list_items/1` ordered every view by `inserted_at` — *discovery* time — so Demon-Haunted World, found weeks ago and imported last, sat well down the list.

The queue keeps `inserted_at` (it's about what was found). Imported and ignored items now order by `updated_at`, which the status change itself stamps and which discovery can't muddy, since `record_candidate/4` skips folders whose files are already imported. On your dev DB the imported list now reads Time War → Demon-Haunted World → Martian → ACOTAR.

## 3. The narrator asymmetry — there isn't one

**The code treats authors and narrators the same.** The tags gave the same shape to both (`artist=Amal El-Mohtar/Max Gladstone`, `composer=Cynthia Farrell/Emily Woo Zeller`). What differed is that the *work* level adopted a provider record and the *recording* level adopted nothing — and only credits with no record behind them fall back to tags.

So the real question is why the recording level found nothing, and the answer is one character. `Tags.get_list/2` split on `;` `,` `&` and and/feat/with — **not `/`**. Measured across all 295 releases: 4 credit values carry a slash, in 3 releases, and it is the only separator character in the entire library that wasn't handled (no `|`, `+`, `·`, `•`; no person's name contains one).

Rare, and expensive out of all proportion:

1. the joined string went into the recording search **as a query token**;
2. every correct candidate — Audible's and Hardcover's, all four of which listed the two readers properly — then failed `apply_narrator/3`, because no single name is 0.85-similar to two names glued together, and took the decisive `@narrator_mismatch` penalty **meant for the wrong reader's edition**;
3. with nothing confident enough to adopt, the tag fallback wrote the joined string in as one person.

Measured before and after on the real release:

| | query | candidate scores | confidence | narrators imported |
|---|---|---|---|---|
| before | `… Amal El-Mohtar/Max Gladstone Cynthia Farrell/Emily Woo Zeller` | 0.5 ×4 | 0.55 | one, from `tags` |
| after | `… Amal El-Mohtar Cynthia Farrell` | **1.0 ×4** | **1.0** | two, from `provider:audible` |

Verified by deleting the bad import (and the junk person) from the dev DB and running the real release through again: two authors from Hardcover, two narrators from Audible, 28 tracks, 28 chapters.

**The lesson past this one character:** the narrator penalty is deliberately decisive rather than blended, and that reasoning is sound — jaro puts two unrelated names at 0.53, so blending left the wrong reader's edition at 0.81. But a decisive rule is only as good as its input, and a scorer that can halve a correct answer deserves the most suspicion of whatever feeds it.

1434 tests green, `mix check` clean.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx