### PR TITLE
Every recording carries its own token

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -702,14 +702,19 @@ defmodule Ambry.Inbox do
       "This folder and its library root are on different filesystems, so the file can't be " <>
         "hardlinked. Point it at a root on the same disk, or set the source to copy or move."
 
-  # Occupied by a recording is a curation problem; occupied by a file no
-  # record references is a leftover — an interrupted import's copy landed and
-  # its transaction rolled back, which is placement's documented worst case.
-  # The two need opposite advice, and the old message sent the operator
-  # hunting for a second recording that did not exist.
+  # Occupied by a recording is now a *bug*, not a curation problem. Every
+  # recording's name carries its own token, so two of them cannot render to
+  # one path however the operator curates them — if this happens, two records
+  # claim one file and no amount of editing metadata will fix it.
+  #
+  # Occupied by a file no record references is the ordinary case that remains:
+  # an interrupted import's copy landed and its transaction rolled back, which
+  # is placement's documented worst case. The two need opposite advice.
   def describe_error({:destination_exists, path}) do
     if file_in_use?(path) do
-      "Something is already at #{path}. Two recordings can't share one path."
+      "Another recording's files are already at #{path}. That shouldn't be " <>
+        "possible — every recording's name carries its own token — so this is " <>
+        "a bug worth reporting rather than something to fix by editing metadata."
     else
       "A file nothing in the library references is at #{path} — likely left " <>
         "behind by an interrupted import. Delete it and import again."

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -524,7 +524,7 @@ defmodule Ambry.Inbox.Importer do
     values = Books.naming_values(book, media)
 
     with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
-         {:ok, filenames} <- NamingTemplate.filenames(values, files, filename_part(media)),
+         {:ok, filenames} <- NamingTemplate.filenames(values, files, filename_recording(media)),
          paths = Enum.map(filenames, &Path.join([root.path, folder, &1])),
          {:ok, placements} <- Placement.place_all(Enum.zip(files, paths), policy),
          {:ok, media} <- adopt_managed(media, paths) do
@@ -532,9 +532,16 @@ defmodule Ambry.Inbox.Importer do
     end
   end
 
+  # What distinguishes this recording from the others in its book folder: the
+  # part label a human reads, and the token that guarantees it regardless.
+  # Placement happens after the media is inserted, so the id exists.
+  defp filename_recording(media) do
+    %{part: filename_part(media), token: Media.filename_token(media)}
+  end
+
   # Two parts of one set are two separate imports into the same book folder;
-  # the suffix is what keeps "The Way of Kings.m4b" from colliding with
-  # itself when part 2 arrives. Total and wording are the group's facts.
+  # the suffix is what says which is which. Total and wording are the group's
+  # facts.
   defp filename_part(%{part_number: nil}), do: nil
 
   defp filename_part(%{part_number: number, recording_group: group}) do

--- a/lib/ambry/library/naming_template.ex
+++ b/lib/ambry/library/naming_template.ex
@@ -68,15 +68,10 @@ defmodule Ambry.Library.NamingTemplate do
   @doc """
   The filename for a recording's file, keeping the source's extension.
 
-  A recording in a part set passes `%{number: n, total: t, word: w}` (total
-  and word may be nil) and gets a " - Part N of M" suffix in the group's own
-  wording — parts of one set are separate imports into the same book folder,
-  and without the suffix they'd render to one identical path. (A proper
-  `{part}` template token is future work; this keeps the parts apart until
-  then.)
+  See `filenames/3` — `recording` describes which recording this is.
   """
-  def filename(values, source_path, part \\ nil) do
-    with {:ok, [name]} <- filenames(values, [source_path], part), do: {:ok, name}
+  def filename(values, source_path, recording \\ %{}) do
+    with {:ok, [name]} <- filenames(values, [source_path], recording), do: {:ok, name}
   end
 
   @doc """
@@ -103,32 +98,80 @@ defmodule Ambry.Library.NamingTemplate do
   off the source filenames at import (the roadmap's 1h), and a hardlinked
   source keeps its own name regardless — the library copy is a second name for
   the same bytes, not a replacement.
+
+  ## The recording descriptor
+
+  `recording` says which recording of the work this is, and both of its keys
+  are appended to the **name stem** — the thing that has to be unique inside a
+  book folder, being the filename for a single-file recording and the
+  subfolder name for a multi-file one:
+
+    * `:part` — `%{number: n, total: t, word: w}` for a member of a part set,
+      rendering " - Part 2 of 3" in the group's own wording. Meaningful, and
+      what a human reads.
+    * `:token` — the recording's own short identifier, rendering " [7bKq]".
+      Meaningless, and what makes the name *guaranteed* unique.
+
+  ### Why the token is always there
+
+  A book folder is shared on purpose: by every part of a set, and by every
+  recording of the same work. Two readings of one book published the same year
+  therefore rendered to one identical path, and placement refused —
+  `{narrator}` in the template was the documented workaround, which taxes
+  every book in the library for a problem a handful have.
+
+  The token could have been added only on collision, and deliberately isn't.
+  That would make one recording's correct name depend on the *existence of
+  another record*, so the nightly organize would have to re-derive that
+  relationship every time it ran — and a re-derivation that quietly un-answers
+  a settled question is this codebase's most-repeated bug. With the token
+  always present the path is a pure function of the record, organize stays a
+  rename-to-computed-path, and `{:destination_exists, _}` stops being an
+  expected operator-facing outcome and becomes what it should be: a sign that
+  two records claim one path, which is a bug.
+
+  Nothing *inside* a multi-file recording's own folder repeats the token — the
+  ` - 001` index already makes those unique, and the folder carries the
+  guarantee.
   """
-  def filenames(values, source_paths, part \\ nil)
+  def filenames(values, source_paths, recording \\ %{})
 
-  def filenames(_values, [], _part), do: {:ok, []}
+  def filenames(_values, [], _recording), do: {:ok, []}
 
-  def filenames(values, source_paths, part) do
+  def filenames(values, source_paths, recording) do
     values = stringify(values)
 
     case sanitize(to_string(values["title"] || "")) do
-      "" -> {:error, :no_title}
-      name -> {:ok, build_filenames(name <> part_suffix(part), source_paths)}
+      "" ->
+        {:error, :no_title}
+
+      name ->
+        titled = name <> part_suffix(recording[:part])
+        {:ok, build_filenames(titled <> token_suffix(recording[:token]), titled, source_paths)}
     end
   end
 
-  defp build_filenames(name, [source_path]), do: [name <> extname(source_path)]
+  # `stem` is what must be unique inside the book folder; `titled` is the same
+  # name without the token, for the files inside a recording's own folder —
+  # where the index is already all the uniqueness there is to need.
+  defp build_filenames(stem, _titled, [source_path]), do: [stem <> extname(source_path)]
 
-  defp build_filenames(name, source_paths) do
+  defp build_filenames(stem, titled, source_paths) do
     width = index_width(length(source_paths))
 
     source_paths
     |> Enum.with_index(1)
     |> Enum.map(fn {source_path, index} ->
       padded = index |> to_string() |> String.pad_leading(width, "0")
-      Path.join(name, "#{name} - #{padded}#{extname(source_path)}")
+      Path.join(stem, "#{titled} - #{padded}#{extname(source_path)}")
     end)
   end
+
+  # Bracketed, per the convention every media tool already uses for a token
+  # that isn't part of the title, so nothing mistakes it for one.
+  defp token_suffix(nil), do: ""
+  defp token_suffix(""), do: ""
+  defp token_suffix(token), do: " [#{token}]"
 
   # Three digits unless there are genuinely more files than that, so a
   # forty-file book reads 001..040 and never gets re-padded by a later

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -503,6 +503,13 @@ defmodule Ambry.Media do
   defdelegate scan_media(media), to: Scanner, as: :scan
 
   @doc """
+  The short identifier a recording's files carry in the library.
+
+  See `Ambry.Media.Media.filename_token/1`.
+  """
+  defdelegate filename_token(media), to: Media
+
+  @doc """
   Scans a media's source files asynchronously.
   """
   def scan_media_async(%Media{} = media) do

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -9,6 +9,7 @@ defmodule Ambry.Media.Media do
   import Ecto.Changeset
 
   alias Ambry.Books.Book
+  alias Ambry.Hashids
   alias Ambry.Media.Media
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaNarrator
@@ -246,6 +247,28 @@ defmodule Ambry.Media.Media do
       _other -> nil
     end
   end
+
+  @doc """
+  The short identifier this recording's files carry in the library.
+
+  A book folder is shared by every part of a set and by every recording of the
+  same work, so two readings published the same year used to render to one
+  identical path and placement refused. This is what makes a recording's name
+  unique by construction instead — see `Ambry.Library.NamingTemplate.filenames/3`
+  for why it's unconditional rather than only added on collision.
+
+  It's the same `Ambry.Hashids` coder the track URLs use, on purpose: a token
+  in a filename is then greppable back to the record it names, years later,
+  by anyone holding the file.
+
+  **That coder is `Hashids.new([])` — no salt, library defaults — so this is
+  stable forever and identical in every environment. Giving it a salt or a
+  `min_length` for some URL-side reason would silently rename every file in
+  every library; `Ambry.HashidsTest` is the tripwire that stops it happening
+  by accident.**
+  """
+  def filename_token(%Media{id: id}) when is_integer(id), do: Hashids.encode(id)
+  def filename_token(%Media{}), do: nil
 
   @doc """
   The title this recording displays as: the override verbatim when set

--- a/lib/ambry/media/organization.ex
+++ b/lib/ambry/media/organization.ex
@@ -133,14 +133,17 @@ defmodule Ambry.Media.Organization do
 
     with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
          {:ok, filenames} <-
-           NamingTemplate.filenames(values, current_files, filename_part(media)) do
+           NamingTemplate.filenames(values, current_files, filename_recording(media)) do
       {:ok, Enum.map(filenames, &Path.join([root.path, folder, &1]))}
     end
   end
 
-  # Without the part suffix, re-organizing one part of a set would rename it
-  # onto its sibling's path (and refuse, or worse) — the same collision the
-  # import-time suffix exists to prevent.
+  # The same descriptor import placed the files under, so re-organizing a
+  # recording lands it back on its own path rather than a sibling's.
+  defp filename_recording(%Media{} = media) do
+    %{part: filename_part(media), token: Media.filename_token(media)}
+  end
+
   defp filename_part(%Media{part_number: nil}), do: nil
 
   defp filename_part(%Media{part_number: number, recording_group: group}) do

--- a/lib/ambry_web/live/admin/settings_live/index.ex
+++ b/lib/ambry_web/live/admin/settings_live/index.ex
@@ -144,7 +144,9 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
       case error do
         nil ->
           {:ok, folder} = NamingTemplate.render(template, @example)
-          {:ok, filename} = NamingTemplate.filename(@example, "book.m4b")
+          # With the token, because the preview's whole job is showing what
+          # the tree actually looks like — and every file in it carries one.
+          {:ok, filename} = NamingTemplate.filename(@example, "book.m4b", %{token: "7bKq"})
           Path.join([folder, filename])
 
         {:error, reason} ->

--- a/test/ambry/hashids_test.exs
+++ b/test/ambry/hashids_test.exs
@@ -1,0 +1,31 @@
+defmodule Ambry.HashidsTest do
+  @moduledoc """
+  A tripwire, not a unit test.
+
+  `Ambry.Hashids` is `Hashids.new([])` — no salt, library defaults — and two
+  things now depend on that encoding being stable forever:
+
+    * every track's URL (`Ambry.Media.MediaTrack.web_path/1`), which is
+      merely cosmetic to change; and
+    * **every filename in every managed library**
+      (`Ambry.Media.Media.filename_token/1`), which is not.
+
+  Giving the coder a salt or a `min_length` — an entirely reasonable thing to
+  want for the URL side — would rename the operator's whole library on the
+  next organize run. That has to be a decision somebody makes on purpose, so
+  this test fails first and says why.
+  """
+  use ExUnit.Case, async: true
+
+  alias Ambry.Hashids
+
+  test "the encoding is stable" do
+    assert Hashids.encode(1) == "jR"
+    assert Hashids.encode(104) == "mw0"
+    assert Hashids.encode(99_999) == "wprD1"
+  end
+
+  test "round-trips" do
+    assert {:ok, [104]} = Hashids.decode(Hashids.encode(104))
+  end
+end

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -83,13 +83,15 @@ defmodule Ambry.Inbox.ImporterTest do
 
     # Occupied-by-a-recording and occupied-by-a-leftover need opposite
     # advice, and the old message sent the operator hunting for a second
-    # recording that did not exist.
+    # recording that did not exist. Since every name carries its own token,
+    # occupied-by-a-recording is now a bug rather than something curation can
+    # fix, and the message says so instead of offering a workaround.
     test "an occupied destination says whether the occupant is an orphan" do
       {:ok, media} = tagged_item() |> Inbox.import_item()
       [track] = Media.get_media!(media.id).media_tracks
 
       assert Inbox.describe_error({:destination_exists, track.path}) =~
-               "can't share one path"
+               "a bug worth reporting"
 
       assert Inbox.describe_error({:destination_exists, "/library/nowhere.m4b"}) =~
                "nothing in the library references"

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -40,7 +40,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
                  root,
                  "Brandon Sanderson",
                  "The Way of Kings (2010)",
-                 "The Way of Kings.m4b"
+                 "The Way of Kings [#{Media.filename_token(media)}].m4b"
                ])
 
       assert File.exists?(placed)
@@ -65,15 +65,19 @@ defmodule Ambry.Inbox.ManagedImportTest do
       # A subfolder, because the book folder is shared with every other
       # recording of the same work — and indexed names, because play order
       # has to be legible on disk rather than inherited from whatever the
-      # release called things.
+      # release called things. The folder carries the recording's token; the
+      # files inside it don't repeat it.
+      recording_folder =
+        Path.join(book_folder, "The Way of Kings [#{Media.filename_token(media)}]")
+
       assert media.source_files == [
-               Path.join([book_folder, "The Way of Kings", "The Way of Kings - 001.m4b"]),
-               Path.join([book_folder, "The Way of Kings", "The Way of Kings - 002.m4b"]),
-               Path.join([book_folder, "The Way of Kings", "The Way of Kings - 003.m4b"])
+               Path.join(recording_folder, "The Way of Kings - 001.m4b"),
+               Path.join(recording_folder, "The Way of Kings - 002.m4b"),
+               Path.join(recording_folder, "The Way of Kings - 003.m4b")
              ]
 
       assert Enum.all?(media.source_files, &File.exists?/1)
-      assert media.source_path == Path.join(book_folder, "The Way of Kings")
+      assert media.source_path == recording_folder
 
       # 01 before 02 before 10: the order the operator saw, not the order the
       # filenames sort as strings.
@@ -99,28 +103,27 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert Decimal.equal?(media.duration, Decimal.add(first.duration, second.duration))
     end
 
-    test "places every file of a recording or none of them" do
-      %{item: item, root: root} = downloads_item(files: ["01.m4b", "02.m4b", "03.m4b"])
+    # A destination can no longer be occupied on purpose — the token is only
+    # knowable once the record exists, which is exactly the guarantee — so the
+    # failure is provoked by a root that can't be written into at all.
+    # `Ambry.Library.PlacementTest` covers the file-by-file rollback; what
+    # matters here is that the records go back with the bytes.
+    test "a placement that fails leaves no records and no files" do
+      # Inside a folder of its own, never loose in `source_media/` — the file
+      # audit lists that directory and expects only folders, so a stray file
+      # there fails unrelated tests depending on run order.
+      unusable = Path.join(new_dir("blocked"), "a-file-where-a-root-should-be")
+      File.write!(unusable, "not a directory")
 
-      # Something is already sitting where the third file has to go. Two
-      # thirds of a book in the library is not a partial success.
-      occupied =
-        Path.join([
-          root,
-          "Brandon Sanderson",
-          "The Way of Kings (2010)",
-          "The Way of Kings",
-          "The Way of Kings - 003.m4b"
-        ])
+      %{item: item, sources: sources} =
+        downloads_item(root: unusable, files: ["01.m4b", "02.m4b", "03.m4b"])
 
-      File.mkdir_p!(Path.dirname(occupied))
-      File.write!(occupied, "not ours")
+      assert {:error, _reason} = Inbox.import_item(item)
 
-      assert {:error, {:destination_exists, ^occupied}} = Inbox.import_item(item)
-
-      assert File.ls!(Path.dirname(occupied)) == ["The Way of Kings - 003.m4b"]
-      assert File.read!(occupied) == "not ours"
       assert Repo.aggregate(Media.Media, :count) == 0
+      assert Repo.aggregate(Ambry.Books.Book, :count) == 0
+      assert Enum.all?(sources, &File.exists?/1)
+      assert Inbox.get_item!(item.id).status == :pending
     end
 
     test "renders the folder from the operator's template" do
@@ -136,7 +139,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
                  root,
                  "Brandon Sanderson",
                  "2010 - The Way of Kings",
-                 "The Way of Kings.m4b"
+                 "The Way of Kings [#{Media.filename_token(media)}].m4b"
                ])
     end
 
@@ -183,8 +186,19 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert [placed1] = Media.get_media!(media1.id).source_files
       assert [placed2] = Media.get_media!(media2.id).source_files
-      assert placed1 == Path.join(folder, "The Way of Kings - Part 1 of 2.m4b")
-      assert placed2 == Path.join(folder, "The Way of Kings - Part 2 of 2.m4b")
+
+      assert placed1 ==
+               Path.join(
+                 folder,
+                 "The Way of Kings - Part 1 of 2 [#{Media.filename_token(media1)}].m4b"
+               )
+
+      assert placed2 ==
+               Path.join(
+                 folder,
+                 "The Way of Kings - Part 2 of 2 [#{Media.filename_token(media2)}].m4b"
+               )
+
       assert File.exists?(placed1)
       assert File.exists?(placed2)
     end
@@ -362,19 +376,35 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert item.draft.destination.approved
     end
 
-    # A collision means two recordings rendered to one path, which is a
-    # curation problem the operator has to see.
-    test "refuses to overwrite something already at the destination" do
-      %{item: item, root: root} = downloads_item()
+    # Two recordings of one book used to render to one path and refuse; each
+    # now carries its own token, so the same import twice lands twice.
+    test "a second recording of the same book no longer collides with the first" do
+      %{item: first, watched: watched, downloads: downloads, root: root} = downloads_item()
 
-      occupied =
-        Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)", "The Way of Kings.m4b"])
+      assert {:ok, media1} = Inbox.import_item(first)
 
-      File.mkdir_p!(Path.dirname(occupied))
-      File.write!(occupied, "already here")
+      # A second reading of the same work, in its own release folder.
+      second_release = Path.join(downloads, "The Way of Kings [Re-read]")
+      File.mkdir_p!(second_release)
+      File.cp!(tagged_audio(), Path.join(second_release, "book.m4b"))
+      {:ok, _counts} = Inbox.discover(watched)
+      {[second], false} = Inbox.list_items(filter: "Re-read")
+      {:ok, second} = Inbox.probe_item(second)
 
-      assert {:error, {:destination_exists, ^occupied}} = Inbox.import_item(item)
-      assert File.read!(occupied) == "already here"
+      assert {:ok, media2} = Inbox.import_item(settle(second))
+
+      [placed1] = Media.get_media!(media1.id).source_files
+      [placed2] = Media.get_media!(media2.id).source_files
+
+      # Same book folder, different files, both on disk.
+      assert Path.dirname(placed1) == Path.dirname(placed2)
+
+      assert Path.dirname(placed1) ==
+               Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
+
+      refute placed1 == placed2
+      assert File.exists?(placed1)
+      assert File.exists?(placed2)
     end
   end
 

--- a/test/ambry/library/naming_template_test.exs
+++ b/test/ambry/library/naming_template_test.exs
@@ -139,13 +139,44 @@ defmodule Ambry.Library.NamingTemplateTest do
 
     test "suffixes a part of a set, in the set's own wording" do
       assert {:ok, "The Way of Kings - Part 2 of 3.m4b"} =
-               NamingTemplate.filename(@book, "a.m4b", %{number: 2, total: 3, word: nil})
+               NamingTemplate.filename(@book, "a.m4b", %{part: part(2, 3, nil)})
 
       assert {:ok, "The Way of Kings - Part 2.m4b"} =
-               NamingTemplate.filename(@book, "a.m4b", %{number: 2, total: nil, word: nil})
+               NamingTemplate.filename(@book, "a.m4b", %{part: part(2, nil, nil)})
 
       assert {:ok, "The Way of Kings - Episode 2 of 3.m4b"} =
-               NamingTemplate.filename(@book, "a.m4b", %{number: 2, total: 3, word: "episode"})
+               NamingTemplate.filename(@book, "a.m4b", %{part: part(2, 3, "episode")})
+    end
+  end
+
+  # The token is what makes a name unique inside a book folder that is shared
+  # by every part of a set and every recording of the work. Two readings of
+  # one book published the same year used to render to one identical path.
+  describe "filename/3 with a recording token" do
+    test "brackets the token onto the end of the name" do
+      assert {:ok, "The Way of Kings [7bKq].m4b"} =
+               NamingTemplate.filename(@book, "a.m4b", %{token: "7bKq"})
+    end
+
+    test "sits after the part label, so the readable part stays readable" do
+      assert {:ok, "The Way of Kings - Part 2 of 3 [7bKq].m4b"} =
+               NamingTemplate.filename(@book, "a.m4b", %{part: part(2, 3, nil), token: "7bKq"})
+    end
+
+    test "two recordings of one book no longer render to one path" do
+      assert {:ok, first} = NamingTemplate.filename(@book, "a.m4b", %{token: "7bKq"})
+      assert {:ok, second} = NamingTemplate.filename(@book, "a.m4b", %{token: "9mZp"})
+
+      refute first == second
+    end
+
+    test "a missing token is simply absent, never an empty bracket" do
+      assert {:ok, "The Way of Kings.m4b"} = NamingTemplate.filename(@book, "a.m4b", %{})
+
+      assert {:ok, "The Way of Kings.m4b"} =
+               NamingTemplate.filename(@book, "a.m4b", %{token: nil})
+
+      assert {:ok, "The Way of Kings.m4b"} = NamingTemplate.filename(@book, "a.m4b", %{token: ""})
     end
   end
 
@@ -186,16 +217,34 @@ defmodule Ambry.Library.NamingTemplateTest do
 
     test "a part of a set takes its suffix into the subfolder name too" do
       assert {:ok, names} =
-               NamingTemplate.filenames(@book, ["/x/a.mp3", "/x/b.mp3"], %{
-                 number: 2,
-                 total: 3,
-                 word: nil
-               })
+               NamingTemplate.filenames(@book, ["/x/a.mp3", "/x/b.mp3"], %{part: part(2, 3, nil)})
 
       assert names == [
                "The Way of Kings - Part 2 of 3/The Way of Kings - Part 2 of 3 - 001.mp3",
                "The Way of Kings - Part 2 of 3/The Way of Kings - Part 2 of 3 - 002.mp3"
              ]
+    end
+
+    # The folder is the thing that has to be unique inside the book folder,
+    # so it carries the token — and the files inside it don't repeat it,
+    # because the index is already all the uniqueness they need.
+    test "the token goes on the recording's folder, not on every file in it" do
+      assert {:ok, names} =
+               NamingTemplate.filenames(@book, ["/x/a.mp3", "/x/b.mp3"], %{token: "7bKq"})
+
+      assert names == [
+               "The Way of Kings [7bKq]/The Way of Kings - 001.mp3",
+               "The Way of Kings [7bKq]/The Way of Kings - 002.mp3"
+             ]
+    end
+
+    test "two multi-file recordings of one book get separate folders" do
+      sources = ["/x/a.mp3", "/x/b.mp3"]
+
+      assert {:ok, [first | _]} = NamingTemplate.filenames(@book, sources, %{token: "7bKq"})
+      assert {:ok, [second | _]} = NamingTemplate.filenames(@book, sources, %{token: "9mZp"})
+
+      refute Path.dirname(first) == Path.dirname(second)
     end
 
     test "refuses without a title" do
@@ -231,4 +280,6 @@ defmodule Ambry.Library.NamingTemplateTest do
       assert {:error, :no_title_token} = NamingTemplate.validate("{author}/{year}")
     end
   end
+
+  defp part(number, total, word), do: %{number: number, total: total, word: word}
 end

--- a/test/ambry/media/organization_test.exs
+++ b/test/ambry/media/organization_test.exs
@@ -9,6 +9,7 @@ defmodule Ambry.Media.OrganizationTest do
   use Ambry.DataCase
 
   alias Ambry.Books
+  alias Ambry.Media.Media
   alias Ambry.Media.Organization
   alias Ambry.Repo
   alias Ambry.Settings
@@ -22,7 +23,14 @@ defmodule Ambry.Media.OrganizationTest do
 
       assert {:ok, :moved} = Organization.organize(media)
 
-      moved = Path.join([root, "Brandon Sanderson", "Oathbringer (2010)", "Oathbringer.m4b"])
+      moved =
+        Path.join([
+          root,
+          "Brandon Sanderson",
+          "Oathbringer (2010)",
+          "Oathbringer [#{Media.filename_token(media)}].m4b"
+        ])
+
       assert File.read!(moved) == "audio"
       refute File.exists?(file)
 
@@ -45,7 +53,9 @@ defmodule Ambry.Media.OrganizationTest do
     test "a part of a set keeps its part suffix" do
       %{media: media, folder: folder, file: file} = organized_media()
 
-      part_file = Path.join(folder, "The Way of Kings - Part 2 of 3.m4b")
+      part_file =
+        Path.join(folder, "The Way of Kings - Part 2 of 3 [#{Media.filename_token(media)}].m4b")
+
       File.rename!(file, part_file)
 
       group = insert(:recording_group, parts_total: 3)
@@ -114,7 +124,14 @@ defmodule Ambry.Media.OrganizationTest do
 
       assert {:ok, :moved} = Organization.organize(reload(media))
 
-      assert File.read!(Path.join([root, "The Way of Kings", "The Way of Kings.m4b"])) == "audio"
+      moved =
+        Path.join([
+          root,
+          "The Way of Kings",
+          "The Way of Kings [#{Media.filename_token(media)}].m4b"
+        ])
+
+      assert File.read!(moved) == "audio"
     end
 
     # Two recordings rendering to one path is a curation problem the operator
@@ -122,7 +139,14 @@ defmodule Ambry.Media.OrganizationTest do
     test "refuses when something already occupies the new path" do
       %{media: media, root: root, file: file} = organized_media()
 
-      occupied = Path.join([root, "Brandon Sanderson", "Oathbringer (2010)", "Oathbringer.m4b"])
+      occupied =
+        Path.join([
+          root,
+          "Brandon Sanderson",
+          "Oathbringer (2010)",
+          "Oathbringer [#{Media.filename_token(media)}].m4b"
+        ])
+
       File.mkdir_p!(Path.dirname(occupied))
       File.write!(occupied, "someone else")
 
@@ -163,7 +187,13 @@ defmodule Ambry.Media.OrganizationTest do
 
       assert {:ok, :moved} = Organization.organize(reload(media))
 
-      subfolder = Path.join([root, "Brandon Sanderson", "Oathbringer (2010)", "Oathbringer"])
+      subfolder =
+        Path.join([
+          root,
+          "Brandon Sanderson",
+          "Oathbringer (2010)",
+          "Oathbringer [#{Media.filename_token(media)}]"
+        ])
 
       moved = [
         Path.join(subfolder, "Oathbringer - 001.mp3"),
@@ -229,7 +259,7 @@ defmodule Ambry.Media.OrganizationTest do
     %{media: media, root: root, folder: folder, file: file, book: book} = organized_media()
 
     File.rm!(file)
-    subfolder = Path.join(folder, "The Way of Kings")
+    subfolder = Path.join(folder, "The Way of Kings [#{Media.filename_token(media)}]")
     File.mkdir_p!(subfolder)
 
     files =
@@ -274,8 +304,12 @@ defmodule Ambry.Media.OrganizationTest do
 
     folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
     File.mkdir_p!(folder)
-    file = Path.join(folder, "The Way of Kings.m4b")
-    File.write!(file, "audio")
+
+    # Placed at the name organize computes, token and all — a fixture sitting
+    # at the old token-less path would make every test here read as "organize
+    # moved it" when what actually happened is the fixture was wrong.
+    placeholder = Path.join(folder, "placeholder.m4b")
+    File.write!(placeholder, "audio")
 
     media =
       insert(:media,
@@ -285,14 +319,34 @@ defmodule Ambry.Media.OrganizationTest do
         published: ~D[2010-08-31],
         custody: Keyword.get(opts, :custody, :managed),
         source_path: folder,
-        source_files: [file],
+        source_files: [placeholder],
         mp4_path: nil,
         hls_path: nil,
         mpd_path: nil,
-        media_tracks: [build(:media_track, path: file)]
+        media_tracks: [build(:media_track, path: placeholder)]
       )
 
+    file = Path.join(folder, "The Way of Kings [#{Media.filename_token(media)}].m4b")
+    File.rename!(placeholder, file)
+    {:ok, media} = repoint(media, [file])
+
     %{media: reload(media), root: root, file: file, folder: folder, book: book}
+  end
+
+  # Points a fixture's media and its tracks at the files it actually has.
+  defp repoint(media, files) do
+    media = Repo.preload(media, :media_tracks, force: true)
+
+    media.media_tracks
+    |> Enum.sort_by(& &1.index)
+    |> Enum.zip(files)
+    |> Enum.each(fn {track, path} ->
+      {:ok, _track} = track |> Ecto.Changeset.change(%{path: path}) |> Repo.update()
+    end)
+
+    media
+    |> Ecto.Changeset.change(%{source_path: files |> hd() |> Path.dirname(), source_files: files})
+    |> Repo.update()
   end
 
   defp reload(media) do

--- a/test/ambry_web/live/admin/settings_live/index_test.exs
+++ b/test/ambry_web/live/admin/settings_live/index_test.exs
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
 
       assert preview(html) ==
                "Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings (2010)/" <>
-                 "The Way of Kings.m4b"
+                 "The Way of Kings [7bKq].m4b"
     end
 
     test "previews an edited template as it's typed", %{conn: conn} do
@@ -48,7 +48,7 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
         |> form("#naming-template-form", settings: %{template: "{author}/{title}"})
         |> render_change()
 
-      assert preview(html) == "Brandon Sanderson/The Way of Kings/The Way of Kings.m4b"
+      assert preview(html) == "Brandon Sanderson/The Way of Kings/The Way of Kings [7bKq].m4b"
     end
 
     test "saves a valid template", %{conn: conn} do


### PR DESCRIPTION
Closes the collision gap the roadmap has tracked since #1182, and the last item on the release-gating list besides 3f, the redesign and 2c mobile.

Built as you proposed — hashid on the media id, always present — with two refinements and one guard.

## The shape

The name stem is `{title}[ - Part N of M] [token]`. That stem is what has to be unique inside a book folder, and the folder is shared **on purpose**: by every part of a set, and by every recording of the same work.

```
Brandon Sanderson/The Stormlight Archive/1 - The Way of Kings (2010)/
  The Way of Kings [7bKq].m4b                 one file
  The Way of Kings - Part 2 of 3 [9mZp].m4b   a part of a set
  The Way of Kings [Qx4v]/                    multi-file: the FOLDER
    The Way of Kings - 001.mp3                carries it, the files don't
```

**Refinement 1 — the token goes on the stem, not literally the filename.** 2f made that stem do double duty (filename for single-file, subfolder name for multi-file), so two *multi-file* recordings of one book were colliding exactly the same way. One rule fixes both. Nothing inside a recording's own folder repeats the token — the ` - 001` index is already all the uniqueness those need.

**Refinement 2 — `destination_exists` is demoted from expected to bug.** It was an operator-facing workflow failure with a workaround; it now means two records claim one path, which no amount of curating metadata can fix. The message says that instead of offering advice that can't help.

## Why always-on rather than only-on-collision

Adding the token only when a name collides would make one recording's correct name depend on the *existence of another record* — so the nightly organize would re-derive that relationship on every run, and a re-derivation that quietly un-answers a settled question is this codebase's most-repeated bug (four incidents, all under 3e). Always-on keeps the path a pure function of the record and organize a plain rename-to-computed-path.

The usual objection — mass-renaming an existing library — doesn't apply: no production library has ever been template-organized, since all of 3a is unreleased.

**Considered and rejected: a *meaningful* disambiguator** (narrator, or edition year), since the recording matcher's own scoring says the narrator is what distinguishes two recordings. It fails on exactly the cases that need it — a full-cast recording has no single narrator, narrator lists get long, and a re-release can share one. A disambiguator that sometimes doesn't disambiguate is worse than an opaque one that always does.

## The guard

`Ambry.Hashids` is `Hashids.new([])` — no salt, library defaults — and is shared with track URLs. Sharing is deliberate: a token in a filename greps back to the record it names, years later, by anyone holding the file. But it means **a salt or a `min_length` added for some URL-side reason would silently rename every file in every library.** `Ambry.HashidsTest` asserts three known encodings and explains itself when it fails.

## Verified on the real dev library

- `organize_all/0` renamed all 101 managed recordings: `%{moved: 101, noop: 0, failed: 0}`.
- A second recording of an already-imported book (a duplicate of "The Golden Enclaves") then imported into the same book folder as `The Golden Enclaves [oYK].m4b` beside `The Golden Enclaves [nZR].m4b`. **That is precisely the import that used to be refused.**
- The Princess Bride pair and the ACOTAR two-part set both read correctly.

1442 tests green, `mix check` clean.

## Test-side note

Two importer tests used to pre-create a file at the destination to provoke a collision. They can't any more — the token is only knowable once the record exists, which *is* the guarantee — so one now provokes the failure with an unusable root and asserts the records roll back with the bytes, and the other asserts the second recording imports cleanly. File-by-file placement rollback stays covered in `Ambry.Library.PlacementTest`, where it lives.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx