### PR TITLE
One vocabulary: Audiobook, Book, Set

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -720,10 +720,10 @@ defmodule Ambry.Inbox do
 
   def describe_error(:no_published_date),
     do:
-      "No publication date, and one can't be invented. Match a work, or tag the file with a date."
+      "No publication date, and one can't be invented. Match a book, or tag the file with a date."
 
   def describe_error(:no_title),
-    do: "Nothing here says what this is. Match a work, or tag the file with a title."
+    do: "Nothing here says what this is. Match a book, or tag the file with a title."
 
   def describe_error({:unreadable, _reason}),
     do: "Couldn't read the file — it may have moved or gone away since it was found."
@@ -747,8 +747,8 @@ defmodule Ambry.Inbox do
   # is placement's documented worst case. The two need opposite advice.
   def describe_error({:destination_exists, path}) do
     if file_in_use?(path) do
-      "Another recording's files are already at #{path}. That shouldn't be " <>
-        "possible — every recording's name carries its own token — so this is " <>
+      "Another audiobook's files are already at #{path}. That shouldn't be " <>
+        "possible — every audiobook's name carries its own token — so this is " <>
         "a bug worth reporting rather than something to fix by editing metadata."
     else
       "A file nothing in the library references is at #{path} — likely left " <>

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -839,7 +839,7 @@ defmodule AmbryWeb.Admin.Decisions do
             phx-click="remove-credit"
             phx-value-section={@section}
             phx-value-index={@index}
-            title="This recording isn't by them"
+            title="This audiobook isn't by them"
           >
             <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-600" />
           </button>
@@ -1621,7 +1621,7 @@ defmodule AmbryWeb.Admin.Decisions do
         class="pl-3 text-sm text-zinc-400"
         data-role="group-sibling-callout"
       >
-        This work already has a recording set — is this another part of the same set?
+        This book already has a set — is this another part of the same set?
       </p>
 
       <%!-- Reads as a sentence across the row — "<set> no. 1 of 3" — with the

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -62,17 +62,17 @@ defmodule AmbryWeb.Admin.Layouts do
           <.icon name="fa-book-journal-whills" class="h-5 w-5 text-current" />
           <p>Series</p>
         </.link>
-        <.link navigate={~p"/admin/groups"} class={nav_class(@active_path =~ "/admin/groups")}>
+        <.link navigate={~p"/admin/sets"} class={nav_class(@active_path =~ "/admin/sets")}>
           <.icon name="fa-layer-group" class="h-5 w-5 text-current" />
-          <p>Groups</p>
+          <p>Sets</p>
         </.link>
         <.link navigate={~p"/admin/universes"} class={nav_class(@active_path =~ "/admin/universes")}>
           <.icon name="fa-globe" class="h-5 w-5 text-current" />
           <p>Universes</p>
         </.link>
-        <.link navigate={~p"/admin/media"} class={nav_class(@active_path =~ "/admin/media")}>
+        <.link navigate={~p"/admin/audiobooks"} class={nav_class(@active_path =~ "/admin/audiobooks")}>
           <.icon name="fa-file-audio" class="h-5 w-5 text-current" />
-          <p>Media</p>
+          <p>Audiobooks</p>
         </.link>
 
         <p class={group_class()}>System</p>

--- a/lib/ambry_web/live/admin/audit_live/index.ex
+++ b/lib/ambry_web/live/admin/audit_live/index.ex
@@ -76,7 +76,7 @@ defmodule AmbryWeb.Admin.AuditLive.Index do
   end
 
   def handle_event("row-click", %{"id" => media_id}, socket) do
-    {:noreply, push_navigate(socket, to: ~p"/admin/media/#{media_id}/edit")}
+    {:noreply, push_navigate(socket, to: ~p"/admin/audiobooks/#{media_id}/edit")}
   end
 
   defp format_filesize(bytes) do

--- a/lib/ambry_web/live/admin/audit_live/index.html.heex
+++ b/lib/ambry_web/live/admin/audit_live/index.html.heex
@@ -14,7 +14,7 @@
     <div class="space-y-14">
       <%= if @audit.orphaned_media_files != [] do %>
         <div class="space-y-4">
-          <h2 class="text-xl font-bold text-zinc-100">Orphaned media files</h2>
+          <h2 class="text-xl font-bold text-zinc-100">Orphaned audiobook files</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
             It should be safe to delete these files, as they are not being used by
@@ -78,10 +78,10 @@
 
       <%= if @audit.broken_media != [] do %>
         <div class="space-y-4">
-          <h2 class="text-xl font-bold text-zinc-100">Broken media</h2>
+          <h2 class="text-xl font-bold text-zinc-100">Broken audiobooks</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
-            These media uploads are broken in some way. They may or may not work
+            These audiobooks' uploads are broken in some way. They may or may not work
             in all cases.
           </p>
 

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -28,7 +28,7 @@
           <.curated_date
             date_field={@form[:published]}
             format_field={@form[:published_format]}
-            label="First print publication"
+            label="First published"
             record={@book}
             hints={@provenance_hints}
             proposals={@chips[:published] || []}

--- a/lib/ambry_web/live/admin/book_live/index.ex
+++ b/lib/ambry_web/live/admin/book_live/index.ex
@@ -92,8 +92,8 @@ defmodule AmbryWeb.Admin.BookLive.Index do
 
       {:error, :has_media} ->
         message = """
-        Can't delete book because this book has uploaded media.
-        You must delete any uploaded media before you can delete this book.
+        Can't delete book because it has audiobooks.
+        You must delete the audiobooks before you can delete this book.
         """
 
         {:noreply, put_flash(socket, :error, message)}

--- a/lib/ambry_web/live/admin/home_live/index.html.heex
+++ b/lib/ambry_web/live/admin/home_live/index.html.heex
@@ -25,9 +25,9 @@
       </.stat>
     </.card>
 
-    <.card navigate={~p"/admin/media"} icon="fa-file-audio">
+    <.card navigate={~p"/admin/audiobooks"} icon="fa-file-audio">
       <.stat>
-        <:title>Media</:title>
+        <:title>Audiobooks</:title>
         <:stat><span data-role="media-count">{@media_count}</span></:stat>
       </.stat>
     </.card>

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -902,7 +902,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     do: "#{count} chapters in the files — start over to stage them here."
 
   def chapter_summary(%InboxItem{probe: probe}) when is_map(probe),
-    do: "No chapters in the files. The recording will have none until they're added."
+    do: "No chapters in the files. The audiobook will have none until they're added."
 
   def chapter_summary(_item), do: "Not read yet."
 
@@ -1006,7 +1006,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def doubt_message(%Recording{doubt: :nothing_found}),
     do:
-      "No provider had a recording matching this. That is common and not a problem — " <>
+      "No provider had a record of this audiobook. That is common and not a problem — " <>
         "a delisted edition vanishes from Audible's search and from ASIN lookup alike. " <>
         "The fields below come from the file's own tags."
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -90,7 +90,7 @@
             import, to link to its own book or take a part number. --%>
         <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
           <p class="text-sm text-zinc-400">
-            These {length(@item.files)} files import as one recording, played in this order.
+            These {length(@item.files)} files import as one audiobook, played in this order.
           </p>
           <button
             type="button"
@@ -99,7 +99,7 @@
             data-role="split"
             class={action_classes()}
           >
-            Not one recording — split into {length(@item.files)} items
+            Not one audiobook — split into {length(@item.files)} items
           </button>
         </div>
       </section>
@@ -116,8 +116,8 @@
         <p class="max-w-prose pt-1 pl-3 text-sm text-zinc-400">
           This one was imported, and everything below is the record of that import — it's
           read-only now.
-          <.brand_link :if={@item.media_id} navigate={~p"/admin/media/#{@item.media_id}/edit"}>
-            Open the media record
+          <.brand_link :if={@item.media_id} navigate={~p"/admin/audiobooks/#{@item.media_id}/edit"}>
+            Open the audiobook
           </.brand_link>
         </p>
       </section>
@@ -142,7 +142,7 @@
       <%!-- ==================== THE WORK ==================== --%>
       <section id="work" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
-          The work — which book this is a recording of
+          The book — what these files are a recording of
         </h2>
 
         <%!-- The first question, and a different KIND of question from the
@@ -358,7 +358,7 @@
                 form={work}
                 type="date"
                 control_class="max-w-48"
-                hint="The work's original publication date, not this recording's release date."
+                hint="The book's original publication date, not this audiobook's own date."
                 field={@item.draft.work.published}
               />
             </.inputs_for>
@@ -433,7 +433,7 @@
       <%!-- ==================== THE RECORDING ==================== --%>
       <section id="recording" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
-          The recording — which reading of it these files are
+          The audiobook — which reading of the book these files are
         </h2>
 
         <div class={[
@@ -441,7 +441,7 @@
           (@item.draft.recording.approved && "border-brand-dark/60") || "border-amber-400/70"
         ]}>
           <div class="flex items-baseline gap-2 pl-3">
-            <.label>Records describing this recording</.label>
+            <.label>Records describing this audiobook</.label>
             <%!-- One badge, not two: "needs confirming" and a frozen
                 confidence said less together than the decision state says
                 alone — and the old pair could contradict each other. --%>
@@ -481,7 +481,7 @@
 
           <p :if={records(@item, "recording") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
             Tick every record of <span class="font-semibold">this reading</span>
-            — the narrator is what tells two recordings of
+            — the narrator is what tells two audiobooks of
             one book apart, so check it before ticking. Databases keep editions the storefront has
             delisted, which is often the only place an older reading still exists.
           </p>
@@ -536,7 +536,7 @@
           </.disclosure>
 
           <p class="pl-3 text-xs text-zinc-400">
-            Every import creates a new recording. Pointing one at an existing recording's files —
+            Every import creates a new audiobook. Pointing one at an existing audiobook's files —
             the upgrade/replace case — is a later addition.
           </p>
         </div>
@@ -551,7 +551,7 @@
           <.inputs_for :let={draft} field={@form[:draft]}>
             <.inputs_for :let={recording} field={draft[:recording]}>
               <.decision_row
-                label="Recording title"
+                label="Audiobook title"
                 section="recording"
                 name={:title}
                 form={recording}
@@ -563,13 +563,13 @@
               />
 
               <.decision_row
-                label="Release date"
+                label="Published"
                 section="recording"
                 name={:published}
                 form={recording}
                 type="date"
                 control_class="max-w-48"
-                hint="When this reading was published, which is rarely the work's own date."
+                hint="When this reading was published, which is rarely the book's own date."
                 field={@item.draft.recording.published}
               />
 
@@ -625,7 +625,7 @@
           />
 
           <.add_button :if={group_absent?(@item.draft)} phx-click="add-group">
-            This release is part of a set
+            This audiobook is part of a set
           </.add_button>
         </div>
 

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -426,6 +426,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     end
   end
 
+  @doc "What a match level is called on the card — the data keys stay work/recording."
+  def level_word("work"), do: "book"
+  def level_word("recording"), do: "audiobook"
+
   def candidate_label(nil), do: "no match"
 
   def candidate_label(candidate) do
@@ -435,7 +439,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   end
 
   def candidate_origin(nil), do: nil
-  def candidate_origin(%{"source" => "local"}), do: "already in library"
+  def candidate_origin(%{"source" => "local"}), do: "already in the library"
   def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
   def candidate_origin(%{"source" => "provider:" <> id}), do: id
   def candidate_origin(_candidate), do: nil

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -77,7 +77,7 @@
             :for={match <- match_summary(item)}
             class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2 text-sm"
           >
-            <span class="text-xs text-zinc-400">{match.level}</span>
+            <span class="text-xs text-zinc-400">{level_word(match.level)}</span>
             <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
               <.badge
                 color={elem(level_state_words(match.state), 1)}

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -95,7 +95,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     socket
     |> assign_form(changeset)
     |> assign(
-      page_title: "New Media",
+      page_title: "New Audiobook",
       media: media,
       recording_groups: [],
       file_stats: nil,
@@ -682,8 +682,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Updated media for #{media.book.title}")
-         |> push_navigate(to: ~p"/admin/media")}
+         |> put_flash(:info, "Updated audiobook for #{media.book.title}")
+         |> push_navigate(to: ~p"/admin/audiobooks")}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -700,8 +700,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Created new media for #{media.book.title}")
-         |> push_navigate(to: ~p"/admin/media")}
+         |> put_flash(:info, "Created new audiobook for #{media.book.title}")
+         |> push_navigate(to: ~p"/admin/audiobooks")}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -811,8 +811,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   end
 
   defp media_path(media, params \\ %{})
-  defp media_path(%Media.Media{id: nil}, params), do: ~p"/admin/media/new?#{params}"
-  defp media_path(media, params), do: ~p"/admin/media/#{media}/edit?#{params}"
+  defp media_path(%Media.Media{id: nil}, params), do: ~p"/admin/audiobooks/new?#{params}"
+  defp media_path(media, params), do: ~p"/admin/audiobooks/#{media}/edit?#{params}"
 
   defp open_file_browser(media), do: JS.patch(media_path(media, %{browse: :files}))
   defp close_modal(media), do: JS.patch(media_path(media), replace: true)

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -10,13 +10,13 @@
     <.evidence_panel
       evidence={@evidence}
       level="recording"
-      title="Records describing this recording"
-      hint="Tick every record of this reading — the narrator is what tells two recordings of one book apart. Ticked records grow chips under the fields below."
+      title="Records describing this audiobook"
+      hint="Tick every record of this reading — the narrator is what tells two audiobooks of one book apart. Ticked records grow chips under the fields below."
       retrying={@retrying}
     />
 
     <.simple_form id="media-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
-      <.form_section title="The recording" id="recording">
+      <.form_section title="The audiobook" id="recording">
         <.field_group>
           <.input
             field={@form[:book_id]}
@@ -40,7 +40,7 @@
               <.curated_date
                 date_field={@form[:published]}
                 format_field={@form[:published_format]}
-                label="Audio publication date"
+                label="Published"
                 record={@media}
                 hints={@provenance_hints}
                 proposals={@chips[:published] || []}
@@ -186,7 +186,7 @@
           </.field_group>
 
           <.add_button :if={!@group_row_visible} phx-click="add-group-row">
-            This recording is part of a set
+            This audiobook is part of a set
           </.add_button>
         </div>
 

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     {:ok,
      socket
      |> assign(
-       page_title: "Media",
+       page_title: "Audiobooks",
        show_header_search: true,
        processing_media_progress_map: %{}
      )
@@ -65,8 +65,8 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
         media: media,
         has_next: has_more?,
         has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/media?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/media?#{prev_opts(list_opts)}",
+        next_page_path: ~p"/admin/audiobooks?#{next_opts(list_opts)}",
+        prev_page_path: ~p"/admin/audiobooks?#{prev_opts(list_opts)}",
         current_sort: list_opts.sort || @default_sort
       )
     else
@@ -110,7 +110,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     socket = maybe_update_media(socket, %{"filter" => query, "page" => "1"})
     list_opts = get_list_opts(socket)
 
-    {:noreply, push_patch(socket, to: ~p"/admin/media?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/audiobooks?#{patch_opts(list_opts)}")}
   end
 
   def handle_event("sort", %{"field" => sort_field}, socket) do
@@ -119,7 +119,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
       |> get_list_opts()
       |> Map.update!(:sort, &apply_sort(&1, sort_field, @valid_sort_fields))
 
-    {:noreply, push_patch(socket, to: ~p"/admin/media?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/audiobooks?#{patch_opts(list_opts)}")}
   end
 
   defp list_media(opts, default_sort) do

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -2,7 +2,7 @@
   <:subheader>
     <.list_controls
       search_form={@search_form}
-      new_path={~p"/admin/media/new"}
+      new_path={~p"/admin/audiobooks/new"}
       has_next={@has_next}
       has_prev={@has_prev}
       next_page_path={@next_page_path}
@@ -23,11 +23,11 @@
   <.flex_table
     rows={@media}
     filter={@list_opts.filter}
-    row_click={fn media -> JS.navigate(~p"/admin/media/#{media}/edit") end}
+    row_click={fn media -> JS.navigate(~p"/admin/audiobooks/#{media}/edit") end}
   >
     <:empty>
-      No media yet.
-      <.brand_link navigate={~p"/admin/media/new"}>
+      No audiobooks yet.
+      <.brand_link navigate={~p"/admin/audiobooks/new"}>
         Create one.
       </.brand_link>
     </:empty>
@@ -83,13 +83,13 @@
 
       <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
         <div class="flex gap-2 pb-2">
-          <.link navigate={~p"/admin/media/#{media}/edit"}>
+          <.link navigate={~p"/admin/audiobooks/#{media}/edit"}>
             <.icon
               name="fa-pencil"
               class="h-4 w-4 text-current transition-colors hover:text-lime-400"
             />
           </.link>
-          <.link navigate={~p"/admin/media/#{media}/replace"} title="Replace audio">
+          <.link navigate={~p"/admin/audiobooks/#{media}/replace"} title="Replace audio">
             <.icon
               name="fa-upload"
               class="h-4 w-4 text-current transition-colors hover:text-lime-400"
@@ -99,7 +99,7 @@
             phx-click="scan"
             phx-value-id={media.id}
             title="Scan files for direct play"
-            data-confirm="Scan this media's source files? Nothing is copied or modified, and clients see no change."
+            data-confirm="Scan this audiobook's source files? Nothing is copied or modified, and clients see no change."
           >
             <.icon
               name="fa-magnifying-glass"

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -70,7 +70,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
             {:noreply,
              socket
              |> put_flash(:info, "Replacing audio for #{media.book.title}")
-             |> push_navigate(to: ~p"/admin/media")}
+             |> push_navigate(to: ~p"/admin/audiobooks")}
 
           {:error, %Changeset{} = changeset} ->
             {:noreply, assign_form(socket, changeset)}
@@ -86,7 +86,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
     {:noreply,
      socket
      |> assign(selected_files: files)
-     |> push_patch(to: ~p"/admin/media/#{socket.assigns.media}/replace", replace: true)}
+     |> push_patch(to: ~p"/admin/audiobooks/#{socket.assigns.media}/replace", replace: true)}
   end
 
   # Consumes browser uploads into a fresh source folder, or references the
@@ -151,6 +151,8 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
     |> Enum.map(&{&1.name(), &1})
   end
 
-  defp open_file_browser(media), do: JS.patch(~p"/admin/media/#{media}/replace?browse=files")
-  defp close_file_browser(media), do: JS.patch(~p"/admin/media/#{media}/replace", replace: true)
+  defp open_file_browser(media), do: JS.patch(~p"/admin/audiobooks/#{media}/replace?browse=files")
+
+  defp close_file_browser(media),
+    do: JS.patch(~p"/admin/audiobooks/#{media}/replace", replace: true)
 end

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -225,10 +225,10 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
 
   defp levels do
     [
-      {:work, "Work-level providers",
+      {:work, "Book-level providers",
        "Books, authors, and series — the abstract side of the library."},
-      {:recording, "Recording-level providers",
-       "Audiobook releases — narrators, square covers, and chapters, keyed by ASIN."},
+      {:recording, "Audiobook-level providers",
+       "Audiobooks — narrators, square covers, and chapters, keyed by ASIN."},
       {:person, "Person-level providers",
        "Bios and photos for the humans behind authors and narrators — keyed on real people, not published-as names."}
     ]
@@ -255,8 +255,8 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
   # the current pairing simply can't represent.
   defp capability_label(:book_search, :recording), do: "audiobook search"
   defp capability_label(:book_details, :recording), do: "audiobook details"
-  defp capability_label(:book_search, _level), do: "work search"
-  defp capability_label(:book_details, _level), do: "work details"
+  defp capability_label(:book_search, _level), do: "book search"
+  defp capability_label(:book_details, _level), do: "book details"
   defp capability_label(:author_search, :person), do: "person search"
   defp capability_label(:author_details, :person), do: "person details"
   defp capability_label(:author_search, _level), do: "author search"

--- a/lib/ambry_web/live/admin/person_live/index.ex
+++ b/lib/ambry_web/live/admin/person_live/index.ex
@@ -99,8 +99,8 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
 
       {:error, :has_narrated_media} ->
         message = """
-        Can't delete person because they have narrated media.
-        You must delete the media before you can delete this person.
+        Can't delete person because they have narrated audiobooks.
+        You must delete the audiobooks before you can delete this person.
         """
 
         {:noreply, put_flash(socket, :error, message)}

--- a/lib/ambry_web/live/admin/playback_debug_live/index.ex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.ex
@@ -142,7 +142,7 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.Index do
 
   defp playthrough_label(playthrough) do
     case playthrough.media do
-      nil -> "Unknown media"
+      nil -> "Unknown audiobook"
       %{book: %{title: title}} -> title
       media -> "Media #{media.id}"
     end

--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     socket
     |> assign_form(changeset)
     |> assign(
-      page_title: "New Group",
+      page_title: "New Set",
       group: group,
       media_options: []
     )
@@ -74,7 +74,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{group.name}")
-         |> push_navigate(to: ~p"/admin/groups")}
+         |> push_navigate(to: ~p"/admin/sets")}
 
       {:error, error} ->
         {:noreply, handle_save_error(socket, error)}
@@ -87,7 +87,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{group.name}")
-         |> push_navigate(to: ~p"/admin/groups")}
+         |> push_navigate(to: ~p"/admin/sets")}
 
       {:error, error} ->
         {:noreply, handle_save_error(socket, error)}
@@ -101,7 +101,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
   end
 
   defp handle_save_error(socket, _other) do
-    put_flash(socket, :error, "Couldn't save one of the recordings' membership.")
+    put_flash(socket, :error, "Couldn't save one of the audiobooks' membership.")
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do

--- a/lib/ambry_web/live/admin/recording_group_live/form.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.html.heex
@@ -24,7 +24,7 @@
           <.input field={@form[:parts_total]} type="number" min="1" label="Total parts (optional)" />
           <.input
             field={@form[:part_word]}
-            label={~s(One release is a… — default "part")}
+            label={~s(One audiobook is a… — default "part")}
             placeholder="part"
           />
           <.input
@@ -37,11 +37,11 @@
         <.input
           field={@form[:show_label]}
           type="checkbox"
-          label="Show the group's name to listeners on this set's stacked tile"
+          label="Show the set's name to listeners on its stacked tile"
         />
       </.field_group>
 
-      <.list_cluster label="Recordings">
+      <.list_cluster label="Audiobooks">
         <.inputs_for :let={member_form} field={@form[:members]}>
           <.sort_input field={@form[:members_sort]} index={member_form.index} />
 
@@ -67,7 +67,7 @@
         </.inputs_for>
 
         <:add>
-          <.add_button field={@form[:members_sort]}>Add recording</.add_button>
+          <.add_button field={@form[:members_sort]}>Add audiobook</.add_button>
           <.delete_input field={@form[:members_drop]} />
         </:add>
       </.list_cluster>

--- a/lib/ambry_web/live/admin/recording_group_live/index.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.ex
@@ -29,7 +29,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:ok,
      socket
      |> assign(
-       page_title: "Groups",
+       page_title: "Sets",
        show_header_search: true
      )
      |> maybe_update_groups(params, true)}
@@ -56,8 +56,8 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
         groups: groups,
         has_next: has_more?,
         has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/groups?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/groups?#{prev_opts(list_opts)}",
+        next_page_path: ~p"/admin/sets?#{next_opts(list_opts)}",
+        prev_page_path: ~p"/admin/sets?#{prev_opts(list_opts)}",
         current_sort: list_opts.sort || @default_sort
       )
     else
@@ -84,14 +84,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:noreply,
      socket
      |> refresh_groups()
-     |> put_flash(:info, "Group deleted successfully")}
+     |> put_flash(:info, "Set deleted successfully")}
   end
 
   def handle_event("search", %{"search" => %{"query" => query}}, socket) do
     socket = maybe_update_groups(socket, %{"filter" => query, "page" => "1"})
     list_opts = get_list_opts(socket)
 
-    {:noreply, push_patch(socket, to: ~p"/admin/groups?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/sets?#{patch_opts(list_opts)}")}
   end
 
   def handle_event("sort", %{"field" => sort_field}, socket) do
@@ -100,7 +100,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
       |> get_list_opts()
       |> Map.update!(:sort, &apply_sort(&1, sort_field, @valid_sort_fields))
 
-    {:noreply, push_patch(socket, to: ~p"/admin/groups?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/sets?#{patch_opts(list_opts)}")}
   end
 
   defp list_groups(opts, default_sort) do

--- a/lib/ambry_web/live/admin/recording_group_live/index.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.html.heex
@@ -2,7 +2,7 @@
   <:subheader>
     <.list_controls
       search_form={@search_form}
-      new_path={~p"/admin/groups/new"}
+      new_path={~p"/admin/sets/new"}
       has_next={@has_next}
       has_prev={@has_prev}
       next_page_path={@next_page_path}
@@ -17,11 +17,11 @@
   <.flex_table
     rows={@groups}
     filter={@list_opts.filter}
-    row_click={fn group -> JS.navigate(~p"/admin/groups/#{group}/edit") end}
+    row_click={fn group -> JS.navigate(~p"/admin/sets/#{group}/edit") end}
   >
     <:empty>
-      No groups yet.
-      <.brand_link navigate={~p"/admin/groups/new"}>
+      No sets yet.
+      <.brand_link navigate={~p"/admin/sets/new"}>
         Create one.
       </.brand_link>
     </:empty>
@@ -41,7 +41,7 @@
       </div>
       <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
         <div class="flex gap-2">
-          <.link navigate={~p"/admin/groups/#{group}/edit"} data-role="edit-group">
+          <.link navigate={~p"/admin/sets/#{group}/edit"} data-role="edit-group">
             <.icon
               name="fa-pencil"
               class="h-4 w-4 text-current transition-colors hover:text-lime-400"
@@ -50,7 +50,7 @@
           <span
             phx-click="delete"
             phx-value-id={group.id}
-            data-confirm={"Delete this group? Its #{length(group.media)} recordings stay in the library but leave the set, losing their part numbers."}
+            data-confirm={"Delete this set? Its #{length(group.media)} audiobooks stay in the library but leave the set, losing their part numbers."}
             data-role="delete-group"
           >
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />

--- a/lib/ambry_web/live/admin/settings_live/index.ex
+++ b/lib/ambry_web/live/admin/settings_live/index.ex
@@ -25,7 +25,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
         <section>
           <h2 class="mb-1 text-lg font-bold">Direct play</h2>
           <p class="mb-4 text-sm text-zinc-400">
-            Direct-play recordings are served as their original files, with no transcoding or
+            Direct-play audiobooks are served as their original files, with no transcoding or
             packaging. Publishing them has to wait for the apps: a client that predates track
             support can't play one, so leave this off until every device in the fleet is on a
             build that understands tracks.
@@ -38,7 +38,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
                 (@direct_play_publishing && "bg-lime-500") || "bg-zinc-600"
               ]} />
               <div class="grow">
-                <h3 class="font-semibold">Publish direct-play recordings</h3>
+                <h3 class="font-semibold">Publish direct-play audiobooks</h3>
                 <p class="text-sm text-zinc-400">
                   {publishing_blurb(@direct_play_publishing)}
                 </p>
@@ -54,7 +54,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
         <section>
           <h2 class="mb-1 text-lg font-bold">Library naming</h2>
           <p class="mb-4 text-sm text-zinc-400">
-            How managed recordings are organized inside a library root. Files imported from a
+            How managed audiobooks are organized inside a library root. Files imported from a
             downloads folder are placed here; external collections are never reorganized.
           </p>
 
@@ -166,10 +166,10 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
   defp template_error(:no_title_token), do: "it needs {title}, or every book shares one folder"
   defp template_error({:unknown_token, token}), do: "there's no {#{token}} token"
 
-  defp publishing_blurb(true), do: "Scanned recordings can be made visible to clients."
+  defp publishing_blurb(true), do: "Scanned audiobooks can be made visible to clients."
 
   defp publishing_blurb(false),
     do:
-      "Recordings can be scanned, but one with only direct-play files can't be marked ready. " <>
+      "Audiobooks can be scanned, but one with only direct-play files can't be marked ready. " <>
         "The old transcoding pipeline is unaffected."
 end

--- a/lib/ambry_web/live/admin/user_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_live/index.html.heex
@@ -51,11 +51,11 @@
             />
           </span>
 
-          <span :if={user.media_in_progress > 0} title="# of in-progress books" data-role="user-in-progress">
+          <span :if={user.media_in_progress > 0} title="# of in-progress audiobooks" data-role="user-in-progress">
             {user.media_in_progress} <.icon name="fa-book-bookmark" class="h-4 w-4 text-current" />
           </span>
 
-          <span :if={user.media_finished > 0} title="# of finished books" data-role="user-finished">
+          <span :if={user.media_finished > 0} title="# of finished audiobooks" data-role="user-finished">
             {user.media_finished} <.icon name="fa-book" class="h-4 w-4 text-current" />
           </span>
         </div>

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -186,9 +186,9 @@ defmodule AmbryWeb.Router do
       live "/series/new", SeriesLive.Form, :new
       live "/series/:id/edit", SeriesLive.Form, :edit
 
-      live "/groups", RecordingGroupLive.Index
-      live "/groups/new", RecordingGroupLive.Form, :new
-      live "/groups/:id/edit", RecordingGroupLive.Form, :edit
+      live "/sets", RecordingGroupLive.Index
+      live "/sets/new", RecordingGroupLive.Form, :new
+      live "/sets/:id/edit", RecordingGroupLive.Form, :edit
 
       live "/universes", UniverseLive.Index
       live "/universes/new", UniverseLive.Form, :new
@@ -203,10 +203,10 @@ defmodule AmbryWeb.Router do
       live "/locations/roots/new", LocationLive.Form, :new_root
       live "/locations/roots/:id/edit", LocationLive.Form, :edit_root
 
-      live "/media", MediaLive.Index
-      live "/media/new", MediaLive.Form, :new
-      live "/media/:id/edit", MediaLive.Form, :edit
-      live "/media/:id/replace", MediaLive.Replace
+      live "/audiobooks", MediaLive.Index
+      live "/audiobooks/new", MediaLive.Form, :new
+      live "/audiobooks/:id/edit", MediaLive.Form, :edit
+      live "/audiobooks/:id/replace", MediaLive.Replace
 
       live "/users", UserLive.Index
       live "/users/new", UserLive.Form, :new

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -94,7 +94,7 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
 
       # Book should still be visible
       assert has_element?(view, "[data-role='book-title']", book.title)
-      assert render(view) =~ "Can&#39;t delete book because this book has uploaded media"
+      assert render(view) =~ "Can&#39;t delete book because it has audiobooks"
     end
   end
 

--- a/test/ambry_web/live/admin/home_live/index_test.exs
+++ b/test/ambry_web/live/admin/home_live/index_test.exs
@@ -38,7 +38,7 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
       assert has_element?(view, "a[href='/admin/people']")
       assert has_element?(view, "a[href='/admin/books']")
       assert has_element?(view, "a[href='/admin/series']")
-      assert has_element?(view, "a[href='/admin/media']")
+      assert has_element?(view, "a[href='/admin/audiobooks']")
       assert has_element?(view, "a[href='/admin/audit']")
       assert has_element?(view, "a[href='/admin/users']")
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -990,7 +990,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert html =~ "Part of a set"
       assert html =~ "Not part of a set"
 
-      view |> element("button", "This release is part of a set") |> render_click()
+      view |> element("button", "This audiobook is part of a set") |> render_click()
 
       assert has_element?(view, "[data-role='group-link']")
 
@@ -1024,7 +1024,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      view |> element("button", "This release is part of a set") |> render_click()
+      view |> element("button", "This audiobook is part of a set") |> render_click()
 
       view
       |> form("#group-part")
@@ -1047,7 +1047,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       item = Inbox.get_item!(item.id)
       assert item.draft.recording.recording_group == nil
-      assert has_element?(view, "button", "This release is part of a set")
+      assert has_element?(view, "button", "This audiobook is part of a set")
     end
   end
 
@@ -1071,7 +1071,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       # Two files are one recording by default — the button is the way to
       # say they aren't, not a precondition for importing them.
-      assert html =~ "import as one recording"
+      assert html =~ "import as one audiobook"
       assert html =~ "split into 2 items"
 
       view |> element("button[data-role='split']") |> render_click()

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -75,7 +75,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     # no draft yet, so the badge falls back to the match-time confidence
     assert html =~ "trusted"
     assert html =~ "The Way of Kings"
-    assert html =~ "already in library"
+    assert html =~ "already in the library"
     assert html =~ "+1 other"
     # the recording level says so rather than going silent
     assert html =~ "no match"

--- a/test/ambry_web/live/admin/media_live/chapters_import_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_import_test.exs
@@ -103,7 +103,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media(markers())
 
-    {:ok, view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     refute html =~ "chapter-title-chips"
 
     html = tick_record(view)
@@ -117,7 +117,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
 
     view |> element("#chapter-title-chips button") |> render_click()
@@ -163,7 +163,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
 
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     html = render_async(view)
@@ -182,7 +182,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     render_async(view)
@@ -206,7 +206,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     media = insert_media(markers())
     {:ok, media} = Ambry.Media.update_media(media, %{chapter_marker_source: :file_boundaries})
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     render_async(view)
@@ -220,7 +220,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media([])
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     html = render_async(view)
@@ -241,7 +241,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
 
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     html = render_async(view)

--- a/test/ambry_web/live/admin/media_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_test.exs
@@ -51,7 +51,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "is part of the edit form, from the default state", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Prologue", :manual)])
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       assert html =~ ~s(id="chapters")
       assert [{"0", "Prologue"}] = rendered_rows(html)
@@ -66,7 +66,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter_marker_source: :file_boundaries
         )
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       assert html =~ "one per file"
       assert html =~ "1 generated"
@@ -75,7 +75,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "is honest about a list that predates the field", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Prologue", nil)])
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       assert html =~ "from before this was recorded"
     end
@@ -90,7 +90,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter_marker_source: :embedded
         )
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       view
       |> form("#media-form", %{
@@ -113,7 +113,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
       media =
         media_with_chapters([chapter(0, "One", :provider)], chapter_marker_source: :embedded)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       view
       |> form("#media-form", %{
@@ -136,7 +136,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "typing a title records it as the operator's", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Chapter 1", :generated)])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       view
       |> form("#media-form", %{
@@ -162,7 +162,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter(600, "Chapter 2", :generated)
         ])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       html =
         view
@@ -183,7 +183,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "gives a row with no title the floor rather than an error", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Prologue", :manual)])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       html =
         view
@@ -206,7 +206,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter(600, "Chapter 2", :generated)
         ])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       html =
         view

--- a/test/ambry_web/live/admin/media_live/curation_test.exs
+++ b/test/ambry_web/live/admin/media_live/curation_test.exs
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.MediaLive.CurationTest do
     test "arrives carrying the book's author", %{conn: conn} do
       media = martian()
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
 
       assert has_element?(view, "form#research-recording input[name='author'][value='Andy Weir']")
 
@@ -75,7 +75,7 @@ defmodule AmbryWeb.Admin.MediaLive.CurationTest do
           }
         })
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
       doc = Floki.parse_document!(html)
 
       assert [^large] = doc |> Floki.find("#image-#{media.id}-preview") |> Floki.attribute("src")
@@ -90,7 +90,7 @@ defmodule AmbryWeb.Admin.MediaLive.CurationTest do
       raw = on_disk("curation-no-thumbs.jpg")
       {:ok, media} = Media.update_media(media, %{image_path: raw})
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
 
       assert [^raw] =
                html

--- a/test/ambry_web/live/admin/media_live/missing_badge_test.exs
+++ b/test/ambry_web/live/admin/media_live/missing_badge_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.Admin.MediaLive.MissingBadgeTest do
   test "flags a recording whose files have gone missing", %{conn: conn} do
     insert(:media, book: build(:book), status: :ready, missing_since: DateTime.utc_now(:second))
 
-    {:ok, _view, html} = live(conn, ~p"/admin/media")
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
 
     assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-missing']") != []
     assert html =~ "missing"
@@ -22,7 +22,7 @@ defmodule AmbryWeb.Admin.MediaLive.MissingBadgeTest do
   test "leaves a healthy recording unflagged", %{conn: conn} do
     insert(:media, book: build(:book), status: :ready, missing_since: nil)
 
-    {:ok, _view, html} = live(conn, ~p"/admin/media")
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
 
     assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-missing']") == []
   end

--- a/test/ambry_web/live/admin/media_live/replace_test.exs
+++ b/test/ambry_web/live/admin/media_live/replace_test.exs
@@ -20,7 +20,7 @@ defmodule AmbryWeb.Admin.MediaLive.ReplaceTest do
       conn: conn,
       media: media
     } do
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/replace")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media}/replace")
 
       assert html =~ "Replacing audio is disruptive"
       assert html =~ "Current audio file(s)"
@@ -28,7 +28,7 @@ defmodule AmbryWeb.Admin.MediaLive.ReplaceTest do
     end
 
     test "shows an error when submitting with no files", %{conn: conn, media: media} do
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media}/replace")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/replace")
 
       html =
         view

--- a/test/ambry_web/live/admin/media_live/scan_test.exs
+++ b/test/ambry_web/live/admin/media_live/scan_test.exs
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.MediaLive.ScanTest do
       |> with_copied_source_files(:m4a)
       |> insert()
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks")
 
     html = view |> element("span[phx-click='scan'][phx-value-id='#{media.id}']") |> render_click()
 
@@ -31,7 +31,7 @@ defmodule AmbryWeb.Admin.MediaLive.ScanTest do
       |> with_copied_source_files(:m4a)
       |> insert()
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks")
     view |> element("span[phx-click='scan'][phx-value-id='#{media.id}']") |> render_click()
 
     assert {:ok, _media} = perform_job(RunScan, %{"media_id" => media.id})

--- a/test/ambry_web/live/admin/person_live/index_test.exs
+++ b/test/ambry_web/live/admin/person_live/index_test.exs
@@ -109,7 +109,7 @@ defmodule AmbryWeb.Admin.PersonLive.IndexTest do
 
       # Person should still be visible
       assert has_element?(view, "[data-role='person-name']", narrator.person.name)
-      assert render(view) =~ "Can&#39;t delete person because they have narrated media"
+      assert render(view) =~ "Can&#39;t delete person because they have narrated audiobooks"
     end
 
     test "can delete a person with no books or media", %{conn: conn} do

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -13,7 +13,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       media_one = insert(:media, book: book)
       media_two = insert(:media, book: book)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/new")
 
       view
       |> form("#group-form")
@@ -30,7 +30,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         }
       })
 
-      assert_redirect(view, "/admin/groups")
+      assert_redirect(view, "/admin/sets")
 
       {[group], false} = Media.list_recording_groups()
       assert %{name: "Season One", parts_total: 2, part_word: "episode"} = group
@@ -41,7 +41,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
 
     test "a group may start empty", %{conn: conn} do
       book = insert(:book)
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/new")
 
       view
       |> form("#group-form")
@@ -49,14 +49,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         recording_group_form: %{name: "Awaiting Parts", book_id: to_string(book.id)}
       })
 
-      assert_redirect(view, "/admin/groups")
+      assert_redirect(view, "/admin/sets")
 
       {[group], false} = Media.list_recording_groups()
       assert %{name: "Awaiting Parts", media: []} = group
     end
 
     test "refuses a blank name", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/new")
 
       html =
         view
@@ -74,7 +74,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       group = insert(:recording_group, name: "GraphicAudio", parts_total: 2, book: book)
       media = insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, _view, html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
       doc = Floki.parse_document!(html)
 
@@ -98,7 +98,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       group = insert(:recording_group, name: "Graphic Audio", book: book)
       insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, view, html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+      {:ok, view, html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
       assert resolver_display(html) == "A Court of Thorns and Roses"
 
@@ -116,7 +116,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       keep = insert(:media, book: book, part_number: 1, recording_group: group)
       drop = insert(:media, book: book, part_number: 2, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
       # removal is the drop checkbox, same mechanics as dropping a series book
       view
@@ -129,7 +129,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         }
       })
 
-      assert_redirect(view, "/admin/groups")
+      assert_redirect(view, "/admin/sets")
 
       updated = Media.get_recording_group!(group.id)
       assert %{name: "After", show_label: true} = updated

--- a/test/ambry_web/live/admin/recording_group_live/index_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/index_test.exs
@@ -9,10 +9,10 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
 
   describe "Index" do
     test "renders group index with empty state when no groups exist", %{conn: conn} do
-      {:ok, view, html} = live(conn, ~p"/admin/groups")
+      {:ok, view, html} = live(conn, ~p"/admin/sets")
 
-      assert html =~ "Groups"
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
+      assert html =~ "Sets"
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
     end
 
     test "renders list of groups with their book and parts summary", %{conn: conn} do
@@ -21,7 +21,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       insert(:media, book: book, part_number: 1, recording_group: group)
       insert(:media, book: book, part_number: 2, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-name']", "GraphicAudio")
       assert has_element?(view, "[data-role='group-book']", "A Court of Thorns and Roses")
@@ -33,15 +33,15 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       group = insert(:recording_group, part_word_plural: "episodes")
       insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-parts']", "1 episodes")
     end
 
     test "updates list in realtime when groups change", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
 
       book = insert(:book)
       {:ok, group} = Media.create_recording_group(%{name: "New Group", book_id: book.id})
@@ -61,7 +61,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       group |> Ambry.Media.PubSub.RecordingGroupDeleted.new() |> Ambry.PubSub.broadcast()
       ensure_all_messages_handled(view.pid)
 
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
     end
   end
 
@@ -71,7 +71,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       group = insert(:recording_group, name: "Delete Me")
       media = insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-name']", "Delete Me")
 
@@ -80,8 +80,8 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       |> render_click()
 
       refute has_element?(view, "[data-role='group-name']", "Delete Me")
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
-      assert render(view) =~ "Group deleted successfully"
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
+      assert render(view) =~ "Set deleted successfully"
 
       reloaded = Media.get_media!(media.id)
       assert reloaded.recording_group_id == nil
@@ -94,7 +94,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       insert(:recording_group, name: "Unique Group Name")
       insert(:recording_group, name: "Another Group")
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-name']", "Unique Group Name")
       assert has_element?(view, "[data-role='group-name']", "Another Group")

--- a/test/ambry_web/live/admin/settings_live/index_test.exs
+++ b/test/ambry_web/live/admin/settings_live/index_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
   test "shows direct-play publishing off, with the reason", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/admin/settings")
 
-    assert html =~ "Publish direct-play recordings"
+    assert html =~ "Publish direct-play audiobooks"
     assert html =~ "can&#39;t be marked ready"
     assert html =~ "Turn on"
   end


### PR DESCRIPTION
First of a three-PR stack (vocabulary → credit lines → prose scrub). **Merge order: this one first; retarget its child to `main` before merging, per the usual stacked flow.**

The same concept was named differently surface to surface: nav said **Media** while the book list counted "# Audiobooks" and a delete flash said "uploaded media"; inbox cards labelled their match rails with the internal level keys `work` / `recording`; a `RecordingGroup` was "Groups" in the nav, "Group" in flashes, and "a set" on every form that mentioned one.

Operator-facing words now follow one rule (code and schema names unchanged):

- the playable thing is an **audiobook** — never media, recording, or release
- the abstract work is a **book** — never work
- a `RecordingGroup` is a **set** — nav says **Sets**
- admin routes follow the words: `/admin/audiobooks`, `/admin/sets` (no redirects; nothing external links into the admin, decided by the operator)
- date labels standardize: **Published** on audiobooks (was "Release date" / "Audio publication date"), **First published** on books (was "First print publication")
- "already in library" / "already in the library" → the latter everywhere

Tests: full suite green, `mix check` clean.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx