### PR TITLE
Credits read like the mobile app: stacked, bare authors, "Read by"

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -384,7 +384,7 @@ defmodule Ambry.Books do
     book = Repo.preload(book, :authors)
     authors = Enum.map_join(book.authors, ", ", & &1.name)
 
-    "#{book.title} • by #{authors}"
+    "#{book.title} by #{authors}"
   end
 
   @doc """

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -1041,7 +1041,7 @@ defmodule Ambry.Media do
         Media.display_title(%{media | book: book})
       )
 
-    "#{description} • narrated by #{narrators}"
+    "#{description} read by #{narrators}"
   end
 
   @doc """

--- a/lib/ambry/media/recording_group.ex
+++ b/lib/ambry/media/recording_group.ex
@@ -26,7 +26,7 @@ defmodule Ambry.Media.RecordingGroup do
 
     # a local name: it distinguishes this set from the book's OTHER
     # recordings ("Graphic Audio"), so it's unique per book, not globally —
-    # displays compose "name — book" where context is missing
+    # displays compose "name (book)" where context is missing
     field :name, :string
     field :parts_total, :integer
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -888,7 +888,6 @@ defmodule AmbryWeb.Admin.Components do
       <div>
         <p class="font-bold">{@book.title}</p>
         <p :if={@book.authors != []} class="text-zinc-400">
-          by
           <span :for={author <- @book.authors} class="group">
             <span>{author.name}</span>
             <br class="group-last:hidden" />

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -895,7 +895,7 @@ defmodule AmbryWeb.Admin.Components do
           </span>
         </p>
         <p :if={@book.narrators != []} class="text-zinc-400">
-          Narrated by
+          Read by
           <span :for={narrator <- @book.narrators} class="group">
             <span>{narrator.name}</span>
             <br class="group-last:hidden" />

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -458,7 +458,7 @@ defmodule AmbryWeb.Admin.Decisions do
       candidate["authors"] && Enum.join(candidate["authors"], ", ")
     ]
     |> Enum.reject(&(&1 in [nil, "", []]))
-    |> Enum.join(" — ")
+    |> Enum.join(" by ")
   end
 
   @doc """
@@ -777,7 +777,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <div class="flex items-center justify-between gap-2 pl-3">
         <p class="min-w-0 truncate text-sm text-zinc-500">
-          {@verb} <span class="line-through">{@credit.name}</span> — removed
+          {@verb} <span class="line-through">{@credit.name}</span> (removed)
         </p>
         <button
           type="button"
@@ -1402,7 +1402,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <div class="flex items-center justify-between gap-2 pl-3">
         <p class="min-w-0 truncate text-sm text-zinc-500">
-          In series <span class="line-through">{@link.name}</span> — removed
+          In series <span class="line-through">{@link.name}</span> (removed)
         </p>
         <button
           type="button"
@@ -1555,7 +1555,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <div class="flex items-center justify-between gap-2 pl-3">
         <p class="min-w-0 truncate text-sm text-zinc-500">
-          Part of <span class="line-through">{@link.name}</span> — removed
+          Part of <span class="line-through">{@link.name}</span> (removed)
         </p>
         <button
           type="button"

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1161,7 +1161,7 @@ defmodule AmbryWeb.CoreComponents do
         </p>
       </div>
       <p class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@book.authors} />
+        <.people_links people={@book.authors} />
       </p>
 
       <div class="text-xs text-zinc-400 sm:text-sm">
@@ -1241,7 +1241,7 @@ defmodule AmbryWeb.CoreComponents do
       </p>
 
       <p :if={@show_authors} class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@edition.representative.book.authors} />
+        <.people_links people={@edition.representative.book.authors} />
       </p>
 
       <div :if={@show_series} class="text-xs text-zinc-400 sm:text-sm">
@@ -1283,11 +1283,11 @@ defmodule AmbryWeb.CoreComponents do
       </div>
 
       <p :if={@show_authors} class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@media.book.authors} />
+        <.people_links people={@media.book.authors} />
       </p>
 
       <p :if={@show_narrators} class="text-sm text-zinc-200 sm:text-base">
-        Narrated by <.people_links people={@media.narrators} full_cast={@media.full_cast} />
+        Read by <.people_links people={@media.narrators} full_cast={@media.full_cast} />
       </p>
 
       <div :if={@show_series} class="text-xs text-zinc-400 sm:text-sm">
@@ -1639,20 +1639,29 @@ defmodule AmbryWeb.CoreComponents do
   attr :book, Book, required: true
   attr :class, :string, default: nil
   attr :title_override, :string, default: nil
+  attr :narrators, :list, default: nil
+  attr :full_cast, :boolean, default: false
+  attr :abridged, :boolean, default: false
 
+  # The credit stack, in the mobile app's order and hierarchy: title, series,
+  # bare author names, then a muted "Read by" line. Size and color carry the
+  # roles, so the author line needs no "by".
   def book_header(assigns) do
     ~H"""
     <div>
       <h1 class={["text-3xl font-bold text-zinc-100 sm:text-4xl", @class]}>
         {@title_override || @book.title}
       </h1>
-      <p class="text-zinc-200 sm:text-lg xl:text-xl">
-        <span>by <.all_people_links people={@book.authors} /></span>
-      </p>
-
-      <div class="text-sm text-zinc-400 sm:text-base">
+      <div class="text-xl text-zinc-100 sm:text-2xl">
         <.series_book_links series_books={@book.series_books} />
       </div>
+      <p class="text-lg text-zinc-300 sm:text-xl">
+        <.all_people_links people={@book.authors} />
+      </p>
+      <p :if={@narrators && (@narrators != [] or @full_cast)} class="text-base text-zinc-400 sm:text-lg">
+        Read by <.all_people_links people={@narrators} full_cast={@full_cast} />
+        <span :if={@abridged}>(Abridged)</span>
+      </p>
     </div>
     """
   end

--- a/lib/ambry_web/controllers/preview/audiobook_html/show.html.heex
+++ b/lib/ambry_web/controllers/preview/audiobook_html/show.html.heex
@@ -2,13 +2,13 @@
   <div class="justify-center sm:flex sm:flex-row">
     <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
       <div class="mb-6 sm:hidden">
-        <.book_header book={@media.book} title_override={media_display_title(@media)} />
-        <p class="mt-4">
-          Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-          <%= if @media.abridged do %>
-            <span>(Abridged)</span>
-          <% end %>
-        </p>
+        <.book_header
+          book={@media.book}
+          title_override={media_display_title(@media)}
+          narrators={@media.narrators}
+          full_cast={@media.full_cast}
+          abridged={@media.abridged}
+        />
       </div>
       <div class={["aspect-1", if(!@media.thumbnails, do: "bg-zinc-800")]}>
         <img
@@ -30,13 +30,13 @@
     </section>
     <section id="description" class="max-w-md sm:ml-10">
       <div class="hidden sm:block">
-        <.book_header book={@media.book} title_override={media_display_title(@media)} />
-        <p class="mt-4">
-          Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-          <%= if @media.abridged do %>
-            <span>(Abridged)</span>
-          <% end %>
-        </p>
+        <.book_header
+          book={@media.book}
+          title_override={media_display_title(@media)}
+          narrators={@media.narrators}
+          full_cast={@media.full_cast}
+          abridged={@media.abridged}
+        />
       </div>
       <.markdown
         :if={@media.description}

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -37,7 +37,7 @@
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="book-title">{book.title}</p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="book-authors">
-          by {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
+          {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="book-series">
           {book.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -643,7 +643,7 @@
             section="recording"
             identities={@narrators}
             people={@people}
-            verb="Narrated by"
+            verb="Read by"
             reveal="This is a stage name"
             backing="Stage name of"
             expanded={expanded?(@expanded, "recording", index, credit)}
@@ -742,7 +742,7 @@
                 value={root.id}
                 selected={@item.draft.destination.root_id == root.id}
               >
-                {root.name} — {root.path}
+                {root.name} ({root.path})
               </option>
             </select>
           </form>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -435,7 +435,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   def candidate_label(candidate) do
     [candidate["title"], join_names(candidate["authors"])]
     |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.join(" — ")
+    |> Enum.join(" by ")
   end
 
   def candidate_origin(nil), do: nil

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -95,7 +95,7 @@
           />
         </.field_group>
 
-        <.list_cluster label="Narrated by">
+        <.list_cluster label="Read by">
           <:flag>
             <.provenance_flag
               :if={@media_narrator_count > 0}

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -57,7 +57,7 @@
           by {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
-          narrated by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
+          read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
           {media.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -54,7 +54,7 @@
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis">{media_display_title(media)}</p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
-          by {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
+          {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
           read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -22,7 +22,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
      |> allow_audio_upload(:audio)
      |> assign_form(changeset)
      |> assign(
-       page_title: "#{Ambry.Media.Media.display_title(media)} - Replace audio",
+       page_title: "Replace audio for #{Ambry.Media.Media.display_title(media)}",
        media: media,
        local_import_path: local_import_path,
        select_files: false,

--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -24,7 +24,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     |> assign_form(changeset)
     |> assign(
       # the composed display: the name is local to the book
-      page_title: "#{group.name} — #{group.book.title}",
+      page_title: "#{group.name} (#{group.book.title})",
       group: group,
       media_options: Media.media_for_select(group.book_id)
     )

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -35,7 +35,7 @@
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="series-name">{series.name}</p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="series-authors">
-          by {series.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
+          {series.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
       </div>
       <div class="hidden w-12 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -21,13 +21,13 @@ defmodule AmbryWeb.AudiobookLive do
       <div class="justify-center sm:flex sm:flex-row">
         <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
           <div class="mb-6 sm:hidden">
-            <.book_header book={@media.book} title_override={media_display_title(@media)} />
-            <p class="mt-4">
-              Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-              <%= if @media.abridged do %>
-                <span>(Abridged)</span>
-              <% end %>
-            </p>
+            <.book_header
+              book={@media.book}
+              title_override={media_display_title(@media)}
+              narrators={@media.narrators}
+              full_cast={@media.full_cast}
+              abridged={@media.abridged}
+            />
           </div>
 
           <div class={["aspect-1", if(!@media.thumbnails, do: "bg-zinc-800")]}>
@@ -131,13 +131,13 @@ defmodule AmbryWeb.AudiobookLive do
         </section>
 
         <section id="description" class="hidden max-w-md sm:ml-10 sm:block">
-          <.book_header book={@media.book} title_override={media_display_title(@media)} />
-          <p class="mt-4">
-            Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-            <%= if @media.abridged do %>
-              <span>(Abridged)</span>
-            <% end %>
-          </p>
+          <.book_header
+            book={@media.book}
+            title_override={media_display_title(@media)}
+            narrators={@media.narrators}
+            full_cast={@media.full_cast}
+            abridged={@media.abridged}
+          />
           <.markdown
             :if={@media.description}
             content={@media.description}

--- a/lib/ambry_web/live/narrator_live.ex
+++ b/lib/ambry_web/live/narrator_live.ex
@@ -22,7 +22,7 @@ defmodule AmbryWeb.NarratorLive do
           />
         </.link>
         <h1 class="text-3xl font-bold text-zinc-100 sm:text-4xl xl:text-5xl">
-          Narrated by
+          Read by
           <.link navigate={~p"/people/#{@narrator.person}"} class="hover:underline">
             {@narrator.name}
           </.link>

--- a/lib/ambry_web/live/person_live.ex
+++ b/lib/ambry_web/live/person_live.ex
@@ -65,7 +65,7 @@ defmodule AmbryWeb.PersonLive do
       <div :for={%{narrator: narrator, media: media, more?: more?} <- @narrated_media}>
         <div class="flex items-baseline gap-4">
           <.books_header>
-            Narrated by <.narrator_name narrator={narrator} person={@person} />
+            Read by <.narrator_name narrator={narrator} person={@person} />
           </.books_header>
 
           <.link :if={more?} navigate={~p"/narrators/#{narrator}"} class="text-zinc-500 hover:underline">

--- a/lib/ambry_web/live/search_live/components.ex
+++ b/lib/ambry_web/live/search_live/components.ex
@@ -88,7 +88,7 @@ defmodule AmbryWeb.SearchLive.Components do
         </p>
       </div>
       <p class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@series.series_books |> Enum.flat_map(& &1.book.authors) |> Enum.uniq()} />
+        <.people_links people={@series.series_books |> Enum.flat_map(& &1.book.authors) |> Enum.uniq()} />
       </p>
     </div>
     """

--- a/lib/ambry_web/live/series_live.ex
+++ b/lib/ambry_web/live/series_live.ex
@@ -17,8 +17,8 @@ defmodule AmbryWeb.SeriesLive do
           {@series.name}
         </h1>
 
-        <p class="text-xl text-zinc-200">
-          by <.all_people_links people={@authors} />
+        <p class="text-xl text-zinc-300">
+          <.all_people_links people={@authors} />
         </p>
       </div>
 

--- a/test/ambry/books_test.exs
+++ b/test/ambry/books_test.exs
@@ -430,8 +430,7 @@ defmodule Ambry.BooksTest do
 
       description = Books.get_book_description(book)
 
-      assert description =~ title
-      assert description =~ author_name
+      assert description == "#{title} by #{author_name}"
     end
   end
 

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -1087,9 +1087,7 @@ defmodule Ambry.MediaTest do
 
       description = Media.get_media_description(loaded_media)
 
-      assert description =~ book.title
-      assert description =~ author.name
-      assert description =~ narrator.name
+      assert description == "#{book.title} by #{author.name} read by #{narrator.name}"
     end
 
     test "uses the display-title override when present" do

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -27,7 +27,7 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
       {:ok, view, _html} = live(conn, ~p"/admin/books")
 
       assert has_element?(view, "[data-role='book-title']", book.title)
-      assert has_element?(view, "[data-role='book-authors']", "by #{author.name}")
+      assert has_element?(view, "[data-role='book-authors']", author.name)
       assert has_element?(view, "[data-role='book-series']", "#{series.name} #1")
     end
 

--- a/test/ambry_web/live/admin/series_live/index_test.exs
+++ b/test/ambry_web/live/admin/series_live/index_test.exs
@@ -26,7 +26,7 @@ defmodule AmbryWeb.Admin.SeriesLive.IndexTest do
       {:ok, view, _html} = live(conn, ~p"/admin/series")
 
       assert has_element?(view, "[data-role='series-name']", series.name)
-      assert has_element?(view, "[data-role='series-authors']", "by #{author.name}")
+      assert has_element?(view, "[data-role='series-authors']", author.name)
       assert has_element?(view, "[data-role='series-book-count']", "1")
     end
 


### PR DESCRIPTION
Second of the stack, on #1233. **Retarget to `main` before merging once #1233 lands.**

The original design never put punctuation between a title and its people — "The Martian by Andy Weir narrated by R.C. Bray", usually on multiple lines — but the refactors introduced em-dash compositions (`Title — Author` on every inbox match row and record row) and three verbs for one relationship (narrated by / Narrated by / read by). This aligns every credit with the mobile app's `BookDetailsText` stack:

- **`book_header` renders the mobile hierarchy**: title (bold) / series / bare author names / muted "Read by …". The audiobook and preview pages feed it their narrators instead of rendering their own "Narrated by" paragraph.
- **Bare authors everywhere** (operator-decided): tiles, search results, series page, admin book card and index rows drop the "by " prefix — the size/color ladder already says who's who.
- **"Read by" replaces "narrated by"** as the verb everywhere, including page titles/og descriptions and the narrator/person page headings. The noun "Narrator" stays.
- **One-line contexts join with words**: `candidate_label`/`candidate_title` and `get_book_description`/`get_media_description` now read "Title by Author read by Narrator" (the `•` separators and ` — ` joins are gone). The description-format tests now pin this exactly.
- **The last dash compositions recast**: library-root options and the set page title use "Name (context)", the replace page is "Replace audio for …", removed-credit ghosts say "(removed)".

Deliberately unchanged: the web's full-cast join ("A, B, and a full cast") keeps its structure rather than adopting mobile's "including" phrasing; publisher lines ("Published March 2020 by Podium") are prose, not credits.

Tests: full suite green, `mix check` clean.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx