### PR TITLE
A linked book is never edited — series included

### DIFF
--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -340,8 +340,36 @@ worded.
 Labels name what the operator decides, not what the system stores. Hints
 teach in one sentence, lowercase-calm, no exclamation. Alerts say what's
 wrong and what to do, with an icon carrying the severity so the words don't
-have to. Headings are sentence case — "Orphaned media files", never
-"Orphaned Media Files"; Title Case is for titles of works.
+have to. Headings are sentence case — "Orphaned audiobook files", never
+"Orphaned Audiobook Files"; Title Case is for titles of works.
+
+**One vocabulary** (decided 2026-08-11). The playable thing is an
+**audiobook** — never "media", "recording", or "release" in anything
+rendered. The abstract work is a **book**, never "work". A
+`RecordingGroup` is a **set**. "Edition" survives only as a relation
+("another edition of this book"). Code, schema, and module names keep
+their old words; the rule is for text an operator or listener reads.
+The admin routes follow the words: `/admin/audiobooks`, `/admin/sets`.
+
+**Credits are the mobile app's stack**: title (bold), series
+("Name #3"), bare author names — no "by" — then "Read by …" muted, with
+size and color carrying the roles. "Narrated by" is retired as a verb;
+the noun "Narrator" stays. When one line must hold it all (page titles,
+match rows, option labels), the joins are words: "The Martian by Andy
+Weir read by R.C. Bray". Names join with commas.
+
+**No em or en dashes in rendered text.** Rewrite the sentence instead:
+two short sentences, a semicolon, parentheses ("Name (context)"), or a
+comma. The only "—" left is the empty-value placeholder in table cells.
+The " · " middle dot stays, but only between metadata facts (file stats,
+record-row facts), never inside a credit.
+
+**Hints are one plain sentence** — two at most, no asides, no "not X,
+but Y" rhetoric, no reassurance ("that is common and not a problem"),
+no mechanism lectures, no changelog notes ("… is a later addition").
+Flashes say what happened, then what to do, in at most two short
+sentences. Control labels that answer a question use a comma: "Yes,
+another edition of this", "No, a different book", "None of these".
 
 ## 9. Curation is the import form, everywhere
 

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -66,8 +66,21 @@ identity clusters, the library-root chooser, an inbox queue item) wears a
 | none / `border-zinc-700` | informational, or out of the queue |
 
 Evidence blocks (record lists) get no rail — they inform decisions, they
-aren't one. The rail is the *only* thing that encodes settledness at block
-level; don't also dim, collapse, or re-order.
+aren't one. The records *cards* on the import form are the boundary case:
+the recording-level card IS the identity decision (import blocks until it's
+answered), so it always wears the rail; the work-level card wears one only
+when it carries a live decision — amber for an unsure match nobody has
+curated (the state it puts in "Still to settle"), lime once a human settled
+it, none for a trusted match or a no-match, whose blue/gray badges already
+say "informational". A rail must never claim "waiting" for a step import
+doesn't require. The rail is the *only* thing that encodes settledness at
+block level; don't also dim, collapse, or re-order.
+
+**Evidence before the decisions it feeds — within a section too.** §9 puts
+the evidence panel above the edit forms; the import form's sections follow
+the same order internally: the records card first, then the identity and
+field decisions below it (the work section asked "already have it?" above
+the records for a while, which had the operator deciding before seeing).
 
 ## 3. Geometry
 

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -66,15 +66,14 @@ identity clusters, the library-root chooser, an inbox queue item) wears a
 | none / `border-zinc-700` | informational, or out of the queue |
 
 Evidence blocks (record lists) get no rail — they inform decisions, they
-aren't one. The records *cards* on the import form are the boundary case:
-the recording-level card IS the identity decision (import blocks until it's
-answered), so it always wears the rail; the work-level card wears one only
-when it carries a live decision — amber for an unsure match nobody has
-curated (the state it puts in "Still to settle"), lime once a human settled
-it, none for a trusted match or a no-match, whose blue/gray badges already
-say "informational". A rail must never claim "waiting" for a step import
-doesn't require. The rail is the *only* thing that encodes settledness at
-block level; don't also dim, collapse, or re-order.
+aren't one. The records *cards* on the import form are decision blocks,
+not bare evidence (each carries the level's identity/doubt state), and
+both wear the rail with one reading: **amber only for an unsure match
+nobody has curated; lime for everything else** — trusted is settled, and
+nothing-found is settled too (there is nothing to choose between; the
+seeder approves both). One card must never rail a state the other card
+shows in a different color. The rail is the *only* thing that encodes
+settledness at block level; don't also dim, collapse, or re-order.
 
 **Evidence before the decisions it feeds — within a section too.** §9 puts
 the evidence panel above the edit forms; the import form's sections follow

--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -384,7 +384,7 @@ defmodule Ambry.Books do
     book = Repo.preload(book, :authors)
     authors = Enum.map_join(book.authors, ", ", & &1.name)
 
-    "#{book.title} • by #{authors}"
+    "#{book.title} by #{authors}"
   end
 
   @doc """

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -720,10 +720,10 @@ defmodule Ambry.Inbox do
 
   def describe_error(:no_published_date),
     do:
-      "No publication date, and one can't be invented. Match a work, or tag the file with a date."
+      "No publication date, and one can't be invented. Match a book, or tag the file with a date."
 
   def describe_error(:no_title),
-    do: "Nothing here says what this is. Match a work, or tag the file with a title."
+    do: "Nothing here says what this is. Match a book, or tag the file with a title."
 
   def describe_error({:unreadable, _reason}),
     do: "Couldn't read the file — it may have moved or gone away since it was found."
@@ -747,8 +747,8 @@ defmodule Ambry.Inbox do
   # is placement's documented worst case. The two need opposite advice.
   def describe_error({:destination_exists, path}) do
     if file_in_use?(path) do
-      "Another recording's files are already at #{path}. That shouldn't be " <>
-        "possible — every recording's name carries its own token — so this is " <>
+      "Another audiobook's files are already at #{path}. That shouldn't be " <>
+        "possible — every audiobook's name carries its own token — so this is " <>
         "a bug worth reporting rather than something to fix by editing metadata."
     else
       "A file nothing in the library references is at #{path} — likely left " <>

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -647,11 +647,10 @@ defmodule Ambry.Inbox do
   defp policy_summary(:hardlink, root),
     do: "Hardlinked into #{root.path} — one copy of the bytes, the download keeps seeding."
 
-  defp policy_summary(:copy, root),
-    do: "Copied into #{root.path} — deliberately duplicating the bytes."
+  defp policy_summary(:copy, root), do: "Copied into #{root.path}, duplicating the bytes."
 
   defp policy_summary(:move, root),
-    do: "Moved into #{root.path} — the downloads folder is left clean."
+    do: "Moved into #{root.path}, leaving the downloads folder clean."
 
   defp policy_summary(_unset, root), do: "Placed into #{root.path}."
 
@@ -726,7 +725,7 @@ defmodule Ambry.Inbox do
     do: "Nothing here says what this is. Match a book, or tag the file with a title."
 
   def describe_error({:unreadable, _reason}),
-    do: "Couldn't read the file — it may have moved or gone away since it was found."
+    do: "Couldn't read the file. It may have moved since it was found."
 
   def describe_error({:source_missing, _path}), do: "The file has gone away since it was found."
 
@@ -747,11 +746,10 @@ defmodule Ambry.Inbox do
   # is placement's documented worst case. The two need opposite advice.
   def describe_error({:destination_exists, path}) do
     if file_in_use?(path) do
-      "Another audiobook's files are already at #{path}. That shouldn't be " <>
-        "possible — every audiobook's name carries its own token — so this is " <>
-        "a bug worth reporting rather than something to fix by editing metadata."
+      "Another audiobook's files are already at #{path}. That should be " <>
+        "impossible, so this is a bug worth reporting."
     else
-      "A file nothing in the library references is at #{path} — likely left " <>
+      "A file nothing in the library references is at #{path}, likely left " <>
         "behind by an interrupted import. Delete it and import again."
     end
   end
@@ -760,9 +758,9 @@ defmodule Ambry.Inbox do
     do: "There's no library root to import into. Add one under Locations."
 
   def describe_error(:ambiguous_library_root),
-    do: "There's more than one library root — say which one this folder imports into."
+    do: "There's more than one library root. Choose which one this folder imports into."
 
-  def describe_error(:already_imported), do: "Already in the library — this item is read-only."
+  def describe_error(:already_imported), do: "Already in the library; this item is read-only."
 
   # The invariant, phrased for a human. It names the count rather than the
   # decisions because the form lists them properly — this is the flash you get

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -53,7 +53,6 @@ defmodule Ambry.Inbox.Draft.Seed do
   import Ecto.Query
 
   alias Ambry.Books
-  alias Ambry.Books.Book
   alias Ambry.Books.Series
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.Draft
@@ -422,14 +421,20 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp put_work_fields(%Work{} = work, records, hints, tags, _item) do
     sources = used(records, work.sources)
-    book_id = if work.mode == :link, do: work.book_id
+
+    # A linked book is not edited by an import, so nothing about it is a
+    # decision — series included (they used to be proposed additively).
+    series =
+      if work.mode == :link,
+        do: [],
+        else: keep_curated(work.series, series_links(sources, tags))
 
     %{
       work
       | title: keep_manual(work.title, title_field(sources, hints, tags)),
         published: keep_manual(work.published, published_field(sources, tags)),
         authors: keep_curated(work.authors, author_credits(sources, tags)),
-        series: keep_curated(work.series, series_links(sources, tags, book_id))
+        series: series
     }
   end
 
@@ -1087,8 +1092,8 @@ defmodule Ambry.Inbox.Draft.Seed do
   # above names as the same bug waiting for Books, now closed the same way.
   # A work the seeder settled as new, whose title now matches exactly one
   # Book with an overlapping author, becomes a link to it; the fields are
-  # then re-derived for link mode (series already on the book stop being
-  # proposed), with `keep_manual`/`keep_curated` holding every answered
+  # then re-derived for link mode (series stop being proposed at all — a
+  # linked book is not edited), with `keep_manual`/`keep_curated` holding every answered
   # question. An identity the operator chose is curated and never touched,
   # and anything short of exactly-one-with-matching-author is left alone —
   # linking a recording to the wrong existing book is the worst outcome this
@@ -1633,10 +1638,7 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## series
 
-  # When linking to an existing book, a proposed series is only offered if the
-  # book doesn't already have it: an import may fill a blank, never overwrite
-  # curation.
-  defp series_links(records, tags, book_id) do
+  defp series_links(records, tags) do
     records
     |> Enum.flat_map(fn record ->
       record
@@ -1649,9 +1651,7 @@ defmodule Ambry.Inbox.Draft.Seed do
       [] -> series_proposals_from_tags(tags)
       proposed -> proposed
     end
-    |> Enum.reject(
-      &(already_on_book?(&1.name, book_id) or author_named_series?(&1.name, records, tags))
-    )
+    |> Enum.reject(&author_named_series?(&1.name, records, tags))
     |> then(fn kept ->
       Enum.map(
         kept,
@@ -1804,18 +1804,6 @@ defmodule Ambry.Inbox.Draft.Seed do
       nil -> []
       name -> [%{name: name, number: numeric(tags["series_number"]), source: "tags"}]
     end
-  end
-
-  defp already_on_book?(_name, nil), do: false
-
-  defp already_on_book?(name, book_id) do
-    Book
-    |> where([b], b.id == ^book_id)
-    |> join(:inner, [b], sb in assoc(b, :series_books))
-    |> join(:inner, [_b, sb], s in assoc(sb, :series))
-    |> select([_b, _sb, s], s.name)
-    |> Repo.all()
-    |> Enum.any?(&same_series?(&1, name))
   end
 
   defp series_link(name, number, source) do

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -97,14 +97,13 @@ defmodule Ambry.Inbox.Draft.Work do
   @doc """
   Everything about this work that still needs a human.
 
-  When linking, the Book's own fields and credits belong to the existing
-  record and are not decided here — only the identity is, plus any *additive*
-  series membership the import proposes that the book doesn't already have.
-  That is the fill-gaps rule: an import may fill a blank, never overwrite
-  curation.
+  When linking, the Book belongs to the library and nothing about it is
+  decided here — the only question is the identity itself. (Additive series
+  memberships used to be proposed on linked books; that made series the one
+  editable field on a book the form said it wouldn't touch, so it's gone.)
   """
   def unresolved(%__MODULE__{mode: :link} = work) do
-    identity(work) ++ unresolved_in(work.series, &SeriesLink.resolved?/1, "Series")
+    identity(work)
   end
 
   def unresolved(%__MODULE__{mode: :create} = work) do

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -153,10 +153,11 @@ defmodule Ambry.Inbox.Importer do
 
   ## the work
 
-  defp resolve_book(%{mode: :link, book_id: book_id} = work, _people) do
+  # A linked book is used exactly as it is — an import never edits it.
+  defp resolve_book(%{mode: :link, book_id: book_id}, _people) do
     case Repo.get(Book, book_id) do
       nil -> {:error, :book_not_found}
-      book -> add_series(book, Enum.reject(work.series, & &1.removed))
+      book -> {:ok, book}
     end
   end
 
@@ -183,23 +184,6 @@ defmodule Ambry.Inbox.Importer do
         |> put_list_provenance("book_authors", work.authors)
         |> put_list_provenance("series_books", work.series)
     )
-  end
-
-  # Fill-gaps on a linked book: an import may add a series membership the book
-  # doesn't have, never touch one it does. The seeder has already dropped
-  # memberships the book already carries, so anything left here is additive.
-  defp add_series(book, []), do: {:ok, book}
-
-  defp add_series(book, links) do
-    book = Repo.preload(book, series_books: :series)
-
-    existing =
-      Enum.map(book.series_books, &%{series_id: &1.series_id, book_number: &1.book_number})
-
-    case Books.update_book(book, %{series_books: existing ++ series_params(links)}) do
-      {:ok, book} -> {:ok, book}
-      {:error, _changeset} = error -> error
-    end
   end
 
   # Tombstoned rows are the operator saying "not this one" — they stay on the

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -1041,7 +1041,7 @@ defmodule Ambry.Media do
         Media.display_title(%{media | book: book})
       )
 
-    "#{description} • narrated by #{narrators}"
+    "#{description} read by #{narrators}"
   end
 
   @doc """

--- a/lib/ambry/media/recording_group.ex
+++ b/lib/ambry/media/recording_group.ex
@@ -26,7 +26,7 @@ defmodule Ambry.Media.RecordingGroup do
 
     # a local name: it distinguishes this set from the book's OTHER
     # recordings ("Graphic Audio"), so it's unique per book, not globally —
-    # displays compose "name — book" where context is missing
+    # displays compose "name (book)" where context is missing
     field :name, :string
     field :parts_total, :integer
 

--- a/lib/ambry_web/components/admin/chapter_editor.ex
+++ b/lib/ambry_web/components/admin/chapter_editor.ex
@@ -236,14 +236,14 @@ defmodule AmbryWeb.Admin.ChapterEditor do
 
       <%= if @pending.result.ok? do %>
         <p :if={@takeable} class="pl-3 text-sm text-zinc-300">
-          {n_things(@pending.result.result.incoming, "title")} for “{@pending.chip.title}” — how
-          each lands is beside its row.
+          {n_things(@pending.result.result.incoming, "title")} for “{@pending.chip.title}”. Each
+          row shows how its title lands.
         </p>
 
         <p :if={!@takeable} class="flex items-baseline gap-1.5 pl-3 text-sm text-amber-300">
           <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none self-center" />
-          {n_things(@pending.result.result.incoming, "title")} for {n_things(@markers, "marker")} —
-          titles are only taken when the counts match. The proposed column shows where the lists
+          {n_things(@pending.result.result.incoming, "title")} for {n_things(@markers, "marker")}.
+          Titles are only taken when the counts match; the proposed column shows where the lists
           diverge.
         </p>
       <% end %>

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -888,7 +888,6 @@ defmodule AmbryWeb.Admin.Components do
       <div>
         <p class="font-bold">{@book.title}</p>
         <p :if={@book.authors != []} class="text-zinc-400">
-          by
           <span :for={author <- @book.authors} class="group">
             <span>{author.name}</span>
             <br class="group-last:hidden" />

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -895,7 +895,7 @@ defmodule AmbryWeb.Admin.Components do
           </span>
         </p>
         <p :if={@book.narrators != []} class="text-zinc-400">
-          Narrated by
+          Read by
           <span :for={narrator <- @book.narrators} class="group">
             <span>{narrator.name}</span>
             <br class="group-last:hidden" />

--- a/lib/ambry_web/components/admin/curation.ex
+++ b/lib/ambry_web/components/admin/curation.ex
@@ -93,7 +93,7 @@ defmodule AmbryWeb.Admin.Curation do
           :if={@evidence.searched? and not @evidence.running? and @evidence.records == []}
           class="pl-3 text-sm text-zinc-400"
         >
-          Nothing came back — try different words.
+          Nothing came back. Try different words.
         </p>
 
         <.provider_outcomes_row

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -458,7 +458,7 @@ defmodule AmbryWeb.Admin.Decisions do
       candidate["authors"] && Enum.join(candidate["authors"], ", ")
     ]
     |> Enum.reject(&(&1 in [nil, "", []]))
-    |> Enum.join(" — ")
+    |> Enum.join(" by ")
   end
 
   @doc """
@@ -777,7 +777,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <div class="flex items-center justify-between gap-2 pl-3">
         <p class="min-w-0 truncate text-sm text-zinc-500">
-          {@verb} <span class="line-through">{@credit.name}</span> — removed
+          {@verb} <span class="line-through">{@credit.name}</span> (removed)
         </p>
         <button
           type="button"
@@ -1402,7 +1402,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <div class="flex items-center justify-between gap-2 pl-3">
         <p class="min-w-0 truncate text-sm text-zinc-500">
-          In series <span class="line-through">{@link.name}</span> — removed
+          In series <span class="line-through">{@link.name}</span> (removed)
         </p>
         <button
           type="button"
@@ -1555,7 +1555,7 @@ defmodule AmbryWeb.Admin.Decisions do
     >
       <div class="flex items-center justify-between gap-2 pl-3">
         <p class="min-w-0 truncate text-sm text-zinc-500">
-          Part of <span class="line-through">{@link.name}</span> — removed
+          Part of <span class="line-through">{@link.name}</span> (removed)
         </p>
         <button
           type="button"

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -839,7 +839,7 @@ defmodule AmbryWeb.Admin.Decisions do
             phx-click="remove-credit"
             phx-value-section={@section}
             phx-value-index={@index}
-            title="This recording isn't by them"
+            title="This audiobook isn't by them"
           >
             <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-600" />
           </button>
@@ -1621,7 +1621,7 @@ defmodule AmbryWeb.Admin.Decisions do
         class="pl-3 text-sm text-zinc-400"
         data-role="group-sibling-callout"
       >
-        This work already has a recording set — is this another part of the same set?
+        This book already has a set — is this another part of the same set?
       </p>
 
       <%!-- Reads as a sentence across the row — "<set> no. 1 of 3" — with the

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -79,7 +79,7 @@ defmodule AmbryWeb.Admin.Decisions do
         >
           {outcome["name"]}: {if @retrying == outcome["id"],
             do: "asking again…",
-            else: "couldn't be reached — retry"}
+            else: "couldn't be reached, retry"}
         </button>
 
         <span
@@ -347,7 +347,7 @@ defmodule AmbryWeb.Admin.Decisions do
         phx-value-id={@book["id"]}
         class={action_classes(:zinc, "flex-none")}
       >
-        Yes — another edition of this
+        Yes, another edition of this
       </button>
 
       <span :if={@linked} class="flex-none text-xs text-zinc-400">using this book</span>
@@ -1004,7 +1004,7 @@ defmodule AmbryWeb.Admin.Decisions do
         </button>
 
         <p :if={length(@persons) > 1} class="pl-3 text-xs text-zinc-400">
-          A shared pen name — {@credit.name} will be one author credited to {length(@persons)} people.
+          A shared pen name: {@credit.name} will be one author credited to {length(@persons)} people.
         </p>
       </div>
     </div>
@@ -1103,7 +1103,7 @@ defmodule AmbryWeb.Admin.Decisions do
               on the row that would otherwise look like it was about to make a
               second person of the same name. --%>
         <p :if={@shared_with} class="min-w-0 text-xs text-zinc-400">
-          Same person as the {@shared_with} — one {Field.value(@person.name)} will be created.
+          Same person as the {@shared_with}. One {Field.value(@person.name)} will be created.
           <button
             type="button"
             phx-click="split-person"
@@ -1130,8 +1130,8 @@ defmodule AmbryWeb.Admin.Decisions do
             gate decides the initial ticks; a differently-spelled record of
             the right person is exactly what the checkbox is for. --%>
       <p :if={@records != []} class="max-w-prose pl-3 text-xs text-zinc-400">
-        Tick every record of <span class="font-semibold">this person</span> — the photos and bios on offer come from the
-        ticked ones. Databases know several people by many names, so check before ticking.
+        Tick every record of <span class="font-semibold">this person</span>. Check the name
+        carefully first; the photos and bios on offer come from the ticked records.
       </p>
 
       <.record_row
@@ -1621,7 +1621,7 @@ defmodule AmbryWeb.Admin.Decisions do
         class="pl-3 text-sm text-zinc-400"
         data-role="group-sibling-callout"
       >
-        This book already has a set — is this another part of the same set?
+        This book already has a set. Is this another part of it?
       </p>
 
       <%!-- Reads as a sentence across the row — "<set> no. 1 of 3" — with the

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -62,17 +62,17 @@ defmodule AmbryWeb.Admin.Layouts do
           <.icon name="fa-book-journal-whills" class="h-5 w-5 text-current" />
           <p>Series</p>
         </.link>
-        <.link navigate={~p"/admin/groups"} class={nav_class(@active_path =~ "/admin/groups")}>
+        <.link navigate={~p"/admin/sets"} class={nav_class(@active_path =~ "/admin/sets")}>
           <.icon name="fa-layer-group" class="h-5 w-5 text-current" />
-          <p>Groups</p>
+          <p>Sets</p>
         </.link>
         <.link navigate={~p"/admin/universes"} class={nav_class(@active_path =~ "/admin/universes")}>
           <.icon name="fa-globe" class="h-5 w-5 text-current" />
           <p>Universes</p>
         </.link>
-        <.link navigate={~p"/admin/media"} class={nav_class(@active_path =~ "/admin/media")}>
+        <.link navigate={~p"/admin/audiobooks"} class={nav_class(@active_path =~ "/admin/audiobooks")}>
           <.icon name="fa-file-audio" class="h-5 w-5 text-current" />
-          <p>Media</p>
+          <p>Audiobooks</p>
         </.link>
 
         <p class={group_class()}>System</p>

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1161,7 +1161,7 @@ defmodule AmbryWeb.CoreComponents do
         </p>
       </div>
       <p class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@book.authors} />
+        <.people_links people={@book.authors} />
       </p>
 
       <div class="text-xs text-zinc-400 sm:text-sm">
@@ -1241,7 +1241,7 @@ defmodule AmbryWeb.CoreComponents do
       </p>
 
       <p :if={@show_authors} class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@edition.representative.book.authors} />
+        <.people_links people={@edition.representative.book.authors} />
       </p>
 
       <div :if={@show_series} class="text-xs text-zinc-400 sm:text-sm">
@@ -1283,11 +1283,11 @@ defmodule AmbryWeb.CoreComponents do
       </div>
 
       <p :if={@show_authors} class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@media.book.authors} />
+        <.people_links people={@media.book.authors} />
       </p>
 
       <p :if={@show_narrators} class="text-sm text-zinc-200 sm:text-base">
-        Narrated by <.people_links people={@media.narrators} full_cast={@media.full_cast} />
+        Read by <.people_links people={@media.narrators} full_cast={@media.full_cast} />
       </p>
 
       <div :if={@show_series} class="text-xs text-zinc-400 sm:text-sm">
@@ -1639,20 +1639,29 @@ defmodule AmbryWeb.CoreComponents do
   attr :book, Book, required: true
   attr :class, :string, default: nil
   attr :title_override, :string, default: nil
+  attr :narrators, :list, default: nil
+  attr :full_cast, :boolean, default: false
+  attr :abridged, :boolean, default: false
 
+  # The credit stack, in the mobile app's order and hierarchy: title, series,
+  # bare author names, then a muted "Read by" line. Size and color carry the
+  # roles, so the author line needs no "by".
   def book_header(assigns) do
     ~H"""
     <div>
       <h1 class={["text-3xl font-bold text-zinc-100 sm:text-4xl", @class]}>
         {@title_override || @book.title}
       </h1>
-      <p class="text-zinc-200 sm:text-lg xl:text-xl">
-        <span>by <.all_people_links people={@book.authors} /></span>
-      </p>
-
-      <div class="text-sm text-zinc-400 sm:text-base">
+      <div class="text-xl text-zinc-100 sm:text-2xl">
         <.series_book_links series_books={@book.series_books} />
       </div>
+      <p class="text-lg text-zinc-300 sm:text-xl">
+        <.all_people_links people={@book.authors} />
+      </p>
+      <p :if={@narrators && (@narrators != [] or @full_cast)} class="text-base text-zinc-400 sm:text-lg">
+        Read by <.all_people_links people={@narrators} full_cast={@full_cast} />
+        <span :if={@abridged}>(Abridged)</span>
+      </p>
     </div>
     """
   end

--- a/lib/ambry_web/controllers/preview/audiobook_html/show.html.heex
+++ b/lib/ambry_web/controllers/preview/audiobook_html/show.html.heex
@@ -2,13 +2,13 @@
   <div class="justify-center sm:flex sm:flex-row">
     <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
       <div class="mb-6 sm:hidden">
-        <.book_header book={@media.book} title_override={media_display_title(@media)} />
-        <p class="mt-4">
-          Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-          <%= if @media.abridged do %>
-            <span>(Abridged)</span>
-          <% end %>
-        </p>
+        <.book_header
+          book={@media.book}
+          title_override={media_display_title(@media)}
+          narrators={@media.narrators}
+          full_cast={@media.full_cast}
+          abridged={@media.abridged}
+        />
       </div>
       <div class={["aspect-1", if(!@media.thumbnails, do: "bg-zinc-800")]}>
         <img
@@ -30,13 +30,13 @@
     </section>
     <section id="description" class="max-w-md sm:ml-10">
       <div class="hidden sm:block">
-        <.book_header book={@media.book} title_override={media_display_title(@media)} />
-        <p class="mt-4">
-          Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-          <%= if @media.abridged do %>
-            <span>(Abridged)</span>
-          <% end %>
-        </p>
+        <.book_header
+          book={@media.book}
+          title_override={media_display_title(@media)}
+          narrators={@media.narrators}
+          full_cast={@media.full_cast}
+          abridged={@media.abridged}
+        />
       </div>
       <.markdown
         :if={@media.description}

--- a/lib/ambry_web/live/admin/audit_live/index.ex
+++ b/lib/ambry_web/live/admin/audit_live/index.ex
@@ -76,7 +76,7 @@ defmodule AmbryWeb.Admin.AuditLive.Index do
   end
 
   def handle_event("row-click", %{"id" => media_id}, socket) do
-    {:noreply, push_navigate(socket, to: ~p"/admin/media/#{media_id}/edit")}
+    {:noreply, push_navigate(socket, to: ~p"/admin/audiobooks/#{media_id}/edit")}
   end
 
   defp format_filesize(bytes) do

--- a/lib/ambry_web/live/admin/audit_live/index.html.heex
+++ b/lib/ambry_web/live/admin/audit_live/index.html.heex
@@ -14,7 +14,7 @@
     <div class="space-y-14">
       <%= if @audit.orphaned_media_files != [] do %>
         <div class="space-y-4">
-          <h2 class="text-xl font-bold text-zinc-100">Orphaned media files</h2>
+          <h2 class="text-xl font-bold text-zinc-100">Orphaned audiobook files</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
             It should be safe to delete these files, as they are not being used by
@@ -78,10 +78,10 @@
 
       <%= if @audit.broken_media != [] do %>
         <div class="space-y-4">
-          <h2 class="text-xl font-bold text-zinc-100">Broken media</h2>
+          <h2 class="text-xl font-bold text-zinc-100">Broken audiobooks</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
-            These media uploads are broken in some way. They may or may not work
+            These audiobooks' uploads are broken in some way. They may or may not work
             in all cases.
           </p>
 

--- a/lib/ambry_web/live/admin/audit_live/index.html.heex
+++ b/lib/ambry_web/live/admin/audit_live/index.html.heex
@@ -17,8 +17,7 @@
           <h2 class="text-xl font-bold text-zinc-100">Orphaned audiobook files</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
-            It should be safe to delete these files, as they are not being used by
-            anything.
+            Nothing references these files; deleting them should be safe.
           </p>
 
           <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
@@ -49,8 +48,7 @@
           <h2 class="text-xl font-bold text-zinc-100">Orphaned source folders</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
-            It should be safe to delete these folders, as they are not being used
-            by anything.
+            Nothing references these folders; deleting them should be safe.
           </p>
 
           <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
@@ -81,8 +79,7 @@
           <h2 class="text-xl font-bold text-zinc-100">Broken audiobooks</h2>
 
           <p class="max-w-prose text-sm text-zinc-400">
-            These audiobooks' uploads are broken in some way. They may or may not work
-            in all cases.
+            These audiobooks have broken or incomplete files.
           </p>
 
           <div class="space-y-2 rounded-lg bg-zinc-900 p-4">

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -214,7 +214,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
     {:noreply,
      socket
      |> assign(evidence: %{socket.assigns.evidence | running?: false}, retrying: nil)
-     |> put_flash(:error, "Searching the providers failed — try again.")}
+     |> put_flash(:error, "Searching the providers failed. Try again.")}
   end
 
   # ── accepting proposals ────────────────────────────────────────────────

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -28,7 +28,7 @@
           <.curated_date
             date_field={@form[:published]}
             format_field={@form[:published_format]}
-            label="First print publication"
+            label="First published"
             record={@book}
             hints={@provenance_hints}
             proposals={@chips[:published] || []}

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -7,7 +7,7 @@
       evidence={@evidence}
       level="work"
       title="Records describing this book"
-      hint="Tick every record that's about this book — the fields below grow chips from the ticked records, and clicking a chip takes that value and remembers where it came from."
+      hint="Tick every record that describes this book. Ticked records offer their values as chips under the fields below."
       retrying={@retrying}
     />
 

--- a/lib/ambry_web/live/admin/book_live/index.ex
+++ b/lib/ambry_web/live/admin/book_live/index.ex
@@ -92,8 +92,8 @@ defmodule AmbryWeb.Admin.BookLive.Index do
 
       {:error, :has_media} ->
         message = """
-        Can't delete book because this book has uploaded media.
-        You must delete any uploaded media before you can delete this book.
+        Can't delete book because it has audiobooks.
+        You must delete the audiobooks before you can delete this book.
         """
 
         {:noreply, put_flash(socket, :error, message)}

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -37,7 +37,7 @@
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="book-title">{book.title}</p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="book-authors">
-          by {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
+          {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="book-series">
           {book.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}

--- a/lib/ambry_web/live/admin/home_live/index.html.heex
+++ b/lib/ambry_web/live/admin/home_live/index.html.heex
@@ -25,9 +25,9 @@
       </.stat>
     </.card>
 
-    <.card navigate={~p"/admin/media"} icon="fa-file-audio">
+    <.card navigate={~p"/admin/audiobooks"} icon="fa-file-audio">
       <.stat>
-        <:title>Media</:title>
+        <:title>Audiobooks</:title>
         <:stat><span data-role="media-count">{@media_count}</span></:stat>
       </.stat>
     </.card>

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -19,7 +19,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   ## Vocabulary
 
-  A credit reads as one line — "Written by" / "Narrated by" — and the person
+  A credit reads as one line — "Written by" / "Read by" — and the person
   layer is folded away behind "This is a pen name" / "This is a stage name".
   An earlier version showed both levels always, on the theory that "Credited
   as / Written by" teaches the model for free; in practice it charged every
@@ -153,12 +153,11 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # Naming the slow part, because it is the part that makes the operator
   # wonder whether the click landed: a multi-file release is re-probed file
   # by file and then every one of them is placed.
-  def busy_label(_job, true), do: "Adding to the library — reading the files and placing them…"
+  def busy_label(_job, true), do: "Adding to the library…"
 
   def busy_label(:working, _importing), do: "Matching…"
 
-  def busy_label(:retrying, _importing),
-    do: "A provider couldn't be reached — waiting to try again…"
+  def busy_label(:retrying, _importing), do: "A provider couldn't be reached. Retrying…"
 
   def busy_label(:queued, _importing), do: "Queued for matching…"
   def busy_label(_idle, _importing), do: "Working…"
@@ -364,7 +363,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       {:ok, children} ->
         {:noreply,
          socket
-         |> put_flash(:info, "Split into #{length(children)} items — scanning each fresh now.")
+         |> put_flash(:info, "Split into #{length(children)} items. Scanning each one now.")
          |> push_navigate(to: ~p"/admin/inbox")}
 
       {:error, _reason} ->
@@ -866,9 +865,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   than an immediate give-up.
   """
   def job_label(:working), do: {"Still matching…", :blue}
-  def job_label(:retrying), do: {"A provider couldn't be reached — waiting to try again", :yellow}
+  def job_label(:retrying), do: {"A provider couldn't be reached, retrying", :yellow}
   def job_label(:queued), do: {"Queued for matching", :blue}
-  def job_label(:failed), do: {"Matching gave up — try Start over", :red}
+  def job_label(:failed), do: {"Matching gave up. Try Start over.", :red}
   def job_label(:never_ran), do: {"The files were never read", :red}
   def job_label(:incomplete), do: {"Never finished matching", :yellow}
   def job_label(_settled), do: nil
@@ -899,7 +898,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   banner already says so). The editor itself renders from the draft.
   """
   def chapter_summary(%InboxItem{probe: %{"chapters" => count}}) when count > 0,
-    do: "#{count} chapters in the files — start over to stage them here."
+    do: "#{count} chapters in the files. Start over to stage them here."
 
   def chapter_summary(%InboxItem{probe: probe}) when is_map(probe),
     do: "No chapters in the files. The audiobook will have none until they're added."
@@ -1006,9 +1005,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def doubt_message(%Recording{doubt: :nothing_found}),
     do:
-      "No provider had a record of this audiobook. That is common and not a problem — " <>
-        "a delisted edition vanishes from Audible's search and from ASIN lookup alike. " <>
-        "The fields below come from the file's own tags."
+      "No provider had a record of this audiobook. The fields below come from the file's own tags."
 
   def doubt_message(_recording), do: nil
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -989,6 +989,22 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def hint_rows(_item), do: []
 
   @doc """
+  The work records card's state rail.
+
+  Amber only when the records question is genuinely open — an unsure match
+  the operator hasn't curated, the one state this card puts in "Still to
+  settle". Lime once a human settled it. A trusted match and a no-match are
+  informational (blue and gray badges say which), so they wear no rail.
+  """
+  def work_records_rail(%Work{} = work) do
+    case Draft.level_state(work) do
+      :confirmed -> "border-l-4 border-brand-dark/60"
+      :unsure -> "border-l-4 border-amber-400/70"
+      _informational -> nil
+    end
+  end
+
+  @doc """
   Why nothing was filled in from a recording match.
 
   "No provider listed this" and "a provider listed a different reader's

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -989,18 +989,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def hint_rows(_item), do: []
 
   @doc """
-  The work records card's state rail.
-
-  Amber only when the records question is genuinely open — an unsure match
-  the operator hasn't curated, the one state this card puts in "Still to
-  settle". Lime once a human settled it. A trusted match and a no-match are
-  informational (blue and gray badges say which), so they wear no rail.
+  The work records card's state rail — the same reading as the recording
+  card's, which the seeder settles for every state but doubt: trusted is
+  settled, nothing-found is settled (nothing to choose between), and only
+  an unsure match nobody has curated is still waiting on the operator.
   """
   def work_records_rail(%Work{} = work) do
     case Draft.level_state(work) do
-      :confirmed -> "border-l-4 border-brand-dark/60"
       :unsure -> "border-l-4 border-amber-400/70"
-      _informational -> nil
+      _settled -> "border-l-4 border-brand-dark/60"
     end
   end
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -902,7 +902,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     do: "#{count} chapters in the files — start over to stage them here."
 
   def chapter_summary(%InboxItem{probe: probe}) when is_map(probe),
-    do: "No chapters in the files. The recording will have none until they're added."
+    do: "No chapters in the files. The audiobook will have none until they're added."
 
   def chapter_summary(_item), do: "Not read yet."
 
@@ -1006,7 +1006,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def doubt_message(%Recording{doubt: :nothing_found}),
     do:
-      "No provider had a recording matching this. That is common and not a problem — " <>
+      "No provider had a record of this audiobook. That is common and not a problem — " <>
         "a delisted edition vanishes from Audible's search and from ASIN lookup alike. " <>
         "The fields below come from the file's own tags."
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -90,7 +90,7 @@
             import, to link to its own book or take a part number. --%>
         <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
           <p class="text-sm text-zinc-400">
-            These {length(@item.files)} files import as one recording, played in this order.
+            These {length(@item.files)} files import as one audiobook, played in this order.
           </p>
           <button
             type="button"
@@ -99,7 +99,7 @@
             data-role="split"
             class={action_classes()}
           >
-            Not one recording — split into {length(@item.files)} items
+            Not one audiobook — split into {length(@item.files)} items
           </button>
         </div>
       </section>
@@ -116,8 +116,8 @@
         <p class="max-w-prose pt-1 pl-3 text-sm text-zinc-400">
           This one was imported, and everything below is the record of that import — it's
           read-only now.
-          <.brand_link :if={@item.media_id} navigate={~p"/admin/media/#{@item.media_id}/edit"}>
-            Open the media record
+          <.brand_link :if={@item.media_id} navigate={~p"/admin/audiobooks/#{@item.media_id}/edit"}>
+            Open the audiobook
           </.brand_link>
         </p>
       </section>
@@ -142,7 +142,7 @@
       <%!-- ==================== THE WORK ==================== --%>
       <section id="work" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
-          The work — which book this is a recording of
+          The book — what these files are a recording of
         </h2>
 
         <%!-- The first question, and a different KIND of question from the
@@ -358,7 +358,7 @@
                 form={work}
                 type="date"
                 control_class="max-w-48"
-                hint="The work's original publication date, not this recording's release date."
+                hint="The book's original publication date, not this audiobook's own date."
                 field={@item.draft.work.published}
               />
             </.inputs_for>
@@ -433,7 +433,7 @@
       <%!-- ==================== THE RECORDING ==================== --%>
       <section id="recording" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
-          The recording — which reading of it these files are
+          The audiobook — which reading of the book these files are
         </h2>
 
         <div class={[
@@ -441,7 +441,7 @@
           (@item.draft.recording.approved && "border-brand-dark/60") || "border-amber-400/70"
         ]}>
           <div class="flex items-baseline gap-2 pl-3">
-            <.label>Records describing this recording</.label>
+            <.label>Records describing this audiobook</.label>
             <%!-- One badge, not two: "needs confirming" and a frozen
                 confidence said less together than the decision state says
                 alone — and the old pair could contradict each other. --%>
@@ -481,7 +481,7 @@
 
           <p :if={records(@item, "recording") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
             Tick every record of <span class="font-semibold">this reading</span>
-            — the narrator is what tells two recordings of
+            — the narrator is what tells two audiobooks of
             one book apart, so check it before ticking. Databases keep editions the storefront has
             delisted, which is often the only place an older reading still exists.
           </p>
@@ -536,7 +536,7 @@
           </.disclosure>
 
           <p class="pl-3 text-xs text-zinc-400">
-            Every import creates a new recording. Pointing one at an existing recording's files —
+            Every import creates a new audiobook. Pointing one at an existing audiobook's files —
             the upgrade/replace case — is a later addition.
           </p>
         </div>
@@ -551,7 +551,7 @@
           <.inputs_for :let={draft} field={@form[:draft]}>
             <.inputs_for :let={recording} field={draft[:recording]}>
               <.decision_row
-                label="Recording title"
+                label="Audiobook title"
                 section="recording"
                 name={:title}
                 form={recording}
@@ -563,13 +563,13 @@
               />
 
               <.decision_row
-                label="Release date"
+                label="Published"
                 section="recording"
                 name={:published}
                 form={recording}
                 type="date"
                 control_class="max-w-48"
-                hint="When this reading was published, which is rarely the work's own date."
+                hint="When this reading was published, which is rarely the book's own date."
                 field={@item.draft.recording.published}
               />
 
@@ -625,7 +625,7 @@
           />
 
           <.add_button :if={group_absent?(@item.draft)} phx-click="add-group">
-            This release is part of a set
+            This audiobook is part of a set
           </.add_button>
         </div>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -643,7 +643,7 @@
             section="recording"
             identities={@narrators}
             people={@people}
-            verb="Narrated by"
+            verb="Read by"
             reveal="This is a stage name"
             backing="Stage name of"
             expanded={expanded?(@expanded, "recording", index, credit)}
@@ -742,7 +742,7 @@
                 value={root.id}
                 selected={@item.draft.destination.root_id == root.id}
               >
-                {root.name} — {root.path}
+                {root.name} ({root.path})
               </option>
             </select>
           </form>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -99,7 +99,7 @@
             data-role="split"
             class={action_classes()}
           >
-            Not one audiobook — split into {length(@item.files)} items
+            Not one audiobook? Split into {length(@item.files)} items
           </button>
         </div>
       </section>
@@ -114,8 +114,7 @@
       >
         <p class="pl-3 font-bold">In the library</p>
         <p class="max-w-prose pt-1 pl-3 text-sm text-zinc-400">
-          This one was imported, and everything below is the record of that import — it's
-          read-only now.
+          This item was imported. Everything below is the read-only record of that import.
           <.brand_link :if={@item.media_id} navigate={~p"/admin/audiobooks/#{@item.media_id}/edit"}>
             Open the audiobook
           </.brand_link>
@@ -142,7 +141,7 @@
       <%!-- ==================== THE WORK ==================== --%>
       <section id="work" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
-          The book — what these files are a recording of
+          The book
         </h2>
 
         <%!-- The first question, and a different KIND of question from the
@@ -168,8 +167,7 @@
           </div>
 
           <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            If so this becomes another edition of it — no second book, and its existing details are
-            left alone.
+            If so, this import becomes another edition of that book.
           </p>
 
           <.local_book_row
@@ -229,7 +227,7 @@
               :if={@item.draft.work.mode == :create and @item.draft.work.approved}
               name="fa-check"
               class="text-brand-dark h-3 w-3 flex-none"
-            /> No — this is a different book
+            /> No, a different book
           </button>
         </div>
 
@@ -278,9 +276,8 @@
           </p>
 
           <p :if={records(@item, "work") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
-            Tick every record that's about this book. Two databases having a record of it is normal —
-            and each knows things the other doesn't, so the description can come from one and the
-            cover from another.
+            Tick every record that describes this book. Ticking more than one is fine; each can
+            fill different fields.
           </p>
 
           <p :if={records(@item, "work") == []} class="max-w-prose pl-3 text-sm text-zinc-400">
@@ -324,8 +321,7 @@
           :if={@item.draft.work.mode == :link}
           class="rounded-lg bg-zinc-900 p-4 text-sm"
         >
-          Using the book already in the library. Its title, date and authors are left exactly as they
-          are — an import fills blanks, it never overwrites curation.
+          Using the book already in the library. Its existing details are not changed.
         </p>
 
         <%!-- Typing lives in a form; choosing does not. They are kept apart
@@ -407,8 +403,7 @@
             :if={@item.draft.work.mode == :link and @item.draft.work.series != []}
             class="max-w-prose pl-3 text-sm text-zinc-400"
           >
-            This book isn't in these yet. Adding is a blank being filled, not a change to what's
-            already there.
+            This book isn't in these yet.
           </p>
 
           <div :if={@item.draft.work.series == []} class="space-y-2 rounded-lg bg-zinc-900 p-4">
@@ -433,7 +428,7 @@
       <%!-- ==================== THE RECORDING ==================== --%>
       <section id="recording" class="space-y-7" inert={@read_only}>
         <h2 class="text-xl font-bold text-zinc-100">
-          The audiobook — which reading of the book these files are
+          The audiobook
         </h2>
 
         <div class={[
@@ -480,10 +475,8 @@
           </p>
 
           <p :if={records(@item, "recording") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
-            Tick every record of <span class="font-semibold">this reading</span>
-            — the narrator is what tells two audiobooks of
-            one book apart, so check it before ticking. Databases keep editions the storefront has
-            delisted, which is often the only place an older reading still exists.
+            Tick every record of <span class="font-semibold">this exact reading</span>. Check the
+            narrator first; that is what tells two audiobooks of one book apart.
           </p>
 
           <.record_list
@@ -521,7 +514,7 @@
                   "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
               ]}
             >
-              None of these — it's in no catalogue
+              None of these
             </button>
           </div>
 
@@ -536,8 +529,7 @@
           </.disclosure>
 
           <p class="pl-3 text-xs text-zinc-400">
-            Every import creates a new audiobook. Pointing one at an existing audiobook's files —
-            the upgrade/replace case — is a later addition.
+            Every import creates a new audiobook.
           </p>
         </div>
 
@@ -557,8 +549,8 @@
                 form={recording}
                 control_class="max-w-xl"
                 placeholder="only if it differs from the book's title"
-                hint={"Leave empty unless this reading is titled differently — " <>
-                "\"The Way of Kings (1 of 3)\", say."}
+                hint={"Leave empty unless this reading has its own title, " <>
+                "like \"The Way of Kings (1 of 3)\"."}
                 field={@item.draft.recording.title}
               />
 
@@ -613,8 +605,8 @@
           <div :if={group_absent?(@item.draft)} class="space-y-2 rounded-lg bg-zinc-900 p-4">
             <.label class="pl-3">Part of a set</.label>
             <p class="pl-3 text-sm text-zinc-400">
-              Not part of a set — the usual case. GraphicAudio-style "Part 1 of 2"
-              releases and episodic seasons are the exception.
+              Most audiobooks are not part of a set. Sets are for GraphicAudio-style
+              "Part 1 of 2" releases and episodic seasons.
             </p>
           </div>
 
@@ -694,8 +686,8 @@
           <div class="space-y-1 rounded-lg bg-zinc-900 p-4">
             <p class="pl-3 text-sm text-zinc-300">{chapter_summary(@item)}</p>
             <p class="pl-3 text-sm text-zinc-400">
-              Markers are taken from the file and never from a provider — provider timestamps describe
-              their own edition, not this rip.
+              Chapter markers always come from the files. Provider timestamps describe a
+              different edition.
             </p>
           </div>
         <% end %>
@@ -797,7 +789,7 @@
           </p>
 
           <p :if={@unresolved == [] and @destination.blocker} class="text-sm text-red-400">
-            Everything is settled, but the files can't be placed yet — see Files &amp; destination.
+            Everything is settled, but the files can't be placed yet. See Files &amp; destination.
           </p>
         </div>
       </.form_footer>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -234,9 +234,7 @@
         <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
           <div class="flex items-baseline gap-2 pl-3">
             <.label>
-              {if @item.draft.work.mode == :link,
-                do: "Records that could fill blanks",
-                else: "Records describing this book"}
+              Records describing this book
             </.label>
             <%!-- Decision state, not match history: confidence was frozen at
                 match time, so the badge kept saying "unsure" after the
@@ -275,9 +273,23 @@
             {doubt_message(@item.draft.work)}
           </p>
 
-          <p :if={records(@item, "work") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
+          <p
+            :if={records(@item, "work") != [] and @item.draft.work.mode == :create}
+            class="max-w-prose pl-3 text-sm text-zinc-400"
+          >
             Tick every record that describes this book. Ticking more than one is fine; each can
             fill different fields.
+          </p>
+
+          <%!-- A linked book takes nothing from these records; they matter
+              because ticking one asks its databases for audio editions,
+              which is the route to a delisted recording. --%>
+          <p
+            :if={records(@item, "work") != [] and @item.draft.work.mode == :link}
+            class="max-w-prose pl-3 text-sm text-zinc-400"
+          >
+            Tick every record that describes this book. Ticked records are asked for their audio
+            editions, which feed the audiobook matches below.
           </p>
 
           <p :if={records(@item, "work") == []} class="max-w-prose pl-3 text-sm text-zinc-400">
@@ -397,19 +409,12 @@
           </.add_button>
         </div>
 
-        <%!-- each series is its own decision, number included --%>
-        <div class="space-y-2">
-          <p
-            :if={@item.draft.work.mode == :link and @item.draft.work.series != []}
-            class="max-w-prose pl-3 text-sm text-zinc-400"
-          >
-            This book isn't in these yet.
-          </p>
-
+        <%!-- each series is its own decision, number included; only for a
+            book being created — a linked book is not edited here, series
+            included --%>
+        <div :if={@item.draft.work.mode == :create} class="space-y-2">
           <div :if={@item.draft.work.series == []} class="space-y-2 rounded-lg bg-zinc-900 p-4">
-            <.label class="pl-3">
-              {if @item.draft.work.mode == :link, do: "Series to add", else: "Series"}
-            </.label>
+            <.label class="pl-3">Series</.label>
             <p class="pl-3 text-sm text-zinc-400">No series was proposed.</p>
           </div>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -144,94 +144,11 @@
           The book
         </h2>
 
-        <%!-- The first question, and a different KIND of question from the
-            records below: linking creates nothing and inherits the book's
-            curation, importing a record creates a Book. Ranking the two
-            together made the form ask one question that was really two. --%>
-        <div
-          class={[
-            "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-            (@item.draft.work.approved && "border-brand-dark/60") || "border-amber-400/70"
-          ]}
-          data-role="local-books"
-        >
-          <div class="flex items-baseline gap-2 pl-3">
-            <.label>Is this a book you already have?</.label>
-            <.badge
-              :if={!@item.draft.work.approved}
-              color={elem(state_words(:unconfirmed), 1)}
-              class="text-xs"
-            >
-              {elem(state_words(:unconfirmed), 0)}
-            </.badge>
-          </div>
-
-          <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            If so, this import becomes another edition of that book.
-          </p>
-
-          <.local_book_row
-            :for={book <- local_records(@item, "work")}
-            book={book}
-            linked={@item.draft.work.mode == :link and @item.draft.work.book_id == book["id"]}
-          />
-
-          <%!-- Matching is keyword-based and good enough for the ordinary case,
-              but a file's idea of its title can be anything: the operator's own
-              copy of Philosopher's Stone is tagged "HP1 - The Philosopher's
-              Stone", and the US edition of the same work is called Sorcerer's
-              Stone, which no amount of string cleverness should be expected to
-              connect. So there is always a way to go and look. --%>
-          <form
-            phx-submit="search-library"
-            phx-change="search-library"
-            id="library-search"
-            class="flex flex-wrap items-center gap-2 pt-1"
-          >
-            <input
-              type="text"
-              name="query"
-              value={@library_query}
-              placeholder="search the library by title, author or series"
-              phx-debounce="300"
-              class={input_classes("min-w-64 px-[11px] max-w-xl flex-grow py-2 leading-6")}
-            />
-            <.button type="submit" color={:zinc}>Search</.button>
-          </form>
-
-          <p
-            :if={@library_query not in [nil, ""] and @library_results == []}
-            class="pl-3 text-sm text-zinc-400"
-          >
-            Nothing in the library matches that.
-          </p>
-
-          <.local_book_row
-            :for={book <- @library_results}
-            book={book}
-            linked={@item.draft.work.mode == :link and @item.draft.work.book_id == book["id"]}
-          />
-
-          <button
-            type="button"
-            phx-click="new-book"
-            class={[
-              "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm",
-              (@item.draft.work.mode == :create and @item.draft.work.approved) &&
-                "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
-              !(@item.draft.work.mode == :create and @item.draft.work.approved) &&
-                "bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100"
-            ]}
-          >
-            <.icon
-              :if={@item.draft.work.mode == :create and @item.draft.work.approved}
-              name="fa-check"
-              class="text-brand-dark h-3 w-3 flex-none"
-            /> No, a different book
-          </button>
-        </div>
-
-        <div class="space-y-2 rounded-lg bg-zinc-900 p-4">
+        <%!-- Evidence first, then the decisions it feeds (§9): what the
+            databases say this is, before "do I already have it?". The records
+            are how the operator recognizes the book, and ticking one asks its
+            databases for audio editions, which feed the audiobook section. --%>
+        <div class={["space-y-2 rounded-lg bg-zinc-900 p-4", work_records_rail(@item.draft.work)]}>
           <div class="flex items-baseline gap-2 pl-3">
             <.label>
               Records describing this book
@@ -325,6 +242,93 @@
               />
             </div>
           </.disclosure>
+        </div>
+
+        <%!-- A different KIND of question from the records above: linking
+            creates nothing and inherits the book's curation, importing a
+            record creates a Book. Ranking the two together made the form ask
+            one question that was really two. --%>
+        <div
+          class={[
+            "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+            (@item.draft.work.approved && "border-brand-dark/60") || "border-amber-400/70"
+          ]}
+          data-role="local-books"
+        >
+          <div class="flex items-baseline gap-2 pl-3">
+            <.label>Is this a book you already have?</.label>
+            <.badge
+              :if={!@item.draft.work.approved}
+              color={elem(state_words(:unconfirmed), 1)}
+              class="text-xs"
+            >
+              {elem(state_words(:unconfirmed), 0)}
+            </.badge>
+          </div>
+
+          <p class="max-w-prose pl-3 text-sm text-zinc-400">
+            If so, this import becomes another edition of that book.
+          </p>
+
+          <.local_book_row
+            :for={book <- local_records(@item, "work")}
+            book={book}
+            linked={@item.draft.work.mode == :link and @item.draft.work.book_id == book["id"]}
+          />
+
+          <%!-- Matching is keyword-based and good enough for the ordinary case,
+              but a file's idea of its title can be anything: the operator's own
+              copy of Philosopher's Stone is tagged "HP1 - The Philosopher's
+              Stone", and the US edition of the same work is called Sorcerer's
+              Stone, which no amount of string cleverness should be expected to
+              connect. So there is always a way to go and look. --%>
+          <form
+            phx-submit="search-library"
+            phx-change="search-library"
+            id="library-search"
+            class="flex flex-wrap items-center gap-2 pt-1"
+          >
+            <input
+              type="text"
+              name="query"
+              value={@library_query}
+              placeholder="search the library by title, author or series"
+              phx-debounce="300"
+              class={input_classes("min-w-64 px-[11px] max-w-xl flex-grow py-2 leading-6")}
+            />
+            <.button type="submit" color={:zinc}>Search</.button>
+          </form>
+
+          <p
+            :if={@library_query not in [nil, ""] and @library_results == []}
+            class="pl-3 text-sm text-zinc-400"
+          >
+            Nothing in the library matches that.
+          </p>
+
+          <.local_book_row
+            :for={book <- @library_results}
+            book={book}
+            linked={@item.draft.work.mode == :link and @item.draft.work.book_id == book["id"]}
+          />
+
+          <button
+            type="button"
+            phx-click="new-book"
+            class={[
+              "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm",
+              (@item.draft.work.mode == :create and @item.draft.work.approved) &&
+                "bg-brand-dark/15 ring-brand-dark/50 ring-2 ring-inset",
+              !(@item.draft.work.mode == :create and @item.draft.work.approved) &&
+                "bg-zinc-800 text-zinc-300 hover:bg-zinc-700 hover:text-zinc-100"
+            ]}
+          >
+            <.icon
+              :if={@item.draft.work.mode == :create and @item.draft.work.approved}
+              name="fa-check"
+              class="text-brand-dark h-3 w-3 flex-none"
+            /> No, a different book
+          </button>
         </div>
 
         <%!-- Linking inherits the book's own fields; only additive series

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -435,7 +435,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   def candidate_label(candidate) do
     [candidate["title"], join_names(candidate["authors"])]
     |> Enum.reject(&(&1 in [nil, ""]))
-    |> Enum.join(" — ")
+    |> Enum.join(" by ")
   end
 
   def candidate_origin(nil), do: nil

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -44,7 +44,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
          put_flash(
            socket,
            :info,
-           "Scanning the watched folder. Nothing is moved or changed — new candidates just show up here."
+           "Scanning the watched folder. New candidates will show up here."
          )}
 
       {:error, _reason} ->
@@ -93,8 +93,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
         message =
           if job.conflict?,
             do: "Already re-reading this one.",
-            else:
-              "Re-reading the files and asking the providers again — this one is slow on purpose."
+            else: "Re-reading the files and asking the providers again. This can take a while."
 
         # Reload, or the row the operator just handed to a job keeps looking
         # idle: the overlay is driven by `@progress`, which is only read when
@@ -203,10 +202,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # here — the row already shows its matches or its issue, and repeating
   # "done" on every settled row is noise that hides the rows that aren't.
   defp progress_label(:working), do: "Working on it…"
-  defp progress_label(:retrying), do: "A provider couldn't be reached — waiting to try again."
+  defp progress_label(:retrying), do: "A provider couldn't be reached. Waiting to try again."
 
   defp progress_label(:queued), do: "Queued"
-  defp progress_label(:failed), do: "A background job failed — try re-scanning."
+  defp progress_label(:failed), do: "A background job failed. Try re-scanning."
 
   defp progress_label(:incomplete), do: "Never finished matching. Try re-scanning."
 

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -426,6 +426,10 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     end
   end
 
+  @doc "What a match level is called on the card — the data keys stay work/recording."
+  def level_word("work"), do: "book"
+  def level_word("recording"), do: "audiobook"
+
   def candidate_label(nil), do: "no match"
 
   def candidate_label(candidate) do
@@ -435,7 +439,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   end
 
   def candidate_origin(nil), do: nil
-  def candidate_origin(%{"source" => "local"}), do: "already in library"
+  def candidate_origin(%{"source" => "local"}), do: "already in the library"
   def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
   def candidate_origin(%{"source" => "provider:" <> id}), do: id
   def candidate_origin(_candidate), do: nil

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -77,7 +77,7 @@
             :for={match <- match_summary(item)}
             class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2 text-sm"
           >
-            <span class="text-xs text-zinc-400">{match.level}</span>
+            <span class="text-xs text-zinc-400">{level_word(match.level)}</span>
             <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
               <.badge
                 color={elem(level_state_words(match.state), 1)}

--- a/lib/ambry_web/live/admin/location_live/form.ex
+++ b/lib/ambry_web/live/admin/location_live/form.ex
@@ -139,17 +139,16 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
   # files can be trusted to stay is the whole distinction.
   defp on_import_options do
     [
-      {"Bring the files in — this folder's files could vanish out from under the library",
-       :bring_in},
-      {"Leave them where they are — these files are staying put", :leave_in_place}
+      {"Bring the files in (this folder's files might not stay)", :bring_in},
+      {"Leave them where they are (these files are trusted to stay)", :leave_in_place}
     ]
   end
 
   defp policy_options do
     [
-      {"Hardlink — same filesystem only, costs no extra storage", :hardlink},
-      {"Copy — duplicates the files", :copy},
-      {"Move — leaves the source folder empty", :move}
+      {"Hardlink (same filesystem only, no extra storage)", :hardlink},
+      {"Copy (duplicates the files)", :copy},
+      {"Move (empties the source folder)", :move}
     ]
   end
 end

--- a/lib/ambry_web/live/admin/location_live/form.html.heex
+++ b/lib/ambry_web/live/admin/location_live/form.html.heex
@@ -15,8 +15,7 @@
           class="pl-3 text-sm text-amber-400"
           data-role="path-status"
         >
-          Nothing at that path right now. You can still save it — a volume that isn't mounted yet
-          is a normal thing to configure ahead of time.
+          Nothing at that path right now. You can still save it and mount the volume later.
         </p>
 
         <p
@@ -52,9 +51,8 @@
           options={on_import_options()}
         />
         <p class="max-w-prose pl-3 text-sm text-zinc-400">
-          The one promise a source makes. A folder a download client controls can lose its files,
-          so the library protects itself with its own copy; a collection that's staying put is
-          simply pointed at, and Ambry never writes to it.
+          Whether import copies these files into the library or references them where they
+          are.
         </p>
 
         <.input field={@form[:enabled]} type="checkbox" label="Watched" />
@@ -69,9 +67,8 @@
             options={policy_options()}
           />
           <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            Hardlinking only works within a single filesystem. If this folder and the library root
-            it imports into are on different disks, import will say so rather than quietly
-            copying and doubling your storage.
+            Hardlinking only works within a single filesystem. Import refuses across
+            filesystems instead of silently copying.
           </p>
         </div>
 
@@ -84,12 +81,11 @@
             prompt={root_prompt(@root_options)}
           />
           <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            Optional. Any source can import into any root — this only preselects one. With
-            a single root, imports never ask.
+            Optional. Any source can import into any root; this preselects one.
           </p>
           <p :if={@root_options == []} class="max-w-prose pl-3 text-sm text-amber-400">
-            There are no library roots yet, so nothing can be brought in. Add one under
-            Locations first — until then, importing an item from this folder will refuse.
+            No library roots yet, so nothing can be brought in. Add one under Locations
+            first.
           </p>
         </div>
       </.field_group>

--- a/lib/ambry_web/live/admin/location_live/index.ex
+++ b/lib/ambry_web/live/admin/location_live/index.ex
@@ -112,7 +112,7 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
 
   defp source_problem(status) do
     cond do
-      !status.exists? -> "Not found — is the volume mounted?"
+      !status.exists? -> "Not found. Is the volume mounted?"
       !status.directory? -> "Not a folder."
       true -> nil
     end
@@ -120,7 +120,7 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
 
   defp root_problem(status) do
     cond do
-      !status.exists? -> "Not found — is the volume mounted?"
+      !status.exists? -> "Not found. Is the volume mounted?"
       !status.directory? -> "Not a folder."
       !status.writable? -> "Read-only, so nothing can land here."
       true -> nil

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -12,9 +12,8 @@
       </div>
 
       <p class="max-w-prose text-sm text-zinc-400">
-        Watched folders audiobooks arrive from — everything they hold reaches the library through
-        the inbox, nothing bypasses it. Each one makes a single promise: whether its files can be
-        trusted to stay.
+        Watched folders that audiobooks arrive from. Everything they hold reaches the library
+        through the inbox.
       </p>
 
       <div :if={@sources == []} class="rounded-lg bg-zinc-900 p-8 text-center">
@@ -116,17 +115,15 @@
       <h2 class="text-xl font-bold text-zinc-100">Library roots</h2>
 
       <p class="max-w-prose text-sm text-zinc-400">
-        The folders managed audio is organized into, by the naming template. Ambry writes here
-        and nowhere else. Hardlinks can't cross a filesystem, so a source can only hardlink into
-        a root sharing its <span class="font-semibold">filesystem</span> tag.
+        The folders managed audio is organized into, using the naming template. Ambry writes
+        only here. A source can only hardlink into a root sharing its <span class="font-semibold">filesystem</span> tag.
       </p>
 
       <%!-- Roots are optional by design: a setup whose sources all leave
           files in place imports nothing into a tree of its own. --%>
       <div :if={@roots == []} class="rounded-lg bg-zinc-900 p-8 text-center">
         <p class="mx-auto max-w-prose text-zinc-400">
-          No roots. That's fine while every source leaves its files in place — add one when a
-          source needs to bring files in.
+          No roots yet. Add one when a source needs to bring files in.
         </p>
         <.add_button navigate={~p"/admin/locations/roots/new"} class="mx-auto mt-3">
           Add a root

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -448,7 +448,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     {:noreply,
      socket
      |> assign(evidence: %{socket.assigns.evidence | running?: false}, retrying: nil)
-     |> put_flash(:error, "Searching the providers failed — try again.")}
+     |> put_flash(:error, "Searching the providers failed. Try again.")}
   end
 
   def handle_async(:chapter_titles, {:ok, fetched}, socket) do

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -95,7 +95,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     socket
     |> assign_form(changeset)
     |> assign(
-      page_title: "New Media",
+      page_title: "New Audiobook",
       media: media,
       recording_groups: [],
       file_stats: nil,
@@ -682,8 +682,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Updated media for #{media.book.title}")
-         |> push_navigate(to: ~p"/admin/media")}
+         |> put_flash(:info, "Updated audiobook for #{media.book.title}")
+         |> push_navigate(to: ~p"/admin/audiobooks")}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -700,8 +700,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
         {:noreply,
          socket
-         |> put_flash(:info, "Created new media for #{media.book.title}")
-         |> push_navigate(to: ~p"/admin/media")}
+         |> put_flash(:info, "Created new audiobook for #{media.book.title}")
+         |> push_navigate(to: ~p"/admin/audiobooks")}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -811,8 +811,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   end
 
   defp media_path(media, params \\ %{})
-  defp media_path(%Media.Media{id: nil}, params), do: ~p"/admin/media/new?#{params}"
-  defp media_path(media, params), do: ~p"/admin/media/#{media}/edit?#{params}"
+  defp media_path(%Media.Media{id: nil}, params), do: ~p"/admin/audiobooks/new?#{params}"
+  defp media_path(media, params), do: ~p"/admin/audiobooks/#{media}/edit?#{params}"
 
   defp open_file_browser(media), do: JS.patch(media_path(media, %{browse: :files}))
   defp close_modal(media), do: JS.patch(media_path(media), replace: true)

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -10,13 +10,13 @@
     <.evidence_panel
       evidence={@evidence}
       level="recording"
-      title="Records describing this recording"
-      hint="Tick every record of this reading — the narrator is what tells two recordings of one book apart. Ticked records grow chips under the fields below."
+      title="Records describing this audiobook"
+      hint="Tick every record of this reading — the narrator is what tells two audiobooks of one book apart. Ticked records grow chips under the fields below."
       retrying={@retrying}
     />
 
     <.simple_form id="media-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
-      <.form_section title="The recording" id="recording">
+      <.form_section title="The audiobook" id="recording">
         <.field_group>
           <.input
             field={@form[:book_id]}
@@ -40,7 +40,7 @@
               <.curated_date
                 date_field={@form[:published]}
                 format_field={@form[:published_format]}
-                label="Audio publication date"
+                label="Published"
                 record={@media}
                 hints={@provenance_hints}
                 proposals={@chips[:published] || []}
@@ -186,7 +186,7 @@
           </.field_group>
 
           <.add_button :if={!@group_row_visible} phx-click="add-group-row">
-            This recording is part of a set
+            This audiobook is part of a set
           </.add_button>
         </div>
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -95,7 +95,7 @@
           />
         </.field_group>
 
-        <.list_cluster label="Narrated by">
+        <.list_cluster label="Read by">
           <:flag>
             <.provenance_flag
               :if={@media_narrator_count > 0}

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -11,7 +11,7 @@
       evidence={@evidence}
       level="recording"
       title="Records describing this audiobook"
-      hint="Tick every record of this reading — the narrator is what tells two audiobooks of one book apart. Ticked records grow chips under the fields below."
+      hint="Tick every record of this exact reading; check the narrator first. Ticked records offer their values as chips under the fields below."
       retrying={@retrying}
     />
 

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     {:ok,
      socket
      |> assign(
-       page_title: "Media",
+       page_title: "Audiobooks",
        show_header_search: true,
        processing_media_progress_map: %{}
      )
@@ -65,8 +65,8 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
         media: media,
         has_next: has_more?,
         has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/media?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/media?#{prev_opts(list_opts)}",
+        next_page_path: ~p"/admin/audiobooks?#{next_opts(list_opts)}",
+        prev_page_path: ~p"/admin/audiobooks?#{prev_opts(list_opts)}",
         current_sort: list_opts.sort || @default_sort
       )
     else
@@ -110,7 +110,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     socket = maybe_update_media(socket, %{"filter" => query, "page" => "1"})
     list_opts = get_list_opts(socket)
 
-    {:noreply, push_patch(socket, to: ~p"/admin/media?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/audiobooks?#{patch_opts(list_opts)}")}
   end
 
   def handle_event("sort", %{"field" => sort_field}, socket) do
@@ -119,7 +119,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
       |> get_list_opts()
       |> Map.update!(:sort, &apply_sort(&1, sort_field, @valid_sort_fields))
 
-    {:noreply, push_patch(socket, to: ~p"/admin/media?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/audiobooks?#{patch_opts(list_opts)}")}
   end
 
   defp list_media(opts, default_sort) do

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -2,7 +2,7 @@
   <:subheader>
     <.list_controls
       search_form={@search_form}
-      new_path={~p"/admin/media/new"}
+      new_path={~p"/admin/audiobooks/new"}
       has_next={@has_next}
       has_prev={@has_prev}
       next_page_path={@next_page_path}
@@ -23,11 +23,11 @@
   <.flex_table
     rows={@media}
     filter={@list_opts.filter}
-    row_click={fn media -> JS.navigate(~p"/admin/media/#{media}/edit") end}
+    row_click={fn media -> JS.navigate(~p"/admin/audiobooks/#{media}/edit") end}
   >
     <:empty>
-      No media yet.
-      <.brand_link navigate={~p"/admin/media/new"}>
+      No audiobooks yet.
+      <.brand_link navigate={~p"/admin/audiobooks/new"}>
         Create one.
       </.brand_link>
     </:empty>
@@ -83,13 +83,13 @@
 
       <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
         <div class="flex gap-2 pb-2">
-          <.link navigate={~p"/admin/media/#{media}/edit"}>
+          <.link navigate={~p"/admin/audiobooks/#{media}/edit"}>
             <.icon
               name="fa-pencil"
               class="h-4 w-4 text-current transition-colors hover:text-lime-400"
             />
           </.link>
-          <.link navigate={~p"/admin/media/#{media}/replace"} title="Replace audio">
+          <.link navigate={~p"/admin/audiobooks/#{media}/replace"} title="Replace audio">
             <.icon
               name="fa-upload"
               class="h-4 w-4 text-current transition-colors hover:text-lime-400"
@@ -99,7 +99,7 @@
             phx-click="scan"
             phx-value-id={media.id}
             title="Scan files for direct play"
-            data-confirm="Scan this media's source files? Nothing is copied or modified, and clients see no change."
+            data-confirm="Scan this audiobook's source files? Nothing is copied or modified, and clients see no change."
           >
             <.icon
               name="fa-magnifying-glass"

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -57,7 +57,7 @@
           by {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
-          narrated by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
+          read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
           {media.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -54,7 +54,7 @@
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis">{media_display_title(media)}</p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
-          by {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
+          {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
           read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -70,7 +70,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
             {:noreply,
              socket
              |> put_flash(:info, "Replacing audio for #{media.book.title}")
-             |> push_navigate(to: ~p"/admin/media")}
+             |> push_navigate(to: ~p"/admin/audiobooks")}
 
           {:error, %Changeset{} = changeset} ->
             {:noreply, assign_form(socket, changeset)}
@@ -86,7 +86,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
     {:noreply,
      socket
      |> assign(selected_files: files)
-     |> push_patch(to: ~p"/admin/media/#{socket.assigns.media}/replace", replace: true)}
+     |> push_patch(to: ~p"/admin/audiobooks/#{socket.assigns.media}/replace", replace: true)}
   end
 
   # Consumes browser uploads into a fresh source folder, or references the
@@ -151,6 +151,8 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
     |> Enum.map(&{&1.name(), &1})
   end
 
-  defp open_file_browser(media), do: JS.patch(~p"/admin/media/#{media}/replace?browse=files")
-  defp close_file_browser(media), do: JS.patch(~p"/admin/media/#{media}/replace", replace: true)
+  defp open_file_browser(media), do: JS.patch(~p"/admin/audiobooks/#{media}/replace?browse=files")
+
+  defp close_file_browser(media),
+    do: JS.patch(~p"/admin/audiobooks/#{media}/replace", replace: true)
 end

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -22,7 +22,7 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
      |> allow_audio_upload(:audio)
      |> assign_form(changeset)
      |> assign(
-       page_title: "#{Ambry.Media.Media.display_title(media)} - Replace audio",
+       page_title: "Replace audio for #{Ambry.Media.Media.display_title(media)}",
        media: media,
        local_import_path: local_import_path,
        select_files: false,

--- a/lib/ambry_web/live/admin/media_live/replace.html.heex
+++ b/lib/ambry_web/live/admin/media_live/replace.html.heex
@@ -9,15 +9,13 @@
       <div class="space-y-2 text-sm">
         <p class="font-semibold">Replacing audio is disruptive.</p>
         <p>
-          This re-processes the book and overwrites the streaming files. It is meant for fixing the
-          files of the <strong>same edition/recording</strong>
-          (e.g. a corrupt or low-quality source), <strong>not</strong>
-          for switching to a different edition.
+          This re-processes the audiobook and overwrites its streaming files. Use it to fix bad
+          files of the <strong>same edition</strong>, never to switch editions.
         </p>
         <p>
-          Chapters and listeners' saved positions are left as-is. Anyone streaming will pick up the new
-          audio automatically, but anyone who <strong>downloaded</strong> this book for offline listening
-          must delete and re-download it to get the new files.
+          Chapters and listening positions are kept, and streams pick up the new audio
+          automatically. Anyone who <strong>downloaded</strong> this audiobook must delete and
+          re-download it.
         </p>
       </div>
     </div>

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -24,9 +24,8 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
     <.layout title={@page_title} user={@current_user}>
       <div class="max-w-4xl space-y-8">
         <p class="text-zinc-400">
-          Providers fill in facts during import; you curate the structure. Priority controls the
-          order providers are offered in import forms. Settings apply immediately; cached responses
-          can be cleared per provider.
+          Priority sets the order providers appear in on import forms. Changes apply
+          immediately.
         </p>
 
         <section :for={{level, title, blurb} <- levels()}>
@@ -225,12 +224,11 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
 
   defp levels do
     [
-      {:work, "Book-level providers",
-       "Books, authors, and series — the abstract side of the library."},
+      {:work, "Book-level providers", "Books, authors, and series."},
       {:recording, "Audiobook-level providers",
-       "Audiobooks — narrators, square covers, and chapters, keyed by ASIN."},
+       "Narrators, square covers, and chapters, keyed by ASIN."},
       {:person, "Person-level providers",
-       "Bios and photos for the humans behind authors and narrators — keyed on real people, not published-as names."}
+       "Bios and photos for the real people behind authors and narrators."}
     ]
   end
 

--- a/lib/ambry_web/live/admin/metadata_live/providers.ex
+++ b/lib/ambry_web/live/admin/metadata_live/providers.ex
@@ -225,10 +225,10 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
 
   defp levels do
     [
-      {:work, "Work-level providers",
+      {:work, "Book-level providers",
        "Books, authors, and series — the abstract side of the library."},
-      {:recording, "Recording-level providers",
-       "Audiobook releases — narrators, square covers, and chapters, keyed by ASIN."},
+      {:recording, "Audiobook-level providers",
+       "Audiobooks — narrators, square covers, and chapters, keyed by ASIN."},
       {:person, "Person-level providers",
        "Bios and photos for the humans behind authors and narrators — keyed on real people, not published-as names."}
     ]
@@ -255,8 +255,8 @@ defmodule AmbryWeb.Admin.MetadataLive.Providers do
   # the current pairing simply can't represent.
   defp capability_label(:book_search, :recording), do: "audiobook search"
   defp capability_label(:book_details, :recording), do: "audiobook details"
-  defp capability_label(:book_search, _level), do: "work search"
-  defp capability_label(:book_details, _level), do: "work details"
+  defp capability_label(:book_search, _level), do: "book search"
+  defp capability_label(:book_details, _level), do: "book details"
   defp capability_label(:author_search, :person), do: "person search"
   defp capability_label(:author_details, :person), do: "person details"
   defp capability_label(:author_search, _level), do: "author search"

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -167,7 +167,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     {:noreply,
      socket
      |> assign(evidence: %{socket.assigns.evidence | running?: false}, retrying: nil)
-     |> put_flash(:error, "Searching the providers failed — try again.")}
+     |> put_flash(:error, "Searching the providers failed. Try again.")}
   end
 
   defp refresh_chips(socket) do

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -7,7 +7,7 @@
       evidence={@evidence}
       level="person"
       title="Records of this person"
-      hint="Tick every record of this person — databases know several people by many names, so check before ticking. Ticked records offer the name, photos and bios below."
+      hint="Tick every record of this person; check the name carefully first. Ticked records offer names, photos and bios below."
       retrying={@retrying}
     />
 

--- a/lib/ambry_web/live/admin/person_live/index.ex
+++ b/lib/ambry_web/live/admin/person_live/index.ex
@@ -99,8 +99,8 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
 
       {:error, :has_narrated_media} ->
         message = """
-        Can't delete person because they have narrated media.
-        You must delete the media before you can delete this person.
+        Can't delete person because they have narrated audiobooks.
+        You must delete the audiobooks before you can delete this person.
         """
 
         {:noreply, put_flash(socket, :error, message)}

--- a/lib/ambry_web/live/admin/playback_debug_live/index.ex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.ex
@@ -142,7 +142,7 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.Index do
 
   defp playthrough_label(playthrough) do
     case playthrough.media do
-      nil -> "Unknown media"
+      nil -> "Unknown audiobook"
       %{book: %{title: title}} -> title
       media -> "Media #{media.id}"
     end

--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     socket
     |> assign_form(changeset)
     |> assign(
-      page_title: "New Group",
+      page_title: "New Set",
       group: group,
       media_options: []
     )
@@ -74,7 +74,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{group.name}")
-         |> push_navigate(to: ~p"/admin/groups")}
+         |> push_navigate(to: ~p"/admin/sets")}
 
       {:error, error} ->
         {:noreply, handle_save_error(socket, error)}
@@ -87,7 +87,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{group.name}")
-         |> push_navigate(to: ~p"/admin/groups")}
+         |> push_navigate(to: ~p"/admin/sets")}
 
       {:error, error} ->
         {:noreply, handle_save_error(socket, error)}
@@ -101,7 +101,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
   end
 
   defp handle_save_error(socket, _other) do
-    put_flash(socket, :error, "Couldn't save one of the recordings' membership.")
+    put_flash(socket, :error, "Couldn't save one of the audiobooks' membership.")
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do

--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -24,7 +24,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     |> assign_form(changeset)
     |> assign(
       # the composed display: the name is local to the book
-      page_title: "#{group.name} — #{group.book.title}",
+      page_title: "#{group.name} (#{group.book.title})",
       group: group,
       media_options: Media.media_for_select(group.book_id)
     )

--- a/lib/ambry_web/live/admin/recording_group_live/form.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.html.heex
@@ -24,12 +24,12 @@
           <.input field={@form[:parts_total]} type="number" min="1" label="Total parts (optional)" />
           <.input
             field={@form[:part_word]}
-            label={~s(One audiobook is a… — default "part")}
+            label="One audiobook is a…"
             placeholder="part"
           />
           <.input
             field={@form[:part_word_plural]}
-            label={~s(…several are — default "parts")}
+            label="…several are…"
             placeholder="parts"
           />
         </div>

--- a/lib/ambry_web/live/admin/recording_group_live/form.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.html.heex
@@ -24,7 +24,7 @@
           <.input field={@form[:parts_total]} type="number" min="1" label="Total parts (optional)" />
           <.input
             field={@form[:part_word]}
-            label={~s(One release is a… — default "part")}
+            label={~s(One audiobook is a… — default "part")}
             placeholder="part"
           />
           <.input
@@ -37,11 +37,11 @@
         <.input
           field={@form[:show_label]}
           type="checkbox"
-          label="Show the group's name to listeners on this set's stacked tile"
+          label="Show the set's name to listeners on its stacked tile"
         />
       </.field_group>
 
-      <.list_cluster label="Recordings">
+      <.list_cluster label="Audiobooks">
         <.inputs_for :let={member_form} field={@form[:members]}>
           <.sort_input field={@form[:members_sort]} index={member_form.index} />
 
@@ -67,7 +67,7 @@
         </.inputs_for>
 
         <:add>
-          <.add_button field={@form[:members_sort]}>Add recording</.add_button>
+          <.add_button field={@form[:members_sort]}>Add audiobook</.add_button>
           <.delete_input field={@form[:members_drop]} />
         </:add>
       </.list_cluster>

--- a/lib/ambry_web/live/admin/recording_group_live/index.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.ex
@@ -29,7 +29,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:ok,
      socket
      |> assign(
-       page_title: "Groups",
+       page_title: "Sets",
        show_header_search: true
      )
      |> maybe_update_groups(params, true)}
@@ -56,8 +56,8 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
         groups: groups,
         has_next: has_more?,
         has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/groups?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/groups?#{prev_opts(list_opts)}",
+        next_page_path: ~p"/admin/sets?#{next_opts(list_opts)}",
+        prev_page_path: ~p"/admin/sets?#{prev_opts(list_opts)}",
         current_sort: list_opts.sort || @default_sort
       )
     else
@@ -84,14 +84,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:noreply,
      socket
      |> refresh_groups()
-     |> put_flash(:info, "Group deleted successfully")}
+     |> put_flash(:info, "Set deleted successfully")}
   end
 
   def handle_event("search", %{"search" => %{"query" => query}}, socket) do
     socket = maybe_update_groups(socket, %{"filter" => query, "page" => "1"})
     list_opts = get_list_opts(socket)
 
-    {:noreply, push_patch(socket, to: ~p"/admin/groups?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/sets?#{patch_opts(list_opts)}")}
   end
 
   def handle_event("sort", %{"field" => sort_field}, socket) do
@@ -100,7 +100,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
       |> get_list_opts()
       |> Map.update!(:sort, &apply_sort(&1, sort_field, @valid_sort_fields))
 
-    {:noreply, push_patch(socket, to: ~p"/admin/groups?#{patch_opts(list_opts)}")}
+    {:noreply, push_patch(socket, to: ~p"/admin/sets?#{patch_opts(list_opts)}")}
   end
 
   defp list_groups(opts, default_sort) do

--- a/lib/ambry_web/live/admin/recording_group_live/index.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.html.heex
@@ -2,7 +2,7 @@
   <:subheader>
     <.list_controls
       search_form={@search_form}
-      new_path={~p"/admin/groups/new"}
+      new_path={~p"/admin/sets/new"}
       has_next={@has_next}
       has_prev={@has_prev}
       next_page_path={@next_page_path}
@@ -17,11 +17,11 @@
   <.flex_table
     rows={@groups}
     filter={@list_opts.filter}
-    row_click={fn group -> JS.navigate(~p"/admin/groups/#{group}/edit") end}
+    row_click={fn group -> JS.navigate(~p"/admin/sets/#{group}/edit") end}
   >
     <:empty>
-      No groups yet.
-      <.brand_link navigate={~p"/admin/groups/new"}>
+      No sets yet.
+      <.brand_link navigate={~p"/admin/sets/new"}>
         Create one.
       </.brand_link>
     </:empty>
@@ -41,7 +41,7 @@
       </div>
       <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
         <div class="flex gap-2">
-          <.link navigate={~p"/admin/groups/#{group}/edit"} data-role="edit-group">
+          <.link navigate={~p"/admin/sets/#{group}/edit"} data-role="edit-group">
             <.icon
               name="fa-pencil"
               class="h-4 w-4 text-current transition-colors hover:text-lime-400"
@@ -50,7 +50,7 @@
           <span
             phx-click="delete"
             phx-value-id={group.id}
-            data-confirm={"Delete this group? Its #{length(group.media)} recordings stay in the library but leave the set, losing their part numbers."}
+            data-confirm={"Delete this set? Its #{length(group.media)} audiobooks stay in the library but leave the set, losing their part numbers."}
             data-role="delete-group"
           >
             <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -35,7 +35,7 @@
       <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
         <p class="overflow-hidden text-ellipsis" data-role="series-name">{series.name}</p>
         <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="series-authors">
-          by {series.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
+          {series.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
       </div>
       <div class="hidden w-12 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">

--- a/lib/ambry_web/live/admin/settings_live/index.ex
+++ b/lib/ambry_web/live/admin/settings_live/index.ex
@@ -25,7 +25,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
         <section>
           <h2 class="mb-1 text-lg font-bold">Direct play</h2>
           <p class="mb-4 text-sm text-zinc-400">
-            Direct-play recordings are served as their original files, with no transcoding or
+            Direct-play audiobooks are served as their original files, with no transcoding or
             packaging. Publishing them has to wait for the apps: a client that predates track
             support can't play one, so leave this off until every device in the fleet is on a
             build that understands tracks.
@@ -38,7 +38,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
                 (@direct_play_publishing && "bg-lime-500") || "bg-zinc-600"
               ]} />
               <div class="grow">
-                <h3 class="font-semibold">Publish direct-play recordings</h3>
+                <h3 class="font-semibold">Publish direct-play audiobooks</h3>
                 <p class="text-sm text-zinc-400">
                   {publishing_blurb(@direct_play_publishing)}
                 </p>
@@ -54,7 +54,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
         <section>
           <h2 class="mb-1 text-lg font-bold">Library naming</h2>
           <p class="mb-4 text-sm text-zinc-400">
-            How managed recordings are organized inside a library root. Files imported from a
+            How managed audiobooks are organized inside a library root. Files imported from a
             downloads folder are placed here; external collections are never reorganized.
           </p>
 
@@ -166,10 +166,10 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
   defp template_error(:no_title_token), do: "it needs {title}, or every book shares one folder"
   defp template_error({:unknown_token, token}), do: "there's no {#{token}} token"
 
-  defp publishing_blurb(true), do: "Scanned recordings can be made visible to clients."
+  defp publishing_blurb(true), do: "Scanned audiobooks can be made visible to clients."
 
   defp publishing_blurb(false),
     do:
-      "Recordings can be scanned, but one with only direct-play files can't be marked ready. " <>
+      "Audiobooks can be scanned, but one with only direct-play files can't be marked ready. " <>
         "The old transcoding pipeline is unaffected."
 end

--- a/lib/ambry_web/live/admin/settings_live/index.ex
+++ b/lib/ambry_web/live/admin/settings_live/index.ex
@@ -26,9 +26,8 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
           <h2 class="mb-1 text-lg font-bold">Direct play</h2>
           <p class="mb-4 text-sm text-zinc-400">
             Direct-play audiobooks are served as their original files, with no transcoding or
-            packaging. Publishing them has to wait for the apps: a client that predates track
-            support can't play one, so leave this off until every device in the fleet is on a
-            build that understands tracks.
+            packaging. Leave this off until every client app understands tracks; older builds
+            can't play them.
           </p>
 
           <div class="rounded-lg bg-zinc-900 p-4">
@@ -69,9 +68,7 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
 
             <p class="text-sm text-zinc-400">
               Available: {Enum.map_join(NamingTemplate.tokens(), ", ", &"{#{&1}}")}. A book with
-              several authors or series uses the first one — reorder them on the book to change
-              which. Empty parts collapse, so a standalone book doesn't get an empty folder or a
-              leading dash.
+              several authors or series uses the first one. Empty parts collapse.
             </p>
 
             <div class="rounded-lg bg-zinc-900 p-4">
@@ -161,8 +158,11 @@ defmodule AmbryWeb.Admin.SettingsLive.Index do
   end
 
   defp template_error(:blank), do: "it can't be empty"
-  defp template_error(:absolute), do: "it can't start with / — it's relative to a library root"
-  defp template_error(:traversal), do: "it can't contain .. — that would climb out of the root"
+
+  defp template_error(:absolute),
+    do: "it can't start with /; paths are relative to a library root"
+
+  defp template_error(:traversal), do: "it can't contain .."
   defp template_error(:no_title_token), do: "it needs {title}, or every book shares one folder"
   defp template_error({:unknown_token, token}), do: "there's no {#{token}} token"
 

--- a/lib/ambry_web/live/admin/user_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_live/index.html.heex
@@ -51,11 +51,11 @@
             />
           </span>
 
-          <span :if={user.media_in_progress > 0} title="# of in-progress books" data-role="user-in-progress">
+          <span :if={user.media_in_progress > 0} title="# of in-progress audiobooks" data-role="user-in-progress">
             {user.media_in_progress} <.icon name="fa-book-bookmark" class="h-4 w-4 text-current" />
           </span>
 
-          <span :if={user.media_finished > 0} title="# of finished books" data-role="user-finished">
+          <span :if={user.media_finished > 0} title="# of finished audiobooks" data-role="user-finished">
             {user.media_finished} <.icon name="fa-book" class="h-4 w-4 text-current" />
           </span>
         </div>

--- a/lib/ambry_web/live/audiobook_live.ex
+++ b/lib/ambry_web/live/audiobook_live.ex
@@ -21,13 +21,13 @@ defmodule AmbryWeb.AudiobookLive do
       <div class="justify-center sm:flex sm:flex-row">
         <section id="cover" class="mb-4 flex-none sm:mb-0 sm:w-80">
           <div class="mb-6 sm:hidden">
-            <.book_header book={@media.book} title_override={media_display_title(@media)} />
-            <p class="mt-4">
-              Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-              <%= if @media.abridged do %>
-                <span>(Abridged)</span>
-              <% end %>
-            </p>
+            <.book_header
+              book={@media.book}
+              title_override={media_display_title(@media)}
+              narrators={@media.narrators}
+              full_cast={@media.full_cast}
+              abridged={@media.abridged}
+            />
           </div>
 
           <div class={["aspect-1", if(!@media.thumbnails, do: "bg-zinc-800")]}>
@@ -131,13 +131,13 @@ defmodule AmbryWeb.AudiobookLive do
         </section>
 
         <section id="description" class="hidden max-w-md sm:ml-10 sm:block">
-          <.book_header book={@media.book} title_override={media_display_title(@media)} />
-          <p class="mt-4">
-            Narrated by <.all_people_links people={@media.narrators} full_cast={@media.full_cast} />
-            <%= if @media.abridged do %>
-              <span>(Abridged)</span>
-            <% end %>
-          </p>
+          <.book_header
+            book={@media.book}
+            title_override={media_display_title(@media)}
+            narrators={@media.narrators}
+            full_cast={@media.full_cast}
+            abridged={@media.abridged}
+          />
           <.markdown
             :if={@media.description}
             content={@media.description}

--- a/lib/ambry_web/live/narrator_live.ex
+++ b/lib/ambry_web/live/narrator_live.ex
@@ -22,7 +22,7 @@ defmodule AmbryWeb.NarratorLive do
           />
         </.link>
         <h1 class="text-3xl font-bold text-zinc-100 sm:text-4xl xl:text-5xl">
-          Narrated by
+          Read by
           <.link navigate={~p"/people/#{@narrator.person}"} class="hover:underline">
             {@narrator.name}
           </.link>

--- a/lib/ambry_web/live/person_live.ex
+++ b/lib/ambry_web/live/person_live.ex
@@ -65,7 +65,7 @@ defmodule AmbryWeb.PersonLive do
       <div :for={%{narrator: narrator, media: media, more?: more?} <- @narrated_media}>
         <div class="flex items-baseline gap-4">
           <.books_header>
-            Narrated by <.narrator_name narrator={narrator} person={@person} />
+            Read by <.narrator_name narrator={narrator} person={@person} />
           </.books_header>
 
           <.link :if={more?} navigate={~p"/narrators/#{narrator}"} class="text-zinc-500 hover:underline">

--- a/lib/ambry_web/live/search_live/components.ex
+++ b/lib/ambry_web/live/search_live/components.ex
@@ -88,7 +88,7 @@ defmodule AmbryWeb.SearchLive.Components do
         </p>
       </div>
       <p class="text-sm text-zinc-200 sm:text-base">
-        by <.people_links people={@series.series_books |> Enum.flat_map(& &1.book.authors) |> Enum.uniq()} />
+        <.people_links people={@series.series_books |> Enum.flat_map(& &1.book.authors) |> Enum.uniq()} />
       </p>
     </div>
     """

--- a/lib/ambry_web/live/series_live.ex
+++ b/lib/ambry_web/live/series_live.ex
@@ -17,8 +17,8 @@ defmodule AmbryWeb.SeriesLive do
           {@series.name}
         </h1>
 
-        <p class="text-xl text-zinc-200">
-          by <.all_people_links people={@authors} />
+        <p class="text-xl text-zinc-300">
+          <.all_people_links people={@authors} />
         </p>
       </div>
 

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -186,9 +186,9 @@ defmodule AmbryWeb.Router do
       live "/series/new", SeriesLive.Form, :new
       live "/series/:id/edit", SeriesLive.Form, :edit
 
-      live "/groups", RecordingGroupLive.Index
-      live "/groups/new", RecordingGroupLive.Form, :new
-      live "/groups/:id/edit", RecordingGroupLive.Form, :edit
+      live "/sets", RecordingGroupLive.Index
+      live "/sets/new", RecordingGroupLive.Form, :new
+      live "/sets/:id/edit", RecordingGroupLive.Form, :edit
 
       live "/universes", UniverseLive.Index
       live "/universes/new", UniverseLive.Form, :new
@@ -203,10 +203,10 @@ defmodule AmbryWeb.Router do
       live "/locations/roots/new", LocationLive.Form, :new_root
       live "/locations/roots/:id/edit", LocationLive.Form, :edit_root
 
-      live "/media", MediaLive.Index
-      live "/media/new", MediaLive.Form, :new
-      live "/media/:id/edit", MediaLive.Form, :edit
-      live "/media/:id/replace", MediaLive.Replace
+      live "/audiobooks", MediaLive.Index
+      live "/audiobooks/new", MediaLive.Form, :new
+      live "/audiobooks/:id/edit", MediaLive.Form, :edit
+      live "/audiobooks/:id/replace", MediaLive.Replace
 
       live "/users", UserLive.Index
       live "/users/new", UserLive.Form, :new

--- a/test/ambry/books_test.exs
+++ b/test/ambry/books_test.exs
@@ -430,8 +430,7 @@ defmodule Ambry.BooksTest do
 
       description = Books.get_book_description(book)
 
-      assert description =~ title
-      assert description =~ author_name
+      assert description == "#{title} by #{author_name}"
     end
   end
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -123,6 +123,26 @@ defmodule Ambry.Inbox.DraftTest do
   end
 
   describe "work identity" do
+    # A linked book belongs to the library, and an import never edits it —
+    # so evidence proposing a series is not a decision on a linked draft.
+    # (Additive series memberships used to be the one exception.)
+    test "a linked book stages no series decisions" do
+      book = insert(:book, title: "Leviathan Wakes")
+      local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}]
+
+      item =
+        item(%{
+          matches: matches([provider_candidate(%{})], local: local),
+          tags: %{"series" => "The Expanse", "series_number" => "1"}
+        })
+
+      draft = Seed.build(item)
+
+      assert draft.work.mode == :link
+      assert draft.work.series == []
+      refute Enum.any?(Draft.unresolved(draft), &(&1.label =~ "Series"))
+    end
+
     test "a strong local hit links the existing book rather than creating one" do
       book = insert(:book, title: "Leviathan Wakes")
       local = [%{"id" => book.id, "title" => "Leviathan Wakes", "score" => 1.0}]

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -337,6 +337,36 @@ defmodule Ambry.Inbox.ImporterTest do
       assert Repo.aggregate(Book, :count) == 1
     end
 
+    # Drafts stored before "a linked book is never edited" can still carry a
+    # series row in link mode; the importer must ignore it rather than land
+    # it on the library's book.
+    test "a stale series decision on a linked draft never reaches the book" do
+      first = tagged_item(narrator: "Em Grosland")
+      second = tagged_item(name: "A Better Rip", narrator: "Em Grosland")
+
+      assert {:ok, _media} = Inbox.import_item(first)
+
+      second = Inbox.get_item!(second.id)
+      assert second.draft.work.mode == :link
+
+      stale = %Draft.SeriesLink{
+        name: "Extra Saga",
+        number: "2",
+        mode: :create,
+        approved: true,
+        curated: true
+      }
+
+      draft = %{second.draft | work: %{second.draft.work | series: [stale]}}
+      {:ok, second} = Inbox.update_draft(second, Inbox.dump_draft(draft))
+
+      assert {:ok, media} = Inbox.import_item(settle(second))
+
+      book = Repo.preload(Books.get_book!(media.book_id), :series_books)
+      assert book.series_books == []
+      assert Repo.aggregate(Ambry.Books.Series, :count) == 0
+    end
+
     test "an identity the operator settled as new stays new" do
       first = tagged_item(narrator: "Em Grosland")
       second = tagged_item(name: "A Deliberate Twin", narrator: "Em Grosland")

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -1087,9 +1087,7 @@ defmodule Ambry.MediaTest do
 
       description = Media.get_media_description(loaded_media)
 
-      assert description =~ book.title
-      assert description =~ author.name
-      assert description =~ narrator.name
+      assert description == "#{book.title} by #{author.name} read by #{narrator.name}"
     end
 
     test "uses the display-title override when present" do

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -27,7 +27,7 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
       {:ok, view, _html} = live(conn, ~p"/admin/books")
 
       assert has_element?(view, "[data-role='book-title']", book.title)
-      assert has_element?(view, "[data-role='book-authors']", "by #{author.name}")
+      assert has_element?(view, "[data-role='book-authors']", author.name)
       assert has_element?(view, "[data-role='book-series']", "#{series.name} #1")
     end
 

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -94,7 +94,7 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
 
       # Book should still be visible
       assert has_element?(view, "[data-role='book-title']", book.title)
-      assert render(view) =~ "Can&#39;t delete book because this book has uploaded media"
+      assert render(view) =~ "Can&#39;t delete book because it has audiobooks"
     end
   end
 

--- a/test/ambry_web/live/admin/home_live/index_test.exs
+++ b/test/ambry_web/live/admin/home_live/index_test.exs
@@ -38,7 +38,7 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
       assert has_element?(view, "a[href='/admin/people']")
       assert has_element?(view, "a[href='/admin/books']")
       assert has_element?(view, "a[href='/admin/series']")
-      assert has_element?(view, "a[href='/admin/media']")
+      assert has_element?(view, "a[href='/admin/audiobooks']")
       assert has_element?(view, "a[href='/admin/audit']")
       assert has_element?(view, "a[href='/admin/users']")
 

--- a/test/ambry_web/live/admin/inbox_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/chapters_test.exs
@@ -138,7 +138,7 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
       html = render_async(view)
       # the proposed titles render into the rows, and the counts match
       assert html =~ "The Dungeon Opens"
-      assert html =~ "beside its row"
+      assert html =~ "shows how its title lands"
 
       view |> element("button[phx-click='apply-chapter-titles']") |> render_click()
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -990,7 +990,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert html =~ "Part of a set"
       assert html =~ "Not part of a set"
 
-      view |> element("button", "This release is part of a set") |> render_click()
+      view |> element("button", "This audiobook is part of a set") |> render_click()
 
       assert has_element?(view, "[data-role='group-link']")
 
@@ -1024,7 +1024,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      view |> element("button", "This release is part of a set") |> render_click()
+      view |> element("button", "This audiobook is part of a set") |> render_click()
 
       view
       |> form("#group-part")
@@ -1047,7 +1047,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       item = Inbox.get_item!(item.id)
       assert item.draft.recording.recording_group == nil
-      assert has_element?(view, "button", "This release is part of a set")
+      assert has_element?(view, "button", "This audiobook is part of a set")
     end
   end
 
@@ -1071,7 +1071,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       # Two files are one recording by default — the button is the way to
       # say they aren't, not a precondition for importing them.
-      assert html =~ "import as one recording"
+      assert html =~ "import as one audiobook"
       assert html =~ "split into 2 items"
 
       view |> element("button[data-role='split']") |> render_click()

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -60,7 +60,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       html = view |> element("button[data-role='import']") |> render_click()
 
-      assert html =~ "reading the files and placing them"
+      assert html =~ "Adding to the library…"
       assert has_element?(view, "[data-role='busy-overlay']")
 
       # Waits for the import to land rather than leaving it running into the
@@ -917,7 +917,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       # "waiting out a rate limit" and "queued" are the same blank form and
       # completely different situations
-      assert html =~ "waiting to try again"
+      assert html =~ "Retrying…"
     end
 
     # Matching keeps retrying until every provider has answered, and rebuilds
@@ -988,7 +988,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
       assert html =~ "Part of a set"
-      assert html =~ "Not part of a set"
+      assert html =~ "not part of a set"
 
       view |> element("button", "This audiobook is part of a set") |> render_click()
 
@@ -1072,7 +1072,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       # Two files are one recording by default — the button is the way to
       # say they aren't, not a precondition for importing them.
       assert html =~ "import as one audiobook"
-      assert html =~ "split into 2 items"
+      assert html =~ "Split into 2 items"
 
       view |> element("button[data-role='split']") |> render_click()
       assert_redirect(view, ~p"/admin/inbox")

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -209,7 +209,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
     html = view |> element("button[phx-click='scan']") |> render_click()
 
-    assert html =~ "Nothing is moved or changed"
+    assert html =~ "New candidates will show up here"
     assert_enqueued(worker: RunDiscovery)
   end
 

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -75,7 +75,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     # no draft yet, so the badge falls back to the match-time confidence
     assert html =~ "trusted"
     assert html =~ "The Way of Kings"
-    assert html =~ "already in library"
+    assert html =~ "already in the library"
     assert html =~ "+1 other"
     # the recording level says so rather than going silent
     assert html =~ "no match"

--- a/test/ambry_web/live/admin/location_live/index_test.exs
+++ b/test/ambry_web/live/admin/location_live/index_test.exs
@@ -17,7 +17,7 @@ defmodule AmbryWeb.Admin.LocationLive.IndexTest do
   test "an empty roots section says roots are optional", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/admin/locations")
 
-    assert html =~ "fine while every source leaves its files in place"
+    assert html =~ "Add one when a source needs to bring files in"
   end
 
   test "lists sources and roots as two sections", %{conn: conn} do
@@ -57,7 +57,7 @@ defmodule AmbryWeb.Admin.LocationLive.IndexTest do
     {:ok, _view, html} = live(conn, ~p"/admin/locations")
 
     assert html =~ "Not found"
-    assert html =~ "is the volume mounted?"
+    assert html =~ "Is the volume mounted?"
   end
 
   test "pauses and resumes a source", %{conn: conn} do

--- a/test/ambry_web/live/admin/media_live/chapters_import_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_import_test.exs
@@ -126,7 +126,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     # The proposed titles land beside the rows — the rows are the preview.
     assert html =~ "The Dungeon Opens"
     assert html =~ "Princess Donut"
-    assert html =~ "beside its row"
+    assert html =~ "shows how its title lands"
 
     html =
       view |> element("button[phx-click='apply-chapter-titles']") |> render_click()

--- a/test/ambry_web/live/admin/media_live/chapters_import_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_import_test.exs
@@ -103,7 +103,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media(markers())
 
-    {:ok, view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     refute html =~ "chapter-title-chips"
 
     html = tick_record(view)
@@ -117,7 +117,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
 
     view |> element("#chapter-title-chips button") |> render_click()
@@ -163,7 +163,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
 
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     html = render_async(view)
@@ -182,7 +182,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     render_async(view)
@@ -206,7 +206,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     media = insert_media(markers())
     {:ok, media} = Ambry.Media.update_media(media, %{chapter_marker_source: :file_boundaries})
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     render_async(view)
@@ -220,7 +220,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
     patch_providers()
     media = insert_media([])
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     html = render_async(view)
@@ -241,7 +241,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
 
     media = insert_media(markers())
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
     tick_record(view)
     view |> element("#chapter-title-chips button") |> render_click()
     html = render_async(view)

--- a/test/ambry_web/live/admin/media_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_test.exs
@@ -51,7 +51,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "is part of the edit form, from the default state", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Prologue", :manual)])
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       assert html =~ ~s(id="chapters")
       assert [{"0", "Prologue"}] = rendered_rows(html)
@@ -66,7 +66,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter_marker_source: :file_boundaries
         )
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       assert html =~ "one per file"
       assert html =~ "1 generated"
@@ -75,7 +75,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "is honest about a list that predates the field", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Prologue", nil)])
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       assert html =~ "from before this was recorded"
     end
@@ -90,7 +90,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter_marker_source: :embedded
         )
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       view
       |> form("#media-form", %{
@@ -113,7 +113,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
       media =
         media_with_chapters([chapter(0, "One", :provider)], chapter_marker_source: :embedded)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       view
       |> form("#media-form", %{
@@ -136,7 +136,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "typing a title records it as the operator's", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Chapter 1", :generated)])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       view
       |> form("#media-form", %{
@@ -162,7 +162,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter(600, "Chapter 2", :generated)
         ])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       html =
         view
@@ -183,7 +183,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     test "gives a row with no title the floor rather than an error", %{conn: conn} do
       media = media_with_chapters([chapter(0, "Prologue", :manual)])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       html =
         view
@@ -206,7 +206,7 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
           chapter(600, "Chapter 2", :generated)
         ])
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
       html =
         view

--- a/test/ambry_web/live/admin/media_live/curation_test.exs
+++ b/test/ambry_web/live/admin/media_live/curation_test.exs
@@ -37,7 +37,7 @@ defmodule AmbryWeb.Admin.MediaLive.CurationTest do
     test "arrives carrying the book's author", %{conn: conn} do
       media = martian()
 
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
 
       assert has_element?(view, "form#research-recording input[name='author'][value='Andy Weir']")
 
@@ -75,7 +75,7 @@ defmodule AmbryWeb.Admin.MediaLive.CurationTest do
           }
         })
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
       doc = Floki.parse_document!(html)
 
       assert [^large] = doc |> Floki.find("#image-#{media.id}-preview") |> Floki.attribute("src")
@@ -90,7 +90,7 @@ defmodule AmbryWeb.Admin.MediaLive.CurationTest do
       raw = on_disk("curation-no-thumbs.jpg")
       {:ok, media} = Media.update_media(media, %{image_path: raw})
 
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
 
       assert [^raw] =
                html

--- a/test/ambry_web/live/admin/media_live/missing_badge_test.exs
+++ b/test/ambry_web/live/admin/media_live/missing_badge_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.Admin.MediaLive.MissingBadgeTest do
   test "flags a recording whose files have gone missing", %{conn: conn} do
     insert(:media, book: build(:book), status: :ready, missing_since: DateTime.utc_now(:second))
 
-    {:ok, _view, html} = live(conn, ~p"/admin/media")
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
 
     assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-missing']") != []
     assert html =~ "missing"
@@ -22,7 +22,7 @@ defmodule AmbryWeb.Admin.MediaLive.MissingBadgeTest do
   test "leaves a healthy recording unflagged", %{conn: conn} do
     insert(:media, book: build(:book), status: :ready, missing_since: nil)
 
-    {:ok, _view, html} = live(conn, ~p"/admin/media")
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
 
     assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-missing']") == []
   end

--- a/test/ambry_web/live/admin/media_live/replace_test.exs
+++ b/test/ambry_web/live/admin/media_live/replace_test.exs
@@ -20,7 +20,7 @@ defmodule AmbryWeb.Admin.MediaLive.ReplaceTest do
       conn: conn,
       media: media
     } do
-      {:ok, _view, html} = live(conn, ~p"/admin/media/#{media}/replace")
+      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media}/replace")
 
       assert html =~ "Replacing audio is disruptive"
       assert html =~ "Current audio file(s)"
@@ -28,7 +28,7 @@ defmodule AmbryWeb.Admin.MediaLive.ReplaceTest do
     end
 
     test "shows an error when submitting with no files", %{conn: conn, media: media} do
-      {:ok, view, _html} = live(conn, ~p"/admin/media/#{media}/replace")
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/replace")
 
       html =
         view

--- a/test/ambry_web/live/admin/media_live/scan_test.exs
+++ b/test/ambry_web/live/admin/media_live/scan_test.exs
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.MediaLive.ScanTest do
       |> with_copied_source_files(:m4a)
       |> insert()
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks")
 
     html = view |> element("span[phx-click='scan'][phx-value-id='#{media.id}']") |> render_click()
 
@@ -31,7 +31,7 @@ defmodule AmbryWeb.Admin.MediaLive.ScanTest do
       |> with_copied_source_files(:m4a)
       |> insert()
 
-    {:ok, view, _html} = live(conn, ~p"/admin/media")
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks")
     view |> element("span[phx-click='scan'][phx-value-id='#{media.id}']") |> render_click()
 
     assert {:ok, _media} = perform_job(RunScan, %{"media_id" => media.id})

--- a/test/ambry_web/live/admin/person_live/index_test.exs
+++ b/test/ambry_web/live/admin/person_live/index_test.exs
@@ -109,7 +109,7 @@ defmodule AmbryWeb.Admin.PersonLive.IndexTest do
 
       # Person should still be visible
       assert has_element?(view, "[data-role='person-name']", narrator.person.name)
-      assert render(view) =~ "Can&#39;t delete person because they have narrated media"
+      assert render(view) =~ "Can&#39;t delete person because they have narrated audiobooks"
     end
 
     test "can delete a person with no books or media", %{conn: conn} do

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -13,7 +13,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       media_one = insert(:media, book: book)
       media_two = insert(:media, book: book)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/new")
 
       view
       |> form("#group-form")
@@ -30,7 +30,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         }
       })
 
-      assert_redirect(view, "/admin/groups")
+      assert_redirect(view, "/admin/sets")
 
       {[group], false} = Media.list_recording_groups()
       assert %{name: "Season One", parts_total: 2, part_word: "episode"} = group
@@ -41,7 +41,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
 
     test "a group may start empty", %{conn: conn} do
       book = insert(:book)
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/new")
 
       view
       |> form("#group-form")
@@ -49,14 +49,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         recording_group_form: %{name: "Awaiting Parts", book_id: to_string(book.id)}
       })
 
-      assert_redirect(view, "/admin/groups")
+      assert_redirect(view, "/admin/sets")
 
       {[group], false} = Media.list_recording_groups()
       assert %{name: "Awaiting Parts", media: []} = group
     end
 
     test "refuses a blank name", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/new")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/new")
 
       html =
         view
@@ -74,7 +74,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       group = insert(:recording_group, name: "GraphicAudio", parts_total: 2, book: book)
       media = insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, _view, html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+      {:ok, _view, html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
       doc = Floki.parse_document!(html)
 
@@ -98,7 +98,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       group = insert(:recording_group, name: "Graphic Audio", book: book)
       insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, view, html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+      {:ok, view, html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
       assert resolver_display(html) == "A Court of Thorns and Roses"
 
@@ -116,7 +116,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       keep = insert(:media, book: book, part_number: 1, recording_group: group)
       drop = insert(:media, book: book, part_number: 2, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups/#{group.id}/edit")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
       # removal is the drop checkbox, same mechanics as dropping a series book
       view
@@ -129,7 +129,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         }
       })
 
-      assert_redirect(view, "/admin/groups")
+      assert_redirect(view, "/admin/sets")
 
       updated = Media.get_recording_group!(group.id)
       assert %{name: "After", show_label: true} = updated

--- a/test/ambry_web/live/admin/recording_group_live/index_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/index_test.exs
@@ -9,10 +9,10 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
 
   describe "Index" do
     test "renders group index with empty state when no groups exist", %{conn: conn} do
-      {:ok, view, html} = live(conn, ~p"/admin/groups")
+      {:ok, view, html} = live(conn, ~p"/admin/sets")
 
-      assert html =~ "Groups"
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
+      assert html =~ "Sets"
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
     end
 
     test "renders list of groups with their book and parts summary", %{conn: conn} do
@@ -21,7 +21,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       insert(:media, book: book, part_number: 1, recording_group: group)
       insert(:media, book: book, part_number: 2, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-name']", "GraphicAudio")
       assert has_element?(view, "[data-role='group-book']", "A Court of Thorns and Roses")
@@ -33,15 +33,15 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       group = insert(:recording_group, part_word_plural: "episodes")
       insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-parts']", "1 episodes")
     end
 
     test "updates list in realtime when groups change", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
 
       book = insert(:book)
       {:ok, group} = Media.create_recording_group(%{name: "New Group", book_id: book.id})
@@ -61,7 +61,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       group |> Ambry.Media.PubSub.RecordingGroupDeleted.new() |> Ambry.PubSub.broadcast()
       ensure_all_messages_handled(view.pid)
 
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
     end
   end
 
@@ -71,7 +71,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       group = insert(:recording_group, name: "Delete Me")
       media = insert(:media, book: book, part_number: 1, recording_group: group)
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-name']", "Delete Me")
 
@@ -80,8 +80,8 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       |> render_click()
 
       refute has_element?(view, "[data-role='group-name']", "Delete Me")
-      assert has_element?(view, "[data-role='empty-message']", "No groups yet.")
-      assert render(view) =~ "Group deleted successfully"
+      assert has_element?(view, "[data-role='empty-message']", "No sets yet.")
+      assert render(view) =~ "Set deleted successfully"
 
       reloaded = Media.get_media!(media.id)
       assert reloaded.recording_group_id == nil
@@ -94,7 +94,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.IndexTest do
       insert(:recording_group, name: "Unique Group Name")
       insert(:recording_group, name: "Another Group")
 
-      {:ok, view, _html} = live(conn, ~p"/admin/groups")
+      {:ok, view, _html} = live(conn, ~p"/admin/sets")
 
       assert has_element?(view, "[data-role='group-name']", "Unique Group Name")
       assert has_element?(view, "[data-role='group-name']", "Another Group")

--- a/test/ambry_web/live/admin/series_live/index_test.exs
+++ b/test/ambry_web/live/admin/series_live/index_test.exs
@@ -26,7 +26,7 @@ defmodule AmbryWeb.Admin.SeriesLive.IndexTest do
       {:ok, view, _html} = live(conn, ~p"/admin/series")
 
       assert has_element?(view, "[data-role='series-name']", series.name)
-      assert has_element?(view, "[data-role='series-authors']", "by #{author.name}")
+      assert has_element?(view, "[data-role='series-authors']", author.name)
       assert has_element?(view, "[data-role='series-book-count']", "1")
     end
 

--- a/test/ambry_web/live/admin/settings_live/index_test.exs
+++ b/test/ambry_web/live/admin/settings_live/index_test.exs
@@ -83,7 +83,7 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
         |> form("#naming-template-form", settings: %{template: "../{title}"})
         |> render_submit()
 
-      assert html =~ "climb out of the root"
+      assert html =~ "can&#39;t contain .."
       assert Settings.library_naming_template() == NamingTemplate.default_template()
     end
   end

--- a/test/ambry_web/live/admin/settings_live/index_test.exs
+++ b/test/ambry_web/live/admin/settings_live/index_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.Admin.SettingsLive.IndexTest do
   test "shows direct-play publishing off, with the reason", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/admin/settings")
 
-    assert html =~ "Publish direct-play recordings"
+    assert html =~ "Publish direct-play audiobooks"
     assert html =~ "can&#39;t be marked ready"
     assert html =~ "Turn on"
   end


### PR DESCRIPTION
Fourth of the stack, on #1235. **Retarget before merging, per the usual flow.**

The import form said "Using the book already in the library. Its existing details are not changed" and then offered series rows anyway — additive series memberships were a deliberate fill-gaps exception, which made series the one editable field on a book the form promised not to touch. Operator's call: the promise wins.

- **Seeder**: link mode stages no series decisions at all; flipping an identity from create to link drops them (`already_on_book?` and its query are gone — nothing filters what is never proposed)
- **`Work.unresolved`** in link mode is the identity question alone
- **Importer**: a linked book is fetched and used exactly as it is; `add_series` is deleted. A stale series row on a pre-change stored draft is ignored rather than landed — pinned by a regression test, since real drafts in the field can carry them
- **Form**: the series section renders only for a book being created; the "This book isn't in these yet." prose is gone

**Why the records section stays in link mode** (investigated): ticking a work-level record triggers `Inbox.fetch_editions`, which asks the work databases for that book's audio editions and adds them to the recording-level candidates — the route to delisted editions (the R.C. Bray Martian case). Nothing "fills blanks" anymore though, so the link-mode header stops claiming that: it's now "Records describing this book" with a hint saying ticked records feed the audiobook matches below.

Tests: full suite green (2 new regression tests), `mix check` clean.

https://claude.ai/code/session_01GttiY8Xqm2cyn4qn9AZCpx