### PR TITLE
Provider outcomes, the person level, and a scan that can't disturb what you settled

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -62,6 +62,10 @@ config :ambry, AmbryWeb.Endpoint,
     ]
   ]
 
+# Undo an import: delete what it created and put the item back in the queue.
+# Development and test only, never prod — see `Ambry.Inbox.Undo`.
+config :ambry, allow_undo_import: true
+
 # Enable dev routes for dashboard and mailbox
 config :ambry, dev_routes: true
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -27,6 +27,10 @@ config :ambry, AmbryWeb.Endpoint,
 # process that enqueued them.
 config :ambry, Oban, testing: :manual
 
+# Undo an import, so the tests that cover it have something to call. Dev and
+# test only — never set in prod config.
+config :ambry, allow_undo_import: true
+
 # Only in tests, remove the complexity from the password hashing algorithm
 config :argon2_elixir, t_cost: 1, m_cost: 8
 

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -260,21 +260,33 @@ divergence by documenting both halves as intentional; that is how this one
 survived two audits.
 
 **The documented exception: a derived list has no add.** The import form's
-**New people** section lists one card per human the import will create, and
+**People** section lists one card per human the import introduces, and
 the operator cannot add one there — a person exists because a *credit* names
 them (`Draft.referenced_keys/1` mints the decisions from the credits), so
 adding a person happens on the credit and appears here. The label and the
 rows are the ordinary grammar; the add below the container is absent, and
 that absence is the honest statement that this list is derived rather than
-built. People already in the library are *not* listed: they were chosen in
-the credit's typeahead, they carry their own curation which an import may
+built. The people behind a *linked credit* are not listed: they were chosen
+in the credit's typeahead, they carry their own curation which an import may
 never overwrite, and the one dangerous case — a name matching two existing
 identities — is a decision on the credit, where `Credit.state/1` computes it.
+A person the operator matched to the library *from their own card* does stay,
+because that decision was made here: dropping the card the moment the link is
+made takes the way back with it.
+
+**A card asks nothing it can state.** The person card carries no name box in
+the ordinary import, because the credit names the human and a box on every
+card in every state is what left "This is a pen name" with no visible effect
+to have. Reveal the exception, state the rule: the box appears when the name
+is genuinely the person's own, and a control that reveals it always offers
+the way back. The other question a card like this answers — is this somebody
+the library already has — is *evidence*, and wears the local-row costume the
+work level uses ("Yes, it's them"), not a permanent search box.
 
 **Pen names are bracketed, not nested.** One author credit can stand for
 several humans, so those person cards sit adjacent under a shared labelled
-rail naming the credit ("James S.A. Corey"), and each card also names its own
-role in its header. A bracket is a label and a rail, never a filled block —
+rail. The label states what the cards can't — "2 people behind this name" —
+because each card is already titled by the credit it belongs to. A bracket is a label and a rail, never a filled block —
 wrapping cards in a card is what eats the elevation ladder, and this is the
 same device the person rows used when they were nested inside a credit,
 promoted to group siblings instead.
@@ -290,7 +302,7 @@ It is the one thing always in view, and `Draft.unresolved/1` already returns
 a section and a label for every decision still waiting — so it names them and
 links to them. Without that, a form long enough to have sections has work
 below the fold that nothing announces, which is the objection that decided
-where the New people section goes.
+where the People section goes.
 
 **One form measure: `max-w-4xl`.** The import form always had it; the
 legacy forms sat at `3xl` and the two settings-ish pages centered

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -165,9 +165,14 @@ operator mostly doesn't need (evidence panels, file stats), not for the
 thing a section exists to edit.
 
 **One label column for annotated rows.** Any run of "label: value" rows
-(match lines, `Proposed`/`Asked` rows, the source line) shares a fixed label
-column via grid (`grid-cols-[<w>_minmax(0,1fr)]`), sized once per surface;
-wrapped content stays in the value column.
+(match lines, `Proposed`/`Results` rows, the source line) shares a fixed label
+column via grid (`grid-cols-[4rem_minmax(0,1fr)]`), sized once per surface;
+wrapped content stays in the value column. The width is the *widest label in
+the family* and nothing more — `Proposed` at 11px uppercase is a shade under
+4rem, and the column was 4.5rem for a while, which left the short ones
+(`Results`, `Photos`) sitting in a lake of air. The alignment is the point,
+so the answer is to size the column honestly, never to give each row its own
+width: `max-content` in separate grids lines nothing up at all.
 
 **A proposal-chip row is one line or a list, never a partial wrap.** A row
 that breaks just its last chip reads as an accident; either every chip

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -58,22 +58,52 @@ Every **decision block** (a `decision_row`, a series row, the work/recording
 identity clusters, the library-root chooser, an inbox queue item) wears a
 `border-l-4` rail that says its state at a scroll:
 
-| Rail | Meaning |
-|---|---|
-| `border-amber-400/70` | waiting on the operator |
-| `border-brand-dark/60` | settled / ready |
-| `border-red-400/70` | blocked (nothing proposed it, files changed) |
-| none / `border-zinc-700` | informational, or out of the queue |
+| Rail | Meaning | Condition |
+|---|---|---|
+| `border-red-400/70` | blocked — nothing proposed a value, or the files changed | not settled, and nothing to choose from |
+| `border-amber-400/70` | the machine couldn't settle it; look here | not settled |
+| `border-blue-400/70` | the machine settled it and nobody has looked | settled, not curated |
+| `border-brand-dark/60` | you've been here | curated |
+
+**Four tiers, not two, and the fourth is the point** (operator, 2026-08-13).
+Lime-versus-amber answered "is this settled" and threw away the more useful
+question, which is *did a human ever look at this*. A freshly matched import
+is now entirely blue, and greens accumulate as the operator works through it,
+so the form is a map of where they have been. Amber and red are what still
+need them; **blue is a legitimate end state** — the machine was confident and
+you don't have to look if you don't want to. The goal of an import is no
+amber and no red, never "all green", or every import becomes a chore of
+clicking chips that were already right.
+
+**Green is one-way.** It records that a human looked, which is a fact about
+history and cannot be un-done; a control that turned it back to blue would
+assert something false. What must always exist instead is a way back to the
+machine's *value* — reverting a field leaves it green, because you looked and
+decided the machine was right, which is exactly the distinction the tier
+buys. Green is set by changing a decision, never by merely touching the UI:
+unfolding something, scrolling, or opening a form marks nothing.
+
+**A card whose children disagree reads worst-first**: red if any child is
+red, else amber if any is amber, else green only if *every* child is green,
+else blue. That keeps a scroll honest — you look for amber, then decide
+whether you care about blue — and it is what makes an item's progress from
+all-blue to all-green mean anything.
 
 Evidence blocks (record lists) get no rail — they inform decisions, they
-aren't one. The records *cards* on the import form are decision blocks,
-not bare evidence (each carries the level's identity/doubt state), and
-both wear the rail with one reading: **amber only for an unsure match
-nobody has curated; lime for everything else** — trusted is settled, and
-nothing-found is settled too (there is nothing to choose between; the
-seeder approves both). One card must never rail a state the other card
-shows in a different color. The rail is the *only* thing that encodes
+aren't one. The records *cards* on the import form are decision blocks, not
+bare evidence (each carries the level's identity state), and they wear the
+same four tiers as everything else. One card must never rail a state another
+card shows in a different colour. The rail is the *only* thing that encodes
 settledness at block level; don't also dim, collapse, or re-order.
+
+**One vocabulary, and the rail is it.** The form used to carry two
+settledness systems with different words for the same states — per-decision
+("settled", "needs confirming") and per-level ("confirmed", "trusted",
+"unsure") — plus a Confirm button that, in every state where it was visible,
+changed nothing but its own badge. Identity and field decisions are the same
+shape (options, a choice, settled, touched-by-a-human), so they wear one
+encoding. **Importing is the confirmation**: pressing Add accepts every blue
+on the item, which is what the button was groping for.
 
 **Evidence before the decisions it feeds — within a section too.** §9 puts
 the evidence panel above the edit forms; the import form's sections follow
@@ -229,11 +259,38 @@ same content type wore a different anatomy depending on the form, which
 divergence by documenting both halves as intentional; that is how this one
 survived two audits.
 
+**The documented exception: a derived list has no add.** The import form's
+**New people** section lists one card per human the import will create, and
+the operator cannot add one there — a person exists because a *credit* names
+them (`Draft.referenced_keys/1` mints the decisions from the credits), so
+adding a person happens on the credit and appears here. The label and the
+rows are the ordinary grammar; the add below the container is absent, and
+that absence is the honest statement that this list is derived rather than
+built. People already in the library are *not* listed: they were chosen in
+the credit's typeahead, they carry their own curation which an import may
+never overwrite, and the one dangerous case — a name matching two existing
+identities — is a decision on the credit, where `Credit.state/1` computes it.
+
+**Pen names are bracketed, not nested.** One author credit can stand for
+several humans, so those person cards sit adjacent under a shared labelled
+rail naming the credit ("James S.A. Corey"), and each card also names its own
+role in its header. A bracket is a label and a rail, never a filled block —
+wrapping cards in a card is what eats the elevation ladder, and this is the
+same device the person rows used when they were nested inside a credit,
+promoted to group siblings instead.
+
 **Every form saves from the same place: the sticky footer slab**
 (`<.form_footer>` — shadowed `zinc-900`, `-bottom-4`, with `-mb-4` on the
 page wrapper per §3's sticky rule). A bare Save floating on the ground
 after the last card was the legacy forms' tell, at its worst on the
 47-row chapters form.
+
+**The footer is also where outstanding work is listed**, not merely counted.
+It is the one thing always in view, and `Draft.unresolved/1` already returns
+a section and a label for every decision still waiting — so it names them and
+links to them. Without that, a form long enough to have sections has work
+below the fold that nothing announces, which is the objection that decided
+where the New people section goes.
 
 **One form measure: `max-w-4xl`.** The import form always had it; the
 legacy forms sat at `3xl` and the two settings-ish pages centered

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -1054,21 +1054,18 @@ defmodule Ambry.Inbox do
       Enum.any?(files, &MapSet.member?(imported, &1)) ->
         :skipped
 
-      item = Map.get(known, path) ->
-        refresh_known(item, files, source)
-
       # The operator split this folder: a finer partition already exists.
       # Respect it — re-recording the folder whole would re-merge what they
-      # just took apart, an hour later, silently. Each existing child is
-      # refreshed with the files under it, at whatever grain it was split to;
-      # a file no child claims becomes its own item, which is the right
-      # default for a folder the operator declared "not one book".
+      # just took apart, an hour later, silently. Tested *before* the
+      # same-path branch below, because a folder split can leave a child on
+      # the folder's own path (a stray file beside the subfolders), and
+      # refreshing that one with everything underneath is precisely the merge
+      # this exists to prevent.
       children = partition_of(path, known) ->
-        Enum.map(children, &refresh_known(&1, files_under(files, &1.path), source)) ++
-          Enum.map(
-            unclaimed(files, children),
-            &record_candidate({&1, [&1]}, known, imported, source)
-          )
+        refresh_partition(path, files, children, known, imported, source)
+
+      item = Map.get(known, path) ->
+        refresh_known(item, files, source)
 
       true ->
         create_item(path, files, source)
@@ -1085,13 +1082,31 @@ defmodule Ambry.Inbox do
     end
   end
 
-  defp files_under(files, path), do: Enum.filter(files, &(&1 == path or under?(&1, path)))
+  # Each file goes to the *deepest* child that holds it, so a folder-split
+  # series gives every book folder its own files and a stray file at the top
+  # stays with whatever owns the top. A file no child claims becomes its own
+  # item — unless something already holds this folder itself, in which case
+  # the leftovers are its.
+  defp refresh_partition(path, files, children, known, imported, source) do
+    claimed = Enum.group_by(files, &claimant(&1, children))
+    refreshed = Enum.map(children, &refresh_known(&1, Map.get(claimed, &1.path, []), source))
+    leftover = Map.get(claimed, nil, [])
 
-  defp unclaimed(files, children),
-    do:
-      Enum.reject(files, fn file ->
-        Enum.any?(children, &(file == &1.path or under?(file, &1.path)))
-      end)
+    case Map.get(known, path) do
+      nil ->
+        refreshed ++ Enum.map(leftover, &record_candidate({&1, [&1]}, known, imported, source))
+
+      item ->
+        refreshed ++ [refresh_known(item, leftover, source)]
+    end
+  end
+
+  defp claimant(file, children) do
+    children
+    |> Enum.filter(&(file == &1.path or under?(file, &1.path)))
+    |> Enum.max_by(&String.length(&1.path), fn -> nil end)
+    |> then(&(&1 && &1.path))
+  end
 
   defp under?(path, parent), do: String.starts_with?(path, parent <> "/")
 

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -42,6 +42,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.Lookup
   alias Ambry.Inbox.Progress
   alias Ambry.Inbox.RunDiscovery
+  alias Ambry.Inbox.RunImport
   alias Ambry.Inbox.RunMatch
   alias Ambry.Inbox.RunProbe
   alias Ambry.Library
@@ -708,6 +709,23 @@ defmodule Ambry.Inbox do
         update_item(item, %{issue: describe_error(reason)})
         error
     end
+  end
+
+  @doc """
+  Queues the import and hands the operator back their afternoon.
+
+  Placing a release is the longest thing the inbox does — every file
+  re-probed, then every byte copied — and running it inside the form meant
+  the operator watched a spinner they could kill by closing the tab. The job
+  belongs to the server; the row says what is happening to it.
+
+  Refuses an item that is already in the library, since the queued job would
+  only rediscover that a minute later and write it onto the row as an issue.
+  """
+  def import_item_async(%InboxItem{status: :imported}), do: {:error, :already_imported}
+
+  def import_item_async(%InboxItem{} = item) do
+    %{inbox_item_id: item.id} |> RunImport.new() |> Oban.insert()
   end
 
   @doc """

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -926,16 +926,19 @@ defmodule Ambry.Inbox do
   @doc """
   How many items each grain would produce, for the controls that offer them.
 
-  A grain that produces one item is not a split, and the form doesn't offer
-  it: `%{file: 35, folder: 5}` on a GraphicAudio set, `%{file: 3}` on three
-  files in one folder.
+  **A grain only appears when it divides further than the coarser one.** A
+  set of three folders holding one file each is the same three items either
+  way, and offering both asks the operator to choose between identical
+  outcomes: `%{folder: 5, file: 35}` on a GraphicAudio set, `%{folder: 3}` on
+  three books in three folders, `%{file: 3}` on three files in one.
   """
   def split_grains(%InboxItem{} = item) do
-    for grain <- [:folder, :file],
-        count = length(split_groups(item, grain)),
-        count > 1,
-        into: %{},
-        do: {grain, count}
+    folders = length(split_groups(item, :folder))
+    files = length(split_groups(item, :file))
+
+    %{}
+    |> put_if(:folder, folders, folders > 1)
+    |> put_if(:file, files, files > folders)
   end
 
   # Files keep the order they were discovered in *within* a group — that is

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -45,6 +45,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.RunImport
   alias Ambry.Inbox.RunMatch
   alias Ambry.Inbox.RunProbe
+  alias Ambry.Inbox.Undo
   alias Ambry.Library
   alias Ambry.Library.Root
   alias Ambry.Library.Source
@@ -558,6 +559,18 @@ defmodule Ambry.Inbox do
   defdelegate research_person(item, key, name), to: Lookup
 
   @doc """
+  Deletes what an import created and puts the item back in the queue.
+
+  Development only — `undo_available?/0` says whether this build has it. The
+  awkward releases are the ones worth running through the form, and each of
+  them could only be imported once; see `Ambry.Inbox.Undo`.
+  """
+  defdelegate undo_import(item), to: Undo
+
+  @doc "Whether this build can undo an import at all."
+  defdelegate undo_available?, to: Undo, as: :available?
+
+  @doc """
   Asks one provider again — the one that was unreachable during matching.
   """
   defdelegate retry_provider(item, level, provider_id), to: Lookup
@@ -779,6 +792,18 @@ defmodule Ambry.Inbox do
     do: "There's more than one library root. Choose which one this folder imports into."
 
   def describe_error(:already_imported), do: "Already in the library; this item is read-only."
+
+  def describe_error(:undo_unavailable), do: "Undoing an import is a development-only tool."
+
+  def describe_error(:not_imported),
+    do: "This item isn't in the library, so there's nothing to undo."
+
+  # Refused rather than half-done: a `move` policy leaves the library copy as
+  # the only copy, and deleting it would be a loss rather than an undo.
+  def describe_error(:source_files_missing),
+    do:
+      "The files this was found as are gone, so the library copy is the only one left. " <>
+        "Undoing would delete it."
 
   # The invariant, phrased for a human. It names the count rather than the
   # decisions because the form lists them properly — this is the flash you get

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -24,6 +24,28 @@ defmodule Ambry.Inbox do
 
   That's measured against a real downloads tree rather than assumed — see
   `directory_candidate/1`.
+
+  ## What a scan may change, and what it may not
+
+  The walk runs hourly over folders the operator is working in, so what it
+  is *allowed* to do matters more than what it finds. **Ownership decides,
+  not the walk**: every file the queue or the library already holds belongs
+  to something, and the grouping the walk proposes is consulted only for
+  files that belong to nothing.
+
+  A scan may therefore do exactly three things:
+
+    * create items from files nothing owns,
+    * give an unowned file to the item that owns the folder above it,
+    * drop a file that is gone from its owner (which marks that item's draft
+      stale, since the draft describes files that moved under it).
+
+  It may never move a file from one item to another, and it never touches an
+  imported item at all. That is what makes a split durable without a marker:
+  once the operator says five folders are five releases, the files are owned,
+  and re-walking the folder that holds them has nothing to say. It is a
+  property of the construction rather than a rule the code has to remember —
+  `record_candidate/3` groups by owner before it looks at anything else.
   """
 
   use Boundary,
@@ -183,13 +205,12 @@ defmodule Ambry.Inbox do
 
   defp scan(root, source) do
     if File.dir?(root) do
-      known = known_paths()
-      imported = imported_files()
+      ledger = ledger()
 
       results =
         root
         |> candidates()
-        |> Enum.flat_map(&List.wrap(record_candidate(&1, known, imported, source)))
+        |> Enum.flat_map(&List.wrap(record_candidate(&1, ledger, source)))
 
       {:ok,
        %{
@@ -1049,66 +1070,65 @@ defmodule Ambry.Inbox do
     path |> Path.extname() |> String.downcase() |> Kernel.in(Scanner.extensions())
   end
 
-  defp record_candidate({path, files}, known, imported, source) do
+  @doc false
+  # **Ownership decides, not the walk.** Every file the queue or the library
+  # already holds belongs to something, and a scan's only job is to find the
+  # ones that don't. Which release a *known* file belongs to is settled — the
+  # operator may have split its folder into five, or into thirty-five, and no
+  # amount of re-walking that folder is allowed to have an opinion about it.
+  #
+  # That is the whole of the safety property, and it is structural: this
+  # groups the candidate's files by who owns them *before* looking at
+  # anything, so the grouping the walk proposes is only ever consulted for
+  # files with no owner at all.
+  defp record_candidate({path, files}, ledger, source) do
+    files
+    |> Enum.group_by(&owner_of(&1, ledger))
+    |> Enum.flat_map(fn
+      {nil, orphans} -> List.wrap(adopt(path, files, orphans, source))
+      {:library, _theirs} -> [:skipped]
+      {%InboxItem{} = item, theirs} -> [refresh_owner(item, theirs, source)]
+    end)
+  end
+
+  # A file's owner, in the order that decides it: the item that already lists
+  # it, the library, then the nearest item *above* it — which is how a file
+  # that appears in a known release folder joins that release rather than
+  # becoming an item of its own.
+  defp owner_of(file, ledger) do
     cond do
-      Enum.any?(files, &MapSet.member?(imported, &1)) ->
-        :skipped
-
-      # The operator split this folder: a finer partition already exists.
-      # Respect it — re-recording the folder whole would re-merge what they
-      # just took apart, an hour later, silently. Tested *before* the
-      # same-path branch below, because a folder split can leave a child on
-      # the folder's own path (a stray file beside the subfolders), and
-      # refreshing that one with everything underneath is precisely the merge
-      # this exists to prevent.
-      children = partition_of(path, known) ->
-        refresh_partition(path, files, children, known, imported, source)
-
-      item = Map.get(known, path) ->
-        refresh_known(item, files, source)
-
-      true ->
-        create_item(path, files, source)
+      item = ledger.by_file[file] -> item
+      MapSet.member?(ledger.library, file) -> :library
+      item = nearest_owner(file, ledger.by_path) -> item
+      true -> nil
     end
   end
 
-  # The items the operator's own split left inside this folder, at whatever
-  # grain they chose: a per-file split leaves children keyed by file, a
-  # per-folder split by folder, and both are simply paths underneath.
-  defp partition_of(path, known) do
-    case Enum.filter(known, fn {child, _item} -> under?(child, path) end) do
-      [] -> nil
-      children -> Enum.map(children, fn {_path, item} -> item end)
-    end
+  # Walked up from the file rather than searched across every item: depth is
+  # single digits, the item list is hundreds, and this runs per file.
+  defp nearest_owner(file, by_path) do
+    file
+    |> Stream.unfold(fn
+      path when path in ["/", ".", ""] -> nil
+      path -> {Path.dirname(path), Path.dirname(path)}
+    end)
+    |> Enum.find_value(&Map.get(by_path, &1))
   end
 
-  # Each file goes to the *deepest* child that holds it, so a folder-split
-  # series gives every book folder its own files and a stray file at the top
-  # stays with whatever owns the top. A file no child claims becomes its own
-  # item — unless something already holds this folder itself, in which case
-  # the leftovers are its.
-  defp refresh_partition(path, files, children, known, imported, source) do
-    claimed = Enum.group_by(files, &claimant(&1, children))
-    refreshed = Enum.map(children, &refresh_known(&1, Map.get(claimed, &1.path, []), source))
-    leftover = Map.get(claimed, nil, [])
+  # An imported item is the record of what was imported; its source files may
+  # not even be where they were. Nothing about a scan may touch it.
+  defp refresh_owner(%InboxItem{status: :imported}, _files, _source), do: :skipped
+  defp refresh_owner(%InboxItem{} = item, files, source), do: refresh_known(item, files, source)
 
-    case Map.get(known, path) do
-      nil ->
-        refreshed ++ Enum.map(leftover, &record_candidate({&1, [&1]}, known, imported, source))
+  # Nobody owns these. A candidate that is entirely unowned is a release, at
+  # the grain the walk proposes; anything left over in a folder that is
+  # *partly* owned goes to the finest grain there is, because something has
+  # already declared that folder to be more than one release.
+  defp adopt(path, files, orphans, source) when files == orphans,
+    do: create_item(path, orphans, source)
 
-      item ->
-        refreshed ++ [refresh_known(item, leftover, source)]
-    end
-  end
-
-  defp claimant(file, children) do
-    children
-    |> Enum.filter(&(file == &1.path or under?(file, &1.path)))
-    |> Enum.max_by(&String.length(&1.path), fn -> nil end)
-    |> then(&(&1 && &1.path))
-  end
-
-  defp under?(path, parent), do: String.starts_with?(path, parent <> "/")
+  defp adopt(_path, _files, orphans, source),
+    do: Enum.map(orphans, &create_item(&1, [&1], source))
 
   # A known item's files can legitimately change (a torrent finished, a file
   # was replaced). Its status is left alone: ignored stays ignored.
@@ -1165,8 +1185,19 @@ defmodule Ambry.Inbox do
     end
   end
 
-  defp known_paths do
-    InboxItem |> select([i], {i.path, i}) |> Repo.all() |> Map.new()
+  # Who owns what, read once per scan.
+  #
+  # `by_file` is the authority — an item's own list of files — and `by_path`
+  # only answers for files nothing has claimed yet, so a new file in a known
+  # folder joins the item that holds the folder.
+  defp ledger do
+    items = Repo.all(InboxItem)
+
+    %{
+      by_file: for(item <- items, file <- item.files, into: %{}, do: {file, item}),
+      by_path: Map.new(items, &{&1.path, &1}),
+      library: imported_files()
+    }
   end
 
   # Files the library already has, by either route: a direct-play track or a

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -41,6 +41,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.Lookup
   alias Ambry.Inbox.Progress
+  alias Ambry.Inbox.ReleaseName
   alias Ambry.Inbox.RunDiscovery
   alias Ambry.Inbox.RunImport
   alias Ambry.Inbox.RunMatch
@@ -793,6 +794,9 @@ defmodule Ambry.Inbox do
 
   def describe_error(:already_imported), do: "Already in the library; this item is read-only."
 
+  def describe_error(:not_divisible),
+    do: "These files are all in one folder, so splitting by folder would change nothing."
+
   def describe_error(:undo_unavailable), do: "Undoing an import is a development-only tool."
 
   def describe_error(:not_imported),
@@ -843,29 +847,53 @@ defmodule Ambry.Inbox do
   def delete_item(%InboxItem{} = item), do: Repo.delete(item)
 
   @doc """
-  Splits a multi-file item into one item per file.
+  Splits a wrongly-grouped item into several, `by: :folder` or `by: :file`.
 
   The grouping heuristic is folder-based — a folder holding audio directly is
-  one release — and its known failure is two unrelated single-file books
-  sharing a folder. The operator is the one who can tell; this is how they
-  say so. Each file becomes its own item in the shape a loose file has always
-  had (`path` = the file), with a fresh probe (and the match that follows it)
-  queued, because the parent's probe, tags and matches described its first
-  file only.
+  one release, and a folder of "1 of 5" subfolders is one release in parts —
+  and it has two known failures, at two different grains. Two unrelated
+  single-file books can share a folder; and a set can be *five recordings*
+  rather than one in five parts, which is exactly what a GraphicAudio release
+  is. The operator is the one who can tell, so the split asks them at which
+  grain it was wrong:
+
+    * `:folder` — one item per folder the files live in. The five parts of
+      The Way of Kings become five items of seven files each, each free to
+      take its own part number in a set.
+    * `:file` — one item per file, the finest grain there is, for the folder
+      that was never one release at all.
+
+  Children are inserted in the shape discovery gives an item of that grain
+  (`path` = the folder, or the file), with a fresh probe and the match that
+  follows it queued, because the parent's probe, tags and matches described
+  its first file only.
 
   A split survives rescans without any marker: discovery respects a finer
   partition that already exists — see `record_candidate/4`.
 
-  Refused once imported (the item is the record of what was imported), and
-  meaningless below two files.
+  Refused once imported (the item is the record of what was imported), below
+  two files, and when the chosen grain wouldn't actually divide anything —
+  splitting a single-folder item by folder is a no-op, and doing it silently
+  would delete and recreate the item for nothing.
   """
-  def split_item(%InboxItem{status: :imported}), do: {:error, :already_imported}
-  def split_item(%InboxItem{files: files}) when length(files) < 2, do: {:error, :not_multi_file}
+  def split_item(item, by \\ :file)
 
-  def split_item(%InboxItem{} = item) do
+  def split_item(%InboxItem{status: :imported}, _by), do: {:error, :already_imported}
+
+  def split_item(%InboxItem{files: files}, _by) when length(files) < 2,
+    do: {:error, :not_multi_file}
+
+  def split_item(%InboxItem{} = item, by) do
+    case split_groups(item, by) do
+      [_one] -> {:error, :not_divisible}
+      groups -> replace_with_children(item, groups)
+    end
+  end
+
+  defp replace_with_children(%InboxItem{} = item, groups) do
     Repo.transact(fn ->
       with {:ok, _parent} <- Repo.delete(item),
-           {:ok, children} <- insert_children(item) do
+           {:ok, children} <- insert_children(item, groups) do
         # In the transaction on purpose: a job for a child that didn't get
         # created must not exist either.
         Enum.each(children, fn child -> {:ok, _job} = probe_item_async(child) end)
@@ -874,11 +902,36 @@ defmodule Ambry.Inbox do
     end)
   end
 
-  defp insert_children(%InboxItem{} = item) do
-    item.files
-    |> Enum.reduce_while({:ok, []}, fn file, {:ok, acc} ->
+  @doc """
+  How many items each grain would produce, for the controls that offer them.
+
+  A grain that produces one item is not a split, and the form doesn't offer
+  it: `%{file: 35, folder: 5}` on a GraphicAudio set, `%{file: 3}` on three
+  files in one folder.
+  """
+  def split_grains(%InboxItem{} = item) do
+    for grain <- [:folder, :file],
+        count = length(split_groups(item, grain)),
+        count > 1,
+        into: %{},
+        do: {grain, count}
+  end
+
+  # Files keep the order they were discovered in *within* a group — that is
+  # playing order, and re-sorting it here would quietly reorder a book.
+  defp split_groups(%InboxItem{files: files}, :file), do: Enum.map(files, &{&1, [&1]})
+
+  defp split_groups(%InboxItem{files: files}, :folder) do
+    files
+    |> Enum.group_by(&Path.dirname/1)
+    |> Enum.sort_by(fn {dir, _files} -> dir end)
+  end
+
+  defp insert_children(%InboxItem{} = item, groups) do
+    groups
+    |> Enum.reduce_while({:ok, []}, fn {path, files}, {:ok, acc} ->
       %InboxItem{}
-      |> InboxItem.changeset(%{path: file, files: [file], source_id: item.source_id})
+      |> InboxItem.changeset(%{path: path, files: files, source_id: item.source_id})
       |> Repo.insert()
       |> case do
         {:ok, child} -> {:cont, {:ok, [child | acc]}}
@@ -959,15 +1012,10 @@ defmodule Ambry.Inbox do
     end
   end
 
-  # Deliberately strict. "Disc 02" and "3 of 5" are parts; "Gwendy's Button
-  # Box 2" and "01 - The Restaurant at the End of the Universe" are their own
-  # books, and a looser pattern (anything ending in a number) would swallow
-  # them into one item.
-  @part_folder ~r/^(disc|cd|part|vol|volume)\s*\.?\s*\d+$|^\d+\s*of\s*\d+$|\((disc|cd|part)\s*\d+\)$/i
-
-  defp part_folder?(dir) do
-    dir |> Path.basename() |> String.trim() |> then(&Regex.match?(@part_folder, &1))
-  end
+  # The shape lives in `ReleaseName` because two callers read it: this walk,
+  # deciding a folder of parts is one release, and an item named after one of
+  # those folders, which has to say what it is a part *of*.
+  defp part_folder?(dir), do: dir |> Path.basename() |> ReleaseName.part_folder?()
 
   defp entries(dir) do
     case File.ls(dir) do
@@ -1009,18 +1057,43 @@ defmodule Ambry.Inbox do
       item = Map.get(known, path) ->
         refresh_known(item, files, source)
 
-      # The operator split this folder: a finer partition already exists,
-      # keyed by file path. Respect it — re-recording the folder whole would
-      # re-merge what they just took apart, an hour later, silently. A file
-      # that has since appeared in the folder becomes its own item, which is
-      # the right default for a folder the operator declared "not one book".
-      Enum.any?(files, &Map.has_key?(known, &1)) ->
-        Enum.map(files, &record_candidate({&1, [&1]}, known, imported, source))
+      # The operator split this folder: a finer partition already exists.
+      # Respect it — re-recording the folder whole would re-merge what they
+      # just took apart, an hour later, silently. Each existing child is
+      # refreshed with the files under it, at whatever grain it was split to;
+      # a file no child claims becomes its own item, which is the right
+      # default for a folder the operator declared "not one book".
+      children = partition_of(path, known) ->
+        Enum.map(children, &refresh_known(&1, files_under(files, &1.path), source)) ++
+          Enum.map(
+            unclaimed(files, children),
+            &record_candidate({&1, [&1]}, known, imported, source)
+          )
 
       true ->
         create_item(path, files, source)
     end
   end
+
+  # The items the operator's own split left inside this folder, at whatever
+  # grain they chose: a per-file split leaves children keyed by file, a
+  # per-folder split by folder, and both are simply paths underneath.
+  defp partition_of(path, known) do
+    case Enum.filter(known, fn {child, _item} -> under?(child, path) end) do
+      [] -> nil
+      children -> Enum.map(children, fn {_path, item} -> item end)
+    end
+  end
+
+  defp files_under(files, path), do: Enum.filter(files, &(&1 == path or under?(&1, path)))
+
+  defp unclaimed(files, children),
+    do:
+      Enum.reject(files, fn file ->
+        Enum.any?(children, &(file == &1.path or under?(file, &1.path)))
+      end)
+
+  defp under?(path, parent), do: String.starts_with?(path, parent <> "/")
 
   # A known item's files can legitimately change (a torrent finished, a file
   # was replaced). Its status is left alone: ignored stays ignored.

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -449,6 +449,19 @@ defmodule Ambry.Inbox.AutoMatch do
     end
   end
 
+  @doc """
+  The people the library already has by this name.
+
+  Kept away from the provider candidates for the same reason a local book is:
+  it answers a different question. A provider record is evidence about a
+  human; one of these *is* a human, and choosing them creates nobody.
+
+  Shared with `Ambry.Inbox.Lookup`, which asks again when the operator
+  re-searches — the held answer is about the name that was asked before, and a
+  rename is exactly when that stops being true.
+  """
+  def local_people(name), do: name |> People.people_named() |> Enum.map(&local_person/1)
+
   defp local_person(person) do
     %{
       "source" => "local",
@@ -550,16 +563,18 @@ defmodule Ambry.Inbox.AutoMatch do
   providers happened to be asked in — and the operator saw plainly wrong
   humans above the right one.
 
-  Scores anything arriving without one, because a re-search merges fresh
-  records into a list staged before people were scored at all, and sorting
-  those to the bottom would bury records the operator may already have
-  ticked.
+  **Every candidate is scored against the name being asked about now**, not
+  only the ones arriving without a score. A score is the answer to "how well
+  does this record answer the name we are asking about", and a re-search is
+  the operator changing the question: looking up "David Wong" and then Jason
+  Pargin left the David Wong records wearing the 100% they earned under the
+  old question, sitting above the humans actually searched for. Nothing is
+  dropped — a record that no longer answers the question sinks, which is what
+  the fold below `record_list`'s threshold is for.
   """
   def rank_people(candidates, asked_for) do
     candidates
-    |> Enum.map(fn candidate ->
-      Map.put_new_lazy(candidate, "score", fn -> person_score(candidate["name"], asked_for) end)
-    end)
+    |> Enum.map(&Map.put(&1, "score", person_score(&1["name"], asked_for)))
     |> Enum.sort_by(&{&1["score"] || 0.0, person_substance(&1)}, :desc)
   end
 

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -462,13 +462,25 @@ defmodule Ambry.Inbox.AutoMatch do
   end
 
   defp search_person(name, opts) do
-    Enum.reduce(PersonSearch.providers(), {[], []}, fn entry, {candidates, outcomes} ->
-      {matches, provider_outcomes} = PersonSearch.matches_with_outcome(entry, name, opts)
-      {candidates ++ Enum.map(matches, &person_candidate/1), outcomes ++ provider_outcomes}
-    end)
+    {candidates, outcomes} =
+      Enum.reduce(PersonSearch.providers(), {[], []}, fn entry, {candidates, outcomes} ->
+        {matches, provider_outcomes} = PersonSearch.matches_with_outcome(entry, name, opts)
+
+        {candidates ++ Enum.map(matches, &person_candidate(&1, name)),
+         outcomes ++ provider_outcomes}
+      end)
+
+    {rank_people(candidates, name), outcomes}
   end
 
-  defp person_candidate(%PersonSearch.Match{} = match) do
+  @doc """
+  One provider's answer about a human, scored against the name we asked for.
+
+  Shared with `Ambry.Inbox.Lookup`, which builds the same records when the
+  operator searches a person again — it had its own copy, which is how the
+  two drifted into one being scored and the other not.
+  """
+  def person_candidate(%PersonSearch.Match{} = match, asked_for) do
     %{
       "source" => "provider:#{match.provider_id}",
       "provider_name" => match.provider_name,
@@ -478,8 +490,84 @@ defmodule Ambry.Inbox.AutoMatch do
       # what tells two same-named humans apart in a grid — TMDB's known-for
       # credits, mostly
       "note" => presence(match.note),
-      "images" => match.images
+      "images" => match.images,
+      "score" => person_score(match.name, asked_for)
     }
+  end
+
+  @doc """
+  How well a returned name answers the name we asked about.
+
+  **Not a string distance.** Jaro cannot separate a legitimate variant from a
+  different human — measured, "Ty Franck" against "Tyler Corey Franck" scores
+  *lower* than "Ty Franck" against a Corey mismatch — so the ordering is by
+  what the names structurally share, which is the same reasoning
+  `author_agreement/2` already follows:
+
+    * `1.0` — the same name once accents and punctuation are folded away
+      (`person_key/1`), so "Émile Zola" and "Emile Zola" are one person
+    * `0.8` — one name's words are all inside the other's: "Ty Franck" within
+      "Tyler Corey Franck", the pen-name-and-full-name case
+    * `0.6` — they share a word, which is the floor `PersonSearch` already
+      filters at
+    * `0.0` — nothing shared, which a filtered search shouldn't return
+
+  Ties are common and are broken by usefulness rather than by nothing: a
+  candidate carrying a photo and a biography is both more useful to the
+  operator and more likely to be the documented human, and a stable sort
+  leaves the operator's provider priority deciding the rest.
+  """
+  def person_score(name, asked_for) do
+    wanted = name_tokens(asked_for)
+    got = name_tokens(name)
+
+    cond do
+      person_key(name || "") == person_key(asked_for || "") -> 1.0
+      Enum.empty?(wanted) or Enum.empty?(got) -> 0.0
+      covered?(wanted, got) or covered?(got, wanted) -> 0.8
+      Enum.any?(wanted, fn word -> Enum.any?(got, &same_word?(&1, word)) end) -> 0.6
+      true -> 0.0
+    end
+  end
+
+  # Every word on one side answered by a word on the other.
+  defp covered?(words, others),
+    do: Enum.all?(words, fn word -> Enum.any?(others, &same_word?(&1, word)) end)
+
+  # A shortening is the same word: "Ty" is how Tyler Corey Franck is credited,
+  # and "Dan" is Daniel. Exact-token comparison missed exactly the case this
+  # scoring exists for, which is the one `Ambry.Metadata.PersonSearch`'s
+  # moduledoc names. Words under two characters were already dropped, so this
+  # can't collapse initials onto everything.
+  defp same_word?(word, other),
+    do: String.starts_with?(word, other) or String.starts_with?(other, word)
+
+  @doc """
+  People, best answer first.
+
+  The work and recording levels have ranked their candidates since they
+  existed; the person level never did, so the list was whatever order the
+  providers happened to be asked in — and the operator saw plainly wrong
+  humans above the right one.
+
+  Scores anything arriving without one, because a re-search merges fresh
+  records into a list staged before people were scored at all, and sorting
+  those to the bottom would bury records the operator may already have
+  ticked.
+  """
+  def rank_people(candidates, asked_for) do
+    candidates
+    |> Enum.map(fn candidate ->
+      Map.put_new_lazy(candidate, "score", fn -> person_score(candidate["name"], asked_for) end)
+    end)
+    |> Enum.sort_by(&{&1["score"] || 0.0, person_substance(&1)}, :desc)
+  end
+
+  # A face and a biography, as a tie-break between equally-named candidates.
+  defp person_substance(candidate) do
+    has_image = if candidate["images"] in [nil, []], do: 0, else: 1
+    has_bio = if presence(candidate["description"]), do: 1, else: 0
+    has_image + has_bio
   end
 
   # **Everyone any plausible reading of the evidence would credit**, which is

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -44,6 +44,7 @@ defmodule Ambry.Inbox.AutoMatch do
   alias Ambry.Books
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.ReleaseName
+  alias Ambry.Metadata.Outcome
   alias Ambry.Metadata.PersonSearch
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Providers
@@ -462,8 +463,8 @@ defmodule Ambry.Inbox.AutoMatch do
 
   defp search_person(name, opts) do
     Enum.reduce(PersonSearch.providers(), {[], []}, fn entry, {candidates, outcomes} ->
-      {matches, outcome} = PersonSearch.matches_with_outcome(entry, name, opts)
-      {candidates ++ Enum.map(matches, &person_candidate/1), outcomes ++ [outcome]}
+      {matches, provider_outcomes} = PersonSearch.matches_with_outcome(entry, name, opts)
+      {candidates ++ Enum.map(matches, &person_candidate/1), outcomes ++ provider_outcomes}
     end)
   end
 
@@ -738,13 +739,23 @@ defmodule Ambry.Inbox.AutoMatch do
   defp hydrate_top(%{"candidates" => candidates} = result, opts) do
     wanted = candidates |> top_group() |> MapSet.new(&ref/1)
 
-    %{
-      result
-      | "candidates" =>
-          Enum.map(candidates, fn record ->
-            if MapSet.member?(wanted, ref(record)), do: details(record, opts), else: record
-          end)
-    }
+    {hydrated, failures} =
+      Enum.map_reduce(candidates, [], fn record, failures ->
+        if MapSet.member?(wanted, ref(record)) do
+          case details_with_outcome(record, opts) do
+            {record, nil} -> {record, failures}
+            {record, outcome} -> {record, failures ++ [outcome]}
+          end
+        else
+          {record, failures}
+        end
+      end)
+
+    result
+    |> Map.put("candidates", hydrated)
+    # One chip per provider however many of its records were hydrated: asking
+    # Hardcover about four of its own works is four calls but one answer.
+    |> Map.put("providers", merge_outcomes(result["providers"] || [], tally(failures)))
   end
 
   defp hydrate_top(result, _opts), do: result
@@ -771,40 +782,81 @@ defmodule Ambry.Inbox.AutoMatch do
   may lack.
   """
   def details(record, opts \\ []) do
+    {record, _outcome} = details_with_outcome(record, opts)
+    record
+  end
+
+  @doc """
+  The same fetch, plus a failed outcome when the provider couldn't be reached.
+
+  **A thin record and an unfetched record are not the same thing**, and this
+  is the difference. Leaving the summary in place is still the right
+  behaviour — it is a usable candidate, and one enrichment call failing must
+  not fail an item that otherwise matched — but doing it *quietly* meant a
+  rate-limited details call cost the record its description, its cover, its
+  publisher and its edition list with nothing anywhere saying so. Measured on
+  a cold scan of 353 releases, the shared rreading-glasses instance 429'd
+  about 6% of requests, none of which surfaced.
+
+  The outcome is what makes it visible and what makes it come back:
+  `RunMatch` fails a job with any unreached provider, and provider errors are
+  never cached, so the retry re-asks exactly this call.
+  """
+  def details_with_outcome(record, opts \\ []) do
     case details_for(record, opts) do
-      nil -> record
-      fuller -> record |> Map.merge(fuller) |> hydrated()
+      # Not a provider record, or a provider the registry doesn't know: there
+      # is nothing to report and nothing a retry could do.
+      :no_provider ->
+        {record, nil}
+
+      {:ok, entry, fuller} ->
+        # Success is reported too, and it has to be: outcomes replace each
+        # other by id, so a details call that only ever spoke up when it
+        # failed would leave "couldn't be reached" on the chip forever, even
+        # after the retry that fixed it.
+        {record |> Map.merge(fuller) |> hydrated(), Outcome.ok(entry, 1, :details)}
+
+      {:error, entry, reason} ->
+        {record, Outcome.failed(entry, reason, :details)}
     end
   end
 
   defp details_for(%{"source" => "provider:" <> provider_id, "id" => id}, opts)
        when is_binary(id) do
-    case Providers.book_details(provider_id, id, opts) do
+    case Registry.fetch(provider_id) do
+      {:ok, entry} -> details_from(entry, id, opts)
+      {:error, _unknown} -> :no_provider
+    end
+  end
+
+  defp details_for(_record, _opts), do: :no_provider
+
+  defp details_from(entry, id, opts) do
+    case Providers.book_details(entry.id, id, opts) do
       {:ok, book} ->
         # Only fields the summary can be *missing*. The title, authors and
         # score stay as matched — re-deriving them here would silently move
         # what the operator already saw ranked.
-        %{
-          "description" => presence(book.description),
-          "cover_url" => presence(book.cover_url),
-          "publisher" => presence(book.publisher),
-          "series" => series_refs(book.series)
-        }
-        |> Enum.reject(fn {_key, value} -> value in [nil, []] end)
-        |> Map.new()
+        fuller =
+          %{
+            "description" => presence(book.description),
+            "cover_url" => presence(book.cover_url),
+            "publisher" => presence(book.publisher),
+            "series" => series_refs(book.series)
+          }
+          |> Enum.reject(fn {_key, value} -> value in [nil, []] end)
+          |> Map.new()
+
+        {:ok, entry, fuller}
 
       {:error, reason} ->
-        # Never fatal: the summary is still a usable candidate, and an item
-        # that matched shouldn't fail because one enrichment call didn't.
         Logger.warning(fn ->
-          "Auto-match: details for #{provider_id}/#{id}: #{inspect(reason)}"
+          "Auto-match: details for #{entry.id}/#{id}: #{inspect(reason)}"
         end)
 
-        nil
+        {:error, entry, reason}
     end
   end
-
-  defp details_for(_candidate, _opts), do: nil
 
   # An ASIN is a recording-level key, so when there is one it *is* the query:
   # a hit on it is definitive in a way no title match ever is.
@@ -1062,13 +1114,28 @@ defmodule Ambry.Inbox.AutoMatch do
   # row. It also hid a real number — the inbox de-duplicates outcomes by id and
   # keeps the last, so a provider that found thirteen editions for one work and
   # none for the next reported **none**.
+  #
+  # **A failure outranks an answer.** Collapsing four calls to one chip used to
+  # let any success speak for the group, so a provider that answered about
+  # three works and was rate-limited on the fourth reported a clean `ok` and
+  # the fourth work's editions were never seen again — the same silent miss in
+  # miniature. Now the chip says "couldn't be reached" while still carrying
+  # what did come back, and `RunMatch` sends the item round again for the rest.
+  @doc """
+  Collapses many calls to one provider into the one chip the operator reads.
+  """
+  def tally_outcomes(outcomes), do: tally(outcomes)
+
   defp tally(outcomes) do
     outcomes
     |> Enum.group_by(& &1["id"])
     |> Enum.map(fn {_id, [first | _rest] = group} ->
-      case Enum.filter(group, &(&1["status"] == "ok")) do
-        [] -> first
-        answered -> %{first | "status" => "ok", "count" => Enum.sum_by(answered, & &1["count"])}
+      answered = Enum.reject(group, &Outcome.failed?/1)
+      count = Enum.sum_by(answered, &(&1["count"] || 0))
+
+      case Enum.find(group, &Outcome.failed?/1) do
+        nil -> %{first | "status" => "ok", "count" => count}
+        failure -> %{failure | "count" => count}
       end
     end)
   end
@@ -1100,36 +1167,17 @@ defmodule Ambry.Inbox.AutoMatch do
             &(&1 |> provider_candidate(entry, hints) |> Map.put("of_work", of_work))
           )
 
-        {candidates,
-         [
-           %{
-             "id" => "#{provider_id}:editions",
-             "name" => "#{entry.display_name} editions",
-             "status" => "ok",
-             "count" => length(candidates)
-           }
-         ]}
+        {candidates, [Outcome.ok(entry, length(candidates), :editions)]}
 
       {:error, reason} ->
         Logger.warning(fn -> "Auto-match: editions for #{provider_id}: #{inspect(reason)}" end)
 
-        {[],
-         [
-           %{
-             "id" => "#{provider_id}:editions",
-             "name" => "#{provider_name(provider_id)} editions",
-             "status" => "failed",
-             "count" => 0,
-             "reason" => describe(reason)
-           }
-         ]}
-    end
-  end
-
-  defp provider_name(provider_id) do
-    case Registry.fetch(provider_id) do
-      {:ok, entry} -> entry.display_name
-      _unknown -> provider_id
+        # The registry is what names a provider on a chip, and an id it has
+        # never heard of can't be retried anyway.
+        case Registry.fetch(provider_id) do
+          {:ok, entry} -> {[], [Outcome.failed(entry, reason, :editions)]}
+          {:error, _unknown} -> {[], []}
+        end
     end
   end
 
@@ -1649,27 +1697,14 @@ defmodule Ambry.Inbox.AutoMatch do
         candidates =
           books |> Enum.take(@candidate_limit) |> Enum.map(&provider_candidate(&1, entry, hints))
 
-        {candidates,
-         %{
-           "id" => entry.id,
-           "name" => entry.display_name,
-           "status" => "ok",
-           "count" => length(candidates)
-         }}
+        {candidates, Outcome.ok(entry, length(candidates))}
 
       {:error, reason} ->
         Logger.warning(fn ->
           "Auto-match: #{entry.id} failed for #{inspect(to_string(query))}: #{inspect(reason)}"
         end)
 
-        {[],
-         %{
-           "id" => entry.id,
-           "name" => entry.display_name,
-           "status" => "failed",
-           "count" => 0,
-           "reason" => describe(reason)
-         }}
+        {[], Outcome.failed(entry, reason)}
     end
   end
 
@@ -1701,12 +1736,6 @@ defmodule Ambry.Inbox.AutoMatch do
       |> String.trim()
 
     if plainer != "" and plainer != String.trim(title), do: plainer
-  end
-
-  # Enough for the operator to tell a rate limit from a bad token from an
-  # instance being down, without leaking a whole HTTP response into jsonb.
-  defp describe(reason) do
-    reason |> inspect() |> String.slice(0, 200)
   end
 
   @doc """

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -919,8 +919,10 @@ defmodule Ambry.Inbox.AutoMatch do
         # after the retry that fixed it.
         {record |> Map.merge(fuller) |> hydrated(), Outcome.ok(entry, 1, :details)}
 
+      # nil when the provider was never asked — it implements no details call,
+      # or it is switched off. `retry/4` and the hydrate path both drop it.
       {:error, entry, reason} ->
-        {record, Outcome.failed(entry, reason, :details)}
+        {record, Outcome.from_error(entry, reason, :details)}
     end
   end
 
@@ -1278,7 +1280,7 @@ defmodule Ambry.Inbox.AutoMatch do
         # The registry is what names a provider on a chip, and an id it has
         # never heard of can't be retried anyway.
         case Registry.fetch(provider_id) do
-          {:ok, entry} -> {[], [Outcome.failed(entry, reason, :editions)]}
+          {:ok, entry} -> {[], List.wrap(Outcome.from_error(entry, reason, :editions))}
           {:error, _unknown} -> {[], []}
         end
     end
@@ -1775,7 +1777,9 @@ defmodule Ambry.Inbox.AutoMatch do
     |> Registry.enabled()
     |> Enum.map(&search_provider(&1, query, hints, opts))
     |> Enum.reduce({[], []}, fn {candidates, outcome}, {all, outcomes} ->
-      {all ++ candidates, outcomes ++ [outcome]}
+      # nil where the provider was never asked — switched off between the
+      # registry read and the call, or missing its credentials.
+      {all ++ candidates, outcomes ++ List.wrap(outcome)}
     end)
   end
 
@@ -1807,7 +1811,7 @@ defmodule Ambry.Inbox.AutoMatch do
           "Auto-match: #{entry.id} failed for #{inspect(to_string(query))}: #{inspect(reason)}"
         end)
 
-        {[], Outcome.failed(entry, reason)}
+        {[], Outcome.from_error(entry, reason)}
     end
   end
 

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -157,6 +157,64 @@ defmodule Ambry.Inbox.Draft do
     do: credit.person_keys |> Enum.map(&person(draft, &1)) |> Enum.reject(&is_nil/1)
 
   @doc """
+  The humans this import will create, grouped by the credit that introduces
+  them.
+
+  ## Why people are a section and not a decoration on a credit
+
+  The model already says people are a level: `PersonDecision` is keyed, one
+  human is one record, and `appearances/1` exists to answer which credits
+  reference them. The form said otherwise — it rendered a person *inside* each
+  credit that named them, so an author who reads their own book appeared
+  twice, and the row had to print "Same person as the author. One X will be
+  created" to apologise for a duplication the model had deliberately deleted.
+
+  A person is therefore listed once, under the first credit that names them,
+  and the credits carry a reference instead. Grouping by credit is what keeps
+  a composite pen name's people adjacent: "James S.A. Corey" is one credit
+  standing for two humans, and any other ordering scatters the pair.
+
+  **Only people this import will create.** Someone already in the library was
+  chosen in the credit's typeahead, carries curation an import may never
+  overwrite, and has nothing left to decide — and the one dangerous case, a
+  name matching two existing identities, is a decision on the credit where
+  `Credit.state/1` computes it.
+
+  Returns `[%{credit:, kind:, section:, index:, people: [...]}]`, dropping
+  credits that introduce nobody new.
+  """
+  def people_groups(nil), do: []
+
+  def people_groups(%__MODULE__{} = draft) do
+    {groups, _seen} =
+      Enum.reduce(credits(draft), {[], MapSet.new()}, fn {kind, section, index, credit},
+                                                         {groups, seen} ->
+        people = new_people(draft, credit, seen)
+
+        if people == [] do
+          {groups, seen}
+        else
+          group = %{credit: credit, kind: kind, section: section, index: index, people: people}
+          {groups ++ [group], MapSet.union(seen, MapSet.new(people, & &1.key))}
+        end
+      end)
+
+    groups
+  end
+
+  # A removed credit holds its person keys for a possible restore, but a
+  # person only a tombstone references is nobody's decision — the same rule
+  # `referenced_keys/1` follows.
+  defp new_people(_draft, %Credit{removed: true}, _seen), do: []
+  defp new_people(_draft, %Credit{mode: :link}, _seen), do: []
+
+  defp new_people(draft, %Credit{} = credit, seen) do
+    credit.person_keys
+    |> Enum.map(&person(draft, &1))
+    |> Enum.reject(&(is_nil(&1) or &1.mode == :link or MapSet.member?(seen, &1.key)))
+  end
+
+  @doc """
   Which credits reference each person, so the form can say where they appear.
 
   Returns `%{key => [%{kind:, section:, index:, name:}]}`. This is display

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -174,11 +174,18 @@ defmodule Ambry.Inbox.Draft do
   a composite pen name's people adjacent: "James S.A. Corey" is one credit
   standing for two humans, and any other ordering scatters the pair.
 
-  **Only people this import will create.** Someone already in the library was
-  chosen in the credit's typeahead, carries curation an import may never
-  overwrite, and has nothing left to decide — and the one dangerous case, a
-  name matching two existing identities, is a decision on the credit where
-  `Credit.state/1` computes it.
+  **Only people this import introduces.** A credit pointing at an identity the
+  library already has brings no humans with it: that person was chosen in the
+  credit's typeahead, carries curation an import may never overwrite, and has
+  nothing left to decide — and the one dangerous case, a name matching two
+  existing identities, is a decision on the credit where `Credit.state/1`
+  computes it.
+
+  A person the operator matched to somebody already in the library *from their
+  card* is a different thing and stays listed. Nothing else proposes that link
+  — the seeder never does — so dropping them the moment it is made took the
+  decision off the form and the way back with it, leaving the credit's chip
+  pointing at a card that no longer existed.
 
   Returns `[%{credit:, kind:, section:, index:, people: [...]}]`, dropping
   credits that introduce nobody new.
@@ -211,7 +218,7 @@ defmodule Ambry.Inbox.Draft do
   defp new_people(draft, %Credit{} = credit, seen) do
     credit.person_keys
     |> Enum.map(&person(draft, &1))
-    |> Enum.reject(&(is_nil(&1) or &1.mode == :link or MapSet.member?(seen, &1.key)))
+    |> Enum.reject(&(is_nil(&1) or MapSet.member?(seen, &1.key)))
   end
 
   @doc """

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -207,39 +207,6 @@ defmodule Ambry.Inbox.Draft do
   end
 
   @doc """
-  How settled a level's identity question is, as one badge-sized fact.
-
-  This replaces showing the match confidence forever: confidence is how sure
-  the *machine* was at match time, and it never moved again — an operator
-  could pick the right work and the badge still said "unsure", with no way
-  to say "you were right". But they do say it: ticking records, linking a
-  book, settling uncatalogued all clear the level's doubt. The badge now
-  listens to the same signals as the rest of the form.
-
-    * `:confirmed` — a human answered (ticked records, answered identity)
-    * `:trusted` — the machine believed its match and nobody has had to touch it
-    * `:unsure` — doubt outstanding; the doubt banner carries the numbers
-    * `:no_match` — nothing was found (which is an answer, not a failure)
-  """
-  def level_state(%Work{} = work) do
-    cond do
-      work.curated or work.evidence_curated -> :confirmed
-      work.doubt == :nothing_found -> :no_match
-      work.doubt in [nil, :none] -> :trusted
-      true -> :unsure
-    end
-  end
-
-  def level_state(%Recording{} = recording) do
-    cond do
-      recording.evidence_curated -> :confirmed
-      recording.doubt == :nothing_found -> :no_match
-      recording.doubt in [nil, :none] -> :trusted
-      true -> :unsure
-    end
-  end
-
-  @doc """
   Whether a human has answered anything in this draft yet.
 
   What tells "matched but untouched" from "the operator has been working on

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -206,6 +206,14 @@ defmodule Ambry.Inbox.Draft.Edit do
     |> reseed(item, :recording)
   end
 
+  def uncatalogued(draft, %InboxItem{} = item, :work) do
+    draft
+    |> update_in([Access.key(:work)], fn work ->
+      %{work | sources: [], evidence_curated: true, doubt: :none, doubt_detail: nil}
+    end)
+    |> reseed(item, :work)
+  end
+
   # Ticking a record answers the question the level was asking, and a doubt
   # the operator has now overruled stops being a doubt.
   defp settle(decision, :recording),

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -108,6 +108,13 @@ defmodule Ambry.Inbox.Draft.Edit do
   or typed surviving, as always — which is also how a differently-spelled
   record of the right human gets to contribute a face the gate couldn't
   auto-admit.
+
+  **Touching the evidence answers the level**, exactly as it does for a
+  recording. A person the matcher doubted (it found humans of roughly that
+  name and believed none of them) is seeded unapproved, and until this the
+  only thing in the whole form that could approve one was linking them to
+  somebody already in the library — so 96 of the operator's 344 queued items
+  held a person no control could settle.
   """
   def toggle_person_source(draft, %InboxItem{} = item, key, record) do
     matched = get_in(item.matches, ["people", key])
@@ -121,20 +128,70 @@ defmodule Ambry.Inbox.Draft.Edit do
         end
 
       Seed.rederive_person_evidence(
-        %{person | sources: sources, curated: true, evidence_curated: true},
+        %{
+          person
+          | sources: sources,
+            curated: true,
+            evidence_curated: true,
+            approved: true,
+            doubt: :none,
+            doubt_detail: nil
+        },
         matched
       )
     end)
   end
 
   @doc """
-  Settles the recording as one no catalogue lists, described by the file alone.
+  Settles a person as one no database has a record of.
+
+  The person level's "None of these", and it needed one for the same reason
+  the other two levels do: a doubted level stays outstanding until somebody
+  says otherwise. The difference is only in what it costs — a human nobody
+  has a record of is *still perfectly importable*, since a name is all a
+  Person needs, so this settles the level and leaves them with no photo and
+  no biography rather than blocking anything.
+  """
+  def uncatalogued_person(draft, %InboxItem{} = item, key) do
+    matched = get_in(item.matches, ["people", key])
+
+    update_person(draft, key, fn person ->
+      Seed.rederive_person_evidence(
+        %{
+          person
+          | sources: [],
+            curated: true,
+            evidence_curated: true,
+            approved: true,
+            doubt: :none,
+            doubt_detail: nil
+        },
+        matched
+      )
+    end)
+  end
+
+  @doc """
+  Settles a level as one no catalogue lists, described by the file alone.
 
   A real answer rather than a failure: a delisted edition disappears from
   Audible's search *and* from direct ASIN lookup, so plenty of perfectly good
   rips are in no storefront at all.
+
+  **Both levels need it, and only the recording had it.** A doubted work
+  leaves "Provider records" outstanding until a record is ticked, and
+  answering the *identity* question ("no, a new book") doesn't touch it — so
+  an operator who believed none of the records had one way out: tick one they
+  didn't believe. Measured on the operator's own queue, 22 of the pending
+  items were in exactly that state.
+
+  The recording's `approved` is set because at that level it means "the
+  evidence question is answered"; the work's means "is this a book you
+  already have", which is a different question this must not answer.
   """
-  def uncatalogued(draft, %InboxItem{} = item) do
+  def uncatalogued(draft, item, level \\ :recording)
+
+  def uncatalogued(draft, %InboxItem{} = item, :recording) do
     draft
     |> update_in([Access.key(:recording)], fn recording ->
       %{
@@ -290,18 +347,21 @@ defmodule Ambry.Inbox.Draft.Edit do
   defp mint_keys(credit, _name), do: credit.person_keys
 
   # A person still called what the credit called them is still tracking it, so
-  # they follow the rename. One the operator has already named is theirs and
-  # is left alone — which is what makes the pen-name case two ordinary edits
-  # rather than a special mode: rename the credit, reveal the pen name, rename
-  # the person.
+  # they follow the rename. One whose name is their own is left alone — which
+  # is what makes the pen-name case two ordinary edits rather than a special
+  # mode: rename the credit, say it's a pen name, rename the person. The
+  # `own_name` flag is checked as well as the names, because the two agree for
+  # exactly as long as it takes to type the real one, and fixing the credit's
+  # spelling in that window must not drag the human's name along.
   defp follow_credit_name(draft, nil, _name), do: draft
 
   defp follow_credit_name(draft, %Credit{} = was, name) do
     Enum.reduce(was.person_keys, draft, fn key, draft ->
       update_person(draft, key, fn person ->
-        if person.mode == :create and tracking?(Field.value(person.name), was.name),
-          do: %{person | name: Field.edit(person.name, name)},
-          else: person
+        if person.mode == :create and not person.own_name and
+             tracking?(Field.value(person.name), was.name),
+           do: %{person | name: Field.edit(person.name, name)},
+           else: person
       end)
     end)
   end
@@ -359,9 +419,10 @@ defmodule Ambry.Inbox.Draft.Edit do
   A credit and a human are two different questions and the form used to ask
   them in one control: the credited name doubled as the person's name, so
   "David Wong" could only ever be imported as a person called David Wong when
-  the human is Jason Pargin. Separating them un-approves the person's name —
-  it is now a decision nobody has answered — which puts their card in front of
-  the operator instead of leaving a wrong name settled.
+  the human is Jason Pargin. Separating them gives the person a name of their
+  own — which is what puts a name box on their card, the thing this control
+  does that can be seen — and un-approves it, because it is now a decision
+  nobody has answered.
 
   Marking the credit curated is what stops a background re-match folding the
   two back together.
@@ -371,9 +432,46 @@ defmodule Ambry.Inbox.Draft.Edit do
     |> update_credit(section, index, &%{&1 | curated: true})
     |> then(fn draft ->
       case Enum.at(credit_at(draft, section, index).person_keys, 0) do
-        nil -> draft
-        key -> update_person(draft, key, &%{&1 | curated: true, name: unapprove(&1.name)})
+        nil ->
+          draft
+
+        key ->
+          update_person(
+            draft,
+            key,
+            &%{&1 | own_name: true, curated: true, name: unapprove(&1.name)}
+          )
       end
+    end)
+  end
+
+  @doc """
+  Takes it back: the credited name is this human's name after all.
+
+  Every way in needs a way out, and a name box the operator can only ever
+  *reveal* is the fold that could never be folded again in a different
+  costume. Putting the credited name back is the whole of it — the box goes,
+  and the name resumes following the credit.
+  """
+  def use_credited_name(draft, key) do
+    name = crediting_name(draft, key)
+
+    update_person(draft, key, fn person ->
+      %{
+        person
+        | own_name: false,
+          curated: true,
+          name: if(name, do: Field.edit(person.name, name), else: person.name)
+      }
+    end)
+  end
+
+  # What the credit that introduces this human calls them. The credits are the
+  # only thing that knows: a key is a normalised string, minted once and then
+  # left alone through every later rename.
+  defp crediting_name(draft, key) do
+    Enum.find_value(credits_in(draft, :work) ++ credits_in(draft, :recording), fn credit ->
+      if not credit.removed and key in credit.person_keys, do: credit.name
     end)
   end
 

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -782,17 +782,6 @@ defmodule Ambry.Inbox.Draft.Edit do
   This is the missing single click. It changes no sources — it only records
   that a human looked.
   """
-  def confirm_level(draft, :work) do
-    update_in(draft.work, &%{&1 | evidence_curated: true, doubt: :none, doubt_detail: nil})
-  end
-
-  def confirm_level(draft, :recording) do
-    update_in(
-      draft.recording,
-      &%{&1 | approved: true, evidence_curated: true, doubt: :none, doubt_detail: nil}
-    )
-  end
-
   def approve_work(draft, approved?), do: update_in(draft.work.approved, fn _ -> approved? end)
 
   def approve_recording(draft, approved?),

--- a/lib/ambry/inbox/draft/edit.ex
+++ b/lib/ambry/inbox/draft/edit.ex
@@ -354,6 +354,35 @@ defmodule Ambry.Inbox.Draft.Edit do
   end
 
   @doc """
+  Says that the credited name is not the person's name.
+
+  A credit and a human are two different questions and the form used to ask
+  them in one control: the credited name doubled as the person's name, so
+  "David Wong" could only ever be imported as a person called David Wong when
+  the human is Jason Pargin. Separating them un-approves the person's name —
+  it is now a decision nobody has answered — which puts their card in front of
+  the operator instead of leaving a wrong name settled.
+
+  Marking the credit curated is what stops a background re-match folding the
+  two back together.
+  """
+  def separate_person_name(draft, section, index) do
+    draft
+    |> update_credit(section, index, &%{&1 | curated: true})
+    |> then(fn draft ->
+      case Enum.at(credit_at(draft, section, index).person_keys, 0) do
+        nil -> draft
+        key -> update_person(draft, key, &%{&1 | curated: true, name: unapprove(&1.name)})
+      end
+    end)
+  end
+
+  defp credit_at(draft, :work, index), do: Enum.at(draft.work.authors, index)
+  defp credit_at(draft, :recording, index), do: Enum.at(draft.recording.narrators, index)
+
+  defp unapprove(%Field{} = field), do: %{field | approved: false}
+
+  @doc """
   Adds another human behind a credit.
 
   Two or more is a shared pen name — the whole of the composite-author case,

--- a/lib/ambry/inbox/draft/group_link.ex
+++ b/lib/ambry/inbox/draft/group_link.ex
@@ -134,10 +134,17 @@ defmodule Ambry.Inbox.Draft.GroupLink do
 
   def resolved?(%__MODULE__{}), do: false
 
+  @doc """
+  Why it isn't resolved.
+
+  `:unnumbered` rather than `:missing`, the same distinction the series row
+  draws: a set a provider named and gave no part number to is not a set
+  nobody proposed, and saying so beside "from hardcover" contradicts itself.
+  """
   def state(%__MODULE__{} = link) do
     cond do
       resolved?(link) -> :approved
-      is_nil(link.part_number) -> :missing
+      is_nil(link.part_number) -> :unnumbered
       true -> :unconfirmed
     end
   end

--- a/lib/ambry/inbox/draft/person_decision.ex
+++ b/lib/ambry/inbox/draft/person_decision.ex
@@ -61,6 +61,18 @@ defmodule Ambry.Inbox.Draft.PersonDecision do
 
     field :approved, :boolean, default: false
 
+    # Whether this human's name is theirs rather than the credit's. Almost
+    # never: "David Wong" is Jason Pargin and "James S.A. Corey" is two people,
+    # but the other ninety-nine imports in a hundred credit a human by their
+    # name and have nothing to type. So the card carries a name box only when
+    # this is set, and "This is a pen name" is what sets it — the control's
+    # whole visible effect, which is what it was missing.
+    #
+    # A flag rather than "the names differ", because it is set at the moment
+    # they still agree: the operator says the credited name is a pseudonym
+    # first and types the real one second.
+    field :own_name, :boolean, default: false
+
     # Set the moment the operator touches this person, so re-deriving from a
     # changed record set never discards a photo they went and found.
     field :curated, :boolean, default: false
@@ -94,6 +106,7 @@ defmodule Ambry.Inbox.Draft.PersonDecision do
       :mode,
       :person_id,
       :approved,
+      :own_name,
       :curated,
       :evidence_curated,
       :doubt,
@@ -150,6 +163,17 @@ defmodule Ambry.Inbox.Draft.PersonDecision do
   case that needs naming and "Person: " with nothing after it names nothing.
   """
   def label(%__MODULE__{} = person), do: Field.value(person.name) || person.key
+
+  @doc """
+  Whether the operator has said no record here describes this human.
+
+  The same reading as the other two levels: they touched the evidence and
+  left nothing ticked. A person in no database at all is a normal outcome —
+  a name is all it takes to create one — so this settles the level rather
+  than blocking it.
+  """
+  def uncatalogued?(%__MODULE__{sources: [], evidence_curated: true}), do: true
+  def uncatalogued?(%__MODULE__{}), do: false
 
   @doc """
   Whether the operator has said this provider record describes this human.

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -147,9 +147,7 @@ defmodule Ambry.Inbox.Draft.Recording do
   defp identity(%__MODULE__{approved: true}), do: []
 
   defp identity(%__MODULE__{}),
-    do: [
-      %{section: :recording, label: "Which records describe this recording", state: :unconfirmed}
-    ]
+    do: [%{section: :recording, label: "Audiobook records", state: :unconfirmed}]
 
   @doc """
   Whether the operator has said this provider record describes the recording.

--- a/lib/ambry/inbox/draft/series_link.ex
+++ b/lib/ambry/inbox/draft/series_link.ex
@@ -129,10 +129,19 @@ defmodule Ambry.Inbox.Draft.SeriesLink do
 
   def resolved?(%__MODULE__{}), do: false
 
+  @doc """
+  Why it isn't resolved.
+
+  A membership with no number is `:unnumbered`, not `:missing`. Both block the
+  import, but they are different facts and the badge said the wrong one: a
+  series a provider named and gave no number to rendered "nothing proposed
+  it" beside "from rreading-glasses", which is two contradictory sentences
+  about one row. What is missing is the number, and the row says so.
+  """
   def state(%__MODULE__{} = link) do
     cond do
       resolved?(link) -> :approved
-      is_nil(link.number) -> :missing
+      is_nil(link.number) -> :unnumbered
       true -> :unconfirmed
     end
   end

--- a/lib/ambry/inbox/draft/tier.ex
+++ b/lib/ambry/inbox/draft/tier.ex
@@ -116,6 +116,11 @@ defmodule Ambry.Inbox.Draft.Tier do
   defp from(:approved, true), do: :reviewed
   defp from(:approved, _untouched), do: :unreviewed
   defp from(:missing, _curated), do: :blocked
+
+  # A membership the operator has to number is as blocked as a field nobody
+  # proposed a value for: `books_series.book_number` is a required column, so
+  # there is nothing to import until it is answered.
+  defp from(:unnumbered, _curated), do: :blocked
   defp from(_unsettled, _curated), do: :waiting
 
   @doc """

--- a/lib/ambry/inbox/draft/tier.ex
+++ b/lib/ambry/inbox/draft/tier.ex
@@ -1,0 +1,148 @@
+defmodule Ambry.Inbox.Draft.Tier do
+  @moduledoc """
+  How settled one decision is, in the four words the whole form speaks.
+
+  ## Why four and not two
+
+  Settled-versus-waiting answered "can this be imported" and threw away the
+  more useful question, which is **did a human ever look at this**. The form
+  had two vocabularies for the remaining nuance — per-decision ("settled",
+  "needs confirming") and per-level ("confirmed", "trusted", "unsure") — plus
+  a Confirm button that, in every state where it was visible, changed nothing
+  but its own badge, because everything it set was already set.
+
+  One vocabulary replaces all of it:
+
+    * `:blocked` — nothing proposed a value and none can be chosen; the
+      operator has to supply one or the import is refused
+    * `:waiting` — the machine couldn't settle it; look here
+    * `:unreviewed` — the machine settled it and nobody has looked
+    * `:reviewed` — a human has been here
+
+  A freshly matched import is therefore entirely `:unreviewed`, and
+  `:reviewed` accumulates as the operator works through it. **`:unreviewed` is
+  a legitimate end state**: the goal of an import is no `:waiting` and no
+  `:blocked`, never "all reviewed", or every import becomes a chore of
+  re-picking values that were already right.
+
+  ## Reviewed is one-way
+
+  It records that a human looked, which is a fact about history — a control
+  that took it back to `:unreviewed` would assert something false. What always
+  exists instead is a way back to the machine's *value*; taking it leaves the
+  decision `:reviewed`, because the operator looked and decided the machine
+  was right, which is exactly the distinction the tier buys.
+
+  It also has teeth beyond the rail: `Draft.curated?/1` reads the same flags,
+  and a curated draft is re-derived around the operator's answers rather than
+  rebuilt when a retrying provider finally comes back.
+  """
+
+  alias Ambry.Inbox.Draft.Chapters
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Destination
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.GroupLink
+  alias Ambry.Inbox.Draft.PersonDecision
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.Work
+
+  @typedoc "Worst to best, which is also the order `worst/1` ranks them in."
+  @type t :: :blocked | :waiting | :unreviewed | :reviewed
+
+  # Best first. `worst/1` takes the last one it finds.
+  @order [:reviewed, :unreviewed, :waiting, :blocked]
+
+  @doc """
+  The tier of one decision.
+
+  Every decision type already answers `state/1` with the same four words, so
+  this is the same shape everywhere: what the machine managed, crossed with
+  whether a human has since touched it.
+  """
+  def of(%Field{} = field), do: from(Field.state(field), field.curated)
+  def of(%Credit{} = credit), do: from(Credit.state(credit), credit.curated)
+  def of(%SeriesLink{} = link), do: from(SeriesLink.state(link), link.curated)
+  def of(%GroupLink{} = link), do: from(GroupLink.state(link), link.curated)
+  def of(%PersonDecision{} = person), do: from(PersonDecision.state(person), curated?(person))
+
+  # Chapters answer `resolved?/1` rather than `state/1`: a list of markers
+  # read off the files is never *missing*, only unapproved.
+  def of(%Chapters{} = chapters),
+    do:
+      from(if(Chapters.resolved?(chapters), do: :approved, else: :unconfirmed), chapters.curated)
+
+  # A level asks two questions and shows them on two cards, so each card gets
+  # its own tier and the level itself is the worse of them. Collapsing both
+  # into one number made the cards identical, which tells the operator
+  # something needs them without saying which.
+  def of(%Work{} = work), do: worst([of_evidence(work), of_identity(work)])
+  def of(%Recording{} = recording), do: of_evidence(recording)
+
+  # The destination has no `curated` flag of its own — choosing a root is the
+  # only way it is ever approved, so approved *is* the operator's answer.
+  def of(%Destination{approved: true}), do: :reviewed
+  def of(%Destination{}), do: :waiting
+
+  @doc """
+  Which provider records describe this thing — the records card's own tier.
+
+  `doubt` is the machine explaining itself, which the doubt banner renders;
+  here it is simply the reason the level isn't settled.
+  """
+  def of_evidence(%Work{} = work),
+    do: from(level_state(work.approved, work.doubt), work.evidence_curated)
+
+  def of_evidence(%Recording{} = recording),
+    do: from(level_state(recording.approved, recording.doubt), recording.evidence_curated)
+
+  @doc """
+  Whether this is a book the library already has — the identity card's tier.
+
+  Only the work level asks it: a recording is always created, never linked.
+  """
+  def of_identity(%Work{} = work),
+    do: from(if(work.approved, do: :approved, else: :unconfirmed), work.curated)
+
+  # A level that found nothing is settled: there is nothing to choose
+  # between, and the seeder approves it. A doubted one is not.
+  defp level_state(_approved, :low_confidence), do: :unconfirmed
+  defp level_state(true, _doubt), do: :approved
+  defp level_state(_unapproved, _doubt), do: :unconfirmed
+
+  defp curated?(%{curated: curated, evidence_curated: evidence}), do: curated or evidence
+
+  defp from(:approved, true), do: :reviewed
+  defp from(:approved, _untouched), do: :unreviewed
+  defp from(:missing, _curated), do: :blocked
+  defp from(_unsettled, _curated), do: :waiting
+
+  @doc """
+  The tier a card wears on behalf of its children.
+
+  Worst-first, and `:reviewed` only when *every* child is: a card claiming
+  the operator has been through it while one field inside still waits is the
+  aggregate lying. Scanning stays honest — look for `:blocked` and `:waiting`,
+  then decide whether you care about `:unreviewed`.
+
+  An empty list is `:unreviewed`: "Not in a series" is something the machine
+  worked out and nobody has confirmed, not something a human decided.
+  """
+  def worst([]), do: :unreviewed
+
+  def worst(tiers) when is_list(tiers),
+    do: Enum.max_by(tiers, &Enum.find_index(@order, fn tier -> tier == &1 end))
+
+  @doc """
+  The tiers of a list of decisions, collapsed to the one its card wears.
+  """
+  def of_all(decisions), do: decisions |> Enum.map(&of/1) |> worst()
+
+  @doc """
+  Whether this tier still wants the operator.
+
+  What the footer counts and what "no amber, no red" means in code.
+  """
+  def outstanding?(tier), do: tier in [:blocked, :waiting]
+end

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -147,6 +147,17 @@ defmodule Ambry.Inbox.Draft.Work do
   defp state_of(%SeriesLink{} = link), do: SeriesLink.state(link)
 
   @doc """
+  Whether the operator has said no record here describes this book.
+
+  The work level's mirror of `Recording.uncatalogued?/1`, and read the same
+  way: they touched the evidence and left nothing ticked, which is an answer.
+  Reading it off `sources == []` alone would claim the answer had been given
+  on every freshly matched item that happened to find nothing.
+  """
+  def uncatalogued?(%__MODULE__{sources: [], evidence_curated: true}), do: true
+  def uncatalogued?(%__MODULE__{}), do: false
+
+  @doc """
   Whether the operator has said this provider record describes the book.
   """
   def uses?(%__MODULE__{sources: sources}, record),

--- a/lib/ambry/inbox/draft/work.ex
+++ b/lib/ambry/inbox/draft/work.ex
@@ -119,7 +119,7 @@ defmodule Ambry.Inbox.Draft.Work do
   # tag-derived. Saying so is what stops "the provider found nothing" and "the
   # provider found something we don't believe" looking identical.
   defp doubted(%__MODULE__{doubt: :low_confidence}),
-    do: [%{section: :work, label: "Which records describe this book", state: :unconfirmed}]
+    do: [%{section: :work, label: "Book records", state: :unconfirmed}]
 
   defp doubted(%__MODULE__{}), do: []
 

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -13,6 +13,7 @@ defmodule Ambry.Inbox.InboxItem do
   import Ecto.Changeset
 
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.ReleaseName
   alias Ambry.Library.Source
   alias Ambry.Media.Media
 
@@ -82,6 +83,16 @@ defmodule Ambry.Inbox.InboxItem do
   @doc """
   A short label for the item: the folder or file name, which is usually the
   release name and the most recognizable thing about it.
+
+  The exception is a name that states nothing but a position in a set: an item split out of "The Way of Kings/1 of 5" is called "1 of 5",
+  which in a queue of five siblings and 300 other releases says nothing at
+  all. Those carry the folder they are a part of.
   """
-  def name(%__MODULE__{path: path}), do: Path.basename(path)
+  def name(%__MODULE__{path: path}) do
+    base = Path.basename(path)
+
+    if ReleaseName.part_folder?(base),
+      do: Path.join(Path.basename(Path.dirname(path)), base),
+      else: base
+  end
 end

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -147,7 +147,7 @@ defmodule Ambry.Inbox.Lookup do
 
     item
     |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
-    |> update_outcomes(level, [outcome])
+    |> update_outcomes(level, List.wrap(outcome), clear: Outcome.id(entry.id, :search))
   end
 
   # Every record of this provider's that matching meant to hydrate, not just
@@ -173,7 +173,9 @@ defmodule Ambry.Inbox.Lookup do
 
     item
     |> update_records(level, fn _existing -> records end)
-    |> update_outcomes(level, AutoMatch.tally_outcomes(outcomes))
+    |> update_outcomes(level, AutoMatch.tally_outcomes(outcomes),
+      clear: Outcome.id(entry.id, :details)
+    )
   end
 
   # Editions hang off the work records, whatever level the chip was rendered
@@ -192,7 +194,7 @@ defmodule Ambry.Inbox.Lookup do
 
     item
     |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
-    |> update_outcomes(level, outcomes)
+    |> update_outcomes(level, outcomes, clear: Outcome.id(entry.id, :editions))
   end
 
   defp retry(item, _level, _entry, _kind), do: {:ok, item}
@@ -326,17 +328,27 @@ defmodule Ambry.Inbox.Lookup do
     |> Repo.update()
   end
 
-  defp update_outcomes({:ok, item}, level, outcomes), do: update_outcomes(item, level, outcomes)
-  defp update_outcomes({:error, _reason} = error, _level, _outcomes), do: error
+  defp update_outcomes(item_or_result, level, outcomes, opts \\ [])
 
-  defp update_outcomes(%InboxItem{} = item, level, outcomes) do
+  defp update_outcomes({:ok, item}, level, outcomes, opts),
+    do: update_outcomes(item, level, outcomes, opts)
+
+  defp update_outcomes({:error, _reason} = error, _level, _outcomes, _opts), do: error
+
+  defp update_outcomes(%InboxItem{} = item, level, outcomes, opts) do
     matches = item.matches || %{}
     level_map = Map.get(matches, level, %{})
     existing = Map.get(level_map, "providers", []) || []
 
     # An outcome replaces the earlier one for the same provider: "couldn't be
     # reached" must stop saying that once it has been reached.
-    fresh = MapSet.new(outcomes, & &1["id"])
+    #
+    # `:clear` is what the retry chip needs on top of that. A retry that comes
+    # back with **nothing to report** — the provider turned out to implement
+    # no such call — would otherwise leave the failure it was retrying
+    # standing, which is a red chip that can be clicked forever and never
+    # goes away. Retrying an id is an answer about that id either way.
+    fresh = outcomes |> MapSet.new(& &1["id"]) |> maybe_clear(opts[:clear])
     kept = Enum.reject(existing, &MapSet.member?(fresh, &1["id"]))
 
     updated = Map.put(level_map, "providers", kept ++ outcomes)
@@ -345,6 +357,9 @@ defmodule Ambry.Inbox.Lookup do
     |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
     |> Repo.update()
   end
+
+  defp maybe_clear(ids, nil), do: ids
+  defp maybe_clear(ids, id), do: MapSet.put(ids, id)
 
   defp remember_query({:ok, item}, level, query), do: remember_query(item, level, query)
   defp remember_query({:error, _reason} = error, _level, _query), do: error

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -208,7 +208,14 @@ defmodule Ambry.Inbox.Lookup do
   Writes into `matches["people"][key]` exactly as matching does, so the
   person's photo and bio fields pick the results up on the next reseed. The
   same rule as everywhere else here: **evidence is added, never replaced**, so
-  a re-search cannot un-choose a photo the operator already picked.
+  a re-search cannot un-choose a photo the operator already picked. What
+  changes is the *ranking*: every candidate is re-scored against the name now
+  being asked about, so the ones the old name found sink instead of sitting at
+  100% beside the new ones.
+
+  The library is asked again too. "Already in your library" is an answer about
+  a name, and after a rename the held one is about somebody else — which is
+  the case this exists for.
   """
   def research_person(%InboxItem{} = item, key, name) do
     case String.trim(name || "") do
@@ -240,6 +247,7 @@ defmodule Ambry.Inbox.Lookup do
           name
         )
       )
+      |> Map.put("local", AutoMatch.local_people(name))
       |> Map.put("providers", outcomes)
 
     item

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -25,6 +25,7 @@ defmodule Ambry.Inbox.Lookup do
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Metadata.Outcome
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Registry
   alias Ambry.Metadata.Search
@@ -40,13 +41,23 @@ defmodule Ambry.Inbox.Lookup do
   the same work with seventeen.
   """
   def hydrate(%InboxItem{} = item, level, record_ref) do
-    update_records(item, level, fn records ->
-      Enum.map(records, fn record ->
-        if AutoMatch.ref(record) == record_ref and !record["hydrated"],
-          do: AutoMatch.details(record),
-          else: record
+    {records, failures} =
+      item
+      |> records(level)
+      |> Enum.map_reduce([], fn record, failures ->
+        if AutoMatch.ref(record) == record_ref and !record["hydrated"] do
+          case AutoMatch.details_with_outcome(record) do
+            {record, nil} -> {record, failures}
+            {record, outcome} -> {record, failures ++ [outcome]}
+          end
+        else
+          {record, failures}
+        end
       end)
-    end)
+
+    item
+    |> update_records(level, fn _existing -> records end)
+    |> update_outcomes(level, failures)
   end
 
   @doc """
@@ -109,24 +120,82 @@ defmodule Ambry.Inbox.Lookup do
   Without this, a 429 during a scan costs an item that provider's records
   until somebody re-runs the whole match. The "couldn't be reached" chip is
   the retry button.
+
+  **The chip carries what kind of call failed, and this has to honour it.**
+  A provider is asked three different things about one item — a search, the
+  details behind its hits, the editions of the work it named — and they fail
+  independently. Re-running the search when what failed was a details call
+  would report success having fixed nothing, which is how the `:editions`
+  chip came to be a button that did nothing at all: its id
+  (`hardcover:editions`) is not a registry id, so the lookup missed, and the
+  clause below returned the item untouched without a word.
   """
-  def retry_provider(%InboxItem{} = item, level, provider_id) do
-    hints = AutoMatch.hints(item)
-    query = stored_query(item, level) || query_from(%{})
+  def retry_provider(%InboxItem{} = item, level, outcome_id) do
+    {provider_id, kind} = Outcome.split(outcome_id)
 
     case Registry.fetch(provider_id) do
-      {:ok, entry} ->
-        {books, outcome} = Search.books_one(entry, query)
-        found = AutoMatch.records_from(books, entry, hints)
-
-        item
-        |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
-        |> update_outcomes(level, [outcome])
-
-      {:error, _reason} ->
-        {:ok, item}
+      {:ok, entry} -> retry(item, level, entry, kind)
+      {:error, reason} -> {:error, reason}
     end
   end
+
+  defp retry(item, level, entry, :search) do
+    hints = AutoMatch.hints(item)
+    query = stored_query(item, level) || query_from(%{})
+    {books, outcome} = Search.books_one(entry, query)
+    found = AutoMatch.records_from(books, entry, hints)
+
+    item
+    |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
+    |> update_outcomes(level, [outcome])
+  end
+
+  # Every record of this provider's that matching meant to hydrate, not just
+  # one: they all feed the field candidates, so a retry that fixed the top
+  # record and left its siblings thin would clear the chip while the evidence
+  # it was warning about was still missing.
+  defp retry(item, level, entry, :details) do
+    source = "provider:#{entry.id}"
+
+    {records, outcomes} =
+      item
+      |> records(level)
+      |> Enum.map_reduce([], fn record, outcomes ->
+        if record["source"] == source and !record["hydrated"] do
+          case AutoMatch.details_with_outcome(record, refresh: true) do
+            {record, nil} -> {record, outcomes}
+            {record, outcome} -> {record, outcomes ++ [outcome]}
+          end
+        else
+          {record, outcomes}
+        end
+      end)
+
+    item
+    |> update_records(level, fn _existing -> records end)
+    |> update_outcomes(level, AutoMatch.tally_outcomes(outcomes))
+  end
+
+  # Editions hang off the work records, whatever level the chip was rendered
+  # at — the recording level is where they land, and the work level is where
+  # they came from.
+  defp retry(item, level, entry, :editions) do
+    hints = AutoMatch.hints(item)
+
+    records =
+      item
+      |> records("work")
+      |> Enum.filter(&(&1["source"] == "provider:#{entry.id}"))
+      |> AutoMatch.top_group()
+
+    {found, outcomes} = AutoMatch.editions_for(records, hints, refresh: true)
+
+    item
+    |> update_records(level, &(&1 |> add(found) |> refine(item, level, hints)))
+    |> update_outcomes(level, outcomes)
+  end
+
+  defp retry(item, _level, _entry, _kind), do: {:ok, item}
 
   @doc """
   Asks every person-capable database about one human again.

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -217,20 +217,9 @@ defmodule Ambry.Inbox.Lookup do
 
       name ->
         {matches, outcomes} = Search.people(name)
-        update_person(item, key, name, Enum.map(matches, &person_record/1), outcomes)
+        found = Enum.map(matches, &AutoMatch.person_candidate(&1, name))
+        update_person(item, key, name, found, outcomes)
     end
-  end
-
-  defp person_record(match) do
-    %{
-      "source" => "provider:#{match.provider_id}",
-      "provider_name" => match.provider_name,
-      "id" => to_string(match.id),
-      "name" => match.name,
-      "description" => match.description,
-      "note" => match.note,
-      "images" => match.images
-    }
   end
 
   defp update_person(%InboxItem{} = item, key, name, found, outcomes) do
@@ -245,8 +234,11 @@ defmodule Ambry.Inbox.Lookup do
       |> Map.put("name", name)
       |> Map.put(
         "candidates",
-        (Map.get(held, "candidates", []) || []) ++
-          Enum.reject(found, &MapSet.member?(known, AutoMatch.ref(&1)))
+        AutoMatch.rank_people(
+          (Map.get(held, "candidates", []) || []) ++
+            Enum.reject(found, &MapSet.member?(known, AutoMatch.ref(&1))),
+          name
+        )
       )
       |> Map.put("providers", outcomes)
 

--- a/lib/ambry/inbox/progress.ex
+++ b/lib/ambry/inbox/progress.ex
@@ -35,11 +35,12 @@ defmodule Ambry.Inbox.Progress do
   import Ecto.Query
 
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.RunImport
   alias Ambry.Inbox.RunMatch
   alias Ambry.Inbox.RunProbe
   alias Ambry.Repo
 
-  @workers [RunProbe, RunMatch]
+  @workers [RunProbe, RunMatch, RunImport]
 
   @doc """
   Whether a background job currently owns this item.
@@ -56,7 +57,7 @@ defmodule Ambry.Inbox.Progress do
   provider finally comes back. Anything typed into it in the meantime would be
   thrown away by a job the operator couldn't see.
   """
-  def busy?(status), do: status in [:working, :queued, :retrying]
+  def busy?(status), do: status in [:working, :queued, :retrying, :importing]
 
   @doc """
   The status of each given item, as a map of item id to status.
@@ -65,6 +66,7 @@ defmodule Ambry.Inbox.Progress do
 
   Statuses:
 
+    * `:importing` — the item is being added to the library
     * `:working` — a job is executing right now
     * `:retrying` — a job failed and is waiting to try again
     * `:queued` — a job is waiting to run
@@ -86,8 +88,15 @@ defmodule Ambry.Inbox.Progress do
     status(item, Map.get(job_states([item.id]), item.id, []))
   end
 
-  defp status(%InboxItem{} = item, states) do
+  defp status(%InboxItem{} = item, jobs) do
+    states = Enum.map(jobs, &elem(&1, 1))
+
     cond do
+      # Named apart from every other job because it is the one the operator
+      # started themselves and the one that takes minutes — "Working on it"
+      # over a row they just pressed Add on says nothing about whether the
+      # press landed.
+      importing?(jobs) -> :importing
       "executing" in states -> :working
       "retryable" in states -> :retrying
       Enum.any?(states, &(&1 in ~w(available scheduled))) -> :queued
@@ -110,11 +119,22 @@ defmodule Ambry.Inbox.Progress do
     from(j in "oban_jobs",
       where: j.worker in ^Enum.map(@workers, &worker_name/1),
       where: fragment("?->>'inbox_item_id'", j.args) in ^ids,
-      select: {fragment("?->>'inbox_item_id'", j.args), j.state}
+      select: {fragment("?->>'inbox_item_id'", j.args), j.worker, j.state}
     )
     |> Repo.all()
-    |> Enum.group_by(fn {id, _state} -> String.to_integer(id) end, fn {_id, state} -> state end)
+    |> Enum.group_by(
+      fn {id, _worker, _state} -> String.to_integer(id) end,
+      fn {_id, worker, state} -> {worker, state} end
+    )
   end
 
   defp worker_name(module), do: module |> to_string() |> String.replace_prefix("Elixir.", "")
+
+  @importing_states ~w(available scheduled executing retryable)
+
+  defp importing?(jobs) do
+    Enum.any?(jobs, fn {worker, state} ->
+      worker == worker_name(RunImport) and state in @importing_states
+    end)
+  end
 end

--- a/lib/ambry/inbox/release_name.ex
+++ b/lib/ambry/inbox/release_name.ex
@@ -135,6 +135,24 @@ defmodule Ambry.Inbox.ReleaseName do
     end
   end
 
+  # Deliberately strict. "Disc 02" and "3 of 5" are parts; "Gwendy's Button
+  # Box 2" and "01 - The Restaurant at the End of the Universe" are their own
+  # books, and a looser pattern (anything ending in a number) would swallow
+  # them into one item.
+  @part_folder ~r/^(disc|cd|part|vol|volume)\s*\.?\s*\d+$|^\d+\s*of\s*\d+$|\((disc|cd|part)\s*\d+\)$/i
+
+  @doc """
+  Whether a folder name states nothing but a position in a set.
+
+  Discovery reads it to decide that a folder of such subfolders is one
+  release rather than several, and an item named after one reads it to say
+  which release it belongs to — "1 of 5" alone names nothing.
+  """
+  def part_folder?(name) when is_binary(name),
+    do: name |> String.trim() |> then(&Regex.match?(@part_folder, &1))
+
+  def part_folder?(_other), do: false
+
   @doc """
   The part-set position a name states, as `{number, total}`, or nil.
 

--- a/lib/ambry/inbox/run_import.ex
+++ b/lib/ambry/inbox/run_import.ex
@@ -1,0 +1,70 @@
+defmodule Ambry.Inbox.RunImport do
+  @moduledoc """
+  Adds one settled inbox item to the library.
+
+  ## Why this is a job and not a click
+
+  Importing is the longest thing the inbox does: every file is re-probed and
+  then every byte is placed. Measured on a 28-file release, that is seven
+  seconds of ffprobe plus a 131MB copy, and a copy off a NAS is slower still.
+
+  Run from the form it was held in an async task owned by the LiveView, which
+  meant the operator had to sit on the page and watch it — and worse, the task
+  **died with the LiveView**. Navigating away or closing the tab killed an
+  import mid-copy. The transaction protected the records, but nothing about
+  the arrangement was honest: a long, resumable-by-nobody operation hanging
+  off a browser tab.
+
+  As a job it belongs to the server. The operator presses the button and goes
+  back to the queue, where the row wears the same busy overlay every other
+  background job gives it — because `Ambry.Inbox.Progress` derives that
+  overlay from the job table, and this worker is simply one more entry there.
+
+  ## Failure is reported on the item, not by the job
+
+  `Inbox.import_item/1` already writes what went wrong onto the item's
+  `issue`, in the same sentence the form used to flash. So a refused import
+  returns `:ok` here rather than failing the job: a discarded job is deleted
+  by the pruner within a day, while the issue is still on the row tomorrow,
+  which is when somebody actually reads it. Only an unexpected crash is
+  allowed to discard, because that is the one case with nothing recorded
+  anywhere else.
+
+  `max_attempts: 1` for the same reason it is 1 on probe and discovery — the
+  refusals are decisions (a destination already occupied, a missing
+  publication date), and none of them fixes itself by being tried again.
+  """
+
+  use Oban.Worker,
+    queue: :media,
+    max_attempts: 1,
+    # The button is behind a busy overlay the moment the first job is
+    # enqueued, but a stale tab can still send the event twice. The row lock
+    # in `Importer` is what makes a double import safe; this is what stops it
+    # being attempted.
+    unique: [period: :infinity, states: Oban.Job.states() -- [:completed, :discarded, :cancelled]]
+
+  alias Ambry.Inbox
+
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"inbox_item_id" => id}}) do
+    case Inbox.fetch_item(id) do
+      {:ok, item} -> import_item(item)
+      # the operator deleted it while the job was queued
+      {:error, :not_found} -> :ok
+    end
+  end
+
+  defp import_item(item) do
+    case Inbox.import_item(item) do
+      {:ok, _media} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(fn -> "Inbox import: item #{item.id} refused: #{inspect(reason)}" end)
+        :ok
+    end
+  end
+end

--- a/lib/ambry/inbox/undo.ex
+++ b/lib/ambry/inbox/undo.ex
@@ -1,0 +1,272 @@
+defmodule Ambry.Inbox.Undo do
+  @moduledoc """
+  Puts an imported item back the way it was, for development only.
+
+  ## Why this exists at all
+
+  The import form is designed by running real releases through it, and the
+  interesting releases are the awkward ones — a pen name, a composite author,
+  a set of three parts. Each of those can only be imported once, so every
+  round of "that reads wrong, try again" cost a hand-written cleanup of a
+  Media, a Book, two identities and however many People, in the right order,
+  before the same release could be run again. The loop the whole staged form
+  exists to support was the one thing the system made expensive.
+
+  ## What it does, and what it deliberately won't
+
+  Undo deletes the records this import created and flips the item back to
+  pending with its draft intact, so the next run starts from the same
+  decisions rather than from a fresh match.
+
+  **Only what this import created.** The draft is the record of that: a
+  `:link` decision reused something that was already there and is never
+  touched, a `:create` decision made something new. Anything created here but
+  since referenced by another recording — a book with a second edition, a
+  narrator who has read something else — is kept, and named in the summary.
+  Nothing about undoing one import may damage another.
+
+  **Only when the source still exists.** Placement with a `move` policy is the
+  case that makes this dangerous: the library copy is the only copy, and
+  deleting it is not an undo, it is a loss. So the files the item was
+  discovered as are checked first, and a release whose source is gone is
+  refused with `:source_files_missing` rather than half-undone.
+
+  **Dev only.** Gated on `:allow_undo_import`, which dev and test config set
+  and no other config does, so on a production build every call returns
+  `{:error, :undo_unavailable}` — the button not rendering is the explanation,
+  this is the enforcement. `Ambry.Inbox.undo_available?/0` is what the admin
+  form asks before offering it.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Books
+  alias Ambry.Books.Book
+  alias Ambry.Books.Series
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.PersonDecision
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Media
+  alias Ambry.People
+  alias Ambry.People.Author
+  alias Ambry.People.Narrator
+  alias Ambry.People.Person
+  alias Ambry.Repo
+
+  @doc "Whether this build has the undo at all."
+  def available?, do: Application.get_env(:ambry, :allow_undo_import, false)
+
+  @doc """
+  Deletes what an import created and returns the item to the queue.
+
+  Returns `{:ok, summary}` where the summary says what went and what was kept,
+  which is the interesting half: "the book stayed, another recording uses it"
+  is the answer to a question the operator would otherwise ask by hand.
+  """
+  def undo_import(item, opts \\ [])
+
+  def undo_import(%InboxItem{status: status}, _opts) when status != :imported,
+    do: {:error, :not_imported}
+
+  def undo_import(%InboxItem{} = item, _opts) do
+    with :ok <- allowed(),
+         :ok <- source_intact(item) do
+      draft = item.draft
+      media = item.media_id && Repo.get(Media.Media, item.media_id)
+
+      # Records first, then the item: an item back in the queue while its
+      # media still exists is the one state that would let the operator
+      # import a second copy of what is already there.
+      summary =
+        %{deleted: [], kept: []}
+        |> drop_media(media)
+        |> drop_book(draft, media)
+        |> drop_series(draft)
+        |> drop_people(draft)
+        |> drop_identities(draft)
+
+      with {:ok, item} <- requeue(item) do
+        # Every other queued item that might have been about to reuse one of
+        # these records has to be re-derived, exactly as it was when the
+        # import created them.
+        Ambry.Inbox.refresh_siblings(item)
+
+        {:ok,
+         %{item: item, deleted: Enum.reverse(summary.deleted), kept: Enum.reverse(summary.kept)}}
+      end
+    end
+  end
+
+  defp allowed do
+    if available?(), do: :ok, else: {:error, :undo_unavailable}
+  end
+
+  # The check that makes this safe to offer. A `move` policy leaves the
+  # library copy as the only copy, and `Media.delete_media/1` deletes a
+  # managed recording's files — so without the source on disk, "undo" would
+  # delete the release.
+  defp source_intact(%InboxItem{files: []}), do: :ok
+
+  defp source_intact(%InboxItem{files: files}) do
+    if Enum.all?(files, &File.exists?/1), do: :ok, else: {:error, :source_files_missing}
+  end
+
+  ## the records
+
+  defp drop_media(summary, nil), do: note(summary, :kept, "no audiobook: the item had none")
+
+  defp drop_media(summary, %Media.Media{} = media) do
+    # Custody decides the bytes, as everywhere else: a managed recording's
+    # library copies go with it, an adopted one's files are somebody else's
+    # and are only ever dereferenced.
+    case Media.delete_media(media) do
+      {:ok, _media} -> note(summary, :deleted, "the audiobook")
+      {:error, reason} -> note(summary, :kept, "the audiobook: #{inspect(reason)}")
+    end
+  end
+
+  # A linked book was already in the library and is never touched. A created
+  # one goes, unless a second recording has since joined it — `delete_book/1`
+  # answers that itself rather than us racing it with a count.
+  defp drop_book(summary, %Draft{work: %{mode: :create}}, %Media.Media{book_id: book_id}) do
+    case Repo.get(Book, book_id) do
+      nil ->
+        summary
+
+      book ->
+        case Books.delete_book(book) do
+          {:ok, _book} -> note(summary, :deleted, "the book")
+          {:error, :has_media} -> note(summary, :kept, "the book: another audiobook uses it")
+          {:error, reason} -> note(summary, :kept, "the book: #{inspect(reason)}")
+        end
+    end
+  end
+
+  defp drop_book(summary, _draft, _media), do: summary
+
+  defp drop_series(summary, %Draft{work: %{series: links}}) do
+    Enum.reduce(links, summary, fn
+      %SeriesLink{mode: :create, name: name}, summary -> drop_series_named(summary, name)
+      _linked_or_removed, summary -> summary
+    end)
+  end
+
+  defp drop_series(summary, _draft), do: summary
+
+  defp drop_series_named(summary, name) do
+    case Repo.one(from s in Series, where: s.name == ^name, preload: :series_books) do
+      %Series{series_books: []} = series ->
+        case Books.delete_series(series) do
+          {:ok, _series} -> note(summary, :deleted, "the series #{name}")
+          {:error, reason} -> note(summary, :kept, "the series #{name}: #{inspect(reason)}")
+        end
+
+      %Series{} ->
+        note(summary, :kept, "the series #{name}: other books are in it")
+
+      nil ->
+        summary
+    end
+  end
+
+  # People before identities: `People.delete_person/1` deletes the authors
+  # that exist only for this human, which is most of them, and cascades their
+  # narrator rows. What is left over afterwards is a composite pen name whose
+  # other half survives, which `drop_identities/2` sweeps.
+  defp drop_people(summary, %Draft{people: people}) do
+    Enum.reduce(people, summary, fn
+      %PersonDecision{mode: :create} = decision, summary ->
+        drop_person(summary, Draft.Field.value(decision.name))
+
+      _linked, summary ->
+        summary
+    end)
+  end
+
+  defp drop_people(summary, _draft), do: summary
+
+  defp drop_person(summary, nil), do: summary
+
+  defp drop_person(summary, name) do
+    case Repo.all(from p in Person, where: p.name == ^name) do
+      [%Person{} = person] ->
+        case People.delete_person(person) do
+          {:ok, _person} ->
+            note(summary, :deleted, "the person #{name}")
+
+          {:error, reason} ->
+            note(summary, :kept, "the person #{name}: #{undo_reason(reason)}")
+        end
+
+      [] ->
+        summary
+
+      several ->
+        # Two humans of one name is exactly the case the split control
+        # exists for, and guessing which one this import made would be a
+        # coin flip with somebody's curation on the other side.
+        note(summary, :kept, "the person #{name}: #{length(several)} people share that name")
+    end
+  end
+
+  # Identities the import created that nothing points at any more. Deleted by
+  # name and only when bare, because an identity is the one record here with
+  # no owner: `Author` belongs to no person in the composite case, and a
+  # narrator identity outlives the media that referenced it.
+  defp drop_identities(summary, %Draft{} = draft) do
+    credits =
+      ((draft.work && draft.work.authors) || []) ++
+        ((draft.recording && draft.recording.narrators) || [])
+
+    Enum.reduce(credits, summary, fn
+      %Credit{mode: :create, kind: kind, name: name}, summary ->
+        drop_identity(summary, kind, name)
+
+      _linked, summary ->
+        summary
+    end)
+  end
+
+  defp drop_identities(summary, _draft), do: summary
+
+  defp drop_identity(summary, :author, name) do
+    case Repo.one(from a in Author, where: a.name == ^name, preload: [:books, :author_people]) do
+      %Author{books: [], author_people: []} = author ->
+        Repo.delete!(author)
+        note(summary, :deleted, "the author #{name}")
+
+      _still_used_or_absent ->
+        summary
+    end
+  end
+
+  defp drop_identity(summary, :narrator, name) do
+    case Repo.one(from n in Narrator, where: n.name == ^name, preload: :media) do
+      %Narrator{media: []} = narrator ->
+        Repo.delete!(narrator)
+        note(summary, :deleted, "the narrator #{name}")
+
+      _still_used_or_absent ->
+        summary
+    end
+  end
+
+  ## the item
+
+  # The draft is kept deliberately. The point of undoing is to run the same
+  # decisions again with the form changed underneath them; rebuilding from
+  # the providers is what "Start over" is for, and it stays one click away.
+  defp requeue(%InboxItem{} = item) do
+    item
+    |> InboxItem.changeset(%{status: :pending, media_id: nil, issue: nil})
+    |> Repo.update()
+  end
+
+  defp note(summary, key, words), do: Map.update!(summary, key, &[words | &1])
+
+  defp undo_reason(:has_authored_books), do: "they still have books"
+  defp undo_reason(:has_narrated_media), do: "they have narrated something else"
+  defp undo_reason(other), do: inspect(other)
+end

--- a/lib/ambry/metadata.ex
+++ b/lib/ambry/metadata.ex
@@ -10,6 +10,8 @@ defmodule Ambry.Metadata do
   use Boundary,
     deps: [Ambry.Repo, Ambry.Utils, AmbryScraping],
     exports: [
+      # what a provider did when asked, and the ids the retry chips carry back
+      Outcome,
       {Provider, []},
       # with its submodules: `Match` is the shape every caller pattern-matches
       # on, the same reason `Provider`'s normalized structs are exported

--- a/lib/ambry/metadata/outcome.ex
+++ b/lib/ambry/metadata/outcome.ex
@@ -74,6 +74,33 @@ defmodule Ambry.Metadata.Outcome do
     }
   end
 
+  # A provider that cannot be asked, as opposed to one that couldn't be
+  # reached: it doesn't implement this kind of call, it is switched off, or it
+  # has no credentials. No request was made, so there is nothing to report and
+  # nothing a retry could change.
+  @unaskable [:unsupported_capability, :provider_disabled, :provider_not_configured]
+
+  # The provider answered, and the answer is that it has no such record. That
+  # is "found nothing", which is a count of zero — not a failure.
+  @answered [:not_found]
+
+  @doc """
+  What to record when a call comes back an error.
+
+  **Not every error is a failure to reach a provider**, and treating them
+  alike is what put a permanent red "couldn't be reached, retry" chip on
+  items whose retry could never succeed: Audible implements no details call
+  at all, and a Hardcover details lookup that 404s is a definite answer. Both
+  also kept `Ambry.Inbox.unreached_providers/1` non-empty, which sent the
+  matching job round again for as long as it had attempts left.
+
+  Returns nil when there is nothing to say, so callers drop it.
+  """
+  def from_error(entry, reason, kind \\ :search)
+  def from_error(_entry, reason, _kind) when reason in @unaskable, do: nil
+  def from_error(entry, reason, kind) when reason in @answered, do: ok(entry, 0, kind)
+  def from_error(entry, reason, kind), do: failed(entry, reason, kind)
+
   @doc "True if this outcome says the provider couldn't be reached."
   def failed?(%{"status" => "failed"}), do: true
   def failed?(_outcome), do: false

--- a/lib/ambry/metadata/outcome.ex
+++ b/lib/ambry/metadata/outcome.ex
@@ -1,0 +1,89 @@
+defmodule Ambry.Metadata.Outcome do
+  @moduledoc """
+  What one provider actually did when asked, as the askers record it.
+
+  Every fan-out reports one of these per provider, because "found nothing"
+  and "couldn't be reached" must never look the same — a rate-limited source
+  otherwise reads as one that was never consulted.
+
+  ## Why a call needs a kind
+
+  A provider is asked more than one kind of question about a single item: a
+  search, then the details behind the hits it returned, then the editions of
+  the work it named. Those succeed and fail independently, and reporting them
+  under one id meant the last one written won: a details call that was
+  rate-limited disappeared behind the search that had already said `ok`, and
+  the record silently kept the summary — no description, no cover, no
+  edition list — with nothing anywhere saying so.
+
+  So a kind other than `:search` gets its own id and its own chip:
+  `hardcover` searched, `hardcover:details` hydrated, `hardcover:editions`
+  listed editions. `Ambry.Inbox.unreached_providers/1` reads all of them, so
+  any one of them failing is enough to send `Ambry.Inbox.RunMatch` back
+  around — which is the whole point, since provider errors are never cached
+  and a retry re-asks only what it missed.
+  """
+
+  @kinds [:search, :details, :editions, :chapters]
+
+  @doc "The outcome id a provider's answer of this kind is recorded under."
+  def id(provider_id, kind \\ :search)
+  def id(provider_id, :search), do: provider_id
+  def id(provider_id, kind) when kind in @kinds, do: "#{provider_id}:#{kind}"
+
+  @doc """
+  Splits a recorded id back into the provider and what it was asked.
+
+  The retry chip carries the id, and re-running a search when what failed
+  was a details call would report success having fixed nothing.
+  """
+  def split(outcome_id) when is_binary(outcome_id) do
+    case String.split(outcome_id, ":", parts: 2) do
+      [provider_id, kind] when kind in ~w(details editions chapters) ->
+        {provider_id, String.to_existing_atom(kind)}
+
+      _search ->
+        {outcome_id, :search}
+    end
+  end
+
+  @doc "A provider answered."
+  def ok(entry, count, kind \\ :search) do
+    %{
+      "id" => id(entry.id, kind),
+      "name" => name(entry, kind),
+      "status" => "ok",
+      "count" => count
+    }
+  end
+
+  @doc """
+  A provider couldn't answer.
+
+  The reason is kept short and human — enough for the operator to tell a rate
+  limit from a bad token from an instance being down, without leaking a whole
+  HTTP response into jsonb.
+  """
+  def failed(entry, reason, kind \\ :search) do
+    %{
+      "id" => id(entry.id, kind),
+      "name" => name(entry, kind),
+      "status" => "failed",
+      "count" => 0,
+      "reason" => describe(reason)
+    }
+  end
+
+  @doc "True if this outcome says the provider couldn't be reached."
+  def failed?(%{"status" => "failed"}), do: true
+  def failed?(_outcome), do: false
+
+  @doc "Shortens a provider error to something a chip's tooltip can hold."
+  def describe(reason) when is_binary(reason), do: String.slice(reason, 0, 200)
+  def describe(reason), do: reason |> inspect() |> String.slice(0, 200)
+
+  defp name(entry, :search), do: entry.display_name
+  defp name(entry, :details), do: "#{entry.display_name} details"
+  defp name(entry, :editions), do: "#{entry.display_name} editions"
+  defp name(entry, :chapters), do: "#{entry.display_name} chapters"
+end

--- a/lib/ambry/metadata/person_search.ex
+++ b/lib/ambry/metadata/person_search.ex
@@ -23,6 +23,7 @@ defmodule Ambry.Metadata.PersonSearch do
   person, and which one belongs in the library is a judgement.
   """
 
+  alias Ambry.Metadata.Outcome
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Providers
   alias Ambry.Metadata.Registry
@@ -59,70 +60,82 @@ defmodule Ambry.Metadata.PersonSearch do
   end
 
   @doc """
-  The same search, plus what the provider actually did.
+  The same search, plus what the provider actually did — one outcome per kind
+  of call it took.
 
   The picker doesn't care — an operator staring at an empty column has the
   same problem whether the provider was down or simply had nobody. Matching
   does: it runs unattended, and "this provider found nobody" and "this
   provider was unreachable" have to be told apart afterwards, which is the
   same rule the work and recording levels already follow.
+
+  **Two calls, so up to two outcomes.** A name search that succeeds is
+  followed by a details call per plausible hit, and that call is where the
+  biography and the headshots are. Measured on a cold scan of 353 releases,
+  the shared rreading-glasses instance 429'd about 6% of requests — and
+  because a hit with no photo and no bio is dropped from the grid on the very
+  next line, a rate-limited details call didn't just thin the candidate, it
+  **deleted the person** while this function still reported `ok`. So a details
+  failure is reported under its own `:details` id, which is what makes
+  `Ambry.Inbox.RunMatch` come back for it.
   """
   def matches_with_outcome(entry, query, opts \\ []) do
     case Providers.search_authors(entry.id, query, opts) do
       {:ok, results} ->
-        matches =
+        {hydrated, errors} =
           results
           |> Enum.filter(&plausible?(query, &1.name))
           |> Enum.take(@hits)
-          |> Enum.map(&hydrate(entry, &1, opts))
-          |> Enum.reject(&(&1.images == [] and is_nil(&1.description)))
+          |> Enum.map_reduce([], fn summary, errors ->
+            case hydrate(entry, summary, opts) do
+              {match, nil} -> {match, errors}
+              {match, reason} -> {match, [reason | errors]}
+            end
+          end)
 
-        {matches,
-         %{
-           "id" => entry.id,
-           "name" => entry.display_name,
-           "status" => "ok",
-           "count" => length(matches)
-         }}
+        matches = Enum.reject(hydrated, &(&1.images == [] and is_nil(&1.description)))
+
+        {matches, [Outcome.ok(entry, length(matches)) | details_outcome(entry, errors)]}
 
       {:error, reason} ->
         Logger.info(fn ->
           "Person search: #{entry.id} for #{inspect(query)}: #{inspect(reason)}"
         end)
 
-        {[],
-         %{
-           "id" => entry.id,
-           "name" => entry.display_name,
-           "status" => "failed",
-           "count" => 0,
-           "reason" => reason |> inspect() |> String.slice(0, 200)
-         }}
+        {[], [Outcome.failed(entry, reason)]}
     end
   end
+
+  defp details_outcome(_entry, []), do: []
+  defp details_outcome(entry, [reason | _rest]), do: [Outcome.failed(entry, reason, :details)]
 
   # The search hit is a summary; the details call is where the biography and
   # the full set of headshots live. Worth one request per plausible hit — this
   # runs for a single person with somebody waiting on it, not across a scan.
+  #
+  # Returns the reason alongside, because a hit that failed to hydrate and a
+  # hit the provider genuinely knows nothing more about produce the same
+  # thin `Match` and must not be reported the same way.
   defp hydrate(entry, %Provider.Author{} = summary, opts) do
-    detailed =
+    {detailed, error} =
       case Providers.author_details(entry.id, summary.id, opts) do
-        {:ok, %Provider.Author{} = full} -> full
-        _no_details -> summary
+        {:ok, %Provider.Author{} = full} -> {full, nil}
+        {:error, reason} -> {summary, reason}
+        _no_details -> {summary, nil}
       end
 
-    %Match{
-      provider_id: entry.id,
-      provider_name: entry.display_name,
-      id: summary.id,
-      name: detailed.name || summary.name,
-      description: detailed.description || summary.description,
-      # The search listing's description doubles as a disambiguator on TMDB
-      # ("Acting — The Expanse"), which is exactly what tells two same-named
-      # people apart in a grid.
-      note: summary.description,
-      images: Enum.uniq(Provider.Author.images(detailed) ++ Provider.Author.images(summary))
-    }
+    {%Match{
+       provider_id: entry.id,
+       provider_name: entry.display_name,
+       id: summary.id,
+       name: detailed.name || summary.name,
+       description: detailed.description || summary.description,
+       # The search listing's description doubles as a disambiguator on TMDB
+       # ("Acting — The Expanse"), which is exactly what tells two same-named
+       # people apart in a grid.
+       note: summary.description,
+       images: Enum.uniq(Provider.Author.images(detailed) ++ Provider.Author.images(summary))
+     }, error}
   end
 
   # Guards against confidently-wrong candidates: rreading-glasses' author

--- a/lib/ambry/metadata/person_search.ex
+++ b/lib/ambry/metadata/person_search.ex
@@ -102,12 +102,14 @@ defmodule Ambry.Metadata.PersonSearch do
           "Person search: #{entry.id} for #{inspect(query)}: #{inspect(reason)}"
         end)
 
-        {[], [Outcome.failed(entry, reason)]}
+        {[], List.wrap(Outcome.from_error(entry, reason))}
     end
   end
 
   defp details_outcome(_entry, []), do: []
-  defp details_outcome(entry, [reason | _rest]), do: [Outcome.failed(entry, reason, :details)]
+
+  defp details_outcome(entry, [reason | _rest]),
+    do: List.wrap(Outcome.from_error(entry, reason, :details))
 
   # The search hit is a summary; the details call is where the biography and
   # the full set of headshots live. Worth one request per plausible hit — this

--- a/lib/ambry/metadata/search.ex
+++ b/lib/ambry/metadata/search.ex
@@ -45,7 +45,7 @@ defmodule Ambry.Metadata.Search do
     |> Registry.enabled()
     |> Enum.reduce({[], []}, fn entry, {found, outcomes} ->
       {books, outcome} = books_one(entry, query, opts)
-      {found ++ [{entry, books}], outcomes ++ [outcome]}
+      {found ++ [{entry, books}], outcomes ++ List.wrap(outcome)}
     end)
   end
 
@@ -107,12 +107,12 @@ defmodule Ambry.Metadata.Search do
 
         {:error, reason} ->
           Logger.warning(fn -> "Metadata chapters: #{entry.id} failed: #{inspect(reason)}" end)
-          {found, outcomes ++ [failed_outcome(entry, reason)]}
+          {found, outcomes ++ List.wrap(failed_outcome(entry, reason))}
       end
     end)
   end
 
   defp ok_outcome(entry, count), do: Outcome.ok(entry, count)
 
-  defp failed_outcome(entry, reason), do: Outcome.failed(entry, reason)
+  defp failed_outcome(entry, reason), do: Outcome.from_error(entry, reason)
 end

--- a/lib/ambry/metadata/search.ex
+++ b/lib/ambry/metadata/search.ex
@@ -23,6 +23,7 @@ defmodule Ambry.Metadata.Search do
       item's tags, a form might not score at all.
   """
 
+  alias Ambry.Metadata.Outcome
   alias Ambry.Metadata.PersonSearch
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Providers
@@ -69,14 +70,16 @@ defmodule Ambry.Metadata.Search do
   Asks every person-capable provider about one human.
 
   Returns `{matches, outcomes}` — flat `PersonSearch` matches across
-  providers, plus the same per-provider outcome maps as `books/2`.
+  providers, plus the same per-provider outcome maps as `books/2`. A provider
+  contributes more than one outcome when more than one kind of call was
+  needed to answer: the search, and the details behind each hit.
   """
   def people(name, opts \\ []) do
     Enum.reduce(PersonSearch.providers(), {[], []}, fn entry, {found, outcomes} ->
-      {matches, outcome} =
+      {matches, provider_outcomes} =
         PersonSearch.matches_with_outcome(entry, name, refresh: Keyword.get(opts, :refresh, true))
 
-      {found ++ matches, outcomes ++ [outcome]}
+      {found ++ matches, outcomes ++ provider_outcomes}
     end)
   end
 
@@ -109,17 +112,7 @@ defmodule Ambry.Metadata.Search do
     end)
   end
 
-  defp ok_outcome(entry, count) do
-    %{"id" => entry.id, "name" => entry.display_name, "status" => "ok", "count" => count}
-  end
+  defp ok_outcome(entry, count), do: Outcome.ok(entry, count)
 
-  defp failed_outcome(entry, reason) do
-    %{
-      "id" => entry.id,
-      "name" => entry.display_name,
-      "status" => "failed",
-      "count" => 0,
-      "reason" => reason |> inspect() |> String.slice(0, 200)
-    }
-  end
+  defp failed_outcome(entry, reason), do: Outcome.failed(entry, reason)
 end

--- a/lib/ambry_web/components/admin/chapter_editor.ex
+++ b/lib/ambry_web/components/admin/chapter_editor.ex
@@ -298,7 +298,7 @@ defmodule AmbryWeb.Admin.ChapterEditor do
     ~H"""
     <div
       :if={@chips != []}
-      class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+      class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       data-role="proposals"
     >
       <.microlabel>Proposed</.microlabel>

--- a/lib/ambry_web/components/admin/curation.ex
+++ b/lib/ambry_web/components/admin/curation.ex
@@ -76,33 +76,11 @@ defmodule AmbryWeb.Admin.Curation do
         {@hint}
       </p>
 
+      <%!-- The query, then who answered, then what they said — the import
+          form's grammar, because a card of search results is a search form
+          with its results below it. Both surfaces had it upside down, with
+          the search under the records it produced. --%>
       <div class="mt-2 space-y-2 rounded-lg bg-zinc-900 p-4">
-        <.record_list records={@evidence.records} used={&Evidence.used?(@evidence, &1)}>
-          <:row :let={record}>
-            <.record_row
-              record={record}
-              used={Evidence.used?(@evidence, record)}
-              level={@level}
-              event="toggle-evidence"
-              note={Evidence.note(@evidence, record)}
-            />
-          </:row>
-        </.record_list>
-
-        <p
-          :if={@evidence.searched? and not @evidence.running? and @evidence.records == []}
-          class="pl-3 text-sm text-zinc-400"
-        >
-          Nothing came back. Try different words.
-        </p>
-
-        <.provider_outcomes_row
-          outcomes={@evidence.outcomes}
-          level={@level}
-          retrying={@retrying}
-          retryable={@level != "person"}
-        />
-
         <.research_form
           :if={@level != "person"}
           level={@level}
@@ -137,6 +115,32 @@ defmodule AmbryWeb.Admin.Curation do
             end}
           </.button>
         </form>
+
+        <.provider_outcomes_row
+          outcomes={@evidence.outcomes}
+          level={@level}
+          retrying={@retrying}
+          retryable={@level != "person"}
+        />
+
+        <.record_list records={@evidence.records} used={&Evidence.used?(@evidence, &1)}>
+          <:row :let={record}>
+            <.record_row
+              record={record}
+              used={Evidence.used?(@evidence, record)}
+              level={@level}
+              event="toggle-evidence"
+              note={Evidence.note(@evidence, record)}
+            />
+          </:row>
+        </.record_list>
+
+        <p
+          :if={@evidence.searched? and not @evidence.running? and @evidence.records == []}
+          class="pl-3 text-sm text-zinc-400"
+        >
+          Nothing came back. Try different words.
+        </p>
       </div>
     </.disclosure>
     """
@@ -230,7 +234,7 @@ defmodule AmbryWeb.Admin.Curation do
     ~H"""
     <div
       :if={@proposals != []}
-      class={["grid-cols-[4.5rem_minmax(0,1fr)] grid gap-x-2 pl-3", (@images? && "items-start") || "items-baseline"]}
+      class={["grid-cols-[4rem_minmax(0,1fr)] grid gap-x-2 pl-3", (@images? && "items-start") || "items-baseline"]}
       data-role="proposals"
     >
       <.microlabel class={@images? && "pt-1.5"}>Proposed</.microlabel>

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -723,8 +723,6 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :people, :list, required: true
   attr :verb, :string, required: true, doc: ~s(the visible label — "Written by")
   attr :reveal, :string, required: true, doc: ~s(the unfold link — "This is a pen name")
-  attr :backing, :string, required: true, doc: ~s(the unfolded label — "Pen name of")
-  attr :expanded, :boolean, required: true
   attr :kind, :atom, required: true, doc: ":author or :narrator"
 
   attr :identity_backing, :map,
@@ -908,110 +906,188 @@ defmodule AmbryWeb.Admin.Decisions do
         </div>
       </div>
 
-      <%!-- The photo and bio belong to the credit itself while there is one
-            implied person behind it, which is nearly always. Putting them
-            inside the pen-name fold hid them behind a control nobody would
-            click to get a picture — they were, for practical purposes, not
-            there at all. --%>
-      <.person_curation
-        :if={@credit.mode == :create and !@expanded and @persons != []}
-        person={hd(@persons)}
-        section={@section}
-        index={@index}
-        person_index={0}
-        kind={@kind}
-        appears={@appearances[hd(@persons).key] || []}
-        searching={@searching_person == hd(@persons).key}
-        expanded={@photos_expanded[hd(@persons).key] || false}
-        records={@person_records[hd(@persons).key] || []}
-        outcomes={@person_outcomes[hd(@persons).key] || []}
-      />
-
-      <%!-- Folded away until it matters, and unfolded automatically the moment
-            it does — a credit backed by somebody else, or by two people, can
-            never be hiding behind a collapsed control. --%>
-      <button
-        :if={@credit.mode == :create and !@expanded}
-        type="button"
-        phx-click="toggle-people"
-        phx-value-section={@section}
-        phx-value-index={@index}
-        class="pl-3 text-xs text-zinc-400 underline"
-      >
-        {@reveal}
-      </button>
-
-      <div :if={@credit.mode == :create and @expanded} class="space-y-3">
-        <.label class="pl-3 text-xs">{@backing}</.label>
-
-        <div
-          :for={{person, person_index} <- Enum.with_index(@persons)}
-          class="space-y-1 border-l-2 border-zinc-700 pl-3"
+      <%!-- A reference, not the person. The human lives once, in the New
+            people section, because one human is one record — rendering them
+            inside every credit that named them is what made an author who
+            reads their own book appear twice, with a sentence apologising for
+            it. What a credit needs is enough to recognise who it means and a
+            way to get there. --%>
+      <div :if={@credit.mode == :create and @persons != []} class="flex flex-wrap gap-2 pl-3">
+        <.link
+          :for={person <- @persons}
+          href={"#person-#{person.key}"}
+          class="bg-white/5 flex items-center gap-2 rounded-full py-1 pr-3 pl-1 text-xs text-zinc-300 hover:bg-white/10"
         >
-          <form
-            id={"credit-#{@section}-#{@index}-person-#{person_index}"}
-            phx-change="person-change"
-            class="flex flex-wrap items-center gap-2"
-          >
-            <input type="hidden" name="key" value={person.key} />
-
-            <.live_component
-              module={EntityResolver}
-              id={"credit-#{@section}-#{@index}-person-#{person_index}-resolver"}
-              name="person_id"
-              text_name="name"
-              options={@people}
-              value={if person.mode == :link, do: person.person_id}
-              text={Field.value(person.name) || ""}
-              placeholder="the person's real name"
-              class={input_classes("w-full")}
-            />
-
-            <button
-              :if={length(@persons) > 1}
-              type="button"
-              phx-click="remove-person"
-              phx-value-section={@section}
-              phx-value-index={@index}
-              phx-value-person={person_index}
-            >
-              <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
-            </button>
-          </form>
-
-          <.person_curation
-            person={person}
-            section={@section}
-            index={@index}
-            person_index={person_index}
-            kind={@kind}
-            appears={@appearances[person.key] || []}
-            searching={@searching_person == person.key}
-            expanded={@photos_expanded[person.key] || false}
-            records={@person_records[person.key] || []}
-            outcomes={@person_outcomes[person.key] || []}
+          <img
+            :if={Field.value(person.image)}
+            src={preview_src(Field.value(person.image), nil)}
+            class="h-6 w-6 flex-none rounded-full object-cover"
+            alt=""
           />
-        </div>
+          <span
+            :if={!Field.value(person.image)}
+            class="h-6 w-6 flex-none rounded-full bg-zinc-800"
+          />
+          {Field.value(person.name) || "unnamed"}
+        </.link>
+      </div>
+
+      <div class="flex flex-wrap gap-x-4 pl-3">
+        <%!-- Not a fold any more: the person layer is a section of its own, so
+              this says the one thing it always meant — the credited name is
+              not the human's name. --%>
+        <button
+          :if={@credit.mode == :create and Credit.simple?(@credit)}
+          type="button"
+          phx-click="separate-name"
+          phx-value-section={@section}
+          phx-value-index={@index}
+          class="text-xs text-zinc-400 underline"
+        >
+          {@reveal}
+        </button>
 
         <%!-- Narrators stay one-to-one with a Person by design; only the
               author control grows a second entry. --%>
         <button
-          :if={@section == "work"}
+          :if={@section == "work" and @credit.mode == :create}
           type="button"
           phx-click="add-person"
           phx-value-section={@section}
           phx-value-index={@index}
-          class="pl-3 text-xs text-zinc-400 underline"
+          class="text-xs text-zinc-400 underline"
         >
           Add another person
         </button>
-
-        <p :if={length(@persons) > 1} class="pl-3 text-xs text-zinc-400">
-          A shared pen name: {@credit.name} will be one author credited to {length(@persons)} people.
-        </p>
       </div>
     </div>
     """
+  end
+
+  attr :person, PersonDecision, required: true
+  attr :group, :map, required: true, doc: "the credit that introduces this human"
+  attr :person_index, :integer, required: true
+  attr :removable, :boolean, default: false, doc: "only a pen name's extra people can be removed"
+  attr :searching, :boolean, default: false
+  attr :photos_expanded, :boolean, default: false
+  attr :records, :list, default: []
+  attr :outcomes, :list, default: []
+  attr :appears, :list, default: []
+  attr :people, :list, default: [], doc: "the library's people, for the typeahead"
+
+  @doc """
+  One human this import will create, as a decision card of their own.
+
+  The card is where a person's own questions live — what they are called, which
+  face, which biography — separately from the *credit*, which asks a different
+  question: which identity does this book credit. They were one control for a
+  long time, which is why an author reading their own book rendered twice.
+
+  The events still address the credit that introduces them (`section`,
+  `index`, `person_index`), because "remove this person" means removing them
+  from that credit — the person exists only as long as a credit names them.
+  """
+  def person_card(assigns) do
+    ~H"""
+    <div
+      id={"person-#{@person.key}"}
+      class={["space-y-3 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@person)]}
+      data-role="person-card"
+    >
+      <div class="flex items-baseline justify-between gap-2 pl-3">
+        <.label>{Field.value(@person.name) || "Unnamed person"}</.label>
+
+        <button
+          :if={@removable}
+          type="button"
+          phx-click="remove-person"
+          phx-value-section={@group.section}
+          phx-value-index={@group.index}
+          phx-value-person={@person_index}
+          title="not one of the people behind this name"
+        >
+          <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
+        </button>
+      </div>
+
+      <%!-- Where they are credited, and — when that is more than one place —
+            the escape hatch for two humans who really do share a name. The
+            card exists once for the person, so this is the only place the
+            question can be asked. --%>
+      <p class="pl-3 text-xs text-zinc-400">
+        {appearance_words(@appears)}
+        <button
+          :if={length(Enum.uniq_by(@appears, & &1.kind)) > 1}
+          type="button"
+          phx-click="split-person"
+          phx-value-section={@group.section}
+          phx-value-index={@group.index}
+          phx-value-person={@person_index}
+          class="underline"
+        >
+          Not the same person?
+        </button>
+      </p>
+
+      <%!-- The name is a decision like any other: a provider's spelling is a
+          proposal, and without a box to overrule it "David Wong" could only
+          be imported as a person called David Wong when the human is Jason
+          Pargin. The typeahead is also how they become somebody already in
+          the library. --%>
+      <form id={"person-#{@person.key}-identity"} phx-change="person-change">
+        <input type="hidden" name="key" value={@person.key} />
+
+        <.live_component
+          module={EntityResolver}
+          id={"person-#{@person.key}-resolver"}
+          name="person_id"
+          text_name="name"
+          options={@people}
+          value={if @person.mode == :link, do: @person.person_id}
+          text={Field.value(@person.name) || ""}
+          placeholder="the person's real name"
+          class={input_classes("w-full")}
+        />
+      </form>
+
+      <.person_curation
+        person={@person}
+        section={@group.section}
+        index={@group.index}
+        person_index={@person_index}
+        kind={@group.kind}
+        appears={@appears}
+        searching={@searching}
+        expanded={@photos_expanded}
+        records={@records}
+        outcomes={@outcomes}
+      />
+    </div>
+    """
+  end
+
+  @doc """
+  Where this human is credited, in words.
+
+  The card is away from the credits now, so it has to say what it belongs to —
+  and for somebody behind two credits, that they are one person rather than
+  two identically named ones.
+  """
+  def appearance_words([]), do: "Not credited anywhere on this import."
+
+  def appearance_words(appears) do
+    appears
+    |> Enum.map(& &1.kind)
+    |> Enum.uniq()
+    |> Enum.map(fn
+      :author -> "author"
+      :narrator -> "narrator"
+      other -> to_string(other)
+    end)
+    |> case do
+      [one] -> "Credited as #{one}."
+      several -> "Credited as #{Enum.join(several, " and ")} — one person, both credits."
+    end
   end
 
   attr :person, PersonDecision, required: true
@@ -1100,24 +1176,6 @@ defmodule AmbryWeb.Admin.Decisions do
           :if={is_nil(@image)}
           class="h-12 w-12 flex-none rounded-full border border-dashed border-zinc-700"
         />
-
-        <%!-- The same human on two credits: an author reading their own book.
-              Approval creates them once, so this is where the form says so —
-              on the row that would otherwise look like it was about to make a
-              second person of the same name. --%>
-        <p :if={@shared_with} class="min-w-0 text-xs text-zinc-400">
-          Same person as the {@shared_with}. One {Field.value(@person.name)} will be created.
-          <button
-            type="button"
-            phx-click="split-person"
-            phx-value-section={@section}
-            phx-value-index={@index}
-            phx-value-person={@person_index}
-            class="underline"
-          >
-            Not the same person?
-          </button>
-        </p>
       </div>
 
       <%!-- Nothing found is a normal outcome, not a failure — plenty of

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -49,10 +49,12 @@ defmodule AmbryWeb.Admin.Decisions do
     ~H"""
     <div
       :if={@outcomes != []}
-      class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+      class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       data-role="provider-outcomes"
     >
-      <.microlabel>Asked</.microlabel>
+      <%!-- Named for what it is now that it sits under the search rather than
+            after the records: these are what the search came back with. --%>
+      <.microlabel>Results</.microlabel>
 
       <div class="flex flex-wrap items-center gap-1.5">
         <%!-- A count is information, not an option — filled and quiet, so it
@@ -95,42 +97,6 @@ defmodule AmbryWeb.Admin.Decisions do
       </div>
     </div>
     """
-  end
-
-  attr :query, :string, default: nil
-  attr :fields, :map, default: %{}
-
-  @doc """
-  The search that produced this level's candidates.
-
-  Shown because the first question anyone asks a bad match is "what did you
-  even search for?" — and the answer is not obvious: the hints come from tags
-  first and the release name second, so a wrong author in an ID3 frame sends
-  the whole level somewhere strange with no visible cause.
-  """
-  def query_row(assigns) do
-    ~H"""
-    <div :if={@query || @fields != %{}} class="pl-3 text-xs text-zinc-400" data-role="query">
-      <span>Searched for</span>
-      <span :for={{key, value} <- ordered_fields(@fields)} class="ml-1">
-        <span class="text-zinc-400">{key}:</span>
-        <span class="font-mono text-zinc-400">{value}</span>
-      </span>
-      <span :if={@fields == %{}} class="font-mono ml-1 text-zinc-400">{@query}</span>
-      <p class="pt-0.5">
-        A provider whose narrow search comes back empty may widen it, so what matched can be broader
-        than this.
-      </p>
-    </div>
-    """
-  end
-
-  # Same order every time, and the order the query is actually built in.
-  defp ordered_fields(fields) do
-    for key <- ~w(title author narrator keywords),
-        value = fields[key],
-        value not in [nil, ""],
-        do: {key, value}
   end
 
   # Where a candidate stops being an alternative and starts being noise. Sits
@@ -273,16 +239,35 @@ defmodule AmbryWeb.Admin.Decisions do
         </span>
       </span>
       <div class="min-w-0 flex-grow">
-        <p class="flex items-baseline gap-2 truncate text-sm font-medium">
-          {candidate_title(@record)}
+        <%!-- Which database said this is the first thing an operator checks,
+              and it used to ride at the end of the facts line, where it was
+              the first thing truncation took. It is a fact about the record
+              rather than one of the record's own, so it wears the badge
+              costume and holds its width; the title gives way instead. --%>
+        <%!-- A div, not a p: `<.badge>` renders a div, and a div inside a
+              paragraph makes the parser close the paragraph early — which
+              put the badge on a line of its own instead of beside the
+              title. --%>
+        <div class="flex items-baseline gap-2 text-sm font-medium">
+          <span class="min-w-0 truncate">{candidate_title(@record)}</span>
+
           <span
             :if={@note}
-            class="bg-brand-dark/15 rounded-sm px-1.5 text-xs font-normal text-lime-300"
+            class="bg-brand-dark/15 flex-none rounded-sm px-1.5 text-xs font-normal text-lime-300"
             data-role="record-note"
           >
             {@note}
           </span>
-        </p>
+
+          <.badge
+            :if={candidate_origin(@record)}
+            color={:gray}
+            class="flex-none text-xs font-normal"
+            data-role="record-source"
+          >
+            {candidate_origin(@record)}
+          </.badge>
+        </div>
         <p class="truncate text-xs text-zinc-400">{candidate_facts(@record)}</p>
       </div>
       <span :if={@working} class="flex-none pt-0.5 text-xs text-zinc-400">
@@ -339,7 +324,18 @@ defmodule AmbryWeb.Admin.Decisions do
       data-linked={@linked && "true"}
     >
       <div class="min-w-0 flex-grow">
-        <p class="truncate text-sm font-semibold">{candidate_title(@book)}</p>
+        <div class="flex items-baseline gap-2 text-sm font-semibold">
+          <span class="min-w-0 truncate">{candidate_title(@book)}</span>
+
+          <.badge
+            :if={candidate_origin(@book)}
+            color={:gray}
+            class="flex-none text-xs font-normal"
+            data-role="record-source"
+          >
+            {candidate_origin(@book)}
+          </.badge>
+        </div>
         <p class="truncate text-xs text-zinc-400">{candidate_facts(@book)}</p>
       </div>
 
@@ -469,6 +465,12 @@ defmodule AmbryWeb.Admin.Decisions do
 
   Narrator and year lead because they are what tell two recordings of one work
   apart — the whole reason the recording level exists.
+
+  **Which database said so is not one of them.** It rode at the end of this
+  line for a while, which is precisely where a truncated line loses it: the
+  facts are what tell two records apart, the source is what the operator
+  weighs them by, and it belongs to the row rather than to the sentence. It
+  renders as a badge beside the title.
   """
   def candidate_facts(candidate) do
     [
@@ -482,7 +484,6 @@ defmodule AmbryWeb.Admin.Decisions do
       candidate["publisher"],
       series_line(candidate["series"]),
       candidate["asin"],
-      candidate_origin(candidate),
       candidate["also_from"] not in [nil, []] &&
         "also #{Enum.join(List.wrap(candidate["also_from"]), ", ")}"
     ]
@@ -660,7 +661,7 @@ defmodule AmbryWeb.Admin.Decisions do
           label on the first image's bottom edge. --%>
       <div
         :if={@field.candidates != []}
-        class={["grid-cols-[4.5rem_minmax(0,1fr)] grid gap-x-2 pl-3", (@preview && "items-start") || "items-baseline"]}
+        class={["grid-cols-[4rem_minmax(0,1fr)] grid gap-x-2 pl-3", (@preview && "items-start") || "items-baseline"]}
       >
         <.microlabel class={@preview && "pt-1.5"}>Proposed</.microlabel>
 
@@ -925,7 +926,7 @@ defmodule AmbryWeb.Admin.Decisions do
           @credit.mode == :create && @credit.proposed_name &&
             @credit.proposed_name != @credit.name
         }
-        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+        class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       >
         <.microlabel>Proposed</.microlabel>
         <div class="flex flex-wrap items-center gap-1.5">
@@ -1515,7 +1516,7 @@ defmodule AmbryWeb.Admin.Decisions do
           </div>
         </div>
 
-        <div :if={@bios != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3">
+        <div :if={@bios != []} class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3">
           <.microlabel>Proposed</.microlabel>
 
           <div
@@ -1809,7 +1810,7 @@ defmodule AmbryWeb.Admin.Decisions do
             stays reachable after a rename or a clear. --%>
       <div
         :if={@link.mode == :create && @link.proposed_name && @link.proposed_name != @link.name}
-        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+        class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       >
         <.microlabel>Proposed</.microlabel>
         <div class="flex flex-wrap items-center gap-1.5">
@@ -1970,7 +1971,7 @@ defmodule AmbryWeb.Admin.Decisions do
             stays reachable after a rename or a clear. --%>
       <div
         :if={@link.mode == :create && @link.proposed_name && @link.proposed_name != @link.name}
-        class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
+        class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       >
         <.microlabel>Proposed</.microlabel>
         <div class="flex flex-wrap items-center gap-1.5">

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -1716,13 +1716,18 @@ defmodule AmbryWeb.Admin.Decisions do
         with the state on the block's left rail (no extra check icon — the
         rail is the only settledness encoding, §2), controls below with
         their labels above them. --%>
-    <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@link)]}>
+    <div
+      class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@link)]}
+      data-role="series-link"
+    >
       <div class="flex items-center justify-between gap-2 pl-3">
         <div class="flex min-w-0 items-baseline gap-2">
           <.label>In series</.label>
 
+          <%!-- Only where it says something the rail can't (§2): "needs
+                confirming" beside an amber rail is the same fact twice. --%>
           <.badge
-            :if={!SeriesLink.resolved?(@link)}
+            :if={explained?(SeriesLink.state(@link))}
             color={elem(state_words(SeriesLink.state(@link)), 1)}
             class="text-xs"
           >
@@ -1870,7 +1875,7 @@ defmodule AmbryWeb.Admin.Decisions do
           <.label>Part of a set</.label>
 
           <.badge
-            :if={!GroupLink.resolved?(@link)}
+            :if={explained?(GroupLink.state(@link))}
             color={elem(state_words(GroupLink.state(@link)), 1)}
             class="text-xs"
           >
@@ -2004,10 +2009,10 @@ defmodule AmbryWeb.Admin.Decisions do
   Whether this state is worth a badge beside the rail.
 
   The rail already says settled-or-not; a badge earns its place only when it
-  names a *reason* the colour can't — which values disagree, or that nothing
-  proposed one at all.
+  names a *reason* the colour can't — which values disagree, that nothing
+  proposed one at all, or which half of a membership is still blank.
   """
-  def explained?(state), do: state in [:missing, :ambiguous, :stale]
+  def explained?(state), do: state in [:missing, :unnumbered, :ambiguous, :stale]
 
   @doc """
   A decision's state as words and a colour.
@@ -2018,6 +2023,9 @@ defmodule AmbryWeb.Admin.Decisions do
   """
   def state_words(:approved), do: {"settled", :brand}
   def state_words(:missing), do: {"nothing proposed it", :red}
+  # What is missing is the number, and a row that says "nothing proposed it"
+  # next to "from rreading-glasses" contradicts itself in two words.
+  def state_words(:unnumbered), do: {"needs a number", :red}
   def state_words(:ambiguous), do: {"sources disagree", :yellow}
   def state_words(:unconfirmed), do: {"needs confirming", :yellow}
   def state_words(:stale), do: {"files changed", :red}

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -15,7 +15,9 @@ defmodule AmbryWeb.Admin.Decisions do
   use Phoenix.Component
   use AmbryWeb, :verified_routes
 
-  import AmbryWeb.Admin.Components, only: [badge: 1, disclosure: 1, microlabel: 1]
+  import AmbryWeb.Admin.Components,
+    only: [badge: 1, busy_overlay: 1, disclosure: 1, microlabel: 1]
+
   import AmbryWeb.CoreComponents
 
   alias Ambry.Inbox.Draft.Credit
@@ -23,7 +25,6 @@ defmodule AmbryWeb.Admin.Decisions do
   alias Ambry.Inbox.Draft.GroupLink
   alias Ambry.Inbox.Draft.PersonDecision
   alias Ambry.Inbox.Draft.SeriesLink
-  alias Ambry.Inbox.Draft.SourceRef
   alias Ambry.Inbox.Draft.Tier
   alias AmbryWeb.Components.EntityResolver
 
@@ -181,8 +182,9 @@ defmodule AmbryWeb.Admin.Decisions do
     """
   end
 
-  # An *unscored* record is not a weak one — person records carry no score at
-  # all, and reading a missing score as zero would fold every one of them away.
+  # An *unscored* record is not a weak one — a record staged before its level
+  # ranked anything carries no score, and reading a missing score as zero
+  # would fold it away unread.
   defp worth_showing?(record, used) do
     case record["score"] do
       score when is_number(score) -> score >= @worth_showing or used.(record)
@@ -720,27 +722,13 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :index, :integer, required: true
   attr :section, :string, required: true
   attr :identities, :list, required: true
-  attr :people, :list, required: true
   attr :verb, :string, required: true, doc: ~s(the visible label — "Written by")
-  attr :reveal, :string, required: true, doc: ~s(the unfold link — "This is a pen name")
-  attr :kind, :atom, required: true, doc: ":author or :narrator"
 
   attr :identity_backing, :map,
     default: %{},
     doc: "identity id => the backing people's names, where they add something"
 
-  attr :person_records, :map,
-    default: %{},
-    doc: "person key => the provider records of people by that name"
-
-  attr :person_outcomes, :map,
-    default: %{},
-    doc: "person key => what each person provider said when asked"
-
   attr :persons, :list, required: true, doc: "the PersonDecisions this credit references"
-  attr :appearances, :map, default: %{}, doc: "person key => every credit referencing them"
-  attr :searching_person, :string, default: nil, doc: "the person being looked up again"
-  attr :photos_expanded, :map, default: %{}, doc: "person key => whether all photos show"
 
   attr :count, :integer,
     default: 1,
@@ -754,9 +742,8 @@ defmodule AmbryWeb.Admin.Decisions do
   A credited name IS an identity. How many humans stand behind it is a fact
   about the *person* — not about this book — and no provider reports it, so
   asking on every import buried the two cases where the answer is interesting
-  under dozens where it isn't. The person layer is therefore folded away
-  behind "This is a pen name" / "This is a stage name", and unfolds itself
-  whenever the credit is anything but the 1:1 default (`Credit.simple?/1`).
+  under dozens where it isn't. The person layer is a section of its own, and
+  the credit carries a reference to it: names, faces, and a link.
 
   ## The name is editable
 
@@ -764,6 +751,8 @@ defmodule AmbryWeb.Admin.Decisions do
   overrule it, "David Wong" could only be imported as a person called David
   Wong — the human is Jason Pargin, and that import is one author plus one
   differently-named person, which is now two edits rather than impossible.
+  "This is a pen name" is the second of the two: it gives the human a name of
+  their own and takes the operator to the card that now has a box for it.
 
   A link decision always targets an identity, never a Person. That is the
   generalized fix for the pen-name bug where matching found a Person and
@@ -847,38 +836,86 @@ defmodule AmbryWeb.Admin.Decisions do
         </div>
       </div>
 
-      <form
-        id={"credit-#{@section}-#{@index}-identity"}
-        phx-change="credit-change"
-        class="flex flex-wrap items-baseline gap-2"
-      >
-        <input type="hidden" name="section" value={@section} />
-        <input type="hidden" name="index" value={@index} />
-
-        <.live_component
-          module={EntityResolver}
-          id={"credit-#{@section}-#{@index}-resolver"}
-          name="identity_id"
-          text_name="name"
-          options={@identities}
-          value={if @credit.mode == :link, do: @credit.identity_id}
-          text={@credit.name || ""}
-          placeholder="name"
-          class={input_classes("w-full")}
-        />
-
-        <%!-- The prefix segment already says "Existing"; this only speaks
-              when the linked identity is backed by other humans — a pen
-              name's real names are worth a line, "already in the library"
-              twice is not. --%>
-        <span
-          :if={@credit.mode == :link && @identity_backing[@credit.identity_id]}
-          class="text-xs text-zinc-400"
-          data-role="identity-backing"
+      <%!-- The people ride beside the box rather than under it. A credit is
+            one line of meaning — this name, these humans — and a full-cast
+            recording is a run of these rows, where a second line each is what
+            turns the section into a wall. --%>
+      <div class="flex flex-wrap items-center gap-2">
+        <form
+          id={"credit-#{@section}-#{@index}-identity"}
+          phx-change="credit-change"
+          class="min-w-48 flex flex-grow flex-wrap items-baseline gap-2"
         >
-          {@identity_backing[@credit.identity_id]}
-        </span>
-      </form>
+          <input type="hidden" name="section" value={@section} />
+          <input type="hidden" name="index" value={@index} />
+
+          <.live_component
+            module={EntityResolver}
+            id={"credit-#{@section}-#{@index}-resolver"}
+            name="identity_id"
+            text_name="name"
+            options={@identities}
+            value={if @credit.mode == :link, do: @credit.identity_id}
+            text={@credit.name || ""}
+            placeholder="name"
+            class={input_classes("w-full")}
+          />
+
+          <%!-- The prefix segment already says "Existing"; this only speaks
+                when the linked identity is backed by other humans — a pen
+                name's real names are worth a line, "already in the library"
+                twice is not. --%>
+          <span
+            :if={@credit.mode == :link && @identity_backing[@credit.identity_id]}
+            class="text-xs text-zinc-400"
+            data-role="identity-backing"
+          >
+            {@identity_backing[@credit.identity_id]}
+          </span>
+        </form>
+
+        <%!-- A reference, not the person. The human lives once, in the People
+              section, because one human is one record — rendering them inside
+              every credit that named them is what made an author who reads
+              their own book appear twice, with a sentence apologising for it.
+              What a credit needs is enough to recognise who it means and a way
+              to get there. --%>
+        <div
+          :if={@credit.mode == :create and @persons != []}
+          class="flex flex-none flex-wrap gap-2"
+          data-role="credit-people"
+        >
+          <.link
+            :for={person <- Enum.take(@persons, person_chips())}
+            href={"#person-#{person.key}"}
+            class="bg-white/5 flex items-center gap-2 rounded-full py-1 pr-3 pl-1 text-xs text-zinc-300 hover:bg-white/10"
+          >
+            <img
+              :if={Field.value(person.image)}
+              src={preview_src(Field.value(person.image), nil)}
+              class="h-6 w-6 flex-none rounded-full object-cover"
+              alt=""
+            />
+            <span
+              :if={!Field.value(person.image)}
+              class="h-6 w-6 flex-none rounded-full bg-zinc-800"
+            />
+            {Field.value(person.name) || "unnamed"}
+          </.link>
+
+          <%!-- One credit standing for a dozen humans would push the row into
+                a paragraph of faces. The rest are a click away in the section
+                that lists every one of them. --%>
+          <.link
+            :if={length(@persons) > person_chips()}
+            href="#people"
+            title={Enum.map_join(Enum.drop(@persons, person_chips()), ", ", &(Field.value(&1.name) || "unnamed"))}
+            class="bg-white/10 flex items-center rounded-full px-3 py-1 text-xs tabular-nums text-zinc-300 hover:bg-white/20"
+          >
+            +{length(@persons) - person_chips()}
+          </.link>
+        </div>
+      </div>
 
       <%!-- The way back after a rename or a clear — the same chip the scalar
             fields have always had. Only speaks while the box disagrees with
@@ -905,61 +942,6 @@ defmodule AmbryWeb.Admin.Decisions do
           </.proposal_chip>
         </div>
       </div>
-
-      <%!-- A reference, not the person. The human lives once, in the New
-            people section, because one human is one record — rendering them
-            inside every credit that named them is what made an author who
-            reads their own book appear twice, with a sentence apologising for
-            it. What a credit needs is enough to recognise who it means and a
-            way to get there. --%>
-      <div :if={@credit.mode == :create and @persons != []} class="flex flex-wrap gap-2 pl-3">
-        <.link
-          :for={person <- @persons}
-          href={"#person-#{person.key}"}
-          class="bg-white/5 flex items-center gap-2 rounded-full py-1 pr-3 pl-1 text-xs text-zinc-300 hover:bg-white/10"
-        >
-          <img
-            :if={Field.value(person.image)}
-            src={preview_src(Field.value(person.image), nil)}
-            class="h-6 w-6 flex-none rounded-full object-cover"
-            alt=""
-          />
-          <span
-            :if={!Field.value(person.image)}
-            class="h-6 w-6 flex-none rounded-full bg-zinc-800"
-          />
-          {Field.value(person.name) || "unnamed"}
-        </.link>
-      </div>
-
-      <div class="flex flex-wrap gap-x-4 pl-3">
-        <%!-- Not a fold any more: the person layer is a section of its own, so
-              this says the one thing it always meant — the credited name is
-              not the human's name. --%>
-        <button
-          :if={@credit.mode == :create and Credit.simple?(@credit)}
-          type="button"
-          phx-click="separate-name"
-          phx-value-section={@section}
-          phx-value-index={@index}
-          class="text-xs text-zinc-400 underline"
-        >
-          {@reveal}
-        </button>
-
-        <%!-- Narrators stay one-to-one with a Person by design; only the
-              author control grows a second entry. --%>
-        <button
-          :if={@section == "work" and @credit.mode == :create}
-          type="button"
-          phx-click="add-person"
-          phx-value-section={@section}
-          phx-value-index={@index}
-          class="text-xs text-zinc-400 underline"
-        >
-          Add another person
-        </button>
-      </div>
     </div>
     """
   end
@@ -971,6 +953,7 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :searching, :boolean, default: false
   attr :photos_expanded, :boolean, default: false
   attr :records, :list, default: []
+  attr :locals, :list, default: [], doc: "people the library already has by this name"
   attr :outcomes, :list, default: []
   attr :appears, :list, default: []
   attr :people, :list, default: [], doc: "the library's people, for the typeahead"
@@ -983,99 +966,318 @@ defmodule AmbryWeb.Admin.Decisions do
   question: which identity does this book credit. They were one control for a
   long time, which is why an author reading their own book rendered twice.
 
+  ## The name box is the exception, not the furniture
+
+  A credited name is the human's name in almost every import, so the card
+  states it and offers nothing to type. The box appears when the name is
+  genuinely the person's own — the operator said the credit is a pen name, or
+  the credit stands for several humans, neither of whom it names. That is also
+  what "This is a pen name" was missing: with a name box on every card in
+  every state, the control had no visible effect at all.
+
   The events still address the credit that introduces them (`section`,
   `index`, `person_index`), because "remove this person" means removing them
   from that credit — the person exists only as long as a credit names them.
   """
   def person_card(assigns) do
+    assigns =
+      assign(assigns,
+        own_name: assigns.person.own_name or not Credit.simple?(assigns.group.credit),
+        linked: linked_person(assigns.people, assigns.person)
+      )
+
     ~H"""
     <div
       id={"person-#{@person.key}"}
-      class={["space-y-3 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@person)]}
+      class={["relative space-y-3 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@person)]}
       data-role="person-card"
     >
-      <div class="flex items-baseline justify-between gap-2 pl-3">
-        <.label>{Field.value(@person.name) || "Unnamed person"}</.label>
+      <%!-- A provider round-trip is the same kind of event as a matching job,
+            and gets the same answer: the card is not yours while it runs. A
+            button changing its own label to "Searching…" was the whole
+            indication, in a fold that could close over it. --%>
+      <.busy_overlay busy={@searching} label={"Looking for #{person_words(@person)}…"} />
 
-        <button
-          :if={@removable}
-          type="button"
-          phx-click="remove-person"
-          phx-value-section={@group.section}
-          phx-value-index={@group.index}
-          phx-value-person={@person_index}
-          title="not one of the people behind this name"
-        >
-          <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
-        </button>
-      </div>
+      <div class="space-y-3" inert={@searching}>
+        <%!-- Titled by the CREDIT, which is the one name on this card that
+              doesn't move: the box below is the human's name, and a header
+              that followed it re-titled the card letter by letter while the
+              operator typed the very thing the card is about. --%>
+        <div class="flex items-baseline justify-between gap-2 pl-3">
+          <div class="flex min-w-0 items-baseline gap-2">
+            <.label>{card_words(@group.credit, @person)}</.label>
 
-      <%!-- Where they are credited, and — when that is more than one place —
-            the escape hatch for two humans who really do share a name. The
-            card exists once for the person, so this is the only place the
-            question can be asked. --%>
-      <p class="pl-3 text-xs text-zinc-400">
-        {appearance_words(@appears)}
-        <button
+            <%!-- Where they are credited is a fact about this card, so it
+                  wears the status costume beside the title rather than a
+                  sentence under it. --%>
+            <.badge :if={@appears != []} color={:gray} class="text-xs">
+              {credited_words(@appears)}
+            </.badge>
+          </div>
+
+          <button
+            :if={@removable}
+            type="button"
+            phx-click="remove-person"
+            phx-value-section={@group.section}
+            phx-value-index={@group.index}
+            phx-value-person={@person_index}
+            title="not one of the people behind this name"
+          >
+            <.icon name="fa-xmark" class="h-3 w-3 cursor-pointer hover:text-red-600" />
+          </button>
+        </div>
+
+        <%!-- One human on two credits is the ordinary reason a name appears
+              twice, so it is the default, and the badge above already says
+              which two. What is left is the escape hatch for the other case,
+              asked here because the card exists once per person. --%>
+        <p
           :if={length(Enum.uniq_by(@appears, & &1.kind)) > 1}
-          type="button"
-          phx-click="split-person"
-          phx-value-section={@group.section}
-          phx-value-index={@group.index}
-          phx-value-person={@person_index}
-          class="underline"
+          class="pl-3 text-xs text-zinc-400"
         >
-          Not the same person?
-        </button>
-      </p>
+          <button
+            type="button"
+            phx-click="split-person"
+            phx-value-section={@group.section}
+            phx-value-index={@group.index}
+            phx-value-person={@person_index}
+            class="underline"
+          >
+            Not the same person?
+          </button>
+        </p>
 
-      <%!-- The name is a decision like any other: a provider's spelling is a
-          proposal, and without a box to overrule it "David Wong" could only
-          be imported as a person called David Wong when the human is Jason
-          Pargin. The typeahead is also how they become somebody already in
-          the library. --%>
-      <form id={"person-#{@person.key}-identity"} phx-change="person-change">
-        <input type="hidden" name="key" value={@person.key} />
+        <%!-- The 99-in-100 case: the credit names the human, the title says so,
+              and the card asks nothing. The link is the whole line — saying
+              "named by the credit" under a card titled by the credit was the
+              same fact twice. --%>
+        <p :if={@person.mode == :create and !@own_name} class="pl-3 text-xs text-zinc-400">
+          <button
+            type="button"
+            phx-click="separate-name"
+            phx-value-section={@group.section}
+            phx-value-index={@group.index}
+            class="underline"
+          >
+            {reveal_words(@group.kind)}
+          </button>
+        </p>
 
-        <.live_component
-          module={EntityResolver}
-          id={"person-#{@person.key}-resolver"}
-          name="person_id"
-          text_name="name"
-          options={@people}
-          value={if @person.mode == :link, do: @person.person_id}
-          text={Field.value(@person.name) || ""}
-          placeholder="the person's real name"
-          class={input_classes("w-full")}
+        <%!-- The exception, revealed: a provider's spelling is a proposal, and
+              without a box to overrule it "David Wong" could only be imported
+              as a person called David Wong when the human is Jason Pargin. The
+              typeahead is also how they become somebody already in the
+              library. --%>
+        <div :if={@person.mode == :create and @own_name} class="space-y-1">
+          <p class="pl-3 text-xs text-zinc-400">{alias_words(@group.kind)}</p>
+
+          <form id={"person-#{@person.key}-identity"} phx-change="person-change">
+            <input type="hidden" name="key" value={@person.key} />
+
+            <.live_component
+              module={EntityResolver}
+              id={"person-#{@person.key}-resolver"}
+              name="person_id"
+              text_name="name"
+              options={@people}
+              value={nil}
+              text={Field.value(@person.name) || ""}
+              placeholder="the person's real name"
+              class={input_classes("w-full")}
+            />
+          </form>
+
+          <%!-- Both escape hatches from the same state, on the rail under the
+                box they belong to. A shared pen name is the composite-author
+                case and it is asked here rather than on the credit, where it
+                changed a card the operator couldn't see. Narrators stay
+                one-to-one with a person by design. --%>
+          <div class="flex flex-wrap items-baseline gap-x-4 pl-3 text-xs text-zinc-400">
+            <span :if={@group.section == "work"}>
+              Is this pen name more than one person?
+              <button
+                type="button"
+                phx-click="add-person"
+                phx-value-section={@group.section}
+                phx-value-index={@group.index}
+                class="underline"
+              >
+                Add a person
+              </button>
+            </span>
+
+            <%!-- Every way in needs a way out: the reveal used to be a fold
+                  that could not be folded back. --%>
+            <button
+              :if={Credit.simple?(@group.credit)}
+              type="button"
+              phx-click="use-credited-name"
+              phx-value-key={@person.key}
+              class="underline"
+            >
+              No, {@group.credit.name} is their name
+            </button>
+          </div>
+        </div>
+
+        <%!-- A different KIND of question from the provider records below, and
+              the same shape the work level gives it: those describe a human,
+              this one IS one, and choosing them creates nobody. Matching
+              collects them whenever a credited name is already in the library
+              — which is exactly the author who turns up narrating. --%>
+        <div :if={@locals != [] or @person.mode == :link} class="space-y-2">
+          <p class="pl-3 text-xs text-zinc-400">
+            {local_people_words(@person, @locals)}
+          </p>
+
+          <.local_person_row
+            :for={local <- @locals}
+            local={local}
+            person_key={@person.key}
+            chosen={@person.mode == :link and @person.person_id == local["id"]}
+          />
+
+          <%!-- Linked to somebody the name search never offered (the typeahead
+                above), so the row is built from the library instead. --%>
+          <.local_person_row
+            :if={@person.mode == :link and not Enum.any?(@locals, &(&1["id"] == @person.person_id))}
+            local={@linked}
+            person_key={@person.key}
+            chosen={true}
+          />
+        </div>
+
+        <.person_curation
+          person={@person}
+          section={@group.section}
+          index={@group.index}
+          person_index={@person_index}
+          kind={@group.kind}
+          appears={@appears}
+          searching={@searching}
+          expanded={@photos_expanded}
+          records={@records}
+          outcomes={@outcomes}
         />
-      </form>
-
-      <.person_curation
-        person={@person}
-        section={@group.section}
-        index={@group.index}
-        person_index={@person_index}
-        kind={@group.kind}
-        appears={@appears}
-        searching={@searching}
-        expanded={@photos_expanded}
-        records={@records}
-        outcomes={@outcomes}
-      />
+      </div>
     </div>
     """
   end
 
+  defp person_words(person), do: Field.value(person.name) || "Unnamed person"
+
+  # The credited name, which is what this card is a card *about*. Falls back
+  # to the human's own name only when the credit has none — a cleared credit
+  # box mid-retype, where a blank title would name nothing at all.
+  defp card_words(%Credit{name: name}, person) when is_binary(name) do
+    if String.trim(name) == "", do: person_words(person), else: name
+  end
+
+  defp card_words(_credit, person), do: person_words(person)
+
+  defp reveal_words(:narrator), do: "This is a stage name"
+  defp reveal_words(_author), do: "This is a pen name"
+
+  defp alias_words(:narrator), do: "A stage name of"
+  defp alias_words(_author), do: "A pen name of"
+
+  # The library's own row for a person linked from the typeahead rather than
+  # from the rows below — enough to say who, and to take it back.
+  defp linked_person(people, %PersonDecision{mode: :link, person_id: id}) do
+    case Enum.find(people, &(&1.id == id)) do
+      nil -> %{"id" => id, "name" => "Somebody in your library"}
+      person -> %{"id" => person.id, "name" => person.label}
+    end
+  end
+
+  defp linked_person(_people, _person), do: nil
+
+  defp local_people_words(%PersonDecision{mode: :link}, _locals),
+    do: "This import will use the person you already have."
+
+  defp local_people_words(_person, [_one]),
+    do: "Somebody by this name is already in your library."
+
+  defp local_people_words(_person, locals),
+    do: "#{length(locals)} people by this name are already in your library."
+
+  attr :local, :map, required: true
+  attr :person_key, :string, required: true
+  attr :chosen, :boolean, required: true
+
   @doc """
-  Where this human is credited, in words.
+  A person the library already has, offered instead of creating another.
 
-  The card is away from the credits now, so it has to say what it belongs to —
-  and for somebody behind two credits, that they are one person rather than
-  two identically named ones.
+  The same well the local-book row is, because it is the same question one
+  level down: reusing a human is the outcome worth having, and the form's job
+  is to make it one click rather than a duplicate nobody notices until two
+  Andy Weirs are sitting in the people list.
   """
-  def appearance_words([]), do: "Not credited anywhere on this import."
+  def local_person_row(assigns) do
+    ~H"""
+    <div
+      class={[
+        "flex items-center gap-3 rounded-md p-3",
+        @chosen && "bg-brand-dark/10 ring-brand-dark/50 ring-2 ring-inset",
+        !@chosen && "bg-zinc-800/60"
+      ]}
+      data-role="local-person"
+      data-linked={@chosen && "true"}
+    >
+      <div class="min-w-0 flex-grow">
+        <p class="truncate text-sm font-semibold">{@local["name"]}</p>
+        <p :if={local_facts(@local)} class="truncate text-xs text-zinc-400">{local_facts(@local)}</p>
+      </div>
 
-  def appearance_words(appears) do
+      <button
+        :if={!@chosen}
+        type="button"
+        phx-click="link-person"
+        phx-value-key={@person_key}
+        phx-value-id={@local["id"]}
+        class={action_classes(:zinc, "flex-none")}
+      >
+        Yes, it's them
+      </button>
+
+      <button
+        :if={@chosen}
+        type="button"
+        phx-click="unlink-person"
+        phx-value-key={@person_key}
+        class={action_classes(:zinc, "flex-none")}
+      >
+        No, a new person
+      </button>
+    </div>
+    """
+  end
+
+  # What the library already knows about them, which is the whole reason to
+  # reuse the record rather than make a second one.
+  defp local_facts(local) do
+    [
+      local["has_image"] && "has a photo",
+      local["has_description"] && "has a biography"
+    ]
+    |> Enum.filter(& &1)
+    |> case do
+      [] -> nil
+      facts -> Enum.join(facts, " · ")
+    end
+  end
+
+  @doc """
+  Where this human is credited, as the badge beside the card's title.
+
+  The card is away from the credits, so it has to say what it belongs to.
+  A badge rather than a sentence because that is what it is: a fact about the
+  card, stated once, in the costume every other status fact wears. The
+  interesting half — that two credits mean one person rather than two of a
+  name — is a line of its own, since it comes with a control.
+  """
+  def credited_words(appears) do
     appears
     |> Enum.map(& &1.kind)
     |> Enum.uniq()
@@ -1085,8 +1287,8 @@ defmodule AmbryWeb.Admin.Decisions do
       other -> to_string(other)
     end)
     |> case do
-      [one] -> "Credited as #{one}."
-      several -> "Credited as #{Enum.join(several, " and ")} — one person, both credits."
+      [] -> "Credited nowhere"
+      kinds -> "Credited as #{Enum.join(kinds, " and ")}"
     end
   end
 
@@ -1178,6 +1380,21 @@ defmodule AmbryWeb.Admin.Decisions do
         />
       </div>
 
+      <%!-- The same three parts in the same order as the work and recording
+            levels, and now with the same name on them: the query, who
+            answered, and what they said. The person level used to carry no
+            label at all and its search hid in a fold under its own results. --%>
+      <.microlabel class="block pl-3">Provider records</.microlabel>
+
+      <.person_research_form
+        at={@at}
+        person_key={@person.key}
+        name={Field.value(@person.name)}
+        running={@searching}
+      />
+
+      <.provider_outcomes_row outcomes={@outcomes} retryable={false} />
+
       <%!-- Nothing found is a normal outcome, not a failure — plenty of
             narrators are in no database at all — but it should say so rather
             than looking like an empty grid nobody filled in. --%>
@@ -1185,38 +1402,46 @@ defmodule AmbryWeb.Admin.Decisions do
         {@person.doubt_detail}
       </p>
 
-      <%!-- The same evidence rule as the work and recording levels, one
-            paradigm across all three: tick every record of THIS human, and
-            the photo and bio pools draw from the ticked set. The exact-name
-            gate decides the initial ticks; a differently-spelled record of
-            the right person is exactly what the checkbox is for. --%>
-      <p :if={@records != []} class="max-w-prose pl-3 text-xs text-zinc-400">
-        Tick every record of <span class="font-semibold">this person</span>. Check the name
-        carefully first; the photos and bios on offer come from the ticked records.
-      </p>
-
-      <.record_row
-        :for={record <- @records}
-        record={record}
-        event="toggle-person-source"
-        person_key={@person.key}
-        used={Enum.any?(@person.sources, &SourceRef.points_at?(&1, record))}
-      />
-
-      <.provider_outcomes_row outcomes={@outcomes} retryable={false} />
-
-      <.disclosure summary="Not the right person? Search again">
-        <div class="pt-2">
-          <.person_research_form
-            at={@at}
+      <%!-- Folded on the same threshold as the work and recording levels, and
+            for the same reason: a re-search under a new name leaves the old
+            name's records scored against a question nobody is asking any
+            more, and eight rows of equal weight is how the wrong human stays
+            in the running. A ticked record is never folded. --%>
+      <.record_list records={@records} used={&PersonDecision.uses?(@person, &1)}>
+        <:row :let={record}>
+          <.record_row
+            record={record}
+            event="toggle-person-source"
             person_key={@person.key}
-            name={Field.value(@person.name)}
-            running={@searching}
+            used={PersonDecision.uses?(@person, record)}
           />
-        </div>
-      </.disclosure>
+        </:row>
+      </.record_list>
 
-      <div :if={@photos != []} class="grid-cols-[4.5rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
+      <%!-- The same answer the other two levels have. A person the matcher
+            doubted — it found humans of roughly this name and believed none
+            of them — stays outstanding until somebody says so, and this is
+            what says so. It costs nothing but the photo and the biography:
+            a name is all it takes to create a person. --%>
+      <div :if={@records != []} class="flex flex-wrap items-center gap-2 pt-1">
+        <button
+          type="button"
+          phx-click="uncatalogued-person"
+          phx-value-key={@person.key}
+          data-role="none-of-these"
+          class={[
+            "px-[11px] rounded-md border py-1 text-xs",
+            PersonDecision.uncatalogued?(@person) &&
+              "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
+            !PersonDecision.uncatalogued?(@person) &&
+              "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
+          ]}
+        >
+          None of these
+        </button>
+      </div>
+
+      <div :if={@photos != []} class="grid-cols-[4rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
         <.microlabel class="pt-1">Photos</.microlabel>
 
         <div class="flex flex-wrap items-center gap-2">
@@ -1322,6 +1547,13 @@ defmodule AmbryWeb.Admin.Decisions do
   end
 
   defp photo_preview, do: @photo_preview
+
+  # How many faces a credit shows before it starts counting instead. Four is
+  # a composite author plus room to spare; a credit standing for more than
+  # that is a list, and the People section is where lists live.
+  @person_chips 4
+
+  defp person_chips, do: @person_chips
 
   defp shown_photos(photos, true), do: photos
   defp shown_photos(photos, _collapsed), do: Enum.take(photos, @photo_preview)

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -24,6 +24,7 @@ defmodule AmbryWeb.Admin.Decisions do
   alias Ambry.Inbox.Draft.PersonDecision
   alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.Draft.SourceRef
+  alias Ambry.Inbox.Draft.Tier
   alias AmbryWeb.Components.EntityResolver
 
   attr :outcomes, :list, required: true
@@ -553,12 +554,17 @@ defmodule AmbryWeb.Admin.Decisions do
           option row) sits on the text rail (pl-3), aligned with the text
           INSIDE the control; only boxes touch the margin edge. See
           docs/admin-design-language.md §1. --%>
-    <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", decision_rail(@field)]}>
+    <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@field)]}>
       <div class="flex items-baseline gap-2 pl-3">
         <.label>{@label}</.label>
 
+        <%!-- Only when it says something the rail can't. Amber already means
+            "look here"; "sources disagree" and "nothing proposed it" are
+            different problems wanting different things from the operator, and
+            a badge repeating "needs confirming" next to an amber rail is the
+            same fact twice (§2). --%>
         <.badge
-          :if={!@field.approved}
+          :if={explained?(Field.state(@field))}
           color={elem(state_words(Field.state(@field)), 1)}
           class="text-xs"
         >
@@ -798,16 +804,13 @@ defmodule AmbryWeb.Admin.Decisions do
     <%!-- A decision block, so it wears the state rail like every other one —
         the rail is the ONLY settledness encoding (design language §2); the
         check icon it used to grow shifted the title sideways on approval. --%>
-    <div class={[
-      "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-      (Credit.resolved?(@credit) && "border-brand-dark/60") || "border-amber-400/70"
-    ]}>
+    <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@credit)]}>
       <div class="flex items-center justify-between gap-2 pl-3">
         <div class="flex min-w-0 items-baseline gap-2">
           <.label>{@verb}</.label>
 
           <.badge
-            :if={!Credit.resolved?(@credit)}
+            :if={explained?(Credit.state(@credit))}
             color={elem(state_words(Credit.state(@credit)), 1)}
             class="text-xs"
           >
@@ -1423,10 +1426,7 @@ defmodule AmbryWeb.Admin.Decisions do
         with the state on the block's left rail (no extra check icon — the
         rail is the only settledness encoding, §2), controls below with
         their labels above them. --%>
-    <div class={[
-      "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-      (SeriesLink.resolved?(@link) && "border-brand-dark/60") || "border-amber-400/70"
-    ]}>
+    <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@link)]}>
       <div class="flex items-center justify-between gap-2 pl-3">
         <div class="flex min-w-0 items-baseline gap-2">
           <.label>In series</.label>
@@ -1572,10 +1572,7 @@ defmodule AmbryWeb.Admin.Decisions do
   def group_row(assigns) do
     ~H"""
     <div
-      class={[
-        "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-        (GroupLink.resolved?(@link) && "border-brand-dark/60") || "border-amber-400/70"
-      ]}
+      class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(@link)]}
       data-role="group-link"
     >
       <div class="flex items-center justify-between gap-2 pl-3">
@@ -1699,16 +1696,28 @@ defmodule AmbryWeb.Admin.Decisions do
     """
   end
 
-  # The block's left rail is the decision's state, readable from a scroll:
-  # lime = settled, amber = waiting on the operator, red = blocked. A 4px
-  # rail renders crisp at any DPI where a tinted hairline goes mushy.
-  defp decision_rail(field) do
-    cond do
-      field.approved -> "border-brand-dark/60"
-      Field.state(field) == :missing -> "border-red-400/70"
-      true -> "border-amber-400/70"
-    end
-  end
+  @doc """
+  The block's left rail — the one thing that encodes settledness (§2).
+
+  Four tiers, because settled-versus-waiting threw away the question the
+  operator actually asks of a machine-matched import: has anyone looked at
+  this yet. A 4px rail renders crisp at any DPI where a tinted hairline goes
+  mushy.
+  """
+  def state_rail(%{__struct__: _} = decision), do: state_rail(Tier.of(decision))
+  def state_rail(:blocked), do: "border-red-400/70"
+  def state_rail(:waiting), do: "border-amber-400/70"
+  def state_rail(:unreviewed), do: "border-blue-400/70"
+  def state_rail(:reviewed), do: "border-brand-dark/60"
+
+  @doc """
+  Whether this state is worth a badge beside the rail.
+
+  The rail already says settled-or-not; a badge earns its place only when it
+  names a *reason* the colour can't — which values disagree, or that nothing
+  proposed one at all.
+  """
+  def explained?(state), do: state in [:missing, :ambiguous, :stale]
 
   @doc """
   A decision's state as words and a colour.
@@ -1725,18 +1734,16 @@ defmodule AmbryWeb.Admin.Decisions do
   def state_words(_other), do: {"needs confirming", :yellow}
 
   @doc """
-  A level's identity state as a badge — `Ambry.Inbox.Draft.level_state/1`'s
-  words. One vocabulary for the queue and the form, or they drift.
+  A tier as words and a colour, for surfaces with no room for a rail.
 
-  "confirmed" is the operator's; "trusted" is the machine's. The distinction
-  is the point: the old badge showed match-time confidence forever, so a
-  human's answer could never update it — and a correct "unsure" match could
-  never be told "you were right" except by this.
+  A queue row is one line: it has nowhere to put a 4px edge per level, so it
+  says the same four states in words. Same vocabulary as the form's rail, or
+  the two drift — which is exactly what happened when the queue had its own.
   """
-  def level_state_words(:confirmed), do: {"confirmed", :brand}
-  def level_state_words(:trusted), do: {"trusted", :blue}
-  def level_state_words(:unsure), do: {"unsure", :yellow}
-  def level_state_words(:no_match), do: {"no match", :gray}
+  def tier_words(:blocked), do: {"blocked", :red}
+  def tier_words(:waiting), do: {"needs you", :yellow}
+  def tier_words(:unreviewed), do: {"matched", :blue}
+  def tier_words(:reviewed), do: {"reviewed", :brand}
 
   @doc """
   Where a cover value can actually be looked at.

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -767,6 +767,7 @@ defmodule AmbryWeb.CoreComponents do
   """
   attr :for, :string, default: nil
   attr :class, :string, default: nil, doc: "class overrides"
+  attr :rest, :global, doc: "passed through — `title` carries a tooltip, e.g. a match score"
   slot :inner_block, required: true
 
   def label(assigns) do
@@ -774,6 +775,7 @@ defmodule AmbryWeb.CoreComponents do
     <label
       for={@for}
       class={["block whitespace-nowrap text-sm font-semibold leading-6 text-zinc-200", @class]}
+      {@rest}
     >
       {render_slot(@inner_block)}
     </label>

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -170,7 +170,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
        |> assign(retrying: provider_id)
        |> start_async(:evidence_search, fn ->
          {books, outcome} = MetadataSearch.books_one(entry, query)
-         {Inbox.score_records(books, entry, hints), [outcome]}
+         {Inbox.score_records(books, entry, hints), List.wrap(outcome)}
        end)}
     else
       _no -> {:noreply, socket}

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -81,6 +81,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      # ignored, or the plain Back button — returns to the tab and page they
      # were on rather than an unfiltered page one.
      |> assign(return_to: return_to(params))
+     # Development only: the undo that makes "run this release again" a click
+     # rather than a hand-written cleanup. Absent from any other build.
+     |> assign(can_undo: Inbox.undo_available?())
      |> attach_hook(:refuse_while_busy, :handle_event, &refuse_while_busy/3)
      |> attach_hook(:refuse_when_imported, :handle_event, &refuse_when_imported/3)
      |> load(item)}
@@ -103,7 +106,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # the record lie. The banner and `inert` explain; this enforces, because
   # markup is advisory and a stale tab can still send anything. The only
   # events allowed through are pure view state.
-  @view_events ~w(toggle-photos)
+  # `undo-import` is the one write an imported item allows, and only where
+  # the dev flag is on — undoing is the opposite of editing the record: it
+  # deletes what the record describes rather than making it lie.
+  @view_events ~w(toggle-photos undo-import)
 
   defp refuse_when_imported(event, _params, socket) do
     if socket.assigns.read_only and event not in @view_events do
@@ -686,6 +692,21 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
+  # Development only — `Inbox.undo_import/1` refuses on any build without the
+  # flag, whatever the markup says.
+  def handle_event("undo-import", _params, socket) do
+    case Inbox.undo_import(socket.assigns.item) do
+      {:ok, summary} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, undo_words(summary))
+         |> load(Inbox.get_item!(socket.assigns.item.id))}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(reason))}
+    end
+  end
+
   def handle_event("ignore", _params, socket) do
     {:ok, _item} = Inbox.ignore_item(socket.assigns.item)
 
@@ -821,6 +842,19 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     )
     |> schedule_tick()
   end
+
+  # What went and what stayed, in one sentence. The kept half is the
+  # interesting one: a book that survived because a second recording joined it
+  # is exactly what somebody would otherwise go and check by hand.
+  defp undo_words(%{deleted: deleted, kept: kept}) do
+    gone = if deleted == [], do: "Nothing to delete.", else: "Deleted #{sentence(deleted)}."
+    stayed = if kept != [], do: " Kept #{sentence(kept)}."
+
+    "#{gone}#{stayed} Back in the queue, with its decisions."
+  end
+
+  defp sentence([one]), do: one
+  defp sentence(items), do: items |> Enum.intersperse(", ") |> Enum.join()
 
   defp atom("work"), do: :work
   defp atom("recording"), do: :recording

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -52,7 +52,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   require Logger
 
   @impl Phoenix.LiveView
-  def mount(%{"id" => id}, _session, socket) do
+  def mount(%{"id" => id} = params, _session, socket) do
     item = Inbox.get_item!(id)
     {:ok, item} = Inbox.prepare_draft(item)
 
@@ -74,12 +74,25 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      # The pending chapter-title fetch, and which ASIN's titles were last
      # poured — the chips' chosen state.
      |> assign(chapter_import: nil, chapters_applied_asin: nil)
-     # An import the operator started, as opposed to a job that found the
-     # item on its own. Both own the form; only this one is theirs.
-     |> assign(importing: false)
+     # Where the operator came from, so every way out of this form — imported,
+     # ignored, or the plain Back button — returns to the tab and page they
+     # were on rather than an unfiltered page one.
+     |> assign(return_to: return_to(params))
      |> attach_hook(:refuse_while_busy, :handle_event, &refuse_while_busy/3)
      |> attach_hook(:refuse_when_imported, :handle_event, &refuse_when_imported/3)
      |> load(item)}
+  end
+
+  # The list state the operator arrived with, echoed back as a path. Only the
+  # keys the index actually reads, so a hand-typed URL can't turn this into an
+  # open redirect or a 500 on a junk param.
+  @list_params ~w(filter page status ready)
+
+  defp return_to(params) do
+    case Map.take(params, @list_params) do
+      empty when map_size(empty) == 0 -> ~p"/admin/inbox"
+      list -> ~p"/admin/inbox?#{list}"
+    end
   end
 
   # An imported item's draft is the record of what was imported — the operator
@@ -120,7 +133,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   not about who took it.
   """
   def busy?(%{assigns: assigns}), do: busy?(assigns)
-  def busy?(%{busy: busy, importing: importing}), do: busy or importing
+  def busy?(%{busy: busy}), do: busy
 
   # How often a busy form looks again. Only ticks while a job is actually on
   # this item, so an idle form costs nothing.
@@ -148,19 +161,14 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   @doc """
   What the job on this item is doing, in the words the overlay uses.
   """
-  def busy_label(_job, importing \\ false)
-
   # Naming the slow part, because it is the part that makes the operator
   # wonder whether the click landed: a multi-file release is re-probed file
   # by file and then every one of them is placed.
-  def busy_label(_job, true), do: "Adding to the library…"
-
-  def busy_label(:working, _importing), do: "Matching…"
-
-  def busy_label(:retrying, _importing), do: "A provider couldn't be reached. Retrying…"
-
-  def busy_label(:queued, _importing), do: "Queued for matching…"
-  def busy_label(_idle, _importing), do: "Working…"
+  def busy_label(:importing), do: "Adding to the library…"
+  def busy_label(:working), do: "Matching…"
+  def busy_label(:retrying), do: "A provider couldn't be reached. Retrying…"
+  def busy_label(:queued), do: "Queued for matching…"
+  def busy_label(_idle), do: "Working…"
 
   @doc """
   Whether a credit's person layer should be showing.
@@ -642,23 +650,30 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> load(item)}
   end
 
-  # Off the LiveView process, because it is not quick and it used to look
-  # broken: importing re-probes every file and then moves the bytes, which
-  # for a 28-file release measured seven seconds of ffprobe plus a 131MB
-  # copy — all of it inside `handle_event`, where the process cannot render.
-  # The operator got a button that did nothing until the page changed under
-  # them, so of course they clicked it again.
+  # Queued and handed back to the queue. Importing re-probes every file and
+  # then moves the bytes — measured on a 28-file release, seven seconds of
+  # ffprobe plus a 131MB copy, and a copy off a NAS is slower still. Held in
+  # an async task it pinned the operator to a spinner, and worse, the task
+  # **died with the LiveView**: closing the tab killed the import mid-copy.
   #
-  # The form already knows how to say "something owns this item and you can't
-  # edit it": same overlay, same `inert`, same event refusal as a matching
-  # job. This just makes an import one of the things that can own it.
+  # Now the server owns it. The operator goes back to the list they came from
+  # and the row wears the same busy overlay every other job gives it.
   def handle_event("import", _params, socket) do
-    item = socket.assigns.item
+    case Inbox.import_item_async(socket.assigns.item) do
+      {:ok, job} ->
+        message =
+          if job.conflict?,
+            do: "Already adding this one.",
+            else: "Adding to the library. The row will say when it's done."
 
-    {:noreply,
-     socket
-     |> assign(importing: true)
-     |> start_async(:import, fn -> Inbox.import_item(item) end)}
+        {:noreply,
+         socket
+         |> put_flash(:info, message)
+         |> push_navigate(to: socket.assigns.return_to)}
+
+      {:error, :already_imported} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_imported))}
+    end
   end
 
   def handle_event("ignore", _params, socket) do
@@ -667,37 +682,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply,
      socket
      |> put_flash(:info, "Ignored. Files untouched.")
-     |> push_navigate(to: ~p"/admin/inbox")}
+     |> push_navigate(to: socket.assigns.return_to)}
   end
 
   @impl Phoenix.LiveView
-  def handle_async(:import, {:ok, {:ok, _media}}, socket) do
-    {:noreply,
-     socket
-     |> put_flash(:info, "Added to the library.")
-     |> push_navigate(to: ~p"/admin/inbox")}
-  end
-
-  def handle_async(:import, {:ok, {:error, reason}}, socket) do
-    {:noreply,
-     socket
-     |> assign(importing: false)
-     |> put_flash(:error, Inbox.describe_error(reason))
-     |> load(Inbox.get_item!(socket.assigns.item.id))}
-  end
-
-  # A crash mid-import is the one case where the form must not stay locked:
-  # the transaction rolled back, so the item is exactly as it was and the
-  # operator can try again once they know.
-  def handle_async(:import, {:exit, reason}, socket) do
-    Logger.error(fn -> "Inbox form: import crashed: #{inspect(reason)}" end)
-
-    {:noreply,
-     socket
-     |> assign(importing: false)
-     |> put_flash(:error, "Adding to the library failed unexpectedly. Nothing was changed.")
-     |> load(Inbox.get_item!(socket.assigns.item.id))}
-  end
 
   def handle_async({:person_search, _key}, {:ok, {:ok, item}}, socket) do
     {:noreply, socket |> assign(searching_person: nil) |> load(item) |> resettle()}

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -383,8 +383,8 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      end)}
   end
 
-  def handle_event("split", _params, socket) do
-    case Inbox.split_item(socket.assigns.item) do
+  def handle_event("split", params, socket) do
+    case Inbox.split_item(socket.assigns.item, atom(params["by"] || "file")) do
       {:ok, children} ->
         {:noreply,
          socket
@@ -845,6 +845,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       # second copy of "who is where" is what used to drift.
       appearances: Draft.appearances(item.draft),
       destination: Inbox.destination_preflight(item),
+      # Which ways of dividing this item would actually divide it, for the
+      # split controls. Both grains exist on a GraphicAudio set; a folder of
+      # three files has only the finer one.
+      grains: Inbox.split_grains(item),
       # Matching retries with a backoff measured in minutes, so an item can be
       # legitimately mid-work while the form looks like nothing was found.
       job: job,
@@ -870,6 +874,8 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   defp sentence([one]), do: one
   defp sentence(items), do: items |> Enum.intersperse(", ") |> Enum.join()
 
+  defp atom("folder"), do: :folder
+  defp atom("file"), do: :file
   defp atom("work"), do: :work
   defp atom("recording"), do: :recording
   defp atom("title"), do: :title

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -179,6 +179,20 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def busy_label(:queued), do: "Queued for matching…"
   def busy_label(_idle), do: "Working…"
 
+  @doc """
+  What a level's search is looking for, for the scrim that covers it.
+
+  Named rather than a bare "Searching…", because the operator has just typed
+  the words into the box above it and seeing them come back is what says the
+  click landed on the search they meant.
+  """
+  def searching_label(fields) do
+    case (fields || %{})["title"] do
+      title when is_binary(title) and title != "" -> "Looking for #{title}…"
+      _untitled -> "Searching…"
+    end
+  end
+
   # What a person is currently called, which is what a re-search asks about.
   defp person_name(draft, key) do
     case Draft.person(draft, key) do

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -262,9 +262,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
-  def handle_event("uncatalogued", _params, socket) do
+  # "None of these" — a real answer at either level, and the only one available
+  # when nothing a provider returned describes the release.
+  def handle_event("uncatalogued", params, socket) do
     item = socket.assigns.item
-    {:noreply, edit(socket, &Draft.Edit.uncatalogued(&1, item))}
+    level = atom(params["level"] || "recording")
+    {:noreply, edit(socket, &Draft.Edit.uncatalogued(&1, item, level))}
   end
 
   def handle_event("move-credit", %{"section" => s, "index" => i, "direction" => d}, socket) do

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -19,14 +19,18 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   ## Vocabulary
 
-  A credit reads as one line — "Written by" / "Read by" — and the person
-  layer is folded away behind "This is a pen name" / "This is a stage name".
-  An earlier version showed both levels always, on the theory that "Credited
-  as / Written by" teaches the model for free; in practice it charged every
+  A credit reads as one line — "Written by" / "Read by" — and the humans
+  behind it live in their own section, one card each. An earlier version
+  showed both levels inside every credit, on the theory that "Credited as /
+  Written by" teaches the model for free; in practice it charged every
   ordinary import for a question about personhood that only two imports in a
-  hundred have an interesting answer to. The fold unfolds itself whenever the
-  credit is anything but one new person of the same name, so nothing
-  interesting can hide inside it.
+  hundred have an interesting answer to, and printed a person twice whenever
+  an author read their own book.
+
+  What is left of that question on the credit is "This is a pen name" /
+  "This is a stage name": the credited name is not the human's name. It gives
+  that human a name of their own and takes the operator to the card where the
+  box for it has just appeared.
   """
 
   use AmbryWeb, :admin_live_view
@@ -66,8 +70,8 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(people: People.people_for_select())
      |> assign(researching: nil, retrying: nil, enriching: nil)
      # Which person is being looked up again, and whose photo strip is showing
-     # in full. Both are view state keyed by person key — the results
-     # themselves are evidence and live on the item.
+     # in full. Both view state keyed by person key — the results themselves
+     # are evidence and live on the item.
      |> assign(searching_person: nil, photos_expanded: %{})
      |> assign(library_query: nil, library_results: [], ticking: false)
      # The pending chapter-title fetch, and which ASIN's titles were last
@@ -177,25 +181,21 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
-  # The person level's records and provider outcomes, keyed by person, for
-  # the same evidence rows the work and recording sections render.
-  defp person_records(item) do
-    for {key, matched} <- item.matches["people"] || %{}, into: %{} do
-      {key, matched["candidates"] || []}
-    end
-  end
-
-  defp person_outcomes(item) do
-    for {key, matched} <- item.matches["people"] || %{}, into: %{} do
-      {key, matched["providers"] || []}
-    end
-  end
-
   @doc "One person's provider records, for their own card."
   def person_records(item, key), do: get_in(item.matches, ["people", key, "candidates"]) || []
 
   @doc "What each person provider said when asked about them."
   def person_outcomes(item, key), do: get_in(item.matches, ["people", key, "providers"]) || []
+
+  @doc """
+  The people the library already has by this human's name.
+
+  Collected by matching whenever a credited name is already in the library —
+  the author who turns up narrating, whose name the credit's typeahead cannot
+  offer because the identity they need doesn't exist yet. Without a route to
+  them the form's only answer was a second Person of the same name.
+  """
+  def person_locals(item, key), do: get_in(item.matches, ["people", key, "local"]) || []
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"inbox_item" => params}, socket) do
@@ -444,12 +444,25 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   # The credited name is not always the human's name — "David Wong" is Jason
-  # Pargin — so this separates the two. It used to be a fold over a person
-  # layer nested in the credit; now that people are a section of their own
-  # there is nothing to unfold, and the control does the one thing it always
-  # meant.
+  # Pargin — so this separates the two: the person gets a name of their own,
+  # which is what puts a box on their card. It is offered from both ends, the
+  # credit and the card, because either is where the operator notices.
   def handle_event("separate-name", %{"section" => section, "index" => index}, socket) do
     {:noreply, edit(socket, &Draft.Edit.separate_person_name(&1, atom(section), to_int(index)))}
+  end
+
+  def handle_event("use-credited-name", %{"key" => key}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.use_credited_name(&1, key))}
+  end
+
+  # Reusing a human the library already has is the outcome worth having, and
+  # the row that offers it is the only thing on the card that creates nothing.
+  def handle_event("link-person", %{"key" => key, "id" => id}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.link_person(&1, key, to_int(id)))}
+  end
+
+  def handle_event("unlink-person", %{"key" => key}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.create_person(&1, key))}
   end
 
   # The photos and bios matching already found are in the person's own fields,
@@ -525,6 +538,14 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
            Draft.Edit.link_person(draft, key, id)
        end
      end)}
+  end
+
+  # "None of these" at the person level. A human no database has heard of is
+  # a normal outcome — plenty of narrators are in none — so this settles the
+  # level and creates them from their name alone.
+  def handle_event("uncatalogued-person", %{"key" => key}, socket) do
+    item = socket.assigns.item
+    {:noreply, edit(socket, &Draft.Edit.uncatalogued_person(&1, item, key))}
   end
 
   def handle_event("approve-person", %{"key" => key} = params, socket) do

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -42,6 +42,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Seed
+  alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
   alias Ambry.Media
@@ -628,10 +629,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.approve_work(&1, params["approved"] == "true"))}
   end
 
-  def handle_event("confirm-level", %{"section" => s}, socket) do
-    {:noreply, edit(socket, &Draft.Edit.confirm_level(&1, atom(s)))}
-  end
-
   def handle_event("choose-root", %{"root_id" => root_id}, socket) do
     id = to_int(root_id)
 
@@ -975,19 +972,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   end
 
   def hint_rows(_item), do: []
-
-  @doc """
-  The work records card's state rail — the same reading as the recording
-  card's, which the seeder settles for every state but doubt: trusted is
-  settled, nothing-found is settled (nothing to choose between), and only
-  an unsure match nobody has curated is still waiting on the operator.
-  """
-  def work_records_rail(%Work{} = work) do
-    case Draft.level_state(work) do
-      :unsure -> "border-l-4 border-amber-400/70"
-      _settled -> "border-l-4 border-brand-dark/60"
-    end
-  end
 
   @doc """
   Why nothing was filled in from a recording match.

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -38,7 +38,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Books
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
-  alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Seed
@@ -65,7 +64,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(author_backing: People.author_backing_names())
      |> assign(narrator_backing: People.narrator_backing_names())
      |> assign(people: People.people_for_select())
-     |> assign(expanded: MapSet.new())
      |> assign(researching: nil, retrying: nil, enriching: nil)
      # Which person is being looked up again, and whose photo strip is showing
      # in full. Both are view state keyed by person key — the results
@@ -101,7 +99,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # the record lie. The banner and `inert` explain; this enforces, because
   # markup is advisory and a stale tab can still send anything. The only
   # events allowed through are pure view state.
-  @view_events ~w(toggle-photos toggle-people)
+  @view_events ~w(toggle-photos)
 
   defp refuse_when_imported(event, _params, socket) do
     if socket.assigns.read_only and event not in @view_events do
@@ -171,17 +169,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def busy_label(:queued), do: "Queued for matching…"
   def busy_label(_idle), do: "Working…"
 
-  @doc """
-  Whether a credit's person layer should be showing.
-
-  Folded away for the ordinary case — one new person of the same name — and
-  unfolded whenever the credit is anything else, so a pen name can never be
-  hiding behind a collapsed control.
-  """
-  def expanded?(expanded, section, index, credit) do
-    MapSet.member?(expanded, {section, index}) or not Credit.simple?(credit)
-  end
-
   # What a person is currently called, which is what a re-search asks about.
   defp person_name(draft, key) do
     case Draft.person(draft, key) do
@@ -203,6 +190,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       {key, matched["providers"] || []}
     end
   end
+
+  @doc "One person's provider records, for their own card."
+  def person_records(item, key), do: get_in(item.matches, ["people", key, "candidates"]) || []
+
+  @doc "What each person provider said when asked about them."
+  def person_outcomes(item, key), do: get_in(item.matches, ["people", key, "providers"]) || []
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"inbox_item" => params}, socket) do
@@ -450,17 +443,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.reset_series_name(&1, to_int(i)))}
   end
 
-  # Whether the person layer is unfolded is view state, not a decision — it
-  # has no business in the stored draft.
-  def handle_event("toggle-people", %{"section" => section, "index" => index}, socket) do
-    {:noreply,
-     update(socket, :expanded, fn expanded ->
-       key = {section, to_int(index)}
-
-       if MapSet.member?(expanded, key),
-         do: MapSet.delete(expanded, key),
-         else: MapSet.put(expanded, key)
-     end)}
+  # The credited name is not always the human's name — "David Wong" is Jason
+  # Pargin — so this separates the two. It used to be a fold over a person
+  # layer nested in the credit; now that people are a section of their own
+  # there is nothing to unfold, and the control does the one thing it always
+  # meant.
+  def handle_event("separate-name", %{"section" => section, "index" => index}, socket) do
+    {:noreply, edit(socket, &Draft.Edit.separate_person_name(&1, atom(section), to_int(index)))}
   end
 
   # The photos and bios matching already found are in the person's own fields,

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -365,17 +365,9 @@
             count={length(@item.draft.work.authors)}
             section="work"
             identities={@authors}
-            people={@people}
             verb="Written by"
-            reveal="This is a pen name"
-            kind={:author}
             identity_backing={@author_backing}
-            person_records={person_records(@item)}
-            person_outcomes={person_outcomes(@item)}
             persons={Draft.people_for(@item.draft, credit)}
-            appearances={@appearances}
-            searching_person={@searching_person}
-            photos_expanded={@photos_expanded}
           />
 
           <.add_button phx-click="add-credit" phx-value-section="work">
@@ -594,17 +586,9 @@
             count={length(@item.draft.recording.narrators)}
             section="recording"
             identities={@narrators}
-            people={@people}
             verb="Read by"
-            reveal="This is a stage name"
-            kind={:narrator}
             identity_backing={@narrator_backing}
-            person_records={person_records(@item)}
-            person_outcomes={person_outcomes(@item)}
             persons={Draft.people_for(@item.draft, credit)}
-            appearances={@appearances}
-            searching_person={@searching_person}
-            photos_expanded={@photos_expanded}
           />
 
           <.add_button phx-click="add-credit" phx-value-section="recording">
@@ -623,21 +607,18 @@
           A *derived* list, so it breaks the list-cluster grammar deliberately
           and has no add of its own (design language §5): a person exists
           because a credit names them, so adding one happens on the credit and
-          shows up here. People already in the library are not listed — they
-          were chosen in the credit's typeahead and carry curation an import
-          may never overwrite. --%>
+          shows up here. A credit pointing at an identity the library already
+          has brings nobody: that person was chosen in the credit's typeahead
+          and carries curation an import may never overwrite. One the operator
+          matched to the library from their own card stays, because that
+          decision was made here and needs a way back. --%>
       <section
         :if={Draft.people_groups(@item.draft) != []}
         id="people"
         class="space-y-7"
         inert={@read_only}
       >
-        <div>
-          <h2 class="text-xl font-bold text-zinc-100">New people</h2>
-          <p class="max-w-prose pt-1 text-sm text-zinc-400">
-            Humans this import will create. Everyone else was already in your library.
-          </p>
-        </div>
+        <h2 class="text-xl font-bold text-zinc-100">People</h2>
 
         <div :for={group <- Draft.people_groups(@item.draft)} class="space-y-3">
           <%!-- A bracket, never a filled block: wrapping cards in a card is
@@ -648,8 +629,11 @@
             class="space-y-3 border-l-2 border-zinc-700 pl-4"
             data-role="pen-name-group"
           >
+            <%!-- The cards each carry the credited name in their own title
+                now, so the bracket states the thing they can't: that there
+                are several of them behind the one name. --%>
             <p class="text-xs text-zinc-400">
-              Behind the pen name <span class="text-zinc-200">{group.credit.name}</span>
+              {length(group.people)} people behind this name
             </p>
 
             <.person_card
@@ -661,8 +645,9 @@
               searching={@searching_person == person.key}
               photos_expanded={@photos_expanded[person.key] || false}
               records={person_records(@item, person.key)}
+              locals={person_locals(@item, person.key)}
               outcomes={person_outcomes(@item, person.key)}
-              appears={Draft.appearances(@item.draft)[person.key] || []}
+              appears={@appearances[person.key] || []}
               people={@people}
             />
           </div>
@@ -676,8 +661,9 @@
             searching={@searching_person == hd(group.people).key}
             photos_expanded={@photos_expanded[hd(group.people).key] || false}
             records={person_records(@item, hd(group.people).key)}
+            locals={person_locals(@item, hd(group.people).key)}
             outcomes={person_outcomes(@item, hd(group.people).key)}
-            appears={Draft.appearances(@item.draft)[hd(group.people).key] || []}
+            appears={@appearances[hd(group.people).key] || []}
             people={@people}
           />
         </div>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -88,19 +88,40 @@
             more often than it is forty books. Splitting is the escape hatch
             for when it genuinely isn't: each split item becomes its own
             import, to link to its own book or take a part number. --%>
-        <div :if={length(@item.files) > 1 and !@read_only} class="pt-2 pl-3">
+        <div :if={@grains != %{} and !@read_only} class="pt-2 pl-3">
           <p class="text-sm text-zinc-400">
             These {length(@item.files)} files import as one audiobook, played in this order.
           </p>
-          <button
-            type="button"
-            phx-click="split"
-            data-confirm={"Split into #{length(@item.files)} separate items? Each file becomes its own inbox item and is scanned fresh."}
-            data-role="split"
-            class={action_classes()}
-          >
-            Not one audiobook? Split into {length(@item.files)} items
-          </button>
+
+          <%!-- Two grains, because the grouping can be wrong at two levels:
+              a folder of "1 of 5" subfolders is one release in parts, and a
+              GraphicAudio set of the same shape is five recordings. Only the
+              grains that would actually divide this item are offered. --%>
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              :if={@grains[:folder]}
+              type="button"
+              phx-click="split"
+              phx-value-by="folder"
+              data-confirm={"Split into #{@grains[:folder]} items, one per folder? Each becomes its own inbox item and is scanned fresh."}
+              data-role="split-folder"
+              class={action_classes()}
+            >
+              Not one audiobook? Split into {@grains[:folder]} folders
+            </button>
+
+            <button
+              :if={@grains[:file]}
+              type="button"
+              phx-click="split"
+              phx-value-by="file"
+              data-confirm={"Split into #{@grains[:file]} items, one per file? Each becomes its own inbox item and is scanned fresh."}
+              data-role="split"
+              class={action_classes()}
+            >
+              Split into {@grains[:file]} files
+            </button>
+          </div>
         </div>
       </section>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -162,85 +162,97 @@
             databases say this is, before "do I already have it?". The records
             are how the operator recognizes the book, and ticking one asks its
             databases for audio editions, which feed the audiobook section. --%>
-        <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(Tier.of_evidence(@item.draft.work))]}>
-          <%!-- No badge and no Confirm button: the rail says which of the four
-              states this is, and pressing Add is what accepts the ones the
-              machine settled. The old pair said it twice in two vocabularies,
-              and the button changed nothing but its own word. The match score
-              stays in the tooltip, where it is history rather than state. --%>
-          <div class="flex items-baseline gap-2 pl-3">
-            <.label title={@item.draft.work.confidence && "match score #{@item.draft.work.confidence}"}>
-              Provider records
-            </.label>
-          </div>
+        <div class={[
+          "relative space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+          state_rail(Tier.of_evidence(@item.draft.work))
+        ]}>
+          <%!-- A provider round-trip is the same kind of event as a matching
+              job, and gets the same answer: the card is not yours while it
+              runs. The person cards have said so since they grew a search of
+              their own; these two were left with a button that changed its
+              own label. --%>
+          <.busy_overlay busy={@researching == "work"} label={searching_label(@item.draft.work.query_fields)} />
 
-          <%!-- The query, then who answered, then what they said. The search
-              that produced these records was folded away under the results it
-              produced, which reads backwards: a card of search results is a
-              search form with results below it. Editable in place, so the
-              wrong tag that sent this somewhere strange is visible and
-              fixable without opening anything. --%>
-          <.research_form
-            level="work"
-            fields={@item.draft.work.query_fields}
-            running={@researching == "work"}
-          />
+          <div class="space-y-2" inert={@researching == "work"}>
+            <%!-- No badge and no Confirm button: the rail says which of the four
+                states this is, and pressing Add is what accepts the ones the
+                machine settled. The old pair said it twice in two vocabularies,
+                and the button changed nothing but its own word. The match score
+                stays in the tooltip, where it is history rather than state. --%>
+            <div class="flex items-baseline gap-2 pl-3">
+              <.label title={@item.draft.work.confidence && "match score #{@item.draft.work.confidence}"}>
+                Provider records
+              </.label>
+            </div>
 
-          <.provider_outcomes_row
-            outcomes={provider_outcomes(@item, "work")}
-            level="work"
-            retrying={@retrying}
-          />
+            <%!-- The query, then who answered, then what they said. The search
+                that produced these records was folded away under the results it
+                produced, which reads backwards: a card of search results is a
+                search form with results below it. Editable in place, so the
+                wrong tag that sent this somewhere strange is visible and
+                fixable without opening anything. --%>
+            <.research_form
+              level="work"
+              fields={@item.draft.work.query_fields}
+              running={@researching == "work"}
+            />
 
-          <%!-- Same as the recording level: a doubted match adopts nothing, and
-              "found nothing" versus "found something we don't believe" have to
-              look different or the empty fields below are unexplained. --%>
-          <p
-            :if={doubt_message(@item.draft.work)}
-            class="bg-amber-400/10 border-amber-400/80 rounded-md border-l-4 p-3 text-sm"
-            data-role="work-doubt"
-          >
-            {doubt_message(@item.draft.work)}
-          </p>
+            <.provider_outcomes_row
+              outcomes={provider_outcomes(@item, "work")}
+              level="work"
+              retrying={@retrying}
+            />
 
-          <p :if={records(@item, "work") == []} class="pl-3 text-sm text-zinc-400">
-            No provider had a record of this.
-          </p>
-
-          <.record_list
-            records={records(@item, "work")}
-            used={&Work.uses?(@item.draft.work, &1)}
-          >
-            <:row :let={record}>
-              <.record_row
-                record={record}
-                level="work"
-                used={Work.uses?(@item.draft.work, record)}
-                working={@enriching == record_ref(record)}
-              />
-            </:row>
-          </.record_list>
-
-          <%!-- The same answer the audiobook level has always had, and the
-              level that needed it just as much: a doubted match leaves this
-              card outstanding until a record is ticked, so believing none of
-              them left ticking one you don't believe as the only way on. --%>
-          <div :if={records(@item, "work") != []} class="flex flex-wrap items-center gap-2 pt-1">
-            <button
-              type="button"
-              phx-click="uncatalogued"
-              phx-value-level="work"
-              data-role="none-of-these"
-              class={[
-                "px-[11px] rounded-md border py-1 text-xs",
-                Work.uncatalogued?(@item.draft.work) &&
-                  "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
-                !Work.uncatalogued?(@item.draft.work) &&
-                  "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
-              ]}
+            <%!-- Same as the recording level: a doubted match adopts nothing, and
+                "found nothing" versus "found something we don't believe" have to
+                look different or the empty fields below are unexplained. --%>
+            <p
+              :if={doubt_message(@item.draft.work)}
+              class="bg-amber-400/10 border-amber-400/80 rounded-md border-l-4 p-3 text-sm"
+              data-role="work-doubt"
             >
-              None of these
-            </button>
+              {doubt_message(@item.draft.work)}
+            </p>
+
+            <p :if={records(@item, "work") == []} class="pl-3 text-sm text-zinc-400">
+              No provider had a record of this.
+            </p>
+
+            <.record_list
+              records={records(@item, "work")}
+              used={&Work.uses?(@item.draft.work, &1)}
+            >
+              <:row :let={record}>
+                <.record_row
+                  record={record}
+                  level="work"
+                  used={Work.uses?(@item.draft.work, record)}
+                  working={@enriching == record_ref(record)}
+                />
+              </:row>
+            </.record_list>
+
+            <%!-- The same answer the audiobook level has always had, and the
+                level that needed it just as much: a doubted match leaves this
+                card outstanding until a record is ticked, so believing none of
+                them left ticking one you don't believe as the only way on. --%>
+            <div :if={records(@item, "work") != []} class="flex flex-wrap items-center gap-2 pt-1">
+              <button
+                type="button"
+                phx-click="uncatalogued"
+                phx-value-level="work"
+                data-role="none-of-these"
+                class={[
+                  "px-[11px] rounded-md border py-1 text-xs",
+                  Work.uncatalogued?(@item.draft.work) &&
+                    "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
+                  !Work.uncatalogued?(@item.draft.work) &&
+                    "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
+                ]}
+              >
+                None of these
+              </button>
+            </div>
           </div>
         </div>
 
@@ -414,74 +426,83 @@
         <h2 class="text-xl font-bold text-zinc-100">Audiobook</h2>
 
         <div class={[
-          "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
+          "relative space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
           state_rail(Tier.of_evidence(@item.draft.recording))
         ]}>
-          <div class="flex items-baseline gap-2 pl-3">
-            <.label title={
-              @item.draft.recording.confidence &&
-                "match score #{@item.draft.recording.confidence}"
-            }>
-              Provider records
-            </.label>
-          </div>
+          <%!-- A provider round-trip is the same kind of event as a matching
+              job, and gets the same answer: the card is not yours while it
+              runs. The person cards have said so since they grew a search of
+              their own; these two were left with a button that changed its
+              own label. --%>
+          <.busy_overlay busy={@researching == "recording"} label={searching_label(@item.draft.recording.query_fields)} />
 
-          <.research_form
-            level="recording"
-            fields={@item.draft.recording.query_fields}
-            running={@researching == "recording"}
-          />
+          <div class="space-y-2" inert={@researching == "recording"}>
+            <div class="flex items-baseline gap-2 pl-3">
+              <.label title={
+                @item.draft.recording.confidence &&
+                  "match score #{@item.draft.recording.confidence}"
+              }>
+                Provider records
+              </.label>
+            </div>
 
-          <.provider_outcomes_row
-            outcomes={provider_outcomes(@item, "recording")}
-            level="recording"
-            retrying={@retrying}
-          />
+            <.research_form
+              level="recording"
+              fields={@item.draft.recording.query_fields}
+              running={@researching == "recording"}
+            />
 
-          <%!-- A doubted match used to be indistinguishable from no match at
-              all: both left every field empty and said nothing. The reason is
-              the whole difference between "tick one" and "type it in". --%>
-          <p
-            :if={doubt_message(@item.draft.recording)}
-            class="bg-amber-400/10 border-amber-400/80 rounded-md border-l-4 p-3 text-sm"
-            data-role="doubt"
-          >
-            {doubt_message(@item.draft.recording)}
-          </p>
+            <.provider_outcomes_row
+              outcomes={provider_outcomes(@item, "recording")}
+              level="recording"
+              retrying={@retrying}
+            />
 
-          <.record_list
-            records={records(@item, "recording")}
-            used={&Recording.uses?(@item.draft.recording, &1)}
-          >
-            <:row :let={record}>
-              <.record_row
-                record={record}
-                level="recording"
-                used={Recording.uses?(@item.draft.recording, record)}
-                working={@enriching == record_ref(record)}
-              />
-            </:row>
-          </.record_list>
-
-          <div class="flex flex-wrap items-center gap-2 pt-1">
-            <%!-- px-[11px]: 1px border + 11px puts the label on the 12px text
-                rail, the same trick the inputs use; the ticked state keeps a
-                transparent border so toggling doesn't shift the box. --%>
-            <button
-              type="button"
-              phx-click="uncatalogued"
-              phx-value-level="recording"
-              data-role="none-of-these"
-              class={[
-                "px-[11px] rounded-md border py-1 text-xs",
-                Recording.uncatalogued?(@item.draft.recording) &&
-                  "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
-                !Recording.uncatalogued?(@item.draft.recording) &&
-                  "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
-              ]}
+            <%!-- A doubted match used to be indistinguishable from no match at
+                all: both left every field empty and said nothing. The reason is
+                the whole difference between "tick one" and "type it in". --%>
+            <p
+              :if={doubt_message(@item.draft.recording)}
+              class="bg-amber-400/10 border-amber-400/80 rounded-md border-l-4 p-3 text-sm"
+              data-role="doubt"
             >
-              None of these
-            </button>
+              {doubt_message(@item.draft.recording)}
+            </p>
+
+            <.record_list
+              records={records(@item, "recording")}
+              used={&Recording.uses?(@item.draft.recording, &1)}
+            >
+              <:row :let={record}>
+                <.record_row
+                  record={record}
+                  level="recording"
+                  used={Recording.uses?(@item.draft.recording, record)}
+                  working={@enriching == record_ref(record)}
+                />
+              </:row>
+            </.record_list>
+
+            <div class="flex flex-wrap items-center gap-2 pt-1">
+              <%!-- px-[11px]: 1px border + 11px puts the label on the 12px text
+                  rail, the same trick the inputs use; the ticked state keeps a
+                  transparent border so toggling doesn't shift the box. --%>
+              <button
+                type="button"
+                phx-click="uncatalogued"
+                phx-value-level="recording"
+                data-role="none-of-these"
+                class={[
+                  "px-[11px] rounded-md border py-1 text-xs",
+                  Recording.uncatalogued?(@item.draft.recording) &&
+                    "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
+                  !Recording.uncatalogued?(@item.draft.recording) &&
+                    "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
+                ]}
+              >
+                None of these
+              </button>
+            </div>
           </div>
         </div>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -88,15 +88,13 @@
             more often than it is forty books. Splitting is the escape hatch
             for when it genuinely isn't: each split item becomes its own
             import, to link to its own book or take a part number. --%>
-        <div :if={@grains != %{} and !@read_only} class="pt-2 pl-3">
-          <p class="text-sm text-zinc-400">
-            These {length(@item.files)} files import as one audiobook, played in this order.
-          </p>
+        <%!-- Two grains, because the grouping can be wrong at two levels: a
+            folder of "1 of 5" subfolders is one release in parts, and a
+            GraphicAudio set of the same shape is five recordings. The
+            question labels them both rather than riding on the first. --%>
+        <div :if={@grains != %{} and !@read_only} class="space-y-2 pt-2">
+          <.label class="pl-3">Not one audiobook?</.label>
 
-          <%!-- Two grains, because the grouping can be wrong at two levels:
-              a folder of "1 of 5" subfolders is one release in parts, and a
-              GraphicAudio set of the same shape is five recordings. Only the
-              grains that would actually divide this item are offered. --%>
           <div class="flex flex-wrap items-center gap-2">
             <button
               :if={@grains[:folder]}
@@ -107,7 +105,7 @@
               data-role="split-folder"
               class={action_classes()}
             >
-              Not one audiobook? Split into {@grains[:folder]} folders
+              Split into {@grains[:folder]} folders
             </button>
 
             <button
@@ -286,7 +284,7 @@
           data-role="local-books"
         >
           <div class="flex items-baseline gap-2 pl-3">
-            <.label>Is this a book you already have?</.label>
+            <.label>Existing book?</.label>
           </div>
 
           <.local_book_row

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -141,9 +141,7 @@
 
       <%!-- ==================== THE WORK ==================== --%>
       <section id="work" class="space-y-7" inert={@read_only}>
-        <h2 class="text-xl font-bold text-zinc-100">
-          The book
-        </h2>
+        <h2 class="text-xl font-bold text-zinc-100">Book</h2>
 
         <%!-- Evidence first, then the decisions it feeds (§9): what the
             databases say this is, before "do I already have it?". The records
@@ -157,9 +155,27 @@
               stays in the tooltip, where it is history rather than state. --%>
           <div class="flex items-baseline gap-2 pl-3">
             <.label title={@item.draft.work.confidence && "match score #{@item.draft.work.confidence}"}>
-              Records describing this book
+              Provider records
             </.label>
           </div>
+
+          <%!-- The query, then who answered, then what they said. The search
+              that produced these records was folded away under the results it
+              produced, which reads backwards: a card of search results is a
+              search form with results below it. Editable in place, so the
+              wrong tag that sent this somewhere strange is visible and
+              fixable without opening anything. --%>
+          <.research_form
+            level="work"
+            fields={@item.draft.work.query_fields}
+            running={@researching == "work"}
+          />
+
+          <.provider_outcomes_row
+            outcomes={provider_outcomes(@item, "work")}
+            level="work"
+            retrying={@retrying}
+          />
 
           <%!-- Same as the recording level: a doubted match adopts nothing, and
               "found nothing" versus "found something we don't believe" have to
@@ -172,27 +188,8 @@
             {doubt_message(@item.draft.work)}
           </p>
 
-          <p
-            :if={records(@item, "work") != [] and @item.draft.work.mode == :create}
-            class="max-w-prose pl-3 text-sm text-zinc-400"
-          >
-            Tick every record that describes this book. Ticking more than one is fine; each can
-            fill different fields.
-          </p>
-
-          <%!-- A linked book takes nothing from these records; they matter
-              because ticking one asks its databases for audio editions,
-              which is the route to a delisted recording. --%>
-          <p
-            :if={records(@item, "work") != [] and @item.draft.work.mode == :link}
-            class="max-w-prose pl-3 text-sm text-zinc-400"
-          >
-            Tick every record that describes this book. Ticked records are asked for their audio
-            editions, which feed the audiobook matches below.
-          </p>
-
-          <p :if={records(@item, "work") == []} class="max-w-prose pl-3 text-sm text-zinc-400">
-            No provider had a record of this. The fields below come from the file's own tags.
+          <p :if={records(@item, "work") == []} class="pl-3 text-sm text-zinc-400">
+            No provider had a record of this.
           </p>
 
           <.record_list
@@ -243,10 +240,6 @@
           <div class="flex items-baseline gap-2 pl-3">
             <.label>Is this a book you already have?</.label>
           </div>
-
-          <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            If so, this import becomes another edition of that book.
-          </p>
 
           <.local_book_row
             :for={book <- local_records(@item, "work")}
@@ -348,7 +341,6 @@
                 form={work}
                 type="date"
                 control_class="max-w-48"
-                hint="The book's original publication date, not this audiobook's own date."
                 field={@item.draft.work.published}
               />
             </.inputs_for>
@@ -404,9 +396,7 @@
 
       <%!-- ==================== THE RECORDING ==================== --%>
       <section id="recording" class="space-y-7" inert={@read_only}>
-        <h2 class="text-xl font-bold text-zinc-100">
-          The audiobook
-        </h2>
+        <h2 class="text-xl font-bold text-zinc-100">Audiobook</h2>
 
         <div class={[
           "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
@@ -417,9 +407,21 @@
               @item.draft.recording.confidence &&
                 "match score #{@item.draft.recording.confidence}"
             }>
-              Records describing this audiobook
+              Provider records
             </.label>
           </div>
+
+          <.research_form
+            level="recording"
+            fields={@item.draft.recording.query_fields}
+            running={@researching == "recording"}
+          />
+
+          <.provider_outcomes_row
+            outcomes={provider_outcomes(@item, "recording")}
+            level="recording"
+            retrying={@retrying}
+          />
 
           <%!-- A doubted match used to be indistinguishable from no match at
               all: both left every field empty and said nothing. The reason is
@@ -430,11 +432,6 @@
             data-role="doubt"
           >
             {doubt_message(@item.draft.recording)}
-          </p>
-
-          <p :if={records(@item, "recording") != []} class="max-w-prose pl-3 text-sm text-zinc-400">
-            Tick every record of <span class="font-semibold">this exact reading</span>. Check the
-            narrator first; that is what tells two audiobooks of one book apart.
           </p>
 
           <.record_list
@@ -450,12 +447,6 @@
               />
             </:row>
           </.record_list>
-
-          <.provider_outcomes_row
-            outcomes={provider_outcomes(@item, "recording")}
-            level="recording"
-            retrying={@retrying}
-          />
 
           <div class="flex flex-wrap items-center gap-2 pt-1">
             <%!-- px-[11px]: 1px border + 11px puts the label on the 12px text
@@ -477,20 +468,6 @@
               None of these
             </button>
           </div>
-
-          <.disclosure summary="Not what you're looking for? Search again">
-            <div class="pt-2">
-              <.research_form
-                level="recording"
-                fields={@item.draft.recording.query_fields}
-                running={@researching == "recording"}
-              />
-            </div>
-          </.disclosure>
-
-          <p class="pl-3 text-xs text-zinc-400">
-            Every import creates a new audiobook.
-          </p>
         </div>
 
         <.simple_form
@@ -509,8 +486,6 @@
                 form={recording}
                 control_class="max-w-xl"
                 placeholder="only if it differs from the book's title"
-                hint={"Leave empty unless this reading has its own title, " <>
-                "like \"The Way of Kings (1 of 3)\"."}
                 field={@item.draft.recording.title}
               />
 
@@ -521,7 +496,6 @@
                 form={recording}
                 type="date"
                 control_class="max-w-48"
-                hint="When this reading was published, which is rarely the book's own date."
                 field={@item.draft.recording.published}
               />
 
@@ -542,7 +516,6 @@
                 placeholder="image URL"
                 preview={true}
                 embedded_src={~p"/admin/inbox/#{@item}/embedded-cover"}
-                hint="Audiobook art is square; a portrait jacket is a print cover."
                 field={@item.draft.recording.cover}
               />
 
@@ -564,10 +537,7 @@
         <div class="space-y-2">
           <div :if={group_absent?(@item.draft)} class="space-y-2 rounded-lg bg-zinc-900 p-4">
             <.label class="pl-3">Part of a set</.label>
-            <p class="pl-3 text-sm text-zinc-400">
-              Most audiobooks are not part of a set. Sets are for GraphicAudio-style
-              "Part 1 of 2" releases and episodic seasons.
-            </p>
+            <p class="pl-3 text-sm text-zinc-400">Not part of a set.</p>
           </div>
 
           <.group_row

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -209,21 +209,27 @@
             </:row>
           </.record_list>
 
-          <.provider_outcomes_row
-            outcomes={provider_outcomes(@item, "work")}
-            level="work"
-            retrying={@retrying}
-          />
-
-          <.disclosure summary="Not what you're looking for? Search again">
-            <div class="pt-2">
-              <.research_form
-                level="work"
-                fields={@item.draft.work.query_fields}
-                running={@researching == "work"}
-              />
-            </div>
-          </.disclosure>
+          <%!-- The same answer the audiobook level has always had, and the
+              level that needed it just as much: a doubted match leaves this
+              card outstanding until a record is ticked, so believing none of
+              them left ticking one you don't believe as the only way on. --%>
+          <div :if={records(@item, "work") != []} class="flex flex-wrap items-center gap-2 pt-1">
+            <button
+              type="button"
+              phx-click="uncatalogued"
+              phx-value-level="work"
+              data-role="none-of-these"
+              class={[
+                "px-[11px] rounded-md border py-1 text-xs",
+                Work.uncatalogued?(@item.draft.work) &&
+                  "bg-brand-dark/15 ring-brand-dark/50 border-transparent ring-2 ring-inset",
+                !Work.uncatalogued?(@item.draft.work) &&
+                  "border-dashed border-zinc-600 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
+              ]}
+            >
+              None of these
+            </button>
+          </div>
         </div>
 
         <%!-- A different KIND of question from the records above: linking
@@ -458,6 +464,8 @@
             <button
               type="button"
               phx-click="uncatalogued"
+              phx-value-level="recording"
+              data-role="none-of-these"
               class={[
                 "px-[11px] rounded-md border py-1 text-xs",
                 Recording.uncatalogued?(@item.draft.recording) &&

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -368,8 +368,6 @@
             people={@people}
             verb="Written by"
             reveal="This is a pen name"
-            backing="Pen name of"
-            expanded={expanded?(@expanded, "work", index, credit)}
             kind={:author}
             identity_backing={@author_backing}
             person_records={person_records(@item)}
@@ -599,8 +597,6 @@
             people={@people}
             verb="Read by"
             reveal="This is a stage name"
-            backing="Stage name of"
-            expanded={expanded?(@expanded, "recording", index, credit)}
             kind={:narrator}
             identity_backing={@narrator_backing}
             person_records={person_records(@item)}
@@ -614,6 +610,76 @@
           <.add_button phx-click="add-credit" phx-value-section="recording">
             Add a narrator
           </.add_button>
+        </div>
+      </section>
+
+      <%!-- ==================== NEW PEOPLE ==================== --%>
+      <%!-- The third level, and a section rather than a decoration on a
+          credit. One human is one record: rendering a person inside every
+          credit that named them made an author who reads their own book
+          appear twice, with a sentence apologising for the duplication the
+          model had deliberately deleted.
+
+          A *derived* list, so it breaks the list-cluster grammar deliberately
+          and has no add of its own (design language §5): a person exists
+          because a credit names them, so adding one happens on the credit and
+          shows up here. People already in the library are not listed — they
+          were chosen in the credit's typeahead and carry curation an import
+          may never overwrite. --%>
+      <section
+        :if={Draft.people_groups(@item.draft) != []}
+        id="people"
+        class="space-y-7"
+        inert={@read_only}
+      >
+        <div>
+          <h2 class="text-xl font-bold text-zinc-100">New people</h2>
+          <p class="max-w-prose pt-1 text-sm text-zinc-400">
+            Humans this import will create. Everyone else was already in your library.
+          </p>
+        </div>
+
+        <div :for={group <- Draft.people_groups(@item.draft)} class="space-y-3">
+          <%!-- A bracket, never a filled block: wrapping cards in a card is
+              what eats the elevation ladder. One author credit can stand for
+              several humans, and the label names the credit they share. --%>
+          <div
+            :if={length(group.people) > 1}
+            class="space-y-3 border-l-2 border-zinc-700 pl-4"
+            data-role="pen-name-group"
+          >
+            <p class="text-xs text-zinc-400">
+              Behind the pen name <span class="text-zinc-200">{group.credit.name}</span>
+            </p>
+
+            <.person_card
+              :for={{person, person_index} <- Enum.with_index(group.people)}
+              person={person}
+              group={group}
+              person_index={person_index}
+              removable={true}
+              searching={@searching_person == person.key}
+              photos_expanded={@photos_expanded[person.key] || false}
+              records={person_records(@item, person.key)}
+              outcomes={person_outcomes(@item, person.key)}
+              appears={Draft.appearances(@item.draft)[person.key] || []}
+              people={@people}
+            />
+          </div>
+
+          <.person_card
+            :if={length(group.people) == 1}
+            person={hd(group.people)}
+            group={group}
+            person_index={0}
+            removable={false}
+            searching={@searching_person == hd(group.people).key}
+            photos_expanded={@photos_expanded[hd(group.people).key] || false}
+            records={person_records(@item, hd(group.people).key)}
+            outcomes={person_outcomes(@item, hd(group.people).key)}
+            appears={Draft.appearances(@item.draft)[hd(group.people).key] || []}
+            people={@people}
+          />
         </div>
       </section>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -6,7 +6,7 @@
           over the whole thing rather than in a badge. --%>
     <.busy_overlay
       busy={busy?(assigns)}
-      label={busy_label(@job, @importing)}
+      label={busy_label(@job)}
       class="sticky top-0 h-screen"
     />
 
@@ -788,7 +788,7 @@
             In the library — read-only.
           </p>
 
-          <.button navigate={~p"/admin/inbox"} color={:zinc}>Back to the inbox</.button>
+          <.button navigate={@return_to} color={:zinc}>Back to the inbox</.button>
 
           <%!-- Why the button is off, always. A blocker that only showed up as a
               red line further up the page could leave this disabled while the

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -119,6 +119,21 @@
             Open the audiobook
           </.brand_link>
         </p>
+
+        <%!-- Development only, and absent everywhere else: the form is
+            designed by running the same awkward release through it until it
+            reads right, and every release could otherwise be imported once. --%>
+        <div :if={@can_undo} class="pt-3 pl-3">
+          <button
+            type="button"
+            phx-click="undo-import"
+            data-confirm="Delete the records this import created and put the item back in the queue? Files this import placed in the library are deleted too; the ones it was found as are left alone."
+            data-role="undo-import"
+            class={action_classes()}
+          >
+            Undo this import (dev)
+          </button>
+        </div>
       </section>
 
       <%!-- The invariant, rendered. Nothing here is a surprise at import time. --%>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -125,6 +125,7 @@
       <section
         :if={@unresolved != []}
         class="border-amber-400/80 rounded-lg border-l-4 bg-zinc-900 p-4"
+        id="unresolved"
         data-role="unresolved"
       >
         <p class="font-bold">Still to settle</p>
@@ -148,35 +149,16 @@
             databases say this is, before "do I already have it?". The records
             are how the operator recognizes the book, and ticking one asks its
             databases for audio editions, which feed the audiobook section. --%>
-        <div class={["space-y-2 rounded-lg bg-zinc-900 p-4", work_records_rail(@item.draft.work)]}>
+        <div class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(Tier.of_evidence(@item.draft.work))]}>
+          <%!-- No badge and no Confirm button: the rail says which of the four
+              states this is, and pressing Add is what accepts the ones the
+              machine settled. The old pair said it twice in two vocabularies,
+              and the button changed nothing but its own word. The match score
+              stays in the tooltip, where it is history rather than state. --%>
           <div class="flex items-baseline gap-2 pl-3">
-            <.label>
+            <.label title={@item.draft.work.confidence && "match score #{@item.draft.work.confidence}"}>
               Records describing this book
             </.label>
-            <%!-- Decision state, not match history: confidence was frozen at
-                match time, so the badge kept saying "unsure" after the
-                operator had answered. The raw score stays in the tooltip. --%>
-            <.badge
-              color={elem(level_state_words(Draft.level_state(@item.draft.work)), 1)}
-              class="text-xs"
-              title={@item.draft.work.confidence && "match score #{@item.draft.work.confidence}"}
-            >
-              {elem(level_state_words(Draft.level_state(@item.draft.work)), 0)}
-            </.badge>
-
-            <%!-- "Yes, you were right" in one click. Clicking the ticked
-                record would untick it — confirming as-is must not cost an
-                untick and a re-tick. --%>
-            <button
-              :if={Draft.level_state(@item.draft.work) == :trusted}
-              type="button"
-              phx-click="confirm-level"
-              phx-value-section="work"
-              data-role="confirm-work"
-              class={action_classes()}
-            >
-              Confirm
-            </button>
           </div>
 
           <%!-- Same as the recording level: a doubted match adopts nothing, and
@@ -249,21 +231,11 @@
             record creates a Book. Ranking the two together made the form ask
             one question that was really two. --%>
         <div
-          class={[
-            "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-            (@item.draft.work.approved && "border-brand-dark/60") || "border-amber-400/70"
-          ]}
+          class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(Tier.of_identity(@item.draft.work))]}
           data-role="local-books"
         >
           <div class="flex items-baseline gap-2 pl-3">
             <.label>Is this a book you already have?</.label>
-            <.badge
-              :if={!@item.draft.work.approved}
-              color={elem(state_words(:unconfirmed), 1)}
-              class="text-xs"
-            >
-              {elem(state_words(:unconfirmed), 0)}
-            </.badge>
           </div>
 
           <p class="max-w-prose pl-3 text-sm text-zinc-400">
@@ -442,34 +414,15 @@
 
         <div class={[
           "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-          (@item.draft.recording.approved && "border-brand-dark/60") || "border-amber-400/70"
+          state_rail(Tier.of_evidence(@item.draft.recording))
         ]}>
           <div class="flex items-baseline gap-2 pl-3">
-            <.label>Records describing this audiobook</.label>
-            <%!-- One badge, not two: "needs confirming" and a frozen
-                confidence said less together than the decision state says
-                alone — and the old pair could contradict each other. --%>
-            <.badge
-              color={elem(level_state_words(Draft.level_state(@item.draft.recording)), 1)}
-              class="text-xs"
-              title={
-                @item.draft.recording.confidence &&
-                  "match score #{@item.draft.recording.confidence}"
-              }
-            >
-              {elem(level_state_words(Draft.level_state(@item.draft.recording)), 0)}
-            </.badge>
-
-            <button
-              :if={Draft.level_state(@item.draft.recording) == :trusted}
-              type="button"
-              phx-click="confirm-level"
-              phx-value-section="recording"
-              data-role="confirm-recording"
-              class={action_classes()}
-            >
-              Confirm
-            </button>
+            <.label title={
+              @item.draft.recording.confidence &&
+                "match score #{@item.draft.recording.confidence}"
+            }>
+              Records describing this audiobook
+            </.label>
           </div>
 
           <%!-- A doubted match used to be indistinguishable from no match at
@@ -716,20 +669,10 @@
             than fixed on the watched folder. With one root this never asks. --%>
         <div
           :if={@item.draft.destination && @item.draft.destination.custody == :managed}
-          class={[
-            "space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4",
-            (@item.draft.destination.approved && "border-brand-dark/60") || "border-amber-400/70"
-          ]}
+          class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(Tier.of(@item.draft.destination))]}
         >
           <div class="flex items-baseline gap-2 pl-3">
             <.label>Library root</.label>
-            <.badge
-              :if={!@item.draft.destination.approved}
-              color={elem(state_words(:unconfirmed), 1)}
-              class="text-xs"
-            >
-              {elem(state_words(:unconfirmed), 0)}
-            </.badge>
           </div>
 
           <form id="destination-root" phx-change="choose-root" class="mt-1">
@@ -793,9 +736,17 @@
           <%!-- Why the button is off, always. A blocker that only showed up as a
               red line further up the page could leave this disabled while the
               outstanding count read zero. --%>
-          <p :if={@unresolved != []} class="text-sm text-zinc-400">
+          <%!-- Sticky, so it is the one thing always in view — which makes it
+              the right place to say what is left, and a link rather than a
+              number so work below the fold is reachable without hunting
+              (§9). --%>
+          <.link
+            :if={@unresolved != []}
+            href="#unresolved"
+            class="text-sm text-zinc-400 underline hover:text-zinc-200"
+          >
             {length(@unresolved)} decision{if length(@unresolved) > 1, do: "s"} still to settle.
-          </p>
+          </.link>
 
           <p :if={@unresolved == [] and @destination.blocker} class="text-sm text-red-400">
             Everything is settled, but the files can't be placed yet. See Files &amp; destination.

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -64,19 +64,25 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     {:noreply, reload(socket)}
   end
 
+  # Queued, not run here. Importing re-probes every file and then copies every
+  # byte, and doing that inside `handle_event` blocked the whole LiveView —
+  # the queue froze for the length of a NAS copy, with no sign the click had
+  # landed. The row wears the busy overlay instead, same as any other job.
   def handle_event("import", %{"id" => id}, socket) do
     id
     |> Inbox.get_item!()
-    |> Inbox.import_item()
+    |> Inbox.import_item_async()
     |> case do
-      {:ok, _media} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Added to the library. Files were left where they are.")
-         |> reload()}
+      {:ok, job} ->
+        message =
+          if job.conflict?,
+            do: "Already adding this one.",
+            else: "Adding to the library. The row will say when it's done."
 
-      {:error, reason} ->
-        {:noreply, put_flash(socket, :error, Inbox.describe_error(reason))}
+        {:noreply, socket |> put_flash(:info, message) |> reload()}
+
+      {:error, :already_imported} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_imported))}
     end
   end
 
@@ -201,6 +207,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # What the row's background work is doing. `:done` and `:issue` say nothing
   # here — the row already shows its matches or its issue, and repeating
   # "done" on every settled row is noise that hides the rows that aren't.
+  defp progress_label(:importing), do: "Adding to the library…"
   defp progress_label(:working), do: "Working on it…"
   defp progress_label(:retrying), do: "A provider couldn't be reached. Waiting to try again."
 
@@ -229,6 +236,17 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   # The same shape from locals rather than assigns — load_items runs before
   # its assigns exist, so `patch/2` can't be used for the page links.
+  @doc """
+  The list state, as the params that reproduce it.
+
+  Carried into the form so every way back out of it — imported, ignored, or
+  the plain Back button — returns to the tab and page the operator was on.
+  Landing them on an unfiltered page one after an import is how "where did my
+  queue go" happens.
+  """
+  def return_query(assigns),
+    do: page_query(assigns.list_opts, assigns.status, assigns.ready, assigns.list_opts.page)
+
   defp page_query(list_opts, status, ready, page) do
     %{
       "filter" => list_opts.filter,

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -9,12 +9,13 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   use AmbryWeb, :admin_live_view
 
-  import AmbryWeb.Admin.Decisions, only: [level_state_words: 1]
+  import AmbryWeb.Admin.Decisions, only: [tier_words: 1]
   import AmbryWeb.Admin.PaginationHelpers
   import AmbryWeb.TimeUtils
 
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.InboxItem
   alias Ambry.Library.Source
 
@@ -415,7 +416,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
         level: level,
         best: List.first(candidates),
         alternatives: max(length(candidates) - 1, 0),
-        state: level_state(item, level),
+        tier: level_tier(item, level),
         confidence: get_in(matches, [level, "confidence"]),
         query: get_in(matches, [level, "query"])
       }
@@ -424,22 +425,23 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   def match_summary(_item), do: []
 
-  # The draft is the live truth: its state moves when the operator decides,
+  # The draft is the live truth: its tier moves when the operator decides,
   # where `matches[level]["confidence"]` was frozen at match time — so the
   # queue used to keep calling an item "unsure" after a human had settled it,
   # and could disagree with the form after a background re-match. The
   # fallback covers the moment between matching and the draft existing.
-  defp level_state(%InboxItem{draft: %Draft{work: %{} = work}}, "work"),
-    do: Draft.level_state(work)
+  #
+  # One vocabulary with the form, or the two drift: the queue says what the
+  # form's rail says, in the same four words.
+  defp level_tier(%InboxItem{draft: %Draft{work: %{} = work}}, "work"), do: Tier.of(work)
 
-  defp level_state(%InboxItem{draft: %Draft{recording: %{} = recording}}, "recording"),
-    do: Draft.level_state(recording)
+  defp level_tier(%InboxItem{draft: %Draft{recording: %{} = recording}}, "recording"),
+    do: Tier.of(recording)
 
-  defp level_state(%InboxItem{matches: matches}, level) do
+  defp level_tier(%InboxItem{matches: matches}, level) do
     case get_in(matches, [level, "confidence"]) || 0.0 do
-      sure when sure >= 0.6 -> :trusted
-      some when some > 0.0 -> :unsure
-      _nothing -> :no_match
+      sure when sure >= 0.6 -> :unreviewed
+      _doubted_or_nothing -> :waiting
     end
   end
 

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -51,7 +51,7 @@
       <.busy_overlay busy={busy?(@progress[item.id])} label={progress_label(@progress[item.id])} />
 
       <div class="min-w-0 flex-grow overflow-hidden" inert={busy?(@progress[item.id])}>
-        <.link navigate={~p"/admin/inbox/#{item}"} class="hover:underline">
+        <.link navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"} class="hover:underline">
           <p class="overflow-hidden text-ellipsis whitespace-nowrap font-semibold">
             {item_name(item)}
           </p>
@@ -189,7 +189,7 @@
 
             <.link
               :if={item.status == :pending and not item.ready}
-              navigate={~p"/admin/inbox/#{item}"}
+              navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
               title="Settle what's outstanding"
               class={action_class(:neutral)}
             >

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -79,12 +79,16 @@
           >
             <span class="text-xs text-zinc-400">{level_word(match.level)}</span>
             <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+              <%!-- The form's rail, in words, because a row is one line and has
+                  nowhere to put a 4px edge per level. Same four states, same
+                  vocabulary — the queue and the form drifted apart when they
+                  each had their own. --%>
               <.badge
-                color={elem(level_state_words(match.state), 1)}
+                color={elem(tier_words(match.tier), 1)}
                 class="text-xs"
                 title={match.confidence && "match score #{match.confidence}"}
               >
-                {elem(level_state_words(match.state), 0)}
+                {elem(tier_words(match.tier), 0)}
               </.badge>
               <%!-- basis-48 + grow keeps the title from being shrunk out of
                     existence (meta wraps down instead); max-w-fit stops the grow

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -413,7 +413,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # visible or the recordings list is short for no stated reason.
   defp retry_fan_out(entry, :search, query, hints) do
     {books, outcome} = MetadataSearch.books_one(entry, query)
-    {Inbox.score_records(books, entry, hints), [outcome]}
+    {Inbox.score_records(books, entry, hints), List.wrap(outcome)}
   end
 
   # The editions chip doesn't hang off a search anybody can re-run on its own:

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -15,6 +15,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   alias Ambry.Inbox
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
+  alias Ambry.Metadata.Outcome
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Registry
   alias Ambry.Metadata.Search, as: MetadataSearch
@@ -326,8 +327,9 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     end
   end
 
-  def handle_event("retry-provider", %{"provider" => provider_id}, socket) do
+  def handle_event("retry-provider", %{"provider" => outcome_id}, socket) do
     query = Provider.Query.from_fields(socket.assigns.evidence.fields)
+    {provider_id, kind} = Outcome.split(outcome_id)
 
     with false <- Provider.Query.blank?(query),
          {:ok, entry} <- Registry.fetch(provider_id) do
@@ -338,11 +340,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
       {:noreply,
        socket
-       |> assign(retrying: provider_id)
-       |> start_async(:evidence_search, fn ->
-         {books, outcome} = MetadataSearch.books_one(entry, query)
-         {Inbox.score_records(books, entry, hints), [outcome]}
-       end)}
+       |> assign(retrying: outcome_id)
+       |> start_async(:evidence_search, fn -> retry_fan_out(entry, kind, query, hints) end)}
     else
       _no -> {:noreply, socket}
     end
@@ -412,6 +411,30 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # "Hardcover: 9" would describe a search whose records aren't shown, but a
   # work provider that was down took its editions with it, and that has to be
   # visible or the recordings list is short for no stated reason.
+  defp retry_fan_out(entry, :search, query, hints) do
+    {books, outcome} = MetadataSearch.books_one(entry, query)
+    {Inbox.score_records(books, entry, hints), [outcome]}
+  end
+
+  # The editions chip doesn't hang off a search anybody can re-run on its own:
+  # editions are asked of a *work record*, so retrying one means finding this
+  # provider's work records again and re-asking about those. Without this the
+  # chip's id (`hardcover:editions`) simply missed the registry and the button
+  # did nothing — visibly red, silently inert.
+  defp retry_fan_out(entry, :editions, query, hints) do
+    {found, _outcomes} = MetadataSearch.books(query, level: :work)
+
+    found
+    |> Enum.flat_map(fn {found_entry, books} ->
+      Inbox.score_records(books, found_entry, hints)
+    end)
+    |> Enum.filter(&(&1["source"] == "provider:#{entry.id}"))
+    |> Inbox.top_group()
+    |> Inbox.editions_of(hints)
+  end
+
+  defp retry_fan_out(_entry, _kind, _query, _hints), do: {[], []}
+
   defp recording_fan_out(query, hints) do
     {audible_found, audible_outcomes} = MetadataSearch.books(query, level: :recording)
 

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -2,6 +2,7 @@ defmodule Ambry.Inbox.AutoMatchTest do
   use Ambry.DataCase
   use Patch
 
+  alias Ambry.Inbox
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.InboxItem
   alias Ambry.Metadata.Provider
@@ -98,6 +99,35 @@ defmodule Ambry.Inbox.AutoMatchTest do
 
       assert {[_edition], [outcome]} = AutoMatch.editions_for(records, hints)
       assert outcome["status"] == "ok"
+      assert outcome["count"] == 1
+    end
+
+    # One chip standing for four calls used to let any success speak for the
+    # group: a provider that answered about three works and was rate-limited
+    # on the fourth reported a clean `ok`, and that work's editions were never
+    # fetched or mentioned again. A failure now outranks an answer — while
+    # still carrying what did come back, because the editions already in hand
+    # are real.
+    @tag :capture_log
+    test "a failure outranks an answer, keeping the count of what came back" do
+      patch(Registry, :fetch, fn "hardcover" ->
+        {:ok,
+         %Registry.Entry{id: "hardcover", display_name: "Hardcover", capabilities: [:editions]}}
+      end)
+
+      patch(Providers, :editions, fn "hardcover", id, _opts ->
+        case id do
+          "w-1" -> {:ok, [%Provider.Book{id: "e-1", title: "A Reading"}]}
+          _rate_limited -> {:error, :rate_limited}
+        end
+      end)
+
+      records = for id <- ~w(w-1 w-2), do: %{"source" => "provider:hardcover", "id" => id}
+      hints = AutoMatch.hints(%InboxItem{path: "/d/A Book", tags: %{}})
+
+      assert {[_edition], [outcome]} = AutoMatch.editions_for(records, hints)
+      assert outcome["id"] == "hardcover:editions"
+      assert outcome["status"] == "failed"
       assert outcome["count"] == 1
     end
   end
@@ -473,13 +503,21 @@ defmodule Ambry.Inbox.AutoMatchTest do
       # this suite wasn't already making live calls is that the fake ids
       # happen not to parse.
       patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
-      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :not_stubbed} end)
+
+      patch(Providers, :book_details, fn _id, id, _opts ->
+        {:ok, %Provider.Book{provider: "test", id: id}}
+      end)
+
       # The people level asks every person-capable provider about every
       # credited human, which is real HTTP unless stubbed — and unlike the
       # book calls there is no fake id to save us, because a person is
       # searched by name.
       patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, []} end)
-      patch(Providers, :author_details, fn _id, _author_id, _opts -> {:error, :not_stubbed} end)
+
+      patch(Providers, :author_details, fn _id, id, _opts ->
+        {:ok, %Provider.Author{provider: "test", id: id}}
+      end)
+
       :ok
     end
 
@@ -1280,6 +1318,71 @@ defmodule Ambry.Inbox.AutoMatchTest do
     end
   end
 
+  # **A call that failed and a call that found nothing must never look the
+  # same.** The search level always knew that; the calls *after* the search
+  # did not, and they are the majority — measured on a cold scan of 353
+  # releases, 84% of provider requests were the details behind a hit. A
+  # rate-limited one left the record thin (no description, no cover, no
+  # editions) and said nothing anywhere, so the item settled, went `ready`,
+  # and imported a book the provider actually knew more about.
+  describe "match/1 reports the calls made after the search" do
+    setup do
+      patch_work_results([book("The Way of Kings", ["Brandon Sanderson"])])
+      patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
+      patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, []} end)
+      :ok
+    end
+
+    defp match_way_of_kings do
+      %{matches: matches} =
+        AutoMatch.match(item(title: "The Way of Kings", author: "Brandon Sanderson"))
+
+      matches
+    end
+
+    defp details_outcome(matches, provider_id \\ "rreading_glasses") do
+      Enum.find(matches["work"]["providers"], &(&1["id"] == "#{provider_id}:details"))
+    end
+
+    @tag :capture_log
+    test "a details call that couldn't be reached leaves a failed outcome" do
+      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :rate_limited} end)
+
+      assert %{"status" => "failed", "reason" => reason} = details_outcome(match_way_of_kings())
+      assert reason =~ "rate_limited"
+    end
+
+    # Thin is still usable — one enrichment call failing must not fail an item
+    # that otherwise matched. The record stays; only the silence goes.
+    @tag :capture_log
+    test "the record survives the failure, unhydrated" do
+      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :rate_limited} end)
+
+      assert [record | _rest] = match_way_of_kings()["work"]["candidates"]
+      assert record["title"] == "The Way of Kings"
+      refute record["hydrated"]
+    end
+
+    test "a details call that worked says so, so the retry chip can clear" do
+      patch(Providers, :book_details, fn _id, id, _opts ->
+        {:ok, %Provider.Book{provider: "test", id: id, description: "The full description"}}
+      end)
+
+      assert %{"status" => "ok"} = details_outcome(match_way_of_kings())
+    end
+
+    # The job is what comes back for it: `RunMatch` fails any match with an
+    # unreached provider, and a details failure is now one.
+    @tag :capture_log
+    test "the failure is what unreached_providers/1 reads" do
+      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :rate_limited} end)
+
+      item = %InboxItem{path: "/d/x", matches: match_way_of_kings()}
+
+      assert "rreading_glasses:details" in Inbox.unreached_providers(item)
+    end
+  end
+
   # The third level. Everything the form does well it does by asking outcome,
   # evidence and preference; people used to get a name string and nothing
   # else, which is why proposed people arrived with no face and no biography
@@ -1288,9 +1391,17 @@ defmodule Ambry.Inbox.AutoMatchTest do
     setup do
       patch(Providers, :search_books, fn _id, _query, _opts -> {:ok, []} end)
       patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
-      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :not_stubbed} end)
+
+      patch(Providers, :book_details, fn _id, id, _opts ->
+        {:ok, %Provider.Book{provider: "test", id: id}}
+      end)
+
       patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, []} end)
-      patch(Providers, :author_details, fn _id, _author_id, _opts -> {:error, :not_stubbed} end)
+
+      patch(Providers, :author_details, fn _id, id, _opts ->
+        {:ok, %Provider.Author{provider: "test", id: id}}
+      end)
+
       :ok
     end
 

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -1387,6 +1387,88 @@ defmodule Ambry.Inbox.AutoMatchTest do
   # evidence and preference; people used to get a name string and nothing
   # else, which is why proposed people arrived with no face and no biography
   # and every import ended with a trip to the person form.
+  # The work and recording levels have ranked their candidates since they
+  # existed. People never did: the list was whatever order the providers were
+  # asked in, three hits each, so an obviously-wrong human sat above the right
+  # one — and because a proposal takes the FIRST candidate carrying a value,
+  # the wrong human's face and biography were the ones proposed.
+  describe "person_score/2 and rank_people/2" do
+    test "the same name, however it is spelled, is the best answer" do
+      assert AutoMatch.person_score("Brandon Sanderson", "Brandon Sanderson") == 1.0
+      assert AutoMatch.person_score("Émile Zola", "Emile Zola") == 1.0
+      assert AutoMatch.person_score("J.R.R. Tolkien", "JRR Tolkien") == 1.0
+    end
+
+    # The case Jaro gets backwards: measured, "Ty Franck" against "Tyler Corey
+    # Franck" scores lower than "Ty Franck" against a Corey mismatch.
+    test "a name contained in the other beats one that merely shares a word" do
+      contained = AutoMatch.person_score("Tyler Corey Franck", "Ty Franck")
+      # a different human who happens to share a surname — which is the floor
+      # `PersonSearch.plausible?/2` already filters at
+      shared = AutoMatch.person_score("Franck Ribéry", "Ty Franck")
+
+      assert contained > shared
+      assert shared > 0.0
+    end
+
+    # An author search keyed on book relevance returns the book's *author*
+    # when you search its narrator, and that name shares nothing with the one
+    # asked for.
+    test "a confidently-wrong hit from a book-relevance search scores nothing" do
+      assert AutoMatch.person_score("James S.A. Corey", "Jefferson Mays") == 0.0
+    end
+
+    # The measured case from `PersonSearch`'s moduledoc, which exact-token
+    # comparison misses: "Ty" is not a word of "Tyler Corey Franck".
+    test "a shortened first name is the same name" do
+      assert AutoMatch.person_score("Tyler Corey Franck", "Ty Franck") == 0.8
+      assert AutoMatch.person_score("Daniel Abraham", "Dan Abraham") == 0.8
+    end
+
+    test "nothing in common scores nothing" do
+      assert AutoMatch.person_score("Jefferson Mays", "Brandon Sanderson") == 0.0
+      assert AutoMatch.person_score(nil, "Brandon Sanderson") == 0.0
+    end
+
+    test "orders best first, whatever order the providers answered in" do
+      candidates = [
+        %{"name" => "James S.A. Corey", "id" => "wrong", "images" => ["a.jpg"]},
+        %{"name" => "Ty Franck", "id" => "right", "images" => ["b.jpg"]}
+      ]
+
+      assert [%{"id" => "right"}, %{"id" => "wrong"}] =
+               AutoMatch.rank_people(candidates, "Ty Franck")
+    end
+
+    # A face and a biography make a candidate both more useful and more likely
+    # to be the documented human.
+    test "an equally-named candidate with a photo and a bio comes first" do
+      candidates = [
+        %{"name" => "Brandon Sanderson", "id" => "bare", "images" => []},
+        %{
+          "name" => "Brandon Sanderson",
+          "id" => "full",
+          "images" => ["a.jpg"],
+          "description" => "Writes fantasy."
+        }
+      ]
+
+      assert [%{"id" => "full"}, %{"id" => "bare"}] =
+               AutoMatch.rank_people(candidates, "Brandon Sanderson")
+    end
+
+    # A re-search merges fresh records into a list staged before people were
+    # scored at all; sorting those to the bottom would bury records the
+    # operator may already have ticked.
+    test "records staged without a score are scored on the way through" do
+      held = [%{"name" => "Ty Franck", "id" => "held", "images" => []}]
+      found = [%{"name" => "James S.A. Corey", "id" => "found", "score" => 0.6, "images" => []}]
+
+      assert [%{"id" => "held"}, %{"id" => "found"}] =
+               AutoMatch.rank_people(held ++ found, "Ty Franck")
+    end
+  end
+
   describe "match/1 people" do
     setup do
       patch(Providers, :search_books, fn _id, _query, _opts -> {:ok, []} end)

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -1457,9 +1457,19 @@ defmodule Ambry.Inbox.AutoMatchTest do
                AutoMatch.rank_people(candidates, "Brandon Sanderson")
     end
 
-    # A re-search merges fresh records into a list staged before people were
-    # scored at all; sorting those to the bottom would bury records the
-    # operator may already have ticked.
+    # A re-search merges fresh records into a list staged under the old name.
+    # Scoring only the new arrivals left the old name's records wearing the
+    # 100% they earned when they were the question — the reported flow:
+    # looking up David Wong, then Jason Pargin, and getting one list where
+    # both are perfect answers.
+    test "a re-search re-scores what was already held, against the name now asked" do
+      held = [%{"name" => "David Wong", "id" => "held", "score" => 1.0, "images" => []}]
+      found = [%{"name" => "Jason Pargin", "id" => "found", "images" => []}]
+
+      assert [%{"id" => "found", "score" => 1.0}, %{"id" => "held", "score" => +0.0}] =
+               AutoMatch.rank_people(held ++ found, "Jason Pargin")
+    end
+
     test "records staged without a score are scored on the way through" do
       held = [%{"name" => "Ty Franck", "id" => "held", "images" => []}]
       found = [%{"name" => "James S.A. Corey", "id" => "found", "score" => 0.6, "images" => []}]

--- a/test/ambry/inbox/draft/tier_test.exs
+++ b/test/ambry/inbox/draft/tier_test.exs
@@ -1,0 +1,135 @@
+defmodule Ambry.Inbox.Draft.TierTest do
+  @moduledoc """
+  The four words the whole form speaks.
+
+  Settled-versus-waiting answered "can this be imported" and threw away the
+  question the operator actually asks of a machine-matched import: has anyone
+  looked at this yet.
+  """
+  use ExUnit.Case, async: true
+
+  alias Ambry.Inbox.Draft.Candidate
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.Tier
+  alias Ambry.Inbox.Draft.Work
+
+  defp candidate(value), do: %Candidate{value: value, source: "provider:hardcover", key: "k"}
+
+  describe "of/1" do
+    test "a field the machine settled and nobody touched is unreviewed" do
+      assert Tier.of(%Field{approved: true, curated: false}) == :unreviewed
+    end
+
+    test "a field a human touched is reviewed" do
+      assert Tier.of(%Field{approved: true, curated: true}) == :reviewed
+    end
+
+    # The distinction the fourth tier buys: taking the machine's own value
+    # still counts as having looked, because the operator did.
+    test "reviewed does not depend on the value differing from the machine's" do
+      machine = %Field{approved: true, curated: false, candidates: [candidate("Dune")]}
+      looked = %{machine | curated: true}
+
+      assert Tier.of(machine) == :unreviewed
+      assert Tier.of(looked) == :reviewed
+      assert Field.value(machine) == Field.value(looked)
+    end
+
+    test "an unsettled field waits" do
+      assert Tier.of(%Field{approved: false, candidates: [candidate("Dune")]}) == :waiting
+    end
+
+    # Red, and rare: measured across 335 live drafts it was 7 fields in 4,817,
+    # every one of them a missing publication date, which refuses the import.
+    test "a required field nothing proposed is blocked" do
+      assert Tier.of(%Field{approved: false, required: true, candidates: []}) == :blocked
+    end
+
+    test "an optional field nothing proposed merely waits" do
+      assert Tier.of(%Field{approved: false, required: false, candidates: []}) == :waiting
+    end
+
+    test "a credit carries its own state and its own touch" do
+      ambiguous = %Credit{approved: false, candidates: [%{}, %{}]}
+
+      assert Tier.of(ambiguous) == :waiting
+      assert Tier.of(%{ambiguous | curated: true}) == :waiting
+    end
+  end
+
+  describe "a level asks two questions" do
+    # Collapsing both into one number made the two cards identical, which
+    # tells the operator something needs them without saying which.
+    test "evidence and identity are tiered separately" do
+      work = %Work{
+        approved: true,
+        curated: false,
+        doubt: :low_confidence,
+        evidence_curated: false
+      }
+
+      assert Tier.of_evidence(work) == :waiting
+      assert Tier.of_identity(work) == :unreviewed
+    end
+
+    test "the level itself is the worse of the two" do
+      work = %Work{approved: true, curated: true, doubt: :low_confidence, evidence_curated: false}
+
+      assert Tier.of_identity(work) == :reviewed
+      assert Tier.of(work) == :waiting
+    end
+
+    # "Found nothing" is an answer, not a failure — there is nothing to choose
+    # between, and plenty of narrators are in no database at all.
+    test "a level that found nothing is settled" do
+      assert Tier.of(%Recording{approved: true, doubt: :nothing_found}) == :unreviewed
+    end
+
+    test "a recording is never linked, so it has no identity question" do
+      recording = %Recording{approved: true, doubt: :none, evidence_curated: true}
+
+      assert Tier.of(recording) == Tier.of_evidence(recording)
+      assert Tier.of(recording) == :reviewed
+    end
+  end
+
+  describe "worst/1" do
+    test "ranks blocked over waiting over unreviewed over reviewed" do
+      assert Tier.worst([:reviewed, :unreviewed]) == :unreviewed
+      assert Tier.worst([:reviewed, :unreviewed, :waiting]) == :waiting
+      assert Tier.worst([:waiting, :blocked]) == :blocked
+    end
+
+    # A card claiming the operator has been through it while one field inside
+    # still waits is the aggregate lying.
+    test "reviewed only when every child is" do
+      assert Tier.worst([:reviewed, :reviewed]) == :reviewed
+      assert Tier.worst([:reviewed, :unreviewed]) != :reviewed
+    end
+
+    # "Not in a series" is something the machine worked out and nobody
+    # confirmed, not something a human decided.
+    test "an empty list is unreviewed" do
+      assert Tier.worst([]) == :unreviewed
+    end
+
+    test "of_all/1 tiers a list of decisions together" do
+      fields = [%Field{approved: true, curated: true}, %Field{approved: false, required: true}]
+
+      assert Tier.of_all(fields) == :blocked
+    end
+  end
+
+  describe "outstanding?/1" do
+    # The goal of an import is no amber and no red — never "all reviewed", or
+    # every import becomes a chore of re-picking values that were right.
+    test "only blocked and waiting want the operator" do
+      assert Tier.outstanding?(:blocked)
+      assert Tier.outstanding?(:waiting)
+      refute Tier.outstanding?(:unreviewed)
+      refute Tier.outstanding?(:reviewed)
+    end
+  end
+end

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1277,6 +1277,28 @@ defmodule Ambry.Inbox.DraftTest do
       assert Draft.curated?(Draft.Edit.new_book(item.draft, item))
     end
 
+    # A doubted work leaves its records card outstanding until something is
+    # ticked, and answering the identity question doesn't touch it — so
+    # believing none of them had exactly one way on: tick one you don't
+    # believe.
+    test "the work level can be settled as one no record describes" do
+      item =
+        item(%{
+          matches: matches([provider_candidate(%{"title" => "Something Else"})], confidence: 0.3),
+          tags: %{}
+        })
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      assert item.draft.work.doubt == :low_confidence
+      assert Enum.any?(Draft.unresolved(item.draft), &(&1.label == "Book records"))
+
+      draft = Draft.Edit.uncatalogued(item.draft, item, :work)
+
+      assert Draft.Work.uncatalogued?(draft.work)
+      assert draft.work.sources == []
+      refute Enum.any?(Draft.unresolved(draft), &(&1.label == "Book records"))
+    end
+
     test "settling the recording as uncatalogued marks the draft curated" do
       item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -185,7 +185,7 @@ defmodule Ambry.Inbox.DraftTest do
       assert draft.work.sources == []
       # nothing was adopted, so the title is a decision rather than a wrong answer
       refute draft.work.title.value == "Something Else"
-      assert Enum.any?(Draft.unresolved(draft), &(&1.label =~ "records describe this book"))
+      assert Enum.any?(Draft.unresolved(draft), &(&1.label == "Book records"))
     end
 
     # The doubt asks "which records describe this book". Ticking one is the
@@ -204,13 +204,13 @@ defmodule Ambry.Inbox.DraftTest do
       {:ok, item} = Inbox.prepare_draft(item)
 
       assert item.draft.work.doubt == :low_confidence
-      assert Enum.any?(Draft.unresolved(item.draft), &(&1.label =~ "records describe this book"))
+      assert Enum.any?(Draft.unresolved(item.draft), &(&1.label == "Book records"))
 
       ticked =
         Draft.Edit.toggle_source(item.draft, item, :work, Enum.at(candidates, 1))
 
       assert ticked.work.doubt == :none
-      refute Enum.any?(Draft.unresolved(ticked), &(&1.label =~ "records describe this book"))
+      refute Enum.any?(Draft.unresolved(ticked), &(&1.label == "Provider records"))
 
       # and un-ticking the last one puts the question back
       untangled = Draft.Edit.toggle_source(ticked, item, :work, Enum.at(candidates, 1))
@@ -937,7 +937,7 @@ defmodule Ambry.Inbox.DraftTest do
 
       assert Enum.any?(
                Draft.unresolved(draft),
-               &(&1.label =~ "describe this recording" and &1.state == :unconfirmed)
+               &(&1.label == "Audiobook records" and &1.state == :unconfirmed)
              )
     end
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -2476,6 +2476,58 @@ defmodule Ambry.Inbox.DraftTest do
       assert Field.value(person.name) == "Ty Franck"
     end
 
+    # The control that had no visible effect: a person's card carried a name
+    # box in every state, so saying the credited name was a pseudonym changed
+    # nothing anybody could see. The name being the human's own is the flag
+    # the card reads.
+    test "declaring a pen name gives the human a name of their own" do
+      item = item(%{matches: matches([provider_candidate(%{"authors" => ["David Wong"]})])})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert [person] = item.draft.people
+      refute person.own_name
+
+      draft = Draft.Edit.separate_person_name(item.draft, :work, 0)
+
+      assert [person] = draft.people
+      assert person.own_name
+      # and it is a question nobody has answered yet
+      refute person.name.approved
+    end
+
+    # Every way in needs a way out. The reveal used to be a fold that could
+    # only be opened, which is the same hole in a different costume.
+    test "the credited name can be taken back" do
+      item = item(%{matches: matches([provider_candidate(%{"authors" => ["David Wong"]})])})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        item.draft
+        |> Draft.Edit.separate_person_name(:work, 0)
+        |> Draft.Edit.rename_person("davidwong", "Jason Pargin")
+        |> Draft.Edit.use_credited_name("davidwong")
+
+      assert [person] = draft.people
+      refute person.own_name
+      assert Field.value(person.name) == "David Wong"
+    end
+
+    # The names agree for exactly as long as it takes to type the real one,
+    # so tracking on the values alone dragged the human's name along with any
+    # credit fix made in that window.
+    test "a credit rename leaves a human who has their own name alone" do
+      item = item(%{matches: matches([provider_candidate(%{"authors" => ["David Wong"]})])})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      draft =
+        item.draft
+        |> Draft.Edit.separate_person_name(:work, 0)
+        |> Draft.Edit.rename_credit(:work, 0, "David Wong Jr.")
+
+      assert [person] = draft.people
+      assert Field.value(person.name) == "David Wong"
+    end
+
     test "a half-typed name is storable but never resolved" do
       item = item(%{matches: matches([provider_candidate(%{})])})
       {:ok, item} = Inbox.prepare_draft(item)

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -765,7 +765,7 @@ defmodule Ambry.Inbox.DraftTest do
       assert [link] = draft.work.series
       refute SeriesLink.resolved?(link)
       assert link.number == nil
-      assert SeriesLink.state(link) == :missing
+      assert SeriesLink.state(link) == :unnumbered
     end
 
     # `book_number` is a required column, so an approved-but-numberless
@@ -781,7 +781,7 @@ defmodule Ambry.Inbox.DraftTest do
       assert [link] = draft.work.series
       assert link.approved
       refute SeriesLink.resolved?(link)
-      assert SeriesLink.state(link) == :missing
+      assert SeriesLink.state(link) == :unnumbered
     end
 
     test "a number from the tags settles it" do
@@ -2561,7 +2561,7 @@ defmodule Ambry.Inbox.DraftTest do
     # and "part of this set, position unknown" stays a question.
     test "resolved?/1 and state/1" do
       refute GroupLink.resolved?(%GroupLink{part_number: nil, approved: true, name: "Set"})
-      assert GroupLink.state(%GroupLink{part_number: nil}) == :missing
+      assert GroupLink.state(%GroupLink{part_number: nil}) == :unnumbered
 
       unapproved = %GroupLink{part_number: 1, name: "Set", mode: :create}
       refute GroupLink.resolved?(unapproved)
@@ -2831,9 +2831,9 @@ defmodule Ambry.Inbox.DraftTest do
       draft = Draft.Edit.link_book(item.draft, item, book.id)
 
       # "is this another part of the same set?" — the position is the open
-      # question, so the link stays :missing until answered or removed
+      # question, so the link stays :unnumbered until answered or removed
       assert %GroupLink{mode: :link, part_number: nil} = draft.recording.recording_group
-      assert GroupLink.state(draft.recording.recording_group) == :missing
+      assert GroupLink.state(draft.recording.recording_group) == :unnumbered
     end
 
     test "several existing sets can't be told apart — they ride along as candidates" do

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -9,6 +9,7 @@ defmodule Ambry.Inbox.DraftTest do
   alias Ambry.Inbox.Draft.PersonDecision
   alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.InboxItem
   alias Ambry.Media.Media.Chapter
   alias Ambry.Repo
@@ -1284,38 +1285,40 @@ defmodule Ambry.Inbox.DraftTest do
       assert Draft.curated?(Draft.Edit.uncatalogued(item.draft, item))
     end
 
-    test "the badge state follows decisions, not match history" do
+    # The rail follows decisions, not match history: confidence was frozen at
+    # match time, so a level kept reading doubted after the operator had
+    # answered.
+    test "a doubted level waits, and answering it reads as reviewed" do
       record = provider_candidate(%{"score" => 0.5})
       item = item(%{matches: matches([record], confidence: 0.3), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
 
-      assert Draft.level_state(item.draft.work) == :unsure
-      assert Draft.level_state(item.draft.recording) == :no_match
+      assert Tier.of_evidence(item.draft.work) == :waiting
 
       # ticking the doubted record is "yes, you were right"
       draft = Draft.Edit.toggle_source(item.draft, item, :work, record)
-      assert Draft.level_state(draft.work) == :confirmed
+      assert Tier.of_evidence(draft.work) == :reviewed
     end
 
-    test "a believed match reads trusted until a human touches it" do
+    # The tier the whole four-state model exists for: the machine settled it
+    # and nobody has looked, which is a legitimate end state — pressing Add is
+    # what accepts it.
+    test "a believed match reads unreviewed until a human touches it" do
       item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
 
-      assert Draft.level_state(item.draft.work) == :trusted
+      assert Tier.of_evidence(item.draft.work) == :unreviewed
+      assert Tier.of(item.draft.work) == :unreviewed
     end
 
-    # Clicking the already-ticked record UNTICKS it, so "yes, you were right"
-    # used to cost an untick and a re-tick with a reseed churning each way.
-    test "confirm approves the machine's ticks without moving them" do
+    # A level found nothing, which is an answer rather than a failure: there
+    # is nothing to choose between, so it does not wait on the operator.
+    test "a level that found nothing is settled, not waiting" do
       item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
-      ticked = item.draft.work.sources
 
-      draft = Draft.Edit.confirm_level(item.draft, :work)
-
-      assert Draft.level_state(draft.work) == :confirmed
-      assert draft.work.sources == ticked
-      assert Draft.curated?(draft)
+      assert item.draft.recording.doubt == :nothing_found
+      assert Tier.of(item.draft.recording) == :unreviewed
     end
 
     test "the tick survives the reseed it triggers" do

--- a/test/ambry/inbox/lookup_test.exs
+++ b/test/ambry/inbox/lookup_test.exs
@@ -131,6 +131,33 @@ defmodule Ambry.Inbox.LookupTest do
                get_in(item.matches, ["work", "providers"])
     end
 
+    # The reported flow: a details call the provider can never answer left a
+    # red chip that stayed red however often it was clicked, because a retry
+    # with nothing to report replaced nothing.
+    test "a retry with nothing to report clears the chip it was retrying" do
+      item =
+        item_with_records(
+          providers: [
+            %{
+              "id" => "hardcover:details",
+              "name" => "Hardcover details",
+              "status" => "failed",
+              "count" => 0,
+              "reason" => ":unsupported_capability"
+            }
+          ]
+        )
+
+      patch(Providers, :book_details, fn _id, _record_id, _opts ->
+        {:error, :unsupported_capability}
+      end)
+
+      {:ok, item} = Inbox.retry_provider(item, "work", "hardcover:details")
+
+      assert get_in(item.matches, ["work", "providers"]) == []
+      assert Inbox.unreached_providers(item) == []
+    end
+
     test "an editions chip re-asks the work for its editions" do
       item = item_with_records()
 

--- a/test/ambry/inbox/lookup_test.exs
+++ b/test/ambry/inbox/lookup_test.exs
@@ -21,7 +21,12 @@ defmodule Ambry.Inbox.LookupTest do
   setup do
     patch(Providers, :search_books, fn _id, _query, _opts -> {:ok, []} end)
     patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
-    patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :not_stubbed} end)
+    # Answering, not erroring: a details call that fails now records a
+    # `<provider>:details` outcome, so a stub meaning "don't care" must answer.
+    patch(Providers, :book_details, fn _id, id, _opts ->
+      {:ok, %Provider.Book{provider: "test", id: id}}
+    end)
+
     :ok
   end
 
@@ -95,10 +100,51 @@ defmodule Ambry.Inbox.LookupTest do
       assert [%{"id" => "hardcover", "status" => "ok"}] = outcomes
     end
 
-    test "an unknown provider is a no-op rather than a crash" do
+    # It used to answer `{:ok, item}` — indistinguishable from a retry that
+    # worked, which is how the `hardcover:editions` chip spent its life as a
+    # button that did nothing: its id is not a registry id, so every click
+    # missed the lookup and reported success.
+    test "an unknown provider is reported rather than silently doing nothing" do
       item = item_with_records()
 
-      assert {:ok, ^item} = Inbox.retry_provider(item, "work", "no-such-provider")
+      assert {:error, :unknown_provider} =
+               Inbox.retry_provider(item, "work", "no-such-provider")
+    end
+
+    test "a details chip re-fetches the details rather than re-running the search" do
+      item = item_with_records()
+
+      patch(Providers, :search_books, fn _id, _query, _opts ->
+        flunk("retrying a details chip must not re-run the search")
+      end)
+
+      patch(Providers, :book_details, fn _id, id, _opts ->
+        {:ok, %Provider.Book{provider: "hardcover", id: id, description: "Fetched at last"}}
+      end)
+
+      {:ok, item} = Inbox.retry_provider(item, "work", "hardcover:details")
+
+      assert [%{"description" => "Fetched at last", "hydrated" => true}] =
+               get_in(item.matches, ["work", "candidates"])
+
+      assert [%{"id" => "hardcover:details", "status" => "ok"}] =
+               get_in(item.matches, ["work", "providers"])
+    end
+
+    test "an editions chip re-asks the work for its editions" do
+      item = item_with_records()
+
+      patch(Providers, :editions, fn "hardcover", _work_id, _opts ->
+        {:ok, [book("Leviathan Wakes", ["James S.A. Corey"])]}
+      end)
+
+      {:ok, item} = Inbox.retry_provider(item, "recording", "hardcover:editions")
+
+      assert [%{"id" => "hardcover:editions", "status" => "ok", "count" => 1}] =
+               get_in(item.matches, ["recording", "providers"])
+
+      assert [%{"title" => "Leviathan Wakes"}] =
+               get_in(item.matches, ["recording", "candidates"])
     end
   end
 

--- a/test/ambry/inbox/run_import_test.exs
+++ b/test/ambry/inbox/run_import_test.exs
@@ -1,0 +1,84 @@
+defmodule Ambry.Inbox.RunImportTest do
+  @moduledoc """
+  Importing belongs to the server, not to a browser tab.
+
+  It used to run in an async task owned by the form's LiveView, so closing the
+  tab killed a multi-gigabyte placement mid-flight, and the operator had to sit
+  and watch it either way.
+
+  The end-to-end path — click, queue, drain, imported — is covered by the
+  inbox LiveView tests, which own the fixture that puts real audio on disk.
+  What is tested here is what only the worker can answer: what it does when
+  there is nothing to import, and where a refusal ends up.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.RunImport
+
+  describe "perform/1" do
+    # The job outlives the row it was queued for: an operator can ignore or
+    # delete an item while its import waits behind a slower one.
+    test "an item deleted while queued is not an error" do
+      assert :ok = perform_job(RunImport, %{inbox_item_id: 0})
+    end
+
+    # A refusal is a decision the operator has to see *tomorrow*, and a
+    # discarded job is deleted by the pruner within a day. `import_item/1`
+    # writes the reason onto the item, so the job reports success — its work
+    # is done — and the row carries the message.
+    @tag :capture_log
+    test "a refusal is recorded on the item rather than discarding the job" do
+      item = unsettled_item()
+
+      assert :ok = perform_job(RunImport, %{inbox_item_id: item.id})
+
+      item = Inbox.get_item!(item.id)
+      assert item.status == :pending
+      assert item.issue
+    end
+  end
+
+  describe "import_item_async/1" do
+    test "queues the work and leaves the library alone until it runs" do
+      item = unsettled_item()
+
+      assert {:ok, _job} = Inbox.import_item_async(item)
+      assert_enqueued(worker: RunImport, args: %{inbox_item_id: item.id})
+      assert Inbox.get_item!(item.id).status == :pending
+    end
+
+    # The row lock in `Importer` is what makes a double import safe; this is
+    # what stops one being attempted, because the wasted attempt is a whole
+    # copy of the release.
+    test "queuing twice queues once" do
+      item = unsettled_item()
+
+      assert {:ok, first} = Inbox.import_item_async(item)
+      assert {:ok, second} = Inbox.import_item_async(item)
+
+      refute first.conflict?
+      assert second.conflict?
+      assert [_only_one] = all_enqueued(worker: RunImport)
+    end
+
+    test "an item already in the library is refused at the door" do
+      item = unsettled_item()
+      {:ok, item} = Inbox.update_item(item, %{status: :imported})
+
+      assert {:error, :already_imported} = Inbox.import_item_async(item)
+    end
+  end
+
+  # Deliberately thin: an item with no probe and no draft can only be refused,
+  # which is exactly what the refusal tests want, and it needs nothing on disk.
+  defp unsettled_item do
+    %InboxItem{}
+    |> InboxItem.changeset(%{
+      path: "/downloads/Nothing Settled Here",
+      files: ["/downloads/Nothing Settled Here/book.m4b"]
+    })
+    |> Repo.insert!()
+  end
+end

--- a/test/ambry/inbox/run_match_test.exs
+++ b/test/ambry/inbox/run_match_test.exs
@@ -5,13 +5,23 @@ defmodule Ambry.Inbox.RunMatchTest do
   alias Ambry.Inbox
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.RunMatch
+  alias Ambry.Metadata.Provider
   alias Ambry.Metadata.Providers
 
   setup do
     patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
-    patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :not_stubbed} end)
+    # Answering, not erroring: an unreachable provider now fails the job by
+    # design, so a stub that means "don't care" has to actually answer.
+    patch(Providers, :book_details, fn _id, id, _opts ->
+      {:ok, %Provider.Book{provider: "test", id: id}}
+    end)
+
     patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, []} end)
-    patch(Providers, :author_details, fn _id, _author_id, _opts -> {:error, :not_stubbed} end)
+
+    patch(Providers, :author_details, fn _id, id, _opts ->
+      {:ok, %Provider.Author{provider: "test", id: id}}
+    end)
+
     :ok
   end
 
@@ -76,6 +86,34 @@ defmodule Ambry.Inbox.RunMatchTest do
       patch(Providers, :search_books, fn _id, _query, _opts -> {:ok, []} end)
 
       assert :ok = RunMatch.perform(job(item()))
+    end
+
+    # The search is not the only call, and for a long time it was the only one
+    # that could report a failure. A rate-limited *details* call left the
+    # record thin — no description, no cover, no edition list — reported
+    # success, and the item settled and went `ready` on evidence the provider
+    # would happily have given us.
+    @tag :capture_log
+    test "a details call that couldn't be reached puts the job back too" do
+      patch(Providers, :search_books, fn id, _query, _opts ->
+        if id == "rreading_glasses",
+          do:
+            {:ok,
+             [%Provider.Book{provider: "rreading_glasses", id: "rg-1", title: "The Way of Kings"}]},
+          else: {:ok, []}
+      end)
+
+      patch(Providers, :book_details, fn _id, _book_id, _opts -> {:error, :rate_limited} end)
+
+      item = item()
+
+      assert {:error, {:providers_unreached, unreached}} = RunMatch.perform(job(item))
+      assert "rreading_glasses:details" in unreached
+
+      # and the partial result is kept, because the retry re-asks only what it
+      # missed — provider errors are never cached, answers are
+      item = Inbox.get_item!(item.id)
+      assert [%{"title" => "The Way of Kings"}] = item.matches["work"]["candidates"]
     end
   end
 

--- a/test/ambry/inbox/undo_test.exs
+++ b/test/ambry/inbox/undo_test.exs
@@ -1,0 +1,146 @@
+defmodule Ambry.Inbox.UndoTest do
+  @moduledoc """
+  Undoing an import, which is the loop the staged form is designed in: run an
+  awkward release through it, see what reads wrong, put it back, run it again.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Books
+  alias Ambry.Inbox
+  alias Ambry.Media
+  alias Ambry.People
+  alias Ambry.Repo
+
+  describe "undoing an import" do
+    test "deletes what the import created and puts the item back in the queue" do
+      %{item: item, source: source} = downloads_item()
+
+      {:ok, media} = Inbox.import_item(item)
+      item = Inbox.get_item!(item.id)
+      [placed] = Media.get_media!(media.id).source_files
+
+      assert {:ok, summary} = Inbox.undo_import(item)
+
+      # the records
+      assert Repo.get(Media.Media, media.id) == nil
+      assert Books.list_books() |> elem(0) == []
+      assert People.list_people() |> elem(0) == []
+
+      # the item, with the decisions it was imported with
+      assert %{status: :pending, media_id: nil} = summary.item
+      assert summary.item.draft.work.title.value == "The Way of Kings"
+
+      # the bytes: the library copy goes, the file it was found as stays
+      assert %{success: 1} = Oban.drain_queue(queue: :default)
+      refute File.exists?(placed)
+      assert File.exists?(source)
+    end
+
+    test "says what it deleted, in words" do
+      %{item: item} = downloads_item()
+      {:ok, _media} = Inbox.import_item(item)
+
+      assert {:ok, summary} = Inbox.undo_import(Inbox.get_item!(item.id))
+
+      assert "the audiobook" in summary.deleted
+      assert "the book" in summary.deleted
+      assert "the person Brandon Sanderson" in summary.deleted
+      assert summary.kept == []
+    end
+
+    test "the same release can then be imported again" do
+      %{item: item} = downloads_item()
+
+      {:ok, first} = Inbox.import_item(item)
+      {:ok, _summary} = Inbox.undo_import(Inbox.get_item!(item.id))
+      assert %{success: 1} = Oban.drain_queue(queue: :default)
+
+      assert {:ok, second} = Inbox.import_item(Inbox.get_item!(item.id))
+      assert second.id != first.id
+      assert Inbox.get_item!(item.id).status == :imported
+    end
+
+    # Nothing about undoing one import may damage another. A book that has
+    # since grown a second recording is the case that would.
+    test "keeps a book another audiobook has joined, and says so" do
+      %{item: item} = downloads_item()
+      {:ok, media} = Inbox.import_item(item)
+
+      # a second recording of the same book, as a re-import would make
+      insert(:media, book_id: media.book_id)
+
+      assert {:ok, summary} = Inbox.undo_import(Inbox.get_item!(item.id))
+
+      assert Repo.get(Books.Book, media.book_id)
+      assert "the book: another audiobook uses it" in summary.kept
+      # the person is exclusive to that book's author, so they stay too
+      assert Enum.any?(summary.kept, &String.starts_with?(&1, "the person"))
+    end
+
+    # A `move` policy leaves the library copy as the only copy. Deleting it
+    # would not be an undo.
+    test "refuses when the files it was found as are gone" do
+      %{item: item, source: source} = downloads_item(policy: :move)
+
+      {:ok, _media} = Inbox.import_item(item)
+      refute File.exists?(source)
+
+      assert {:error, :source_files_missing} = Inbox.undo_import(Inbox.get_item!(item.id))
+      assert Inbox.get_item!(item.id).status == :imported
+    end
+
+    test "refuses an item that was never imported" do
+      %{item: item} = downloads_item()
+
+      assert {:error, :not_imported} = Inbox.undo_import(item)
+    end
+
+    # The button is the explanation; this is the enforcement.
+    test "refuses entirely on a build without the flag" do
+      %{item: item} = downloads_item()
+      {:ok, _media} = Inbox.import_item(item)
+
+      Application.put_env(:ambry, :allow_undo_import, false)
+      on_exit(fn -> Application.put_env(:ambry, :allow_undo_import, true) end)
+
+      refute Inbox.undo_available?()
+      assert {:error, :undo_unavailable} = Inbox.undo_import(Inbox.get_item!(item.id))
+      assert Inbox.get_item!(item.id).status == :imported
+    end
+  end
+
+  # The same arrangement `ManagedImportTest` uses: a watched downloads folder
+  # bringing files into a library root, settled the way the form would leave
+  # it.
+  defp downloads_item(opts \\ []) do
+    root = new_dir("root")
+    insert(:root, path: root, name: "Library")
+
+    downloads = new_dir("downloads")
+    release = Path.join(downloads, "The Way of Kings [M4B]")
+    File.mkdir_p!(release)
+
+    source = Path.join(release, "book.m4b")
+    File.cp!(tagged_audio(), source)
+
+    watched =
+      insert(:source,
+        on_import: :bring_in,
+        import_policy: Keyword.get(opts, :policy, :copy),
+        path: downloads,
+        name: "Downloads #{Ecto.UUID.generate()}"
+      )
+
+    {:ok, _counts} = Inbox.discover(watched)
+    {[item], false} = Inbox.list_items()
+    {:ok, item} = Inbox.probe_item(item)
+
+    %{item: settle(item), root: root, source: source}
+  end
+
+  defp new_dir(prefix) do
+    dir = Ambry.Paths.source_media_disk_path("#{prefix}-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(dir)
+    dir
+  end
+end

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -173,6 +173,94 @@ defmodule Ambry.InboxTest do
     end
   end
 
+  # The safety property the whole mechanism is built on, stated where it can
+  # be broken: **a scan may not change who owns a file.** It creates items
+  # from files nothing owns, adds unowned files to the item that owns their
+  # folder, and drops files that are gone. Nothing else.
+  describe "discover/1 ownership" do
+    test "a file already owned is never re-grouped, however the walk sees it" do
+      root = watched_root()
+      release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+
+      # the operator says these are two books, at the finest grain
+      {[item], false} = Inbox.list_items()
+      {:ok, _children} = Inbox.split_item(item, :file)
+
+      # the walk still sees one folder holding two files, and is not asked
+      assert {:ok, %{created: 0, updated: 0}} = Inbox.discover(root)
+
+      {items, false} = Inbox.list_items()
+      assert length(items) == 2
+
+      assert items |> Enum.flat_map(& &1.files) |> Enum.sort() ==
+               [Path.join(release, "one.m4b"), Path.join(release, "two.m4b")]
+    end
+
+    test "a folder split keeps each part's files, and the leftovers" do
+      root = watched_root()
+      book = Path.join(root, "The Way of Kings")
+      for part <- ["1 of 2", "2 of 2"], do: release_folder(book, part, ["01.mp3", "02.mp3"])
+      copy_audio(book, "stray.mp3")
+
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], false} = Inbox.list_items()
+      assert length(item.files) == 5
+
+      {:ok, _children} = Inbox.split_item(item, :folder)
+      before = ownership()
+
+      assert {:ok, %{created: 0, updated: 0}} = Inbox.discover(root)
+      assert ownership() == before
+    end
+
+    test "an imported item is never touched, even when its files have moved" do
+      root = watched_root()
+      release = release_folder(root, "Already Mine", ["book.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+
+      {[item], false} = Inbox.list_items()
+      {:ok, item} = Inbox.update_item(item, %{status: :imported})
+
+      # a managed import moves the bytes out of the downloads folder
+      File.rm_rf!(release)
+      File.mkdir_p!(release)
+
+      assert {:ok, %{updated: 0}} = Inbox.discover(root)
+
+      assert %{status: :imported, files: files} = Inbox.get_item!(item.id)
+      assert files == item.files
+    end
+
+    test "a new file joins the item that owns its folder, rather than starting one" do
+      root = watched_root()
+      release = release_folder(root, "Growing Release", ["01.mp3"])
+      {:ok, _counts} = Inbox.discover(root)
+
+      copy_audio(release, "02.mp3")
+
+      assert {:ok, %{created: 0, updated: 1}} = Inbox.discover(root)
+      assert {[item], false} = Inbox.list_items()
+      assert length(item.files) == 2
+    end
+
+    test "a new file in a folder the operator took apart becomes its own item" do
+      root = watched_root()
+      release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], false} = Inbox.list_items()
+      {:ok, _children} = Inbox.split_item(item, :file)
+
+      copy_audio(release, "three.m4b")
+
+      assert {:ok, %{created: 1}} = Inbox.discover(root)
+
+      {items, false} = Inbox.list_items()
+      assert length(items) == 3
+      assert Enum.all?(items, &(length(&1.files) == 1))
+    end
+  end
+
   describe "discover/1 idempotency" do
     test "rescanning doesn't duplicate what it already offered" do
       root = watched_root()
@@ -582,6 +670,12 @@ defmodule Ambry.InboxTest do
 
   # Nothing in the inbox may modify what it finds, so every test works
   # against a real throwaway tree of real audio files.
+  # Who owns what, as the property tests compare it.
+  defp ownership do
+    {items, _more} = Inbox.list_items()
+    for item <- items, file <- item.files, into: %{}, do: {file, item.path}
+  end
+
   defp watched_root do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     File.mkdir_p!(root)

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -177,6 +177,40 @@ defmodule Ambry.InboxTest do
   # be broken: **a scan may not change who owns a file.** It creates items
   # from files nothing owns, adds unowned files to the item that owns their
   # folder, and drops files that are gone. Nothing else.
+  # Two grains that produce the same items are one grain wearing two hats,
+  # and the form should not ask the operator to choose between them.
+  describe "split_grains/1" do
+    test "offers the finer grain only when it divides further" do
+      root = watched_root()
+
+      set = Path.join(root, "The Way of Kings")
+      for part <- ["1 of 2", "2 of 2"], do: release_folder(set, part, ["01.mp3", "02.mp3"])
+
+      series = Path.join(root, "Zones of Thought")
+
+      for title <- ["A Fire Upon the Deep", "A Deepness in the Sky"],
+          do: release_folder(series, title, ["book.m4b"])
+
+      copy_audio(series, "stray.mp3")
+
+      pair = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
+
+      {:ok, _counts} = Inbox.discover(root)
+      {items, false} = Inbox.list_items()
+      grains = Map.new(items, &{&1.path, Inbox.split_grains(&1)})
+
+      # parts of several files each: both grains say something different
+      assert grains[set] == %{folder: 2, file: 4}
+
+      # three folders of one file each plus a stray: the folder grain wins,
+      # and the file grain would produce the same four items
+      assert grains[series] == %{folder: 3}
+
+      # one folder, so only the finest grain divides anything
+      assert grains[pair] == %{file: 2}
+    end
+  end
+
   describe "discover/1 ownership" do
     test "a file already owned is never re-grouped, however the walk sees it" do
       root = watched_root()

--- a/test/ambry/metadata/outcome_test.exs
+++ b/test/ambry/metadata/outcome_test.exs
@@ -1,0 +1,70 @@
+defmodule Ambry.Metadata.OutcomeTest do
+  @moduledoc """
+  The vocabulary every fan-out reports in.
+
+  The ids matter more than they look: the retry chip carries one back, and a
+  chip that re-ran the wrong kind of call would report success having fixed
+  nothing.
+  """
+  use ExUnit.Case, async: true
+
+  alias Ambry.Metadata.Outcome
+  alias Ambry.Metadata.Registry
+
+  defp entry, do: %Registry.Entry{id: "hardcover", display_name: "Hardcover"}
+
+  describe "ids" do
+    test "a search is recorded under the provider's own id" do
+      assert Outcome.id("hardcover") == "hardcover"
+      assert Outcome.ok(entry(), 3)["id"] == "hardcover"
+    end
+
+    # Sharing one id meant the last write won, so a rate-limited details call
+    # vanished behind the search that had already said `ok`.
+    test "every other kind of call gets its own" do
+      assert Outcome.id("hardcover", :details) == "hardcover:details"
+      assert Outcome.id("hardcover", :editions) == "hardcover:editions"
+      assert Outcome.ok(entry(), 1, :details)["id"] == "hardcover:details"
+    end
+
+    test "split/1 recovers the provider and what it was asked" do
+      assert Outcome.split("hardcover") == {"hardcover", :search}
+      assert Outcome.split("hardcover:details") == {"hardcover", :details}
+      assert Outcome.split("hardcover:editions") == {"hardcover", :editions}
+    end
+
+    # A provider id that happens to contain a colon is a provider id, not a
+    # kind — guessing otherwise would send a retry to a provider that doesn't
+    # exist.
+    test "an unknown suffix is part of the provider id" do
+      assert Outcome.split("some:provider") == {"some:provider", :search}
+    end
+
+    test "an id survives a round trip" do
+      for kind <- [:search, :details, :editions, :chapters] do
+        assert Outcome.split(Outcome.id("hardcover", kind)) == {"hardcover", kind}
+      end
+    end
+  end
+
+  describe "what a chip reads" do
+    test "the kind is named, so two chips from one provider are tellable apart" do
+      assert Outcome.ok(entry(), 2)["name"] == "Hardcover"
+      assert Outcome.ok(entry(), 2, :details)["name"] == "Hardcover details"
+      assert Outcome.ok(entry(), 2, :editions)["name"] == "Hardcover editions"
+    end
+
+    test "a failure carries a reason short enough for a tooltip" do
+      outcome = Outcome.failed(entry(), String.duplicate("very long ", 100))
+
+      assert outcome["status"] == "failed"
+      assert outcome["count"] == 0
+      assert String.length(outcome["reason"]) <= 200
+      assert Outcome.failed?(outcome)
+    end
+
+    test "an answer is not a failure" do
+      refute Outcome.failed?(Outcome.ok(entry(), 0))
+    end
+  end
+end

--- a/test/ambry/metadata/outcome_test.exs
+++ b/test/ambry/metadata/outcome_test.exs
@@ -13,6 +13,30 @@ defmodule Ambry.Metadata.OutcomeTest do
 
   defp entry, do: %Registry.Entry{id: "hardcover", display_name: "Hardcover"}
 
+  # Not every error is a failure to reach a provider, and treating them alike
+  # put a red "couldn't be reached, retry" chip on items whose retry could
+  # never succeed — and kept the matching job re-queuing itself for as long
+  # as it had attempts left.
+  describe "from_error/3" do
+    test "a provider that cannot be asked reports nothing at all" do
+      assert Outcome.from_error(entry(), :unsupported_capability, :details) == nil
+      assert Outcome.from_error(entry(), :provider_disabled, :details) == nil
+      assert Outcome.from_error(entry(), :provider_not_configured) == nil
+    end
+
+    # The provider answered. "It has no such record" is a count of zero, and
+    # a retry will get the same definite answer every time.
+    test "not-found is an answer, not a failure" do
+      assert %{"id" => "hardcover:details", "status" => "ok", "count" => 0} =
+               Outcome.from_error(entry(), :not_found, :details)
+    end
+
+    test "anything else is a failure worth retrying" do
+      assert %{"status" => "failed", "reason" => ":rate_limited"} =
+               Outcome.from_error(entry(), :rate_limited, :details)
+    end
+  end
+
   describe "ids" do
     test "a search is recorded under the provider's own id" do
       assert Outcome.id("hardcover") == "hardcover"

--- a/test/ambry/metadata/person_search_test.exs
+++ b/test/ambry/metadata/person_search_test.exs
@@ -1,0 +1,98 @@
+defmodule Ambry.Metadata.PersonSearchTest do
+  @moduledoc """
+  Gathering everything every provider knows about a human — and, when one of
+  them couldn't be reached, saying so.
+
+  A person search is two calls deep: a name search, then a details call per
+  plausible hit, which is where the biography and the headshots live. The
+  details call had no way to report failure, and the consequence was worse
+  than a thin result — a hit with no photo and no bio is dropped from the
+  grid, so a rate-limited details call **deleted the person** while the
+  search still reported `ok`. Measured on a cold scan of 353 releases, the
+  shared rreading-glasses instance 429'd about 6% of requests; person calls
+  were 84% of the traffic.
+  """
+  use Ambry.DataCase, async: false
+  use Patch
+
+  alias Ambry.Metadata.PersonSearch
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Registry
+
+  defp entry, do: %Registry.Entry{id: "wikidata", display_name: "Wikidata"}
+
+  defp summary(id \\ "Q1"),
+    do: %Provider.Author{provider: "wikidata", id: id, name: "Brandon Sanderson"}
+
+  describe "matches_with_outcome/3" do
+    test "reports the search and nothing else when every call answered" do
+      patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, [summary()]} end)
+
+      patch(Providers, :author_details, fn _id, id, _opts ->
+        {:ok, %Provider.Author{provider: "wikidata", id: id, description: "Writes fantasy."}}
+      end)
+
+      assert {[match], [outcome]} =
+               PersonSearch.matches_with_outcome(entry(), "Brandon Sanderson")
+
+      assert match.description == "Writes fantasy."
+      assert %{"id" => "wikidata", "status" => "ok", "count" => 1} = outcome
+    end
+
+    @tag :capture_log
+    test "a search that couldn't be reached is one failed outcome" do
+      patch(Providers, :search_authors, fn _id, _query, _opts -> {:error, :rate_limited} end)
+
+      assert {[], [outcome]} = PersonSearch.matches_with_outcome(entry(), "Brandon Sanderson")
+      assert %{"id" => "wikidata", "status" => "failed"} = outcome
+    end
+
+    # The one that used to vanish. The search says `ok` — it did find her —
+    # and the details call that would have given her a face was rate-limited,
+    # so she is dropped from the grid. Without the second outcome, nothing
+    # anywhere records that a human the file credits went missing.
+    test "a details call that couldn't be reached is reported under its own id" do
+      patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, [summary()]} end)
+      patch(Providers, :author_details, fn _id, _author_id, _opts -> {:error, :rate_limited} end)
+
+      assert {matches, outcomes} = PersonSearch.matches_with_outcome(entry(), "Brandon Sanderson")
+
+      assert matches == []
+      assert %{"status" => "ok", "count" => 0} = Enum.find(outcomes, &(&1["id"] == "wikidata"))
+
+      assert %{"status" => "failed", "reason" => reason} =
+               Enum.find(outcomes, &(&1["id"] == "wikidata:details"))
+
+      assert reason =~ "rate_limited"
+    end
+
+    # A provider that simply knows nothing more about somebody is not a
+    # failure, and must not be reported as one — otherwise every scan would
+    # retry forever against a provider that is behaving perfectly.
+    test "a provider with no details to give is not a failure" do
+      patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, [summary()]} end)
+
+      patch(Providers, :author_details, fn _id, _author_id, _opts ->
+        {:ok, %Provider.Author{provider: "wikidata", id: "Q1", description: "Known."}}
+      end)
+
+      assert {[_match], [%{"id" => "wikidata"}]} =
+               PersonSearch.matches_with_outcome(entry(), "Brandon Sanderson")
+    end
+
+    # One chip per provider however many hits it returned: three hits and one
+    # rate limit is still "Wikidata details: couldn't be reached", not three
+    # of them.
+    test "several failed hits collapse to one outcome" do
+      patch(Providers, :search_authors, fn _id, _query, _opts ->
+        {:ok, [summary("Q1"), summary("Q2"), summary("Q3")]}
+      end)
+
+      patch(Providers, :author_details, fn _id, _author_id, _opts -> {:error, :rate_limited} end)
+
+      assert {[], outcomes} = PersonSearch.matches_with_outcome(entry(), "Brandon Sanderson")
+      assert length(outcomes) == 2
+    end
+  end
+end

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -141,6 +141,23 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert Inbox.get_item!(item.id).issue == nil
     end
 
+    # Development only, and the loop the whole staged form is designed in:
+    # run an awkward release through it, see what reads wrong, put it back.
+    test "can be undone in dev, and the form is editable again", %{conn: conn} do
+      item = probed_item() |> settle()
+      {:ok, _media} = Inbox.import_item(item)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert has_element?(view, "[data-role='undo-import']")
+
+      html = view |> element("[data-role='undo-import']") |> render_click()
+
+      assert html =~ "Deleted the audiobook"
+      refute has_element?(view, "[data-role='imported-banner']")
+      assert %{status: :pending, media_id: nil} = Inbox.get_item!(item.id)
+    end
+
     test "the context refuses a second import and any draft write" do
       item = probed_item() |> settle()
       {:ok, _media} = Inbox.import_item(item)

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -808,9 +808,76 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert link.mode == :link
       assert link.series_id == series.id
     end
+
+    # A provider named the series and gave no number, so the row said
+    # "nothing proposed it" beside "from rreading-glasses" — two sentences
+    # about one row, contradicting each other. What is missing is the number.
+    test "a numberless membership says the number is what it needs", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      params = Inbox.dump_draft(item.draft)
+
+      params =
+        put_in(params["work"]["series"], [
+          %{"name" => "The Expanse", "mode" => "create", "source" => "provider:hardcover"}
+        ])
+
+      {:ok, item} = Inbox.update_draft(item, params)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "needs a number"
+      refute html =~ "nothing proposed it"
+      # still a blocker — `book_number` is a required column
+      assert html =~ "from Hardcover"
+    end
+
+    # The rail already says amber; a badge repeating it is the same fact
+    # twice, which is the rule the rest of the form follows.
+    test "a numbered membership awaiting confirmation wears no badge", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      params = Inbox.dump_draft(item.draft)
+
+      params =
+        put_in(params["work"]["series"], [
+          %{"name" => "The Expanse", "mode" => "create", "number" => "1", "source" => "tags"}
+        ])
+
+      {:ok, item} = Inbox.update_draft(item, params)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      row = view |> element("[data-role='series-link']") |> render()
+
+      refute row =~ "needs confirming"
+      refute row =~ "nothing proposed it"
+    end
   end
 
   describe "records are evidence, not identities" do
+    # Which database said this is the first thing an operator checks, and at
+    # the end of the facts line it was the first thing truncation took.
+    test "a record's provider is a badge, not the tail of a long line", %{conn: conn} do
+      item = probed_item() |> with_work_records()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      row = html |> Floki.parse_document!() |> Floki.find("[data-role='record']") |> hd()
+
+      # beside the title, not under it: `<.badge>` renders a div, and a div
+      # inside a `<p>` closes the paragraph early and drops onto its own line
+      assert [title_line] = Floki.find(row, "div.font-medium")
+      assert [badge] = Floki.find(title_line, "[data-role='record-source']")
+      assert Floki.text(badge) =~ "Hardcover"
+
+      # and the facts line no longer carries it, so nothing repeats and
+      # nothing about the source can be truncated away
+      refute row |> Floki.find("p.truncate") |> Floki.text() =~ "Hardcover"
+    end
+
     test "the top record is ticked and the rest are not", %{conn: conn} do
       item = probed_item() |> with_work_records()
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1566,7 +1566,9 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       # Two files are one recording by default — the button is the way to
       # say they aren't, not a precondition for importing them.
       assert html =~ "import as one audiobook"
-      assert html =~ "Split into 2 items"
+      assert html =~ "Split into 2 files"
+      # one folder, so there is nothing for the coarser grain to divide
+      refute has_element?(view, "button[data-role='split-folder']")
 
       view |> element("button[data-role='split']") |> render_click()
       assert_redirect(view, ~p"/admin/inbox")
@@ -1574,6 +1576,50 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {items, _more} = Inbox.list_items(filter: "Two Novellas")
       assert length(items) == 2
       assert Enum.all?(items, &(length(&1.files) == 1))
+    end
+
+    # The other grain the heuristic gets wrong, and the reason this exists: a
+    # folder of "1 of 5" subfolders is one release in five parts when it is a
+    # multi-disc rip, and five recordings when it is a GraphicAudio set. Only
+    # the operator can tell, and one item per *file* was no use to them —
+    # each part is seven files.
+    test "a set of part folders splits by folder, keeping each part whole", %{conn: conn} do
+      root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
+      release = Path.join(root, "The Way of Kings")
+
+      for part <- 1..3, file <- 1..2 do
+        dir = Path.join(release, "#{part} of 3")
+        File.mkdir_p!(dir)
+        File.cp!(tagged_fixture(true, false, nil), Path.join(dir, "part#{file}.m4b"))
+      end
+
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], _more} = Inbox.list_items(filter: "The Way of Kings")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      # discovery reads the part folders as one release, which is the whole
+      # bug from the operator's side
+      assert length(item.files) == 6
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      assert html =~ "Split into 3 folders"
+
+      view |> element("button[data-role='split-folder']") |> render_click()
+      assert_redirect(view, ~p"/admin/inbox")
+
+      {items, _more} = Inbox.list_items(filter: "The Way of Kings")
+      assert length(items) == 3
+      assert Enum.all?(items, &(length(&1.files) == 2))
+
+      # and each says what it is a part of, since "1 of 3" alone names nothing
+      assert Enum.map(items, &InboxItem.name/1) |> Enum.sort() ==
+               ["The Way of Kings/1 of 3", "The Way of Kings/2 of 3", "The Way of Kings/3 of 3"]
+
+      # a rescan must not re-merge what the operator just took apart
+      {:ok, _counts} = Inbox.discover(root)
+      {items, _more} = Inbox.list_items(filter: "The Way of Kings")
+      assert length(items) == 3
     end
   end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1038,9 +1038,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      view
-      |> element("button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']")
-      |> render_click()
+      add_second_person(view, "brandonsanderson")
 
       assert view
              |> render()
@@ -1437,7 +1435,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
       assert html =~ "Part of a set"
-      assert html =~ "not part of a set"
+      assert html =~ "Not part of a set."
 
       view |> element("button", "This audiobook is part of a set") |> render_click()
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -12,6 +12,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.RunImport
   alias Ambry.Metadata.PersonSearch
+  alias Ambry.Metadata.Providers
   alias Ambry.Repo
 
   setup :register_and_log_in_admin_user
@@ -875,6 +876,35 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   end
 
   describe "records are evidence, not identities" do
+    # The person cards have worn the scrim since they grew a search of their
+    # own; these two were left with a button that changed its own label.
+    test "a level being searched wears the busy scrim", %{conn: conn} do
+      test_pid = self()
+
+      patch(Providers, :search_books, fn _id, _query, _opts ->
+        send(test_pid, {:searching, self()})
+        receive do: (:go -> :ok)
+        {:ok, []}
+      end)
+
+      item = probed_item() |> with_work_records()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("form#research-work")
+        |> render_submit(%{"level" => "work", "title" => "The Way of Kings"})
+
+      assert_receive {:searching, task}
+      assert html =~ "Looking for The Way of Kings…"
+
+      send(task, :go)
+      render_async(view)
+
+      refute render(view) =~ "Looking for The Way of Kings…"
+    end
+
     # Which database said this is the first thing an operator checks, and at
     # the end of the facts line it was the first thing truncation took.
     test "a record's provider is a badge, not the tail of a long line", %{conn: conn} do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -861,7 +861,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
              description: "An American author of epic fantasy.",
              images: images
            }
-         ], %{"id" => "wikidata", "name" => "Wikidata", "status" => "ok", "count" => 1}}
+         ], [%{"id" => "wikidata", "name" => "Wikidata", "status" => "ok", "count" => 1}]}
       end)
     end
   end

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -280,7 +280,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   # The third level, and a section rather than a decoration on a credit. The
   # model always said people were a level — keyed decisions, `appearances/1` —
   # while the form rendered them inside every credit that named them.
-  describe "the New people section" do
+  describe "the People section" do
     test "lists a human once, however many credits name them", %{conn: conn} do
       item = probed_item(narrator: "Brandon Sanderson")
 
@@ -307,6 +307,43 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert has_element?(view, "#people [data-role='person-card']")
     end
 
+    # A full-cast recording is a run of credit rows; a second line of faces
+    # each is what turns the section into a wall.
+    test "a credit's people ride beside its box, and a crowd is counted", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # the chips share the row with the identity box
+      assert [chips] =
+               view
+               |> element("#work [data-role='credit-people']")
+               |> render()
+               |> Floki.parse_fragment!()
+
+      assert Floki.find(chips, "a[href^='#person-']") != []
+
+      # six humans behind one credit is a list, not a row of faces
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      Enum.each(1..5, fn _ ->
+        view
+        |> element("#person-brandonsanderson button[phx-click='add-person']")
+        |> render_click()
+      end)
+
+      assert [chips] =
+               view
+               |> element("#work [data-role='credit-people']")
+               |> render()
+               |> Floki.parse_fragment!()
+
+      assert chips |> Floki.find("a[href^='#person-']") |> length() == 4
+      assert chips |> Floki.find("a[href='#people']") |> Floki.text() =~ "+2"
+    end
+
     # The credit keeps the identity decision and carries a reference, so the
     # operator can see who it means without leaving the section.
     test "a credit links to the person's card", %{conn: conn} do
@@ -320,10 +357,27 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert has_element?(view, "#person-#{key}")
     end
 
-    # Somebody already in the library was chosen in the credit's typeahead,
-    # carries curation an import may never overwrite, and has nothing left to
-    # decide.
-    test "leaves out people already in the library", %{conn: conn} do
+    # A credit pointing at an identity the library already has brings no
+    # humans with it: that person was chosen in the credit's typeahead and
+    # carries curation an import may never overwrite.
+    test "leaves out the people behind a linked credit", %{conn: conn} do
+      item = probed_item()
+      author = insert(:author, name: "Brandon Sanderson")
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      draft = Draft.Edit.link_credit(item.draft, :work, 0, author.id)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert hd(Inbox.get_item!(item.id).draft.work.authors).mode == :link
+      refute has_element?(view, "#person-brandonsanderson")
+    end
+
+    # The other direction is a decision made *here*, so it stays here. Losing
+    # the card the moment the link was made took the way back with it, and
+    # left the credit's chip pointing at an anchor that no longer existed.
+    test "keeps a person matched to the library, with the way back", %{conn: conn} do
       item = probed_item()
       person = insert(:person, name: "Brandon Sanderson")
 
@@ -334,7 +388,134 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      refute has_element?(view, "#person-#{key}")
+      assert has_element?(view, "#person-#{key}")
+
+      view
+      |> element("button[phx-click='unlink-person'][phx-value-key='#{key}']")
+      |> render_click()
+
+      assert %{mode: :create} = person_keyed(item, key)
+    end
+  end
+
+  # The credited name is the human's name in almost every import, so the card
+  # states it and offers nothing to type. "This is a pen name" is what puts a
+  # box there — and with a box on every card in every state, the control had
+  # no visible effect at all.
+  describe "the person's name" do
+    test "a card names the human and offers no box", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      card = view |> element("#person-brandonsanderson") |> render()
+
+      assert card =~ "Brandon Sanderson"
+      assert card =~ "Credited as author"
+      # the reveal is the whole line: the title already says where the name
+      # came from
+      assert card =~ "This is a pen name"
+      refute has_element?(view, "#person-brandonsanderson-resolver")
+    end
+
+    test "declaring a pen name is what puts a box there", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      assert has_element?(view, "#person-brandonsanderson-resolver")
+      assert person_keyed(item, "brandonsanderson").own_name
+    end
+
+    # Both people controls live on the card they change. On the credit they
+    # acted on a card the operator couldn't see, which is a change too far
+    # away from the click.
+    test "the credit carries no people controls", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "#work [phx-click='separate-name']")
+      refute has_element?(view, "#work [phx-click='add-person']")
+      assert has_element?(view, "#person-brandonsanderson [phx-click='separate-name']")
+    end
+
+    # The card is titled by the credit, which is the one name on it that
+    # doesn't move: a header following the box re-titled the card letter by
+    # letter while the operator typed the human's name into it.
+    test "the card is titled by the credit, not by what is typed", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      view
+      |> form("#person-brandonsanderson-identity")
+      |> render_change(%{"key" => "brandonsanderson", "name" => "Somebody Else"})
+
+      card = view |> element("#person-brandonsanderson") |> render()
+
+      assert card =~ "Brandon Sanderson"
+      assert card =~ "Credited as author"
+      assert card =~ "A pen name of"
+      assert card =~ "Somebody Else"
+    end
+
+    test "and it can be taken back", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      view
+      |> element("button[phx-click='use-credited-name'][phx-value-key='brandonsanderson']")
+      |> render_click()
+
+      refute has_element?(view, "#person-brandonsanderson-resolver")
+      refute person_keyed(item, "brandonsanderson").own_name
+    end
+
+    # A composite credit names nobody: "James S.A. Corey" is two humans, and
+    # neither of them is called that.
+    test "a credit standing for several humans always offers the box", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      add_second_person(view, "brandonsanderson")
+
+      assert has_element?(view, "#person-brandonsanderson-resolver")
+      # and the second human, whom the credit names no better than the first
+      assert has_element?(view, "[data-role='pen-name-group'] #person-person\\#2")
+    end
+
+    # The author who turns up narrating: the credit's typeahead cannot offer
+    # them, because the identity they need doesn't exist yet. Without a route
+    # to the human the form's only answer was a second Person of the name.
+    test "somebody the library already has is offered on the card", %{conn: conn} do
+      person = insert(:person, name: "Brandon Sanderson")
+      item = probed_item() |> with_local_person(person)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "already in your library"
+
+      view
+      |> element("button[phx-click='link-person'][phx-value-key='brandonsanderson']")
+      |> render_click()
+
+      assert %{mode: :link, person_id: id} = person_keyed(item, "brandonsanderson")
+      assert id == person.id
     end
   end
 
@@ -346,17 +527,12 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       # No fold to open first: people are a section of their own, so "add
       # another person" is reachable from the credit directly.
-      html =
-        view
-        |> element(
-          "button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']"
-        )
-        |> render_click()
+      html = add_second_person(view, "brandonsanderson")
 
-      # the two cards sit adjacent under a bracket naming the credit they share
-      # the two cards sit adjacent inside a bracket naming the credit they
-      # share — the narrators have their own cards elsewhere in the section
-      assert html =~ "Behind the pen name"
+      # the two cards sit adjacent inside a bracket, which states the one
+      # thing their own titles can't: that there are two of them behind the
+      # single credited name
+      assert html =~ "2 people behind this name"
 
       assert [_first, _second] =
                html
@@ -372,9 +548,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      view
-      |> element("button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']")
-      |> render_click()
+      add_second_person(view, "brandonsanderson")
 
       {:ok, item} = Inbox.fetch_item(item.id)
 
@@ -847,6 +1021,39 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert person.description.source == "provider:wikidata"
     end
 
+    # A person the matcher doubted is seeded unapproved, and until this the
+    # only control in the whole form that could approve one was linking them
+    # to somebody already in the library — 96 of the operator's 344 queued
+    # items held a person no control could settle.
+    test "a doubted person can be settled by none of these", %{conn: conn} do
+      # the matcher found humans of roughly this name and believed none of
+      # them, which is what seeds a person unapproved
+      item = probed_item() |> with_namesake_person_matches()
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      person = person_keyed(item, "brandonsanderson")
+
+      refute person.approved
+      assert person.doubt == :low_confidence
+      assert Enum.any?(Draft.unresolved(item.draft), &(&1.label =~ "Brandon Sanderson"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#person-brandonsanderson button[data-role='none-of-these']")
+      |> render_click()
+
+      person = person_keyed(item, "brandonsanderson")
+      assert person.approved
+      assert person.sources == []
+      assert person.doubt == :none
+
+      refute Enum.any?(
+               Draft.unresolved(Inbox.get_item!(item.id).draft),
+               &(&1.label =~ "Brandon Sanderson" and &1.section == :people)
+             )
+    end
+
     # The person level's records are evidence with checkboxes, the same rule
     # as the work and recording levels. Unticking the only record of a
     # namesake — the goalkeeper who shares a narrator's name — takes his face
@@ -868,6 +1075,106 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       # and the tick survives a rebuild of the rest of the draft
       assert person.evidence_curated
+    end
+
+    # A provider round-trip is the same kind of event as a matching job and
+    # gets the same answer. The only sign it was happening used to be a button
+    # changing its own label, inside a fold that closed over it on the very
+    # patch that started the work.
+    test "a person being looked up wears the busy scrim", %{conn: conn} do
+      test_pid = self()
+      patch(PersonSearch, :providers, fn -> [%{id: "wikidata", display_name: "Wikidata"}] end)
+
+      patch(PersonSearch, :matches_with_outcome, fn _provider, _query, _opts ->
+        send(test_pid, {:searching, self()})
+        receive do: (:go -> :ok)
+        {[], [%{"id" => "wikidata", "name" => "Wikidata", "status" => "ok", "count" => 0}]}
+      end)
+
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("form#research-person-work-0-0")
+        |> render_submit(%{"key" => "brandonsanderson", "name" => "Jason Pargin"})
+
+      assert_receive {:searching, task}
+      assert html =~ "Looking for"
+      assert has_element?(view, "#person-brandonsanderson [data-role='busy-overlay']")
+
+      send(task, :go)
+      render_async(view)
+
+      refute has_element?(view, "#person-brandonsanderson [data-role='busy-overlay']")
+    end
+
+    # A card of search results is a search form with results below it. The
+    # search used to be folded away *under* the results it produced, where the
+    # patch carrying its own progress could close it.
+    test "the search sits above the results, unfolded", %{conn: conn} do
+      patch_person_search()
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      card =
+        view |> element("#person-brandonsanderson") |> render() |> Floki.parse_fragment!()
+
+      assert Floki.find(card, "form#research-person-work-0-0") != []
+      # not behind a fold of its own
+      assert card |> Floki.find("details") |> Floki.raw_html() =~ "worse match" or
+               Floki.find(card, "details") == []
+    end
+
+    # The reported flow: looking up David Wong, then Jason Pargin, and getting
+    # one list where both are perfect answers. Evidence is never deleted, so
+    # what has to happen is that it stops competing.
+    test "records the old name found sink out of the way", %{conn: conn} do
+      patch(PersonSearch, :providers, fn -> [%{id: "wikidata", display_name: "Wikidata"}] end)
+
+      patch(PersonSearch, :matches_with_outcome, fn _provider, _query, _opts ->
+        {[
+           %PersonSearch.Match{
+             provider_id: "wikidata",
+             provider_name: "Wikidata",
+             id: "Q2",
+             name: "Jason Pargin",
+             description: "Writes comic horror.",
+             images: []
+           }
+         ], [%{"id" => "wikidata", "name" => "Wikidata", "status" => "ok", "count" => 1}]}
+      end)
+
+      item = probed_item(person_photo: "https://example.test/face.jpg")
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      refute html =~ "worse match"
+
+      # the operator's flow: say the credited name is a pen name, name the
+      # human, then go looking for who they now are
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      view
+      |> form("#person-brandonsanderson-identity")
+      |> render_change(%{"key" => "brandonsanderson", "name" => "Jason Pargin"})
+
+      view
+      |> element("form#research-person-work-0-0")
+      |> render_submit(%{"key" => "brandonsanderson", "name" => "Jason Pargin"})
+
+      html = render_async(view)
+
+      # both are still there — a photo already picked from the old one must
+      # not vanish — but only the human being asked about is in the running
+      assert html =~ "Jason Pargin"
+      assert html =~ "Show 1 worse match"
+
+      assert [%{"name" => "Jason Pargin"}, %{"name" => "Brandon Sanderson", "score" => +0.0}] =
+               Inbox.get_item!(item.id).matches["people"]["brandonsanderson"]["candidates"]
     end
 
     # A person's description is a description like any other: the recording's
@@ -1282,6 +1589,14 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     |> Floki.find("[data-role='record'][data-used='true']")
   end
 
+  # Two humans behind one credit, the way the form now asks it: the composite
+  # case IS a shared pen name, so the add sits on the person's card and only
+  # once the credited name has been called one.
+  defp add_second_person(view, key) do
+    view |> element("#person-#{key} button[phx-click='separate-name']") |> render_click()
+    view |> element("#person-#{key} button[phx-click='add-person']") |> render_click()
+  end
+
   defp person_keyed(item, key) do
     Enum.find(Inbox.get_item!(item.id).draft.people, &(&1.key == key))
   end
@@ -1314,6 +1629,66 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     if !Keyword.get(opts, :busy, false), do: Repo.delete_all(Oban.Job)
 
     with_person_matches(item, Keyword.get(opts, :person_photo))
+  end
+
+  # What matching writes when it found people of roughly this name and none of
+  # them is this human: candidates, but nothing the exact-name gate will take.
+  defp with_namesake_person_matches(item) do
+    people = %{
+      "brandonsanderson" => %{
+        "name" => "Brandon Sanderson",
+        "roles" => ["author"],
+        "local" => [],
+        "candidates" => [
+          %{
+            "source" => "provider:wikidata",
+            "provider_name" => "Wikidata",
+            "id" => "Q9",
+            "name" => "Brandon Sanderson-Smith",
+            "images" => ["https://example.test/somebody-else.jpg"],
+            "description" => "An English professional footballer."
+          }
+        ],
+        "providers" => []
+      }
+    }
+
+    {:ok, item} =
+      item
+      |> InboxItem.changeset(%{matches: Map.put(item.matches || %{}, "people", people)})
+      |> Repo.update()
+
+    item
+  end
+
+  # What matching writes when the credited name is already in the library: it
+  # searches nothing, because the library's own photo and biography are what
+  # an existing person is for.
+  defp with_local_person(item, person) do
+    people = %{
+      "brandonsanderson" => %{
+        "name" => "Brandon Sanderson",
+        "roles" => ["author"],
+        "local" => [
+          %{
+            "source" => "local",
+            "id" => person.id,
+            "name" => person.name,
+            "has_image" => false,
+            "has_description" => false
+          }
+        ],
+        "candidates" => [],
+        "providers" => []
+      }
+    }
+
+    {:ok, item} =
+      item
+      |> InboxItem.changeset(%{matches: Map.put(item.matches || %{}, "people", people)})
+      |> Repo.update()
+
+    item
   end
 
   # What the people level of matching would have written. Stubbing it here

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1621,6 +1621,45 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {items, _more} = Inbox.list_items(filter: "The Way of Kings")
       assert length(items) == 3
     end
+
+    # The stray-file trap, which is where the folder grain earns its keep: one
+    # loose file beside 43 book folders makes the whole series "the release",
+    # because audio in hand means this is it. Splitting by folder takes it
+    # apart — and the piece left holding the stray file sits on the series
+    # folder's own path, which the rescan must not read as "re-record this
+    # folder whole".
+    test "a series collapsed by a stray file splits, and stays split", %{conn: conn} do
+      root = watched_root()
+      series = Path.join(root, "Discworld")
+      File.mkdir_p!(series)
+      File.cp!(tagged_fixture(true, false, nil), Path.join(series, "stray.m4b"))
+
+      for title <- ["Discworld 5 Sourcery", "Discworld 39 Snuff"] do
+        dir = Path.join(series, title)
+        File.mkdir_p!(dir)
+        File.cp!(tagged_fixture(true, false, nil), Path.join(dir, "book.m4b"))
+      end
+
+      {:ok, _counts} = Inbox.discover(root)
+      {[item], _more} = Inbox.list_items(filter: "Discworld")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      assert length(item.files) == 3
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      view |> element("button[data-role='split-folder']") |> render_click()
+
+      {items, _more} = Inbox.list_items(filter: "Discworld")
+      assert length(items) == 3
+
+      {:ok, _counts} = Inbox.discover(root)
+      {items, _more} = Inbox.list_items(filter: "Discworld")
+
+      assert length(items) == 3
+      # each keeps exactly what it claimed: the two books, and the stray
+      assert items |> Enum.map(&length(&1.files)) |> Enum.sort() == [1, 1, 1]
+    end
   end
 
   describe "destination" do
@@ -1753,6 +1792,12 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   defp add_second_person(view, key) do
     view |> element("#person-#{key} button[phx-click='separate-name']") |> render_click()
     view |> element("#person-#{key} button[phx-click='add-person']") |> render_click()
+  end
+
+  defp watched_root do
+    root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(root)
+    root
   end
 
   defp person_keyed(item, key) do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -277,20 +277,75 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  # The third level, and a section rather than a decoration on a credit. The
+  # model always said people were a level — keyed decisions, `appearances/1` —
+  # while the form rendered them inside every credit that named them.
+  describe "the New people section" do
+    test "lists a human once, however many credits name them", %{conn: conn} do
+      item = probed_item(narrator: "Brandon Sanderson")
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      cards =
+        html
+        |> Floki.parse_document!()
+        |> Floki.find("[data-role='person-card']")
+        |> Enum.filter(&(Floki.text(&1) =~ "Brandon Sanderson"))
+
+      assert [card] = cards
+      assert Floki.text(card) =~ "Credited as author and narrator"
+    end
+
+    # A person exists because a credit names them, so the list is derived and
+    # deliberately has no add of its own (design language §5).
+    test "has no add of its own", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "#people button[phx-click='add-credit']")
+      assert has_element?(view, "#people [data-role='person-card']")
+    end
+
+    # The credit keeps the identity decision and carries a reference, so the
+    # operator can see who it means without leaving the section.
+    test "a credit links to the person's card", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      key = hd(hd(Inbox.get_item!(item.id).draft.work.authors).person_keys)
+
+      assert has_element?(view, "a[href='#person-#{key}']")
+      assert has_element?(view, "#person-#{key}")
+    end
+
+    # Somebody already in the library was chosen in the credit's typeahead,
+    # carries curation an import may never overwrite, and has nothing left to
+    # decide.
+    test "leaves out people already in the library", %{conn: conn} do
+      item = probed_item()
+      person = insert(:person, name: "Brandon Sanderson")
+
+      {:ok, item} = Inbox.prepare_draft(item)
+      key = hd(hd(item.draft.work.authors).person_keys)
+      draft = Draft.Edit.link_person(item.draft, key, person.id)
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "#person-#{key}")
+    end
+  end
+
   describe "credits — credited as / written by" do
     test "the composite case is two people behind one credit", %{conn: conn} do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      # the person layer is folded away for the ordinary case, so the pen-name
-      # path starts by saying that this isn't one
-      view
-      |> element(
-        "button[phx-click='toggle-people'][phx-value-section='work'][phx-value-index='0']"
-      )
-      |> render_click()
-
+      # No fold to open first: people are a section of their own, so "add
+      # another person" is reachable from the credit directly.
       html =
         view
         |> element(
@@ -298,7 +353,15 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
         )
         |> render_click()
 
-      assert html =~ "A shared pen name"
+      # the two cards sit adjacent under a bracket naming the credit they share
+      # the two cards sit adjacent inside a bracket naming the credit they
+      # share — the narrators have their own cards elsewhere in the section
+      assert html =~ "Behind the pen name"
+
+      assert [_first, _second] =
+               html
+               |> Floki.parse_document!()
+               |> Floki.find("[data-role='pen-name-group'] [data-role='person-card']")
 
       credit = hd(Inbox.get_item!(item.id).draft.work.authors)
       assert length(credit.person_keys) == 2
@@ -308,12 +371,6 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
-
-      view
-      |> element(
-        "button[phx-click='toggle-people'][phx-value-section='work'][phx-value-index='0']"
-      )
-      |> render_click()
 
       view
       |> element("button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']")
@@ -341,21 +398,29 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert Enum.map(author.people, & &1.name) |> Enum.sort() == ["Daniel Abraham", "Ty Franck"]
     end
 
-    # Reachable from the DEFAULT state, not after unfolding: a self-narrated
-    # import is the ordinary case, and a note explaining what is about to
-    # happen is no use inside a control nobody would open.
-    test "a self-narrated book says it will create one person", %{conn: conn} do
+    # One human is one record, and now one *card*: they used to render inside
+    # every credit that named them, so a self-narrated book showed the same
+    # person twice with a sentence apologising for it.
+    test "a self-narrated book creates one person, listed once", %{conn: conn} do
       item = probed_item(narrator: "Brandon Sanderson")
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "Same person as the author"
+      # one card, not one per credit, and it says it stands for both
+      assert html =~ "Credited as author and narrator"
 
-      # and the escape hatch is right there when two humans really do share a
-      # name
+      assert [_only_one] =
+               html
+               |> Floki.parse_document!()
+               |> Floki.find("[data-role='person-card']")
+               |> Enum.filter(&(Floki.text(&1) =~ "Brandon Sanderson"))
+
+      # and the escape hatch is on that one card, when two humans really do
+      # share a name. It is addressed to the credit that introduced them —
+      # the author, since that is where the person is listed.
       view
       |> element(
-        ~s{button[phx-click='split-person'][phx-value-section='recording'][phx-value-index='0']}
+        ~s{button[phx-click='split-person'][phx-value-section='work'][phx-value-index='0']}
       )
       |> render_click()
 
@@ -731,12 +796,6 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       item = probed_item()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
-
-      view
-      |> element(
-        "button[phx-click='toggle-people'][phx-value-section='work'][phx-value-index='0']"
-      )
-      |> render_click()
 
       view
       |> element("button[phx-click='add-person'][phx-value-section='work'][phx-value-index='0']")

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -10,6 +10,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.RunImport
   alias Ambry.Metadata.PersonSearch
   alias Ambry.Repo
 
@@ -34,38 +35,53 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       refute has_element?(view, "button[data-role='import'][disabled]")
     end
 
-    test "importing creates the library records and returns to the queue", %{conn: conn} do
+    # The import is queued and the operator is handed back to the queue at
+    # once. It used to run in an async task owned by this LiveView, which
+    # pinned them to a spinner and — the real defect — died with the process,
+    # so closing the tab killed a copy mid-flight.
+    test "importing queues a job and returns to the queue", %{conn: conn} do
       item = probed_item() |> settle()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      # The click only *starts* the import — it runs off the LiveView process
-      # so the form can say it's working — so the assertion has to wait for
-      # the redirect that means it landed.
-      html = view |> element("button[data-role='import']") |> render_click()
-      assert html =~ "Adding to the library"
+      view |> element("button[data-role='import']") |> render_click()
 
       assert_redirect(view, ~p"/admin/inbox")
+      assert_enqueued(worker: RunImport, args: %{inbox_item_id: item.id})
 
+      # nothing has touched the library yet — that is the job's to do
+      assert %{status: :pending, media_id: nil} = Inbox.get_item!(item.id)
+
+      assert %{success: 1} = Oban.drain_queue(queue: :media)
       assert %{status: :imported, media_id: media_id} = Inbox.get_item!(item.id)
       assert media_id
     end
 
-    # The whole point of moving it off the process: a click that appears to do
-    # nothing is a click the operator makes again.
-    test "the form says it is working while the import runs", %{conn: conn} do
+    # Returning them to an unfiltered page one is how "where did my queue go"
+    # happens — they were on the ready tab, and that is where they go back.
+    test "importing returns to the list the operator came from", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}?status=pending&ready=true")
+
+      view |> element("button[data-role='import']") |> render_click()
+
+      # params come back in map order, which is fine — it is the same list
+      assert_redirect(view, ~p"/admin/inbox?ready=true&status=pending")
+    end
+
+    # A stale tab can still send the event twice, and the second one must not
+    # queue a second copy of a multi-gigabyte placement.
+    test "a second import click doesn't queue a second job", %{conn: conn} do
       item = probed_item() |> settle()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      view |> element("button[data-role='import']") |> render_click()
 
-      html = view |> element("button[data-role='import']") |> render_click()
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      view |> element("button[data-role='import']") |> render_click()
 
-      assert html =~ "Adding to the library…"
-      assert has_element?(view, "[data-role='busy-overlay']")
-
-      # Waits for the import to land rather than leaving it running into the
-      # next test's sandbox.
-      assert_redirect(view, ~p"/admin/inbox")
+      assert [_only_one] = all_enqueued(worker: RunImport)
     end
 
     test "each outstanding decision is named, not just counted", %{conn: conn} do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -955,7 +955,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "Is this a book you already have?"
+      assert html =~ "Existing book?"
 
       view |> element("button[phx-click='link-book']") |> render_click()
 
@@ -1563,9 +1563,9 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      # Two files are one recording by default — the button is the way to
+      # Two files are one recording by default — the buttons are the way to
       # say they aren't, not a precondition for importing them.
-      assert html =~ "import as one audiobook"
+      assert html =~ "Not one audiobook?"
       assert html =~ "Split into 2 files"
       # one folder, so there is nothing for the coarser grain to divide
       refute has_element?(view, "button[data-role='split-folder']")

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -1,11 +1,11 @@
 defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   use AmbryWeb.ConnCase, async: true
-  use Oban.Testing, repo: Ambry.Repo
 
   import Phoenix.LiveViewTest
 
   alias Ambry.Inbox
   alias Ambry.Inbox.RunDiscovery
+  alias Ambry.Inbox.RunImport
 
   setup :register_and_log_in_admin_user
 
@@ -236,6 +236,9 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert Inbox.get_item!(item.id).status == :pending
   end
 
+  # Queued, not run here: importing re-probes every file and copies every
+  # byte, and doing that inside the event blocked the whole queue page for the
+  # length of a NAS copy.
   test "imports a settled item into the library, leaving files alone", %{conn: conn} do
     item = probed_item() |> settle()
     file = hd(item.files)
@@ -245,10 +248,30 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     html =
       view |> element("span[phx-click='import'][phx-value-id='#{item.id}']") |> render_click()
 
-    assert html =~ "Files were left where they are"
+    assert html =~ "Adding to the library"
+    assert_enqueued(worker: RunImport, args: %{inbox_item_id: item.id})
+    assert Inbox.get_item!(item.id).status == :pending
+
+    # the fixture's own probe job shares this queue, so drain it all
+    assert %{failure: 0, discard: 0} = Oban.drain_queue(queue: :media)
+
     assert %{status: :imported, media_id: media_id} = Inbox.get_item!(item.id)
     assert media_id
     assert File.exists?(file)
+  end
+
+  # A row handed to an import wears the same cover every other background job
+  # gives it, and says which job it is — "Working on it" over a row you just
+  # pressed Add on says nothing about whether the press landed.
+  test "a row being imported says so and refuses clicks", %{conn: conn} do
+    item = probed_item() |> settle()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox")
+    view |> element("span[phx-click='import'][phx-value-id='#{item.id}']") |> render_click()
+
+    html = render(view)
+    assert html =~ "Adding to the library…"
+    assert has_element?(view, "[data-role='busy-overlay']")
   end
 
   # The queue can't say *what* is outstanding, so it doesn't offer a button
@@ -259,7 +282,8 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
     refute has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
-    assert has_element?(view, "a[href='/admin/inbox/#{item.id}']")
+    # the link carries the list state so every way back lands on this tab
+    assert has_element?(view, "a[href^='/admin/inbox/#{item.id}']")
   end
 
   @tag :capture_log

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -73,19 +73,18 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     {:ok, _view, html} = live(conn, ~p"/admin/inbox")
 
     # no draft yet, so the badge falls back to the match-time confidence
-    assert html =~ "trusted"
+    assert html =~ "matched"
     assert html =~ "The Way of Kings"
     assert html =~ "already in the library"
     assert html =~ "+1 other"
     # the recording level says so rather than going silent
-    assert html =~ "no match"
+    assert html =~ "needs you"
   end
 
   # The badge is decision state, not match history: confidence was frozen at
-  # match time, so the queue kept calling an item "unsure" after the operator
-  # had answered — and there was no way to tell a correct-but-doubted match
-  # "you were right" except by deciding, which is exactly what now flips it.
-  test "a level the operator settled reads confirmed", %{conn: conn} do
+  # match time, so the queue kept saying the operator was needed after they
+  # had answered. Same four words as the form's rail, or the two drift.
+  test "a level the operator settled stops asking for them", %{conn: conn} do
     record = %{
       "title" => "The Way of Kings",
       "authors" => ["Brandon Sanderson"],
@@ -108,14 +107,18 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     {:ok, item} = Inbox.prepare_draft(item)
 
     {:ok, _view, html} = live(conn, ~p"/admin/inbox")
-    assert html =~ "unsure"
+    assert html =~ "needs you"
 
     draft = Ambry.Inbox.Draft.Edit.toggle_source(item.draft, item, :work, record)
     {:ok, _item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
 
+    # No longer waiting on the operator. It does not jump straight to
+    # "reviewed": the row reads worst-first over the whole level, and the
+    # identity question ("a book you already have?") is still one the machine
+    # answered and nobody has looked at.
     {:ok, _view, html} = live(conn, ~p"/admin/inbox")
-    assert html =~ "confirmed"
-    refute html =~ ">unsure<"
+    refute html =~ ">needs you<"
+    assert html =~ "matched"
   end
 
   # One button, because the two it replaced were never separable: matching

--- a/test/ambry_web/live/admin/media_live/scan_test.exs
+++ b/test/ambry_web/live/admin/media_live/scan_test.exs
@@ -1,6 +1,5 @@
 defmodule AmbryWeb.Admin.MediaLive.ScanTest do
   use AmbryWeb.ConnCase, async: true
-  use Oban.Testing, repo: Ambry.Repo
 
   import Phoenix.LiveViewTest
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -22,6 +22,11 @@ defmodule AmbryWeb.ConnCase do
       # The default endpoint for testing
       use AmbryWeb, :verified_routes
 
+      # Background work is part of the behaviour these tests assert: an
+      # import is queued rather than run, so a LiveView test has to be able
+      # to say what was enqueued and then drain it.
+      use Oban.Testing, repo: Ambry.Repo
+
       # Import conveniences for testing with connections
       import Ambry.Factory
       import Ambry.InboxHelpers


### PR DESCRIPTION
Seventeen commits from running real releases through the import form and fixing what the operator hit. No migrations. Nothing here changes what a client sees; it is all the admin's own surfaces plus the discovery mechanism underneath them.

### Provider outcomes, end to end

- **Every provider call reports, not just the search** (`7d3d8524`). A details or editions call that failed was invisible, so a rate-limited hydration silently thinned the records an item was built from.
- **Not every error is a provider that couldn't be reached** (`9d74011f`). Audible implements no details call and a Hardcover 404 is a definite answer; both wore a red "retry" chip that could never succeed, and both kept the matching job re-queueing itself. A retry can now clear the chip it was retrying, which it previously could not.

### The import form

- **Importing belongs to the server** (`c14a9f6d`) — the import ran in an async task owned by the LiveView and died with the tab.
- **Four state tiers** (`743c0f8b`, `d9eac53c`) replacing two settledness vocabularies and the no-op Confirm buttons.
- **People are a section, and a person card asks its own questions** (`2d808a31`, `ab3e85fb`, `9acf357d`): one card per human, titled by the credit, with the name box appearing only when the name is genuinely their own; humans already in the library offered on the card; a busy scrim while a search runs; and — measured on the operator's queue — the 96 items holding a person no control could settle now have one.
- **"None of these" at the book level too** (`da0b3a8c`): 22 queued items had a doubted work whose only way forward was ticking a record the operator didn't believe.
- **A membership that needs a number says so** (`06be1f7d`) rather than "nothing proposed it" beside the provider that proposed it.
- **A card of search results is a search form with results below it** (`1e277669`, `993d5c7d`): the search moves above the records on all three levels and in the edit forms' evidence panel, the how-to-use-the-form prose goes, the record's provider becomes a badge that truncation can't eat, and both level searches wear the busy scrim.

### Discovery

- **Split a mis-grouped item at either grain** (`93e6721d`, `62ee1232`, `efc8672f`). A GraphicAudio set of five parts was detected as one audiobook whose only correction was 35 separate files. Splitting now asks at which grain the grouping was wrong, and offers a grain only when it divides further than the coarser one.
- **Ownership decides what a scan may do, not the walk** (`db7d0034`). The rule that a split survives a rescan was true by care, and this round broke it twice. Every file the queue or the library holds now belongs to something, and the walk's grouping is consulted only for files that belong to nothing: a scan may create items from unowned files, give an unowned file to the item that owns its folder, and drop files that are gone. It cannot move a file between items, and never touches an imported item. Verified against the real queue — a full scan of 353 items reports 353 skipped, 0 changed rows.

### Development only

- **Undo an import** (`c99aecc4`), gated on `:allow_undo_import` in dev and test config and nowhere else. The form is designed by running the same awkward release through it repeatedly, and each one could previously be imported exactly once.

`mix check` green. Tested live against the operator's 353-item queue throughout.
