### PR TITLE
Grab bag: image proxy, provider searches, chapters, and the person form

### DIFF
--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -279,6 +279,14 @@ A person the operator matched to the library *from their own card* does stay,
 because that decision was made here: dropping the card the moment the link is
 made takes the way back with it.
 
+**The other documented exception: an upload sits inside its block.** A
+dropzone is not an add-button. `<.file_input>` is a control the block owns —
+the same way the media form's cover and the person form's photo own theirs —
+so it renders inside the card rather than under it, and supplemental files
+follow the cover rather than the series rows. The rule the `:add` slot
+encodes is about the *button that appends a row*, and reading a dropzone as
+one put the only file input in the admin outside the thing it belonged to.
+
 **A card asks nothing it can state.** The person card carries no name box in
 the ordinary import, because the credit names the human and a box on every
 card in every state is what left "This is a pen name" with no visible effect

--- a/lib/ambry/images.ex
+++ b/lib/ambry/images.ex
@@ -18,8 +18,6 @@ defmodule Ambry.Images do
 
   require Logger
 
-  @accepted_mime ~w(image/jpeg image/png image/webp)
-
   @doc """
   Downloads an image and returns its web path.
   """
@@ -30,12 +28,20 @@ defmodule Ambry.Images do
     if valid_url?(url), do: download(url), else: {:error, :invalid_image_url}
   end
 
+  # The bytes decide, for the same reason they decide in `browser_safe/1`:
+  # this used to accept only a `content-type` header in an allowlist, and
+  # Hardcover's CDN labels every asset `application/octet-stream`. A PNG the
+  # operator picked from the person picker therefore passed `valid_url?` on
+  # its extension and then failed the download — silently, since a failed
+  # cover import is not fatal to an import. Sniffing the body means the
+  # preview and the import agree, and the file lands with the extension its
+  # bytes earn rather than the one its header claimed.
   defp download(url) do
-    with {:ok, response} <- Req.get(url: url, headers: [{"user-agent", user_agent()}]),
-         [mime | _rest] when mime in @accepted_mime <-
-           Req.Response.get_header(response, "content-type") do
+    with {:ok, %{status: 200, body: body}} when is_binary(body) <-
+           Req.get(url: url, headers: [{"user-agent", user_agent()}], decode_body: false),
+         {:ok, image, mime} <- browser_safe(body) do
       filename = generate_filename(mime)
-      File.write!(images_disk_path(filename), response.body)
+      File.write!(images_disk_path(filename), image)
 
       {:ok, web_path(filename)}
     else

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -555,6 +555,15 @@ defmodule Ambry.Inbox do
   """
   defdelegate form_hints(fields), to: AutoMatch
 
+  @doc """
+  What this item's tags and release name say it is — the same hints matching
+  searched with.
+
+  The import form seeds its search boxes from these, so a re-search starts
+  from what was actually looked for rather than from nothing.
+  """
+  defdelegate hints(item), to: AutoMatch
+
   @doc "Provider books → scored, ranked evidence records (top-N per provider)."
   defdelegate score_records(books, entry, hints), to: AutoMatch, as: :records_from
 

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -768,18 +768,25 @@ defmodule Ambry.Inbox.Draft.Seed do
       # ambiguity used to be invisible, showing up only as fields that
       # mysteriously stayed empty.
       approved: doubt in [:none, :nothing_found],
-      chapters: chapters_decision(item)
+      chapters: file_chapters(item)
     }
     |> put_recording_fields(records, tags, item)
   end
 
-  # The chapter list, exactly as the probe read it off the files — seeded
-  # approved, because the file's own answer is the lone proposer and a
-  # scalar with exactly one source auto-approves everywhere else here. nil
-  # until a probe has run: "not read yet" must stay distinguishable from
-  # "the files carry no chapters".
-  defp chapters_decision(%InboxItem{probe: %{"chapter_list" => rows} = probe})
-       when is_list(rows) do
+  @doc """
+  The chapter list, exactly as the probe read it off the files.
+
+  Seeded approved, because the file's own answer is the lone proposer and a
+  scalar with exactly one source auto-approves everywhere else here. nil
+  until a probe has run: "not read yet" must stay distinguishable from
+  "the files carry no chapters".
+
+  Public because the form offers this list back as a proposal — the chapters
+  card's way back to the machine's value, which every other decision has.
+  Re-deriving it there rather than keeping a second copy is what stops the
+  chip and the seeder from drifting into two answers about the same files.
+  """
+  def file_chapters(%InboxItem{probe: %{"chapter_list" => rows} = probe}) when is_list(rows) do
     %Chapters{
       chapter_marker_source: marker_source(probe["chapter_marker_source"]),
       approved: true,
@@ -788,7 +795,7 @@ defmodule Ambry.Inbox.Draft.Seed do
     }
   end
 
-  defp chapters_decision(_item), do: nil
+  def file_chapters(_item), do: nil
 
   defp chapter_row(row) do
     %Chapter{

--- a/lib/ambry/people/person.ex
+++ b/lib/ambry/people/person.ex
@@ -31,10 +31,6 @@ defmodule Ambry.People.Person do
 
     field :field_provenance, :map, default: %{}
 
-    # form-only: staging input for linking an existing author, see
-    # AmbryWeb.Admin.PersonLive.Form
-    field :link_author_id, :integer, virtual: true
-
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/ambry/people/person.ex
+++ b/lib/ambry/people/person.ex
@@ -31,6 +31,10 @@ defmodule Ambry.People.Person do
 
     field :field_provenance, :map, default: %{}
 
+    # form-only: staging input for linking an existing author, see
+    # AmbryWeb.Admin.PersonLive.Form
+    field :link_author_id, :integer, virtual: true
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/ambry_web/components/admin/chapter_editor.ex
+++ b/lib/ambry_web/components/admin/chapter_editor.ex
@@ -123,6 +123,11 @@ defmodule AmbryWeb.Admin.ChapterEditor do
     doc: "a form whose :chapters embed uses chapters_sort/chapters_drop"
 
   attr :pending, :any, default: nil, doc: "the pending title fetch, or nil"
+
+  attr :rail, :string,
+    default: nil,
+    doc: "the decision rail, where this card is one of a tree of decisions"
+
   slot :flag, doc: "a provenance flag, worn on the source line"
   slot :proposals, doc: "the title chips, inside the card after the rows"
 
@@ -130,6 +135,12 @@ defmodule AmbryWeb.Admin.ChapterEditor do
   The whole editor as one card: a source line, then the rows in their own
   scroll, with the pending title fetch rendered into them — a proposed
   column and a Take/Cancel header — rather than as a second surface.
+
+  In the inbox it wears a rail like every other decision card. It was the one
+  card in the tree that wore none, so the operator's eye ran down a column of
+  rails and found a gap where chapters should have been — reading as "not a
+  decision" for something the footer was counting all along. The media form
+  passes none: nothing there is staged, so there is no settledness to encode.
   """
   def chapter_rows(assigns) do
     markers = current_chapters(assigns.form)
@@ -149,7 +160,7 @@ defmodule AmbryWeb.Admin.ChapterEditor do
 
     ~H"""
     <div class="space-y-2">
-      <div class="space-y-3 rounded-lg bg-zinc-900 p-4">
+      <div class={["space-y-3 rounded-lg bg-zinc-900 p-4", @rail && "#{@rail} border-l-4"]}>
         <%!-- the card names itself: its facts live inside it, on the rail --%>
         <p class="flex items-baseline gap-2 pl-3 text-sm text-zinc-400">
           <span>{source_line(@markers, current_marker_source(@form))}</span>
@@ -288,22 +299,54 @@ defmodule AmbryWeb.Admin.ChapterEditor do
   attr :id, :string, required: true
   attr :chips, :list, required: true, doc: "maps with :asin, :title, :providers, :chosen"
 
+  attr :file, :map,
+    default: nil,
+    doc: "the files' own list as a chip (%{chosen: boolean}), or nil when they carry none"
+
   @doc """
   What the ticked evidence proposes for the titles: one chip per distinct
   ASIN, in the standard proposal anatomy. A chip is not a value here — it
   names an edition whose chapter list is one fetch away, so clicking loads
   the proposed column rather than applying anything.
+
+  ## The files are a proposal too
+
+  The first chip is the files' own list, and it applies immediately, the way
+  a credit's "go back to what the records proposed" chip does. Without it the
+  operator who wanted exactly what the files carry — the common case, since
+  that is what the rows are seeded from — had no way to *say so*: the card
+  only reached `:reviewed` by editing a row, so agreeing with it cost a
+  pointless edit and disagreeing was the only settled state.
+
+  It is chosen when the rows already match the files, which makes it a
+  statement as well as a control: this is still what the files said.
   """
   def chapter_title_chips(assigns) do
     ~H"""
     <div
-      :if={@chips != []}
+      :if={@chips != [] or @file}
       class="grid-cols-[4rem_minmax(0,1fr)] grid items-baseline gap-x-2 pl-3"
       data-role="proposals"
     >
       <.microlabel>Proposed</.microlabel>
 
       <div id={@id} phx-hook="fit-or-stack" class="flex flex-wrap items-center gap-1.5">
+        <.proposal_chip
+          :if={@file}
+          chosen={@file.chosen}
+          event="take-file-chapters"
+          title="take the timestamps and titles the files carry"
+        >
+          <span class={[
+            "text-[10px] flex-none uppercase tracking-wide",
+            @file.chosen && "bg-brand-dark rounded-sm px-1 text-zinc-900",
+            !@file.chosen && "text-zinc-500"
+          ]}>
+            files
+          </span>
+          <span>timestamps and titles as read</span>
+        </.proposal_chip>
+
         <.proposal_chip
           :for={chip <- @chips}
           chosen={chip.chosen}

--- a/lib/ambry_web/components/admin/chapter_editor.ex
+++ b/lib/ambry_web/components/admin/chapter_editor.ex
@@ -161,9 +161,13 @@ defmodule AmbryWeb.Admin.ChapterEditor do
     ~H"""
     <div class="space-y-2">
       <div class={["space-y-3 rounded-lg bg-zinc-900 p-4", @rail && "#{@rail} border-l-4"]}>
-        <%!-- the card names itself: its facts live inside it, on the rail --%>
-        <p class="flex items-baseline gap-2 pl-3 text-sm text-zinc-400">
-          <span>{source_line(@markers, current_marker_source(@form))}</span>
+        <%!-- Where the markers came from used to be spelled out here
+            ("Markers read from the files' own chapter marks · titles: 40
+            embedded."), which restated what every row already shows in its
+            own source column and pushed the rows down a line on every form
+            that carries them. The provenance flag is the part that says
+            something the rows can't, so it is what is left. --%>
+        <p :if={@flag != []} class="flex items-baseline gap-2 pl-3 text-sm text-zinc-400">
           {render_slot(@flag)}
         </p>
 
@@ -372,13 +376,6 @@ defmodule AmbryWeb.Admin.ChapterEditor do
   # Vocabulary
   # ---------------------------------------------------------------------------
 
-  # The card's one line of orientation: where the timeline came from, and
-  # what the titles are made of.
-  defp source_line([], _source), do: "The files carry no chapters; rows added here are by hand."
-
-  defp source_line(chapters, source),
-    do: "Markers #{marker_source_phrase(source)} · titles: #{title_summary(chapters)}."
-
   @doc """
   How a title got its name, in one muted word for a dense row.
 
@@ -396,39 +393,6 @@ defmodule AmbryWeb.Admin.ChapterEditor do
   def title_source_label("provider"), do: "provider"
   def title_source_label("manual"), do: "typed"
   def title_source_label(_unrecorded), do: nil
-
-  @doc """
-  Where a recording's markers came from, as a phrase the operator can act
-  on.
-  """
-  def marker_source_phrase(:embedded), do: "read from the files' own chapter marks"
-
-  def marker_source_phrase(:file_boundaries),
-    do: "one per file, taken from where each file starts"
-
-  def marker_source_phrase(:manual), do: "set by hand"
-  def marker_source_phrase(_unrecorded), do: "from before this was recorded"
-
-  @doc """
-  What the titles of a chapter list are made of, counted by source.
-  """
-  def title_summary([]), do: nil
-
-  def title_summary(chapters) do
-    chapters
-    |> Enum.frequencies_by(& &1.title_source)
-    |> Enum.sort_by(fn {_source, count} -> -count end)
-    |> Enum.map_join(", ", fn {source, count} ->
-      "#{count} #{title_source_phrase(source)}"
-    end)
-  end
-
-  defp title_source_phrase(:generated), do: "generated"
-  defp title_source_phrase(:embedded), do: "from the files"
-  defp title_source_phrase(:filename), do: "from the filenames"
-  defp title_source_phrase(:provider), do: "from a provider"
-  defp title_source_phrase(:manual), do: "typed"
-  defp title_source_phrase(_unrecorded), do: "unrecorded"
 
   defp n_things(list, word) when length(list) == 1, do: "1 #{word}"
   defp n_things(list, word), do: "#{length(list)} #{word}s"
@@ -452,13 +416,6 @@ defmodule AmbryWeb.Admin.ChapterEditor do
   """
   def current_chapters(form) do
     form.source |> Changeset.apply_changes() |> Map.fetch!(:chapters)
-  end
-
-  @doc """
-  The recorded marker source, read the same way.
-  """
-  def current_marker_source(form) do
-    form.source |> Changeset.apply_changes() |> Map.fetch!(:chapter_marker_source)
   end
 
   @doc """

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -757,7 +757,10 @@ defmodule AmbryWeb.Admin.Components do
   defp file_label(file, ""), do: file
   defp file_label(file, common), do: Path.relative_to(file, common)
 
-  attr :title, :string, required: true
+  attr :title, :string,
+    default: nil,
+    doc: "omit where the section is the form's subject and the page title already says it"
+
   attr :id, :string, default: nil
   attr :class, :any, default: nil
   slot :inner_block, required: true
@@ -768,11 +771,18 @@ defmodule AmbryWeb.Admin.Components do
 
   Headings sit on the ground with no rule under them; the 56px section gap
   and the blocks below do the dividing (§1, §3).
+
+  The heading is optional, because a form's *first* section is usually the
+  thing the form is about and naming it says nothing: the audiobook form
+  opened with "The audiobook" under a page already titled with the
+  audiobook's name. The book and person forms never had one. A section
+  still earns a heading when it is a genuine change of subject — "Chapters",
+  "Audio and processing".
   """
   def form_section(assigns) do
     ~H"""
     <section id={@id} class={["space-y-7", @class]}>
-      <h2 class="text-xl font-bold text-zinc-100">{@title}</h2>
+      <h2 :if={@title} class="text-xl font-bold text-zinc-100">{@title}</h2>
       {render_slot(@inner_block)}
     </section>
     """

--- a/lib/ambry_web/components/admin/curation.ex
+++ b/lib/ambry_web/components/admin/curation.ex
@@ -22,6 +22,7 @@ defmodule AmbryWeb.Admin.Curation do
 
   import AmbryWeb.Admin.Decisions,
     only: [
+      person_research_form: 1,
       provider_outcomes_row: 1,
       proposal_chip: 1,
       record_list: 1,
@@ -90,31 +91,16 @@ defmodule AmbryWeb.Admin.Curation do
         />
 
         <%!-- A person is searched by name — the research form's
-            title/author/narrator fields are the books' vocabulary. --%>
-        <form
+            title/author/narrator fields are the books' vocabulary. The inbox's
+            component, not a second copy of it: this markup was hand-written
+            here and drifted from the one the import form uses. --%>
+        <.person_research_form
           :if={@level == "person"}
-          id="research-person"
-          phx-submit="research"
-          class="flex flex-wrap items-end gap-2"
-        >
-          <label class="text-xs text-zinc-400">
-            <span class="block pl-3">name</span>
-            <input
-              type="text"
-              name="name"
-              value={@evidence.fields["name"]}
-              class={input_classes("mt-1 block")}
-            />
-          </label>
-
-          <.button color={:zinc} type="submit" disabled={@evidence.running?}>
-            {cond do
-              @evidence.running? -> "Searching…"
-              @evidence.searched? -> "Search again"
-              true -> "Search"
-            end}
-          </.button>
-        </form>
+          event="research"
+          name={@evidence.fields["name"]}
+          running={@evidence.running?}
+          label={(@evidence.searched? && "Search again") || "Search"}
+        />
 
         <.provider_outcomes_row
           outcomes={@evidence.outcomes}

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -354,35 +354,48 @@ defmodule AmbryWeb.Admin.Decisions do
     """
   end
 
-  attr :at, :string, required: true, doc: "where this renders — DOM ids key on place, not person"
-  attr :person_key, :string, required: true
+  attr :at, :string,
+    default: nil,
+    doc: "where this renders — DOM ids key on place, not person; nil where there is only one"
+
+  attr :person_key, :string,
+    default: nil,
+    doc: "routes the search to one person; nil where the surface is about a single person"
 
   attr :name, :string,
     default: nil,
     doc: "the name these records were searched for — not the person's own name"
 
+  attr :event, :string, default: "research-person"
+  attr :label, :string, default: "Search again"
   attr :running, :boolean, default: false
 
   @doc """
   The person level's search-again form — the work-level pattern with a name
   where the work has title and author.
 
-  The box holds the *query*, exactly as the work level's holds `query_fields`.
+  The box holds the *query*, exactly as `research_form`'s holds its fields.
   It used to render the person's name decision, so searching for anything else
   worked and then snapped back to the pre-filled name the moment the results
   landed — the one moment the operator needs to see what produced them. The
   two are genuinely different questions: searching "Robert Galbraith" for a
   person the import will create as "J.K. Rowling" is the case this form is
   for, and neither answer should overwrite the other.
+
+  The person edit form hand-wrote this same markup, which is how the two
+  drifted: the copy there grew a three-way button label the inbox never got,
+  and a fix to either reached only half the people searches in the admin.
+  One component, parameterised by the two things that genuinely differ —
+  which event routes it, and whether there is a person key to route *to*.
   """
   def person_research_form(assigns) do
     ~H"""
     <form
-      id={"research-person-#{@at}"}
-      phx-submit="research-person"
+      id={["research-person", @at] |> Enum.reject(&is_nil/1) |> Enum.join("-")}
+      phx-submit={@event}
       class="flex flex-wrap items-end gap-2"
     >
-      <input type="hidden" name="key" value={@person_key} />
+      <input :if={@person_key} type="hidden" name="key" value={@person_key} />
 
       <label class="text-xs text-zinc-400">
         <span class="block pl-3">name</span>
@@ -390,7 +403,7 @@ defmodule AmbryWeb.Admin.Decisions do
       </label>
 
       <.button color={:zinc} type="submit" disabled={@running}>
-        {if @running, do: "Searching…", else: "Search again"}
+        {if @running, do: "Searching…", else: @label}
       </.button>
     </form>
     """
@@ -1013,7 +1026,10 @@ defmodule AmbryWeb.Admin.Decisions do
             and gets the same answer: the card is not yours while it runs. A
             button changing its own label to "Searching…" was the whole
             indication, in a fold that could close over it. --%>
-      <.busy_overlay busy={@searching} label={"Looking for #{person_words(@person)}…"} />
+      <%!-- Named by the QUERY, like the work and recording scrims: a search
+            for a name other than this person's own said "Looking for
+            <the person>…" while looking for somebody else entirely. --%>
+      <.busy_overlay busy={@searching} label={"Looking for #{@query_name || person_words(@person)}…"} />
 
       <div class="space-y-3" inert={@searching}>
         <%!-- Titled by the CREDIT, which is the one name on this card that

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -756,6 +756,10 @@ defmodule AmbryWeb.Admin.Decisions do
 
   attr :persons, :list, required: true, doc: "the PersonDecisions this credit references"
 
+  attr :people, :list,
+    default: [],
+    doc: "the library's people, so a linked person's chip shows the library's own name and face"
+
   attr :count, :integer,
     default: 1,
     doc: "how many rows the list holds — the reorder arrows' ends"
@@ -813,6 +817,8 @@ defmodule AmbryWeb.Admin.Decisions do
   end
 
   def credit_row(assigns) do
+    assigns = assign(assigns, :faces, Enum.map(assigns.persons, &person_face(&1, assigns.people)))
+
     ~H"""
     <%!-- A decision block, so it wears the state rail like every other one —
         the rail is the ONLY settledness encoding (design language §2); the
@@ -912,33 +918,30 @@ defmodule AmbryWeb.Admin.Decisions do
           data-role="credit-people"
         >
           <.link
-            :for={person <- Enum.take(@persons, person_chips())}
-            href={"#person-#{person.key}"}
+            :for={face <- Enum.take(@faces, person_chips())}
+            href={"#person-#{face.key}"}
             class="bg-white/5 flex items-center gap-2 rounded-full py-1 pr-3 pl-1 text-xs text-zinc-300 hover:bg-white/10"
           >
             <img
-              :if={Field.value(person.image)}
-              src={preview_src(Field.value(person.image), nil)}
+              :if={face.src}
+              src={face.src}
               class="h-6 w-6 flex-none rounded-full object-cover"
               alt=""
             />
-            <span
-              :if={!Field.value(person.image)}
-              class="h-6 w-6 flex-none rounded-full bg-zinc-800"
-            />
-            {Field.value(person.name) || "unnamed"}
+            <span :if={!face.src} class="h-6 w-6 flex-none rounded-full bg-zinc-800" />
+            {face.name}
           </.link>
 
           <%!-- One credit standing for a dozen humans would push the row into
                 a paragraph of faces. The rest are a click away in the section
                 that lists every one of them. --%>
           <.link
-            :if={length(@persons) > person_chips()}
+            :if={length(@faces) > person_chips()}
             href="#people"
-            title={Enum.map_join(Enum.drop(@persons, person_chips()), ", ", &(Field.value(&1.name) || "unnamed"))}
+            title={Enum.map_join(Enum.drop(@faces, person_chips()), ", ", & &1.name)}
             class="bg-white/10 flex items-center rounded-full px-3 py-1 text-xs tabular-nums text-zinc-300 hover:bg-white/20"
           >
-            +{length(@persons) - person_chips()}
+            +{length(@faces) - person_chips()}
           </.link>
         </div>
       </div>
@@ -1013,7 +1016,11 @@ defmodule AmbryWeb.Admin.Decisions do
     assigns =
       assign(assigns,
         own_name: assigns.person.own_name or not Credit.simple?(assigns.group.credit),
-        linked: linked_person(assigns.people, assigns.person)
+        linked: linked_person(assigns.people, assigns.person),
+        # A linked person is called what the library calls them, here as well
+        # as on the credit chip — the staged name is a leftover of finding
+        # them, not their name.
+        words: person_words(assigns.person, linked_person(assigns.people, assigns.person))
       )
 
     ~H"""
@@ -1029,7 +1036,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <%!-- Named by the QUERY, like the work and recording scrims: a search
             for a name other than this person's own said "Looking for
             <the person>…" while looking for somebody else entirely. --%>
-      <.busy_overlay busy={@searching} label={"Looking for #{@query_name || person_words(@person)}…"} />
+      <.busy_overlay busy={@searching} label={"Looking for #{@query_name || @words}…"} />
 
       <div class="space-y-3" inert={@searching}>
         <%!-- Titled by the CREDIT, which is the one name on this card that
@@ -1038,7 +1045,7 @@ defmodule AmbryWeb.Admin.Decisions do
               operator typed the very thing the card is about. --%>
         <div class="flex items-baseline justify-between gap-2 pl-3">
           <div class="flex min-w-0 items-baseline gap-2">
-            <.label>{card_words(@group.credit, @person)}</.label>
+            <.label>{card_words(@group.credit, @words)}</.label>
 
             <%!-- Where they are credited is a fact about this card, so it
                   wears the status costume beside the title rather than a
@@ -1161,7 +1168,7 @@ defmodule AmbryWeb.Admin.Decisions do
               — which is exactly the author who turns up narrating. --%>
         <div :if={@locals != [] or @person.mode == :link} class="space-y-2">
           <p class="pl-3 text-xs text-zinc-400">
-            {local_people_words(@person, @locals)}
+            {local_people_words(@person, @locals, @group.kind)}
           </p>
 
           <.local_person_row
@@ -1199,16 +1206,17 @@ defmodule AmbryWeb.Admin.Decisions do
     """
   end
 
-  defp person_words(person), do: Field.value(person.name) || "Unnamed person"
+  defp person_words(_person, %{"name" => name}), do: name
+  defp person_words(person, nil), do: Field.value(person.name) || "Unnamed person"
 
   # The credited name, which is what this card is a card *about*. Falls back
   # to the human's own name only when the credit has none — a cleared credit
   # box mid-retype, where a blank title would name nothing at all.
-  defp card_words(%Credit{name: name}, person) when is_binary(name) do
-    if String.trim(name) == "", do: person_words(person), else: name
+  defp card_words(%Credit{name: name}, words) when is_binary(name) do
+    if String.trim(name) == "", do: words, else: name
   end
 
-  defp card_words(_credit, person), do: person_words(person)
+  defp card_words(_credit, words), do: words
 
   defp reveal_words(:narrator), do: "This is a stage name"
   defp reveal_words(_author), do: "This is a pen name"
@@ -1221,19 +1229,55 @@ defmodule AmbryWeb.Admin.Decisions do
   defp linked_person(people, %PersonDecision{mode: :link, person_id: id}) do
     case Enum.find(people, &(&1.id == id)) do
       nil -> %{"id" => id, "name" => "Somebody in your library"}
-      person -> %{"id" => person.id, "name" => person.label}
+      person -> %{"id" => person.id, "name" => person.label, "image" => person.image}
     end
   end
 
   defp linked_person(_people, _person), do: nil
 
-  defp local_people_words(%PersonDecision{mode: :link}, _locals),
+  @doc """
+  What to show for a person: the library's own name and face where this
+  decision links to one, the staged fields where it will create one.
+
+  A linked decision keeps whatever was typed on the way to finding them, by
+  design — linking must not overwrite staged curation, because unlinking has
+  to give it back. But rendering it is wrong: type "j", pick J.K. Rowling
+  from the typeahead, and the credit chip read "j" beside the portrait of
+  whichever candidate the half-typed name had turned up.
+
+  The src is resolved here rather than by the caller because the two cases
+  need different handling — a library thumbnail is a local path served as-is,
+  a staged image may be a remote provider URL that has to go through the
+  proxy.
+  """
+  def person_face(person, people) do
+    case linked_person(people, person) do
+      nil ->
+        %{
+          key: person.key,
+          name: Field.value(person.name) || "unnamed",
+          src: preview_src(Field.value(person.image), nil)
+        }
+
+      linked ->
+        %{key: person.key, name: linked["name"], src: linked["image"]}
+    end
+  end
+
+  # Linking is an answer to "who is this", and a pen name is an answer to
+  # "whose name is on the book" — the second doesn't stop being true because
+  # the first was answered from the library. Saying so generically here threw
+  # away the more specific thing the card had been saying one state earlier.
+  defp local_people_words(%PersonDecision{mode: :link, own_name: true}, _locals, kind),
+    do: alias_words(kind)
+
+  defp local_people_words(%PersonDecision{mode: :link}, _locals, _kind),
     do: "This import will use the person you already have."
 
-  defp local_people_words(_person, [_one]),
+  defp local_people_words(_person, [_one], _kind),
     do: "Somebody by this name is already in your library."
 
-  defp local_people_words(_person, locals),
+  defp local_people_words(_person, locals, _kind),
     do: "#{length(locals)} people by this name are already in your library."
 
   attr :local, :map, required: true

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -356,12 +356,24 @@ defmodule AmbryWeb.Admin.Decisions do
 
   attr :at, :string, required: true, doc: "where this renders — DOM ids key on place, not person"
   attr :person_key, :string, required: true
-  attr :name, :string, default: nil
+
+  attr :name, :string,
+    default: nil,
+    doc: "the name these records were searched for — not the person's own name"
+
   attr :running, :boolean, default: false
 
   @doc """
   The person level's search-again form — the work-level pattern with a name
   where the work has title and author.
+
+  The box holds the *query*, exactly as the work level's holds `query_fields`.
+  It used to render the person's name decision, so searching for anything else
+  worked and then snapped back to the pre-filled name the moment the results
+  landed — the one moment the operator needs to see what produced them. The
+  two are genuinely different questions: searching "Robert Galbraith" for a
+  person the import will create as "J.K. Rowling" is the case this form is
+  for, and neither answer should overwrite the other.
   """
   def person_research_form(assigns) do
     ~H"""
@@ -959,6 +971,10 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :appears, :list, default: []
   attr :people, :list, default: [], doc: "the library's people, for the typeahead"
 
+  attr :query_name, :string,
+    default: nil,
+    doc: "the name these records were searched for; falls back to the person's own"
+
   @doc """
   One human this import will create, as a decision card of their own.
 
@@ -1160,6 +1176,7 @@ defmodule AmbryWeb.Admin.Decisions do
           expanded={@photos_expanded}
           records={@records}
           outcomes={@outcomes}
+          query_name={@query_name}
         />
       </div>
     </div>
@@ -1304,6 +1321,10 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :records, :list, default: [], doc: "the provider records of people by this name"
   attr :outcomes, :list, default: [], doc: "what each person provider said when asked"
 
+  attr :query_name, :string,
+    default: nil,
+    doc: "the name these records were searched for; falls back to the person's own"
+
   # Enough to see there are alternatives without the row becoming a contact
   # sheet. TMDB keeps every headshot anyone has uploaded and a working actor
   # can have dozens.
@@ -1390,7 +1411,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <.person_research_form
         at={@at}
         person_key={@person.key}
-        name={Field.value(@person.name)}
+        name={@query_name || Field.value(@person.name)}
         running={@searching}
       />
 

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -605,60 +605,94 @@ defmodule AmbryWeb.CoreComponents do
     default: false,
     doc: "also accept an image pasted from the clipboard (adds a JS hook to the drop area)"
 
+  @doc """
+  The drop-or-choose control for a `live_upload`.
+
+  One dashed well rather than the browser's file input stapled to a second
+  box below it. The old one was the last control on the admin still wearing
+  pre-redesign clothes: a 1px-bordered native input whose `file:` button was
+  the only zinc-600 button left, sitting on `zinc-950` *inside* cards —
+  ground-colored, so the elevation ladder ran backwards (§1) — above a
+  browser `<progress>` bar and a `&times;` glyph for a cancel.
+
+  Now: the native input is `sr-only` and its label is the standard small
+  button (§6), so choosing and dropping are one surface. Dashes stay, at
+  2px — this is the one place §1 asks for them, because the box really is
+  saying "drop here". Entries are wells inside it with a real progress bar
+  and the standard remove button.
+  """
   def file_input(assigns) do
     ~H"""
-    <div>
-      <div class="space-y-2">
-        <.label :if={@label} class="pl-3">{@label}</.label>
-        <.live_file_input
-          upload={@upload}
-          class={
-            [
-              "!text-zinc-500 block w-full rounded-sm rounded-b-none border p-0",
-              "focus:outline-none focus:ring-4 sm:text-sm sm:leading-6",
-              "file:p-[11px] file:cursor-pointer file:rounded-none file:border-0",
-              "file:bg-zinc-600 file:font-bold file:text-zinc-100 hover:file:bg-zinc-500"
-            ] ++ input_color_classes(@errors) ++ [@class]
-          }
-        />
-      </div>
+    <div class="space-y-2">
+      <.label :if={@label} class="pl-3">{@label}</.label>
+
       <div
         id={"#{@upload.ref}-drop-area"}
-        class="space-y-4 rounded-b-sm border-2 border-t-0 border-dashed border-zinc-600 bg-zinc-950 p-4 text-zinc-400"
+        class={
+          [
+            "bg-zinc-800/40 space-y-3 rounded-lg border-2 border-dashed border-zinc-700 p-4",
+            "text-zinc-400 transition-colors hover:border-zinc-600"
+          ] ++ [@class]
+        }
         phx-drop-target={@upload.ref}
         phx-hook={if @paste_upload, do: "paste-image"}
         data-upload-name={if @paste_upload, do: @upload.name}
       >
-        <.icon :if={@upload.entries == []} name="fa-upload" class="mx-auto my-4 block h-8 w-8 text-current" />
-        <p :if={@paste_upload && @upload.entries == []} class="text-center text-xs text-zinc-500">
-          drop, or paste from the clipboard
-        </p>
-        <div :if={@upload.entries != []} class="flex flex-wrap gap-4">
-          <article :for={entry <- @upload.entries} class="inline-block">
-            <figure>
-              <.live_image_preview_with_size
-                :if={UploadHelpers.image?(entry.client_type)}
-                entry={entry}
-                class={@image_preview_class}
-              />
-              <figcaption>{entry.client_name}</figcaption>
-            </figure>
-
-            <progress value={entry.progress} max="100">{entry.progress}%</progress>
-
-            <span
-              class="cursor-pointer text-2xl transition-colors hover:text-red-500"
-              phx-click={JS.push(@on_cancel, value: %{ref: entry.ref})}
-            >
-              &times;
-            </span>
-
-            <p :for={err <- upload_errors(@upload, entry)} class="text-red-500">
-              {UploadHelpers.upload_error_to_string(err)}
-            </p>
-          </article>
+        <%!-- The whole empty state is the affordance: one icon, one line
+            saying what this box accepts, one button. --%>
+        <div :if={@upload.entries == []} class="space-y-2 py-2 text-center">
+          <.icon name="fa-upload" class="mx-auto block h-6 w-6 text-zinc-500" />
+          <p class="text-xs text-zinc-500">
+            {if @paste_upload, do: "Drop a file here, or paste one", else: "Drop files here"}
+          </p>
         </div>
-        <p :for={err <- upload_errors(@upload)} class="text-red-500">
+
+        <div :if={@upload.entries != []} class="space-y-2">
+          <div
+            :for={entry <- @upload.entries}
+            class="flex items-center gap-3 rounded-md bg-zinc-800 p-3"
+            data-role="upload-entry"
+          >
+            <.live_image_preview_with_size
+              :if={UploadHelpers.image?(entry.client_type)}
+              entry={entry}
+              class={@image_preview_class || "h-12 w-12 rounded-md object-cover"}
+            />
+
+            <div class="min-w-0 flex-grow space-y-1">
+              <p class="truncate text-sm text-zinc-200">{entry.client_name}</p>
+
+              <%!-- A real bar rather than the browser's `<progress>`, which
+                  is unstyleable across engines and rendered as a grey
+                  lozenge that never matched anything else here. --%>
+              <div class="h-1 overflow-hidden rounded-full bg-zinc-700">
+                <div class="bg-brand-dark h-full transition-all" style={"width: #{entry.progress}%"} />
+              </div>
+
+              <p :for={err <- upload_errors(@upload, entry)} class="text-xs text-red-400">
+                {UploadHelpers.upload_error_to_string(err)}
+              </p>
+            </div>
+
+            <button
+              type="button"
+              phx-click={JS.push(@on_cancel, value: %{ref: entry.ref})}
+              title="Don't upload this one"
+              class="flex-none"
+            >
+              <.icon name="fa-xmark" class="h-4 w-4 cursor-pointer hover:text-red-400" />
+            </button>
+          </div>
+        </div>
+
+        <div class="text-center">
+          <.live_file_input upload={@upload} class="sr-only" />
+          <label for={@upload.ref} class={action_classes()}>
+            {if @upload.entries == [], do: "Choose files", else: "Choose more"}
+          </label>
+        </div>
+
+        <p :for={err <- upload_errors(@upload)} class="text-center text-xs text-red-400">
           {UploadHelpers.upload_error_to_string(err)}
         </p>
       </div>

--- a/lib/ambry_web/controllers/admin/image_proxy_controller.ex
+++ b/lib/ambry_web/controllers/admin/image_proxy_controller.ex
@@ -8,19 +8,30 @@ defmodule AmbryWeb.Admin.ImageProxyController do
   fine and the eventual server-side import succeeds. Serving previews
   same-origin sidesteps that entirely.
 
-  Admin-only, http(s) only, image content types only. Fetching operator-
-  supplied remote URLs server-side matches the existing import behavior
+  Admin-only, http(s) only, images only. Fetching operator-supplied remote
+  URLs server-side matches the existing import behavior
   (`UploadHelpers.handle_image_import/1`).
+
+  What decides "image" is the bytes, not the `content-type` header, because
+  the header is not reliably an answer. Hardcover's CDN serves every asset —
+  author photos included — as `application/octet-stream`, so gating on the
+  header 404'd a perfectly good PNG and left a broken image sitting next to
+  the chip offering it. Sniffing is also the stricter reading: a page that
+  *claims* `image/png` can no longer be echoed back under an image content
+  type, which trusting the header allowed.
+
+  That check is `Ambry.Images.browser_safe/1`, the same one the embedded-art
+  path uses — one policy about what a servable image is, so a preview and the
+  import it precedes can never disagree about whether something is showable.
   """
 
   use AmbryWeb, :controller
 
-  @allowed_content_types ~w(image/jpeg image/png image/webp image/gif)
   @receive_timeout 15_000
 
   def show(conn, %{"url" => url}) do
     with %URI{scheme: scheme} when scheme in ["http", "https"] <- URI.parse(url),
-         {:ok, %{status: 200, body: body} = response} when is_binary(body) <-
+         {:ok, %{status: 200, body: body}} when is_binary(body) <-
            Req.get(
              url: url,
              headers: [{"user-agent", Ambry.Utils.http_user_agent()}],
@@ -28,12 +39,11 @@ defmodule AmbryWeb.Admin.ImageProxyController do
              retry: false,
              decode_body: false
            ),
-         [content_type | _rest] <- Req.Response.get_header(response, "content-type"),
-         true <- String.starts_with?(content_type, @allowed_content_types) do
+         {:ok, image, content_type} <- Ambry.Images.browser_safe(body) do
       conn
       |> put_resp_content_type(content_type, nil)
       |> put_resp_header("cache-control", "private, max-age=86400")
-      |> send_resp(200, body)
+      |> send_resp(200, image)
     else
       _other -> send_resp(conn, 404, "Not Found")
     end

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -6,7 +6,7 @@
     <.evidence_panel
       evidence={@evidence}
       level="work"
-      title="Records describing this book"
+      title="Search providers"
       hint="Tick every record that describes this book. Ticked records offer their values as chips under the fields below."
       retrying={@retrying}
     />

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -42,6 +42,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Books
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Chapters
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Seed
@@ -351,6 +352,24 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   def handle_event("cancel-chapter-import", _params, socket) do
     {:noreply, assign(socket, chapter_import: nil)}
+  end
+
+  # The way back to the machine's value, which every other decision has and
+  # this one didn't: re-derive the rows from the probe and record that the
+  # operator chose them. Taking a value the rows already hold still counts as
+  # reviewing it — that is the whole point of the tier, and why agreeing with
+  # the files must not require editing them first.
+  def handle_event("take-file-chapters", _params, socket) do
+    case Seed.file_chapters(socket.assigns.item) do
+      %Chapters{chapters: [_row | _rest] = rows, chapter_marker_source: source} ->
+        {:noreply,
+         socket
+         |> edit(&Draft.Edit.set_chapters(&1, rows, source))
+         |> assign(chapter_import: nil, chapters_applied_asin: nil)}
+
+      _nothing_to_take ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("research", %{"level" => level} = params, socket) do
@@ -993,6 +1012,42 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
         )
     end
   end
+
+  @doc """
+  The files' own list as a proposal chip, or nil when they carry none.
+
+  Chosen when the staged rows still match what the probe read, so the chip
+  reports as well as offers. Files with no chapters propose nothing: a chip
+  that emptied the rows an operator typed by hand would be a destructive
+  control wearing a proposal's clothes.
+  """
+  def file_chapter_chip(item) do
+    case Seed.file_chapters(item) do
+      %Chapters{chapters: [_row | _rest] = rows} ->
+        %{chosen: same_chapters?(draft_chapter_rows(item), rows)}
+
+      _no_file_chapters ->
+        nil
+    end
+  end
+
+  # Compared on what the operator can see and change — a time and a title.
+  # `title_source` is bookkeeping about where a title came from, and two
+  # identical lists that disagree about it are still the same list.
+  defp same_chapters?(staged, from_files) when length(staged) == length(from_files) do
+    staged
+    |> Enum.zip(from_files)
+    |> Enum.all?(fn {row, file_row} ->
+      row.title == file_row.title and same_time?(row.time, file_row.time)
+    end)
+  end
+
+  defp same_chapters?(_staged, _from_files), do: false
+
+  defp same_time?(%Decimal{} = staged, %Decimal{} = from_file),
+    do: Decimal.equal?(staged, from_file)
+
+  defp same_time?(staged, from_file), do: staged == from_file
 
   # One chip per distinct ASIN among the ticked recording records — the
   # evidence panel is the search, so the chips are wherever its ticks are.

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -70,6 +70,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> assign(narrator_backing: People.narrator_backing_names())
      |> assign(people: People.people_for_select())
      |> assign(researching: nil, retrying: nil, enriching: nil)
+     # What the in-flight search asked for. The stored query only updates
+     # when results land, so a form that renders storage describes the
+     # PREVIOUS search for the whole round trip — the typed words vanish from
+     # the boxes at the click and the scrim names the wrong book. The edit
+     # forms have always captured this (`Evidence.begin/2`); this is the same
+     # discipline for the staged form.
+     |> assign(research_fields: %{}, searching_person_name: nil)
      # Which person is being looked up again, and whose photo strip is showing
      # in full. Both view state keyed by person key — the results themselves
      # are evidence and live on the item.
@@ -181,6 +188,66 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def busy_label(_idle), do: "Working…"
 
   @doc """
+  What a level's search box shows: the query in flight while one is running,
+  and the last one asked otherwise.
+
+  The stored query is only written when results land, so rendering it during
+  the round trip describes the *previous* search — which is why typed words
+  appeared to revert the moment Search was pressed and the scrim named the
+  wrong book. The edit forms never had this because `Evidence.begin/2`
+  records the submitted fields at the click; this is the same rule for a
+  form whose query lives in the database instead of a struct.
+  """
+  def search_fields(level, level, in_flight, _seeded), do: in_flight
+  def search_fields(_researching, _level, _in_flight, seeded), do: seeded
+
+  # The query keys a search form can submit — the same set
+  # `Provider.Query.from_fields/1` reads, so what comes back is exactly what
+  # was asked for.
+  @query_keys ~w(title author narrator)
+
+  defp submitted_fields(params), do: Map.take(params, @query_keys)
+
+  # What each level's boxes hold when no search is in flight.
+  #
+  # The stored query is what was last *asked*, and for a recording matched by
+  # its ASIN that is `%{"keywords" => "B0…"}` — a shape this form has no box
+  # for. So the audiobook card rendered three empty boxes above a button
+  # that submitted a blank query, which `Lookup.research/3` correctly treats
+  # as nothing to do: a dead control that said nothing about why. Falling
+  # back to the hints matching itself used means a box always holds
+  # something submittable, the way the edit forms seed their panel from the
+  # record they belong to.
+  #
+  # Wholesale, never per key: merging hints into a stored query would put
+  # back an author the operator deliberately cleared, which is the bug this
+  # whole pass is about.
+  defp search_seeds(item) do
+    hints = Inbox.hints(item)
+
+    from_hints =
+      %{"title" => hints[:title], "author" => hints[:author], "narrator" => hints[:narrator]}
+      |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+      |> Map.new()
+
+    draft = item.draft
+
+    %{
+      "work" => seeded_fields(draft && draft.work, from_hints),
+      "recording" => seeded_fields(draft && draft.recording, from_hints)
+    }
+  end
+
+  defp seeded_fields(nil, from_hints), do: from_hints
+
+  defp seeded_fields(decision, from_hints) do
+    case Map.take(decision.query_fields || %{}, @query_keys) do
+      no_text_fields when map_size(no_text_fields) == 0 -> from_hints
+      stored -> stored
+    end
+  end
+
+  @doc """
   What a level's search is looking for, for the scrim that covers it.
 
   Named rather than a bare "Searching…", because the operator has just typed
@@ -225,8 +292,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   name and rewritten by every re-search, so the search box can hold the query
   rather than the person's name decision — which is a different answer and
   was snapping the box back the moment results arrived.
+
+  In flight it is the name just submitted, for the same reason
+  `search_fields/3` is: until the results land, storage still describes the
+  previous search.
   """
-  def person_query_name(item, key), do: get_in(item.matches, ["people", key, "name"])
+  def person_query_name(_item, key, key, name) when is_binary(name), do: name
+
+  def person_query_name(item, key, _searching_key, _searching_name),
+    do: get_in(item.matches, ["people", key, "name"])
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"inbox_item" => params}, socket) do
@@ -377,7 +451,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      socket
-     |> assign(researching: level)
+     |> assign(researching: level, research_fields: submitted_fields(params))
      |> start_async({:research, level}, fn -> Inbox.research(item, level, params) end)}
   end
 
@@ -532,7 +606,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      socket
-     |> assign(searching_person: key)
+     |> assign(searching_person: key, searching_person_name: name)
      |> start_async({:person_search, key}, fn -> Inbox.research_person(item, key, name) end)}
   end
 
@@ -632,7 +706,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      socket
-     |> assign(searching_person: key)
+     |> assign(searching_person: key, searching_person_name: name)
      |> start_async({:person_search, key}, fn -> Inbox.research_person(item, key, name) end)}
   end
 
@@ -762,17 +836,22 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   @impl Phoenix.LiveView
 
   def handle_async({:person_search, _key}, {:ok, {:ok, item}}, socket) do
-    {:noreply, socket |> assign(searching_person: nil) |> load(item) |> resettle()}
+    {:noreply,
+     socket
+     |> assign(searching_person: nil, searching_person_name: nil)
+     |> load(item)
+     |> resettle()}
   end
 
   # A provider being down costs its results and nothing else — the person is
   # still perfectly importable without a face.
   def handle_async({:person_search, _key}, _failed, socket) do
-    {:noreply, assign(socket, searching_person: nil)}
+    {:noreply, assign(socket, searching_person: nil, searching_person_name: nil)}
   end
 
   def handle_async({:research, _level}, {:ok, {:ok, item}}, socket) do
-    {:noreply, socket |> assign(researching: nil) |> load(item) |> resettle()}
+    {:noreply,
+     socket |> assign(researching: nil, research_fields: %{}) |> load(item) |> resettle()}
   end
 
   def handle_async({:retry, _level}, {:ok, {:ok, item}}, socket) do
@@ -800,6 +879,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply,
      socket
      |> assign(researching: nil, retrying: nil, enriching: nil)
+     |> assign(research_fields: %{}, searching_person: nil, searching_person_name: nil)
      |> put_flash(:error, "That provider couldn't be reached just now.")}
   end
 
@@ -865,6 +945,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       form: to_form(Inbox.change_draft(item)),
       unresolved: Draft.unresolved(item.draft),
       progress: Draft.progress(item.draft),
+      # What each level's search box starts from, resolved once per load
+      # rather than per render — the hints are parsed out of the release
+      # text.
+      search_seeds: search_seeds(item),
       # A recording group is reachable only through its book, so the picker
       # has options exactly when the work links a library book. A :create
       # work has no groups yet — the resolver is create-only there.

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -217,6 +217,16 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   """
   def person_locals(item, key), do: get_in(item.matches, ["people", key, "local"]) || []
 
+  @doc """
+  The name this person's records were searched for.
+
+  The person level's `query_fields`: seeded by matching with the credited
+  name and rewritten by every re-search, so the search box can hold the query
+  rather than the person's name decision — which is a different answer and
+  was snapping the box back the moment results arrived.
+  """
+  def person_query_name(item, key), do: get_in(item.matches, ["people", key, "name"])
+
   @impl Phoenix.LiveView
   def handle_event("validate", %{"inbox_item" => params}, socket) do
     params = curate_chapter_params(params, socket.assigns.item)

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -719,11 +719,16 @@
               <.inputs_for :let={recording} field={draft[:recording]}>
                 <.inputs_for :let={chapters} field={recording[:chapters]}>
                   <.marker_source_input form={chapters} />
-                  <.chapter_rows form={chapters} pending={@chapter_import}>
+                  <.chapter_rows
+                    form={chapters}
+                    pending={@chapter_import}
+                    rail={state_rail(Tier.of(@item.draft.recording.chapters))}
+                  >
                     <:proposals>
                       <.chapter_title_chips
                         id="chapter-title-chips"
                         chips={chapter_chips(@item, @chapters_applied_asin)}
+                        file={file_chapter_chip(@item)}
                       />
                     </:proposals>
                   </.chapter_rows>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -190,7 +190,7 @@
               runs. The person cards have said so since they grew a search of
               their own; these two were left with a button that changed its
               own label. --%>
-          <.busy_overlay busy={@researching == "work"} label={searching_label(@item.draft.work.query_fields)} />
+          <.busy_overlay busy={@researching == "work"} label={searching_label(@research_fields)} />
 
           <div class="space-y-2" inert={@researching == "work"}>
             <%!-- No badge and no Confirm button: the rail says which of the four
@@ -212,7 +212,7 @@
                 fixable without opening anything. --%>
             <.research_form
               level="work"
-              fields={@item.draft.work.query_fields}
+              fields={search_fields(@researching, "work", @research_fields, @search_seeds["work"])}
               running={@researching == "work"}
             />
 
@@ -453,7 +453,7 @@
               runs. The person cards have said so since they grew a search of
               their own; these two were left with a button that changed its
               own label. --%>
-          <.busy_overlay busy={@researching == "recording"} label={searching_label(@item.draft.recording.query_fields)} />
+          <.busy_overlay busy={@researching == "recording"} label={searching_label(@research_fields)} />
 
           <div class="space-y-2" inert={@researching == "recording"}>
             <div class="flex items-baseline gap-2 pl-3">
@@ -467,7 +467,7 @@
 
             <.research_form
               level="recording"
-              fields={@item.draft.recording.query_fields}
+              fields={search_fields(@researching, "recording", @research_fields, @search_seeds["recording"])}
               running={@researching == "recording"}
             />
 
@@ -680,7 +680,7 @@
               records={person_records(@item, person.key)}
               locals={person_locals(@item, person.key)}
               outcomes={person_outcomes(@item, person.key)}
-              query_name={person_query_name(@item, person.key)}
+              query_name={person_query_name(@item, person.key, @searching_person, @searching_person_name)}
               appears={@appearances[person.key] || []}
               people={@people}
             />
@@ -697,7 +697,7 @@
             records={person_records(@item, hd(group.people).key)}
             locals={person_locals(@item, hd(group.people).key)}
             outcomes={person_outcomes(@item, hd(group.people).key)}
-            query_name={person_query_name(@item, hd(group.people).key)}
+            query_name={person_query_name(@item, hd(group.people).key, @searching_person, @searching_person_name)}
             appears={@appearances[hd(group.people).key] || []}
             people={@people}
           />

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -680,6 +680,7 @@
               records={person_records(@item, person.key)}
               locals={person_locals(@item, person.key)}
               outcomes={person_outcomes(@item, person.key)}
+              query_name={person_query_name(@item, person.key)}
               appears={@appearances[person.key] || []}
               people={@people}
             />
@@ -696,6 +697,7 @@
             records={person_records(@item, hd(group.people).key)}
             locals={person_locals(@item, hd(group.people).key)}
             outcomes={person_outcomes(@item, hd(group.people).key)}
+            query_name={person_query_name(@item, hd(group.people).key)}
             appears={@appearances[hd(group.people).key] || []}
             people={@people}
           />

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -412,6 +412,7 @@
             verb="Written by"
             identity_backing={@author_backing}
             persons={Draft.people_for(@item.draft, credit)}
+            people={@people}
           />
 
           <.add_button phx-click="add-credit" phx-value-section="work">
@@ -622,6 +623,7 @@
             verb="Read by"
             identity_backing={@narrator_backing}
             persons={Draft.people_for(@item.draft, credit)}
+            people={@people}
           />
 
           <.add_button phx-click="add-credit" phx-value-section="recording">

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -431,13 +431,15 @@
 
           <.delete_input field={@form[:supplemental_files_drop]} />
 
-          <:add>
-            <.file_input
-              upload={@uploads.supplemental}
-              on_cancel="cancel-supplemental-upload"
-              image_preview_class="h-12 w-12 rounded-md object-cover"
-            />
-          </:add>
+          <%!-- Inside the card, not under it. A dropzone is not an add-button
+              — it is a control the block owns, the way the cover and the
+              person photo own theirs — and this was the only file input in
+              the admin standing outside the thing it belongs to. --%>
+          <.file_input
+            upload={@uploads.supplemental}
+            on_cancel="cancel-supplemental-upload"
+            image_preview_class="h-12 w-12 rounded-md object-cover"
+          />
         </.list_cluster>
 
         <.field_group>

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -10,13 +10,13 @@
     <.evidence_panel
       evidence={@evidence}
       level="recording"
-      title="Records describing this audiobook"
+      title="Search providers"
       hint="Tick every record of this exact reading; check the narrator first. Ticked records offer their values as chips under the fields below."
       retrying={@retrying}
     />
 
     <.simple_form id="media-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
-      <.form_section title="The audiobook" id="recording">
+      <.form_section id="recording">
         <.field_group>
           <.input
             field={@form[:book_id]}
@@ -395,18 +395,24 @@
           </.disclosure>
         </.field_group>
 
-        <.file_input
-          upload={@uploads.supplemental}
-          on_cancel="cancel-supplemental-upload"
-          label="Upload supplemental files"
-          image_preview_class="h-48"
-        />
+        <%!-- The one list on this form that wasn't a card: a bare upload
+            control on the ground, and a card below it that existed only
+            once there was something in it — so the section had no name
+            until it had contents. `list_cluster`'s grammar instead (§3b),
+            with the dropzone as the add. --%>
+        <.list_cluster label="Supplemental files">
+          <p
+            :if={@live_action != :edit || @form[:supplemental_files].value == []}
+            class="pl-3 text-sm text-zinc-400"
+          >
+            No supplemental files.
+          </p>
 
-        <.field_group
-          :if={@live_action == :edit && @form[:supplemental_files].value != []}
-          label="Supplemental files"
-        >
-          <.inputs_for :let={supplemental_file_form} field={@form[:supplemental_files]}>
+          <.inputs_for
+            :let={supplemental_file_form}
+            :if={@live_action == :edit}
+            field={@form[:supplemental_files]}
+          >
             <.sort_input field={@form[:supplemental_files_sort]} index={supplemental_file_form.index} />
             <.input field={supplemental_file_form[:id]} type="hidden" />
 
@@ -424,7 +430,15 @@
           </.inputs_for>
 
           <.delete_input field={@form[:supplemental_files_drop]} />
-        </.field_group>
+
+          <:add>
+            <.file_input
+              upload={@uploads.supplemental}
+              on_cancel="cancel-supplemental-upload"
+              image_preview_class="h-12 w-12 rounded-md object-cover"
+            />
+          </:add>
+        </.list_cluster>
 
         <.field_group>
           <.label for={@form[:processor].name} class="pl-3">

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -5,6 +5,45 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   and ticked records offer the photos and bios below. This replaced both the
   per-provider import modal and the separate image-picker modal — one
   mechanism for "ask the databases about this person".
+
+  ## Credits are two questions, not two lists
+
+  `Author` and `Narrator` are not roles — they are **credit names**, the name
+  a book or a recording is credited to. The form used to say so out loud: two
+  list clusters ("Writing as", "Narrating as") the operator had to populate,
+  which meant that having just typed "Stephen King" into the name box you
+  were then asked to add an author, and the answer was "Stephen King" again.
+  A schema detail, charged to every ordinary person.
+
+  So the common case is two checkboxes and no boxes to fill: **writes books**,
+  **narrates audiobooks**, each credited under the person's own name, which
+  is *stated* rather than typed. "Both" stops being a special case — it is
+  two ticks. Ticking creates the credit; unticking removes it, and
+  `People.update_person/3` deletes the freed record or refuses the save when
+  a book still credits it (`delete_orphaned_authors/2`), so the checkbox
+  cannot orphan anything.
+
+  The rare cases are escape hatches wearing the import form's own vocabulary
+  (§9), because an operator meets them there first: **"Writes under a pen
+  name"** reveals the names as an editable list, and only in that state does
+  linking an existing author appear — the composite case (James S.A. Corey),
+  where one credit name is backed by several humans. A person whose data
+  already diverges opens revealed, so nothing is hidden behind a control
+  nobody clicked.
+
+  Narrators get the same shape without the linking hatch: a `Narrator`
+  belongs to exactly one `Person`, so there is no shared-narrator case to
+  offer. The asymmetry is the model's, and the form states it rather than
+  faking symmetry.
+
+  ## The name follows
+
+  While a credit is the person's own name, it *is* their name: renaming the
+  person renames it. It used to not, so renaming Stephen King left an author
+  called Stephen King behind, credited on every one of his books. The sync is
+  guarded twice — the credit must currently match the old name, and an author
+  backed by more than one person is never touched, because one human renaming
+  themselves must not rename a pen name they share.
   """
   use AmbryWeb, :admin_live_view
 
@@ -30,7 +69,10 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
        retrying: nil,
        chips: %{},
        provenance_hints: %{},
-       authors: People.authors_for_select()
+       authors: People.authors_for_select(),
+       # The escape hatches, once clicked. Data that already diverges reveals
+       # itself without them — see `revealed?/2`.
+       reveal: MapSet.new()
      )
      |> apply_action(socket.assigns.live_action, params)}
   end
@@ -66,7 +108,12 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"person" => person_params}, socket) do
-    person_params = maybe_link_author(person_params)
+    socket = assign(socket, reveal: reveal_after(socket.assigns.reveal, person_params))
+
+    person_params =
+      person_params
+      |> maybe_link_author()
+      |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
     socket =
       if person_params["image_type"] == "upload" do
@@ -90,7 +137,10 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   def handle_event("submit", %{"person" => person_params}, socket) do
-    person_params = maybe_link_author(person_params)
+    person_params =
+      person_params
+      |> maybe_link_author()
+      |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
     socket =
       assign(socket,
@@ -114,6 +164,21 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   def handle_event("cancel-upload", %{"ref" => ref}, socket) do
     {:noreply, cancel_upload(socket, :image, ref)}
+  end
+
+  # Every way in needs a way out: the reveal used to be the permanent shape
+  # of the form, so there was nothing to go back to.
+  # Both re-derive through `assign_form/2`, because the reveal set feeds the
+  # checkbox: revealing without it left the box rendering unchecked, and the
+  # next change event read that back as "untick" and swept the credit away.
+  def handle_event("reveal-credit", %{"kind" => kind}, socket) do
+    socket = assign(socket, reveal: MapSet.put(socket.assigns.reveal, atom_kind(kind)))
+    {:noreply, assign_form(socket, socket.assigns.form.source)}
+  end
+
+  def handle_event("hide-credit", %{"kind" => kind}, socket) do
+    socket = assign(socket, reveal: MapSet.delete(socket.assigns.reveal, atom_kind(kind)))
+    {:noreply, assign_form(socket, socket.assigns.form.source)}
   end
 
   # ── the evidence panel ─────────────────────────────────────────────────
@@ -154,6 +219,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
       _missing -> {:noreply, socket}
     end
   end
+
+  defp atom_kind("author"), do: :author
+  defp atom_kind("narrator"), do: :narrator
 
   @impl Phoenix.LiveView
   def handle_async(:evidence_search, {:ok, result}, socket) do
@@ -252,8 +320,167 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do
-    assign(socket, :form, to_form(changeset))
+    name = Changeset.get_field(changeset, :name)
+    author_people = Changeset.get_field(changeset, :author_people) || []
+    narrators = Changeset.get_field(changeset, :narrators) || []
+
+    reveal = socket.assigns[:reveal] || MapSet.new()
+
+    socket
+    |> assign(:form, to_form(changeset))
+    # Revealed counts as on even with nothing in the list yet: taking the
+    # pen-name hatch is how a person who is not yet an author gets to the
+    # link control, and the composite case (linking James S.A. Corey to his
+    # second human) starts exactly there. Auto-creating an own-name author
+    # for them would mean deleting it again a click later.
+    |> assign(:writes, author_people != [] or :author in reveal)
+    |> assign(:narrates, narrators != [] or :narrator in reveal)
+    # Data that already disagrees with "credited under their own name" opens
+    # revealed: a pen name hidden behind a control nobody clicked is a pen
+    # name the operator can't see, and this form is where they go to find it.
+    |> assign(:author_diverges, Enum.any?(author_people, &author_diverges?(&1, name)))
+    |> assign(:narrator_diverges, Enum.any?(narrators, &(&1.name != name)))
   end
+
+  # A pen name in either of the two senses: a name that isn't theirs, or a
+  # name that isn't only theirs.
+  defp author_diverges?(%{author: %Author{} = author}, name),
+    do: author.name != name or shared?(author)
+
+  defp author_diverges?(_unloaded, _name), do: false
+
+  defp shared?(%Author{people: people}) when is_list(people), do: length(people) > 1
+  defp shared?(_author), do: false
+
+  @doc """
+  Whether a credit's names are showing as an editable list.
+
+  Either because the operator asked, or because the data says something the
+  checkbox alone cannot.
+  """
+  def revealed?(assigns, :author), do: :author in assigns.reveal or assigns.author_diverges
+  def revealed?(assigns, :narrator), do: :narrator in assigns.reveal or assigns.narrator_diverges
+
+  # Unticking collapses the hatch with it — a revealed list under an
+  # unchecked box describes credits that no longer exist.
+  defp reveal_after(reveal, person_params) do
+    reveal
+    |> drop_if(:author, person_params["writes"] == "false")
+    |> drop_if(:narrator, person_params["narrates"] == "false")
+  end
+
+  defp drop_if(reveal, kind, true), do: MapSet.delete(reveal, kind)
+  defp drop_if(reveal, _kind, _false), do: reveal
+
+  # The checkboxes, and the name that follows them, reconciled with the rows
+  # they stand for.
+  #
+  # It runs on every keystroke, so it has to be idempotent, and the ordinary
+  # case has to be "change nothing". Absent params mean "leave the
+  # association alone" — Ecto's own rule — so an unrevealed credit says
+  # nothing about rows it doesn't render, and only a real transition writes.
+  defp apply_credits(person_params, person, reveal) do
+    person_params
+    |> reconcile_authors(person, :author in reveal)
+    |> reconcile_narrators(person, :narrator in reveal)
+  end
+
+  defp reconcile_authors(params, person, revealed?) do
+    name = params["name"] || ""
+    rows = loaded(person.author_people)
+
+    cond do
+      # Unticked: the whole collection goes. `on_replace: :delete` unlinks
+      # the rows, and `People.update_person/3` then deletes what nothing
+      # credits — or refuses the save and names the book that still does.
+      params["writes"] == "false" ->
+        Map.put(params, "author_people", %{})
+
+      # Revealed: the operator is naming these themselves, in inputs that
+      # are already in the params. Nothing to reconcile and nothing to sync.
+      params["author_people"] != nil ->
+        params
+
+      # The tick itself.
+      # Ticked from the plain state: credited under their own name. Ticked
+      # from the revealed one: the operator is about to say what the name
+      # is, so the list starts empty.
+      rows == [] and params["writes"] == "true" and not revealed? ->
+        put_row(params, "author_people", %{"author" => %{"name" => name}})
+
+      name != person.name ->
+        Map.put(params, "author_people", author_sync(rows, person, name))
+
+      true ->
+        params
+    end
+  end
+
+  defp reconcile_narrators(params, person, revealed?) do
+    name = params["name"] || ""
+    rows = loaded(person.narrators)
+
+    cond do
+      params["narrates"] == "false" ->
+        Map.put(params, "narrators", %{})
+
+      params["narrators"] != nil ->
+        params
+
+      rows == [] and params["narrates"] == "true" and not revealed? ->
+        put_row(params, "narrators", %{"name" => name})
+
+      name != person.name ->
+        Map.put(params, "narrators", narrator_sync(rows, person, name))
+
+      true ->
+        params
+    end
+  end
+
+  defp put_row(params, key, row), do: Map.put(params, key, %{"0" => row})
+
+  # A rename, carried to the credits that are this person's own name.
+  #
+  # The whole collection is re-emitted, because emitting some rows and not
+  # others would delete the rest — `cast_assoc` reads params as the complete
+  # list. Rows that don't sync are emitted as a bare id, which updates
+  # nothing.
+  # The author's own id rides along: `AuthorPerson` casts `:author` with
+  # `on_replace: :raise`, so params without it are read as "replace this
+  # author with a new one" and blow up rather than renaming.
+  defp author_sync(rows, person, new_name) do
+    index_rows(rows, fn author_person ->
+      if syncs_name?(author_person.author, person),
+        do: %{"author" => %{"id" => to_string(author_person.author.id), "name" => new_name}},
+        else: %{}
+    end)
+  end
+
+  defp narrator_sync(rows, person, new_name) do
+    index_rows(rows, fn narrator ->
+      if narrator.name == person.name, do: %{"name" => new_name}, else: %{}
+    end)
+  end
+
+  defp index_rows(rows, changes) do
+    rows
+    |> Enum.with_index()
+    |> Map.new(fn {row, index} ->
+      {to_string(index), Map.put(changes.(row), "id", to_string(row.id))}
+    end)
+  end
+
+  # Guarded twice: the credit has to *be* their current name, and a shared
+  # pen name is never touched — one of James S.A. Corey's two humans
+  # renaming themselves must not rename James S.A. Corey.
+  defp syncs_name?(%Author{} = author, person),
+    do: author.name == person.name and not shared?(author)
+
+  defp syncs_name?(_unloaded, _person), do: false
+
+  defp loaded(rows) when is_list(rows), do: rows
+  defp loaded(_not_loaded), do: []
 
   # Selecting an author in the "link an existing author" autocomplete stages an
   # `author_people` row linking that author (unless it's already present).

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -114,7 +114,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     person_params =
       person_params
       |> maybe_link_author()
-      |> apply_credits(socket.assigns.person, socket.assigns.reveal)
+      |> apply_credits(held(socket.assigns.form.source))
 
     socket =
       if person_params["image_type"] == "upload" do
@@ -141,7 +141,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     person_params =
       person_params
       |> maybe_link_author()
-      |> apply_credits(socket.assigns.person, socket.assigns.reveal)
+      |> apply_credits(held(socket.assigns.form.source))
 
     socket =
       assign(socket,
@@ -165,6 +165,40 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
   def handle_event("cancel-upload", %{"ref" => ref}, socket) do
     {:noreply, cancel_upload(socket, :image, ref)}
+  end
+
+  # Choosing is a named event, not a form field (the import form's rule).
+  # As a checkbox it was form data, so every add and every delete arrived
+  # carrying a tick state derived from the rows those very params were
+  # changing, and the two argued: adding a row posted "unticked" alongside
+  # it and swept it away again.
+  def handle_event("toggle-credit", %{"kind" => kind}, socket) do
+    kind = atom_kind(kind)
+    name = Changeset.get_field(socket.assigns.form.source, :name) || ""
+
+    {key, row} =
+      case kind do
+        :author -> {"author_people", %{"author" => %{"name" => name}}}
+        :narrator -> {"narrators", %{"name" => name}}
+      end
+
+    on? = if kind == :author, do: socket.assigns.writes, else: socket.assigns.narrates
+
+    params =
+      Map.put(socket.assigns.form.params, key, if(on?, do: %{}, else: %{"0" => row}))
+
+    changeset =
+      socket.assigns.person
+      |> People.change_person(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply,
+     socket
+     |> assign(
+       reveal:
+         if(on?, do: MapSet.delete(socket.assigns.reveal, kind), else: socket.assigns.reveal)
+     )
+     |> assign_form(changeset)}
   end
 
   # Every way in needs a way out: the reveal used to be the permanent shape
@@ -325,8 +359,6 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     author_people = Changeset.get_field(changeset, :author_people) || []
     narrators = Changeset.get_field(changeset, :narrators) || []
 
-    reveal = socket.assigns[:reveal] || MapSet.new()
-
     socket
     |> assign(:form, to_form(changeset))
     # Revealed counts as on even with nothing in the list yet: taking the
@@ -334,8 +366,11 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     # link control, and the composite case (linking James S.A. Corey to his
     # second human) starts exactly there. Auto-creating an own-name author
     # for them would mean deleting it again a click later.
-    |> assign(:writes, author_people != [] or :author in reveal)
-    |> assign(:narrates, narrators != [] or :narrator in reveal)
+    # The rows and nothing else. It used to also count "revealed", so
+    # deleting the last credit left the box ticked until the save caught up
+    # — the control disagreeing with the thing it controls.
+    |> assign(:writes, author_people != [])
+    |> assign(:narrates, narrators != [])
     # Data that already disagrees with "credited under their own name" opens
     # revealed: a pen name hidden behind a control nobody clicked is a pen
     # name the operator can't see, and this form is where they go to find it.
@@ -400,105 +435,29 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   # case has to be "change nothing". Absent params mean "leave the
   # association alone" — Ecto's own rule — so an unrevealed credit says
   # nothing about rows it doesn't render, and only a real transition writes.
-  defp apply_credits(person_params, person, reveal) do
+  defp apply_credits(person_params, held) do
     person_params
-    |> reconcile_authors(person, :author in reveal)
-    |> reconcile_narrators(person, :narrator in reveal)
+    |> reconcile("author_people", held.author_people)
+    |> reconcile("narrators", held.narrators)
   end
 
-  defp reconcile_authors(params, person, revealed?) do
-    name = params["name"] || ""
-    rows = loaded(person.author_people)
-
-    cond do
-      # Unticked: the whole collection goes. `on_replace: :delete` unlinks
-      # the rows, and `People.update_person/3` then deletes what nothing
-      # credits — or refuses the save and names the book that still does.
-      params["writes"] == "false" ->
-        Map.put(params, "author_people", %{})
-
-      # Revealed: the operator is naming these themselves, in inputs that
-      # are already in the params. Nothing to reconcile and nothing to sync.
-      params["author_people"] != nil ->
-        params
-
-      # The tick itself.
-      # Ticked from the plain state: credited under their own name. Ticked
-      # from the revealed one: the operator is about to say what the name
-      # is, so the list starts empty.
-      rows == [] and params["writes"] == "true" and not revealed? ->
-        put_row(params, "author_people", %{"author" => %{"name" => name}})
-
-      name != person.name ->
-        Map.put(params, "author_people", author_sync(rows, person, name))
-
-      true ->
-        params
-    end
+  # What the form is holding right now, which is what its params are meant
+  # to describe.
+  defp held(%Changeset{} = changeset) do
+    %{
+      author_people: Changeset.get_field(changeset, :author_people) || [],
+      narrators: Changeset.get_field(changeset, :narrators) || []
+    }
   end
 
-  defp reconcile_narrators(params, person, revealed?) do
-    name = params["name"] || ""
-    rows = loaded(person.narrators)
-
-    cond do
-      params["narrates"] == "false" ->
-        Map.put(params, "narrators", %{})
-
-      params["narrators"] != nil ->
-        params
-
-      rows == [] and params["narrates"] == "true" and not revealed? ->
-        put_row(params, "narrators", %{"name" => name})
-
-      name != person.name ->
-        Map.put(params, "narrators", narrator_sync(rows, person, name))
-
-      true ->
-        params
-    end
+  # The form renders every credit it holds — openly when revealed, as hidden
+  # inputs when not — so absent params mean it holds none. Said plainly:
+  # emptying the list and unticking the box are the same instruction, and
+  # both have to reach `cast_assoc` as an empty collection or the rows in
+  # the database simply stay.
+  defp reconcile(params, key, held) do
+    if params[key] == nil and held == [], do: Map.put(params, key, %{}), else: params
   end
-
-  defp put_row(params, key, row), do: Map.put(params, key, %{"0" => row})
-
-  # A rename, carried to the credits that are this person's own name.
-  #
-  # The whole collection is re-emitted, because emitting some rows and not
-  # others would delete the rest — `cast_assoc` reads params as the complete
-  # list. Rows that don't sync are emitted as a bare id, which updates
-  # nothing.
-  # The author's own id rides along: `AuthorPerson` casts `:author` with
-  # `on_replace: :raise`, so params without it are read as "replace this
-  # author with a new one" and blow up rather than renaming.
-  defp author_sync(rows, person, new_name) do
-    index_rows(rows, fn author_person ->
-      if syncs_name?(author_person.author, person),
-        do: %{"author" => %{"id" => to_string(author_person.author.id), "name" => new_name}},
-        else: %{}
-    end)
-  end
-
-  defp narrator_sync(rows, person, new_name) do
-    index_rows(rows, fn narrator ->
-      if narrator.name == person.name, do: %{"name" => new_name}, else: %{}
-    end)
-  end
-
-  defp index_rows(rows, changes) do
-    rows
-    |> Enum.with_index()
-    |> Map.new(fn {row, index} ->
-      {to_string(index), Map.put(changes.(row), "id", to_string(row.id))}
-    end)
-  end
-
-  # Guarded twice: the credit has to *be* their current name, and a shared
-  # pen name is never touched — one of James S.A. Corey's two humans
-  # renaming themselves must not rename James S.A. Corey.
-  defp syncs_name?(%Author{} = author, person),
-    do: author.name == person.name and not shared?(author)
-
-  defp syncs_name?(_unloaded, _person), do: false
 
   defp loaded(rows) when is_list(rows), do: rows
   defp loaded(_not_loaded), do: []

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -56,7 +56,6 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   alias Ambry.People.Person
   alias AmbryWeb.Admin.Evidence
   alias AmbryWeb.Admin.ProvenanceHints
-  alias AmbryWeb.Components.EntityResolver
   alias Ecto.Changeset
 
   @scalar_kinds %{"name" => :name, "description" => :description, "image" => :image}
@@ -83,6 +82,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
     changeset = People.change_person(person, %{"image_type" => "upload"})
 
     socket
+    |> assign(reveal: seed_reveal(person))
     |> assign_form(changeset)
     |> assign(
       page_title: person.name,
@@ -108,13 +108,12 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   def handle_params(_params, _url, socket), do: {:noreply, socket}
 
   @impl Phoenix.LiveView
-  def handle_event("validate", %{"person" => person_params} = params, socket) do
+  def handle_event("validate", %{"person" => person_params}, socket) do
     socket = assign(socket, reveal: reveal_after(socket.assigns.reveal, person_params))
 
     person_params =
       person_params
-      |> apply_typed_names(params["resolver"], socket.assigns.person)
-      |> normalize_author_rows(socket.assigns.person)
+      |> maybe_link_author()
       |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
     socket =
@@ -138,11 +137,10 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
      |> refresh_chips()}
   end
 
-  def handle_event("submit", %{"person" => person_params} = params, socket) do
+  def handle_event("submit", %{"person" => person_params}, socket) do
     person_params =
       person_params
-      |> apply_typed_names(params["resolver"], socket.assigns.person)
-      |> normalize_author_rows(socket.assigns.person)
+      |> maybe_link_author()
       |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
     socket =
@@ -361,8 +359,28 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   Either because the operator asked, or because the data says something the
   checkbox alone cannot.
   """
-  def revealed?(assigns, :author), do: :author in assigns.reveal or assigns.author_diverges
-  def revealed?(assigns, :narrator), do: :narrator in assigns.reveal or assigns.narrator_diverges
+  def revealed?(assigns, kind), do: kind in assigns.reveal
+
+  # Seeded once, from the record as it was opened — never re-derived from the
+  # changeset. Deriving it per render meant the hatch was computed from the
+  # very field the operator was typing in: renaming the pen name "Bar" to
+  # "Alastair Reynolds" made it stop differing from his name, so the card
+  # collapsed mid-edit, stopped rendering the rows, and dropped the rename on
+  # the floor. A disclosure may not close itself because of what was just
+  # typed into it.
+  defp seed_reveal(%Person{} = person) do
+    Enum.reduce(
+      [
+        {:author, Enum.any?(loaded(person.author_people), &author_diverges?(&1, person.name))},
+        {:narrator, Enum.any?(loaded(person.narrators), &(&1.name != person.name))}
+      ],
+      MapSet.new(),
+      fn
+        {kind, true}, reveal -> MapSet.put(reveal, kind)
+        {_kind, false}, reveal -> reveal
+      end
+    )
+  end
 
   # Unticking collapses the hatch with it — a revealed list under an
   # unchecked box describes credits that no longer exist.
@@ -485,130 +503,50 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   defp loaded(rows) when is_list(rows), do: rows
   defp loaded(_not_loaded), do: []
 
-  # What is in the box right now, which is the only fresh thing in a change
-  # event mid-typing.
-  #
-  # The resolver keeps its answer in two hidden inputs and re-renders them
-  # after its own `filter` round trip — but the parent form's `validate`
-  # fires on the same keystroke, *before* that, carrying the hidden inputs'
-  # previous values. The parent then re-renders the component from its
-  # changeset, which puts the old name back in the box the operator is
-  # typing into. Renaming "Baz" to "David Wong" therefore posted
-  # `author_id=5, name="Baz"` and saved "successfully" having changed
-  # nothing at all.
-  #
-  # The visible box is published under `resolver[<id>]` on every keystroke,
-  # so that is what a rename is read from. A *pick* is told apart by its id:
-  # the resolver sets one, and it differs from the row's own.
-  defp apply_typed_names(params, resolver, person) when is_map(resolver) do
-    case params["author_people"] do
-      rows when is_map(rows) ->
-        current = Map.new(loaded(person.author_people), &{to_string(&1.id), &1})
+  # Selecting an author in the "link an existing author" autocomplete stages an
+  # `author_people` row linking that author (unless it's already present).
+  defp maybe_link_author(%{"link_author_id" => id} = person_params) when id not in [nil, ""] do
+    author_people = person_params["author_people"] || %{}
 
-        Map.put(
-          params,
-          "author_people",
-          Map.new(rows, fn {index, row} ->
-            {index, apply_typed_name(row, resolver["author-#{index}-resolver"], current)}
-          end)
-        )
+    linked_ids =
+      author_people
+      |> Map.values()
+      |> Enum.flat_map(&[&1["author_id"], get_in(&1, ["author", "id"])])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&to_string/1)
 
-      _absent ->
-        params
+    person_params = Map.put(person_params, "link_author_id", "")
+
+    if to_string(id) in linked_ids do
+      person_params
+    else
+      next_index =
+        author_people
+        |> Map.keys()
+        |> Enum.map(&String.to_integer/1)
+        |> Enum.max(fn -> -1 end)
+        |> Kernel.+(1)
+        |> to_string()
+
+      sort = person_params["author_people_sort"] || []
+
+      person_params
+      |> Map.put("author_people", Map.put(author_people, next_index, %{"author_id" => id}))
+      |> Map.put("author_people_sort", sort ++ [next_index])
     end
   end
 
-  defp apply_typed_names(params, _resolver, _person), do: params
+  defp maybe_link_author(person_params), do: person_params
 
-  defp apply_typed_name(row, typed, current) do
-    original = existing_author(current, row["id"])
-
-    cond do
-      picked?(row, original) -> row
-      typed in [nil, ""] -> row
-      original && typed == original.name -> row
-      true -> row |> Map.delete("author_id") |> put_author_name(typed)
-    end
+  defp linked_author_row?(author_person_form) do
+    is_nil(author_person_form.data.id) and
+      author_person_form[:author_id].value not in [nil, ""]
   end
 
-  # An id the row did not already have is the operator choosing from the
-  # list; the row's own id, still sitting in a hidden input the component
-  # has not caught up with yet, is not.
-  defp picked?(%{"author_id" => id}, nil) when id not in [nil, ""], do: true
-
-  defp picked?(%{"author_id" => id}, %Author{id: original}) when id not in [nil, ""],
-    do: to_string(id) != to_string(original)
-
-  defp picked?(_row, _original), do: false
-
-  defp put_author_name(row, name) do
-    Map.update(row, "author", %{"name" => name}, &Map.put(&1, "name", name))
-  end
-
-  # Each pen-name row is one typeahead, so a row means one of two things and
-  # the params have to say which.
-  #
-  # The resolver clears its id the moment you type, so a row carrying an id
-  # was *picked* and a row carrying only text was *typed*. What they mean
-  # differs for a row that already exists:
-  #
-  #   * picked — link this row to that author instead. The one it pointed at
-  #     is cleaned up by `delete_orphaned_authors/2` if nothing else wants
-  #     it, which is what makes relinking safe.
-  #   * typed — rename the author this row already points at. Emitting the
-  #     name without its id would read as "replace this author with a new
-  #     one", and `AuthorPerson` casts `:author` with `on_replace: :raise`,
-  #     so it raises rather than renaming.
-  #
-  # Both halves are also mutually exclusive on the way in: `cast_assoc` and
-  # a changed `author_id` in the same row is the same replace, by a longer
-  # route.
-  defp normalize_author_rows(params, person) do
-    case params["author_people"] do
-      rows when is_map(rows) ->
-        current = Map.new(loaded(person.author_people), &{to_string(&1.id), &1})
-        Map.put(params, "author_people", Map.new(rows, &normalize_row(&1, current)))
-
-      _absent ->
-        params
-    end
-  end
-
-  defp normalize_row({index, row}, current) do
-    author = existing_author(current, row["id"])
-
-    normalized =
-      cond do
-        # The same test `apply_typed_names/3` uses, and it has to be: reading
-        # a stale id as a pick is what threw the typed name away.
-        picked?(row, author) -> Map.delete(row, "author")
-        author -> row |> Map.delete("author_id") |> put_author_id(author.id)
-        true -> Map.delete(row, "author_id")
-      end
-
-    {index, normalized}
-  end
-
-  defp existing_author(current, id) do
-    case current[to_string(id)] do
-      %{author: %Author{} = author} -> author
-      _none -> nil
-    end
-  end
-
-  defp put_author_id(row, id) do
-    Map.update(row, "author", %{"id" => to_string(id)}, &Map.put(&1, "id", to_string(id)))
-  end
-
-  # What the row's box shows. The nested author's name where the row has
-  # one; falling back to the linked author's own, for a row that links to
-  # somebody the operator picked and has not typed over.
-  defp author_row_name(author_person_form) do
-    case author_person_form[:author].value do
-      %Author{name: name} when is_binary(name) -> name
-      %Changeset{} = changeset -> Changeset.get_field(changeset, :name)
-      _none -> nil
-    end
+  defp linked_author_name(authors, value) do
+    Enum.find_value(authors, fn option ->
+      to_string(option.id) == to_string(value) && option.label
+    end)
   end
 
   defp shared_with(author_person_form, person) do

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -56,6 +56,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   alias Ambry.People.Person
   alias AmbryWeb.Admin.Evidence
   alias AmbryWeb.Admin.ProvenanceHints
+  alias AmbryWeb.Components.EntityResolver
   alias Ecto.Changeset
 
   @scalar_kinds %{"name" => :name, "description" => :description, "image" => :image}
@@ -112,7 +113,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
     person_params =
       person_params
-      |> maybe_link_author()
+      |> normalize_author_rows(socket.assigns.person)
       |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
     socket =
@@ -139,7 +140,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   def handle_event("submit", %{"person" => person_params}, socket) do
     person_params =
       person_params
-      |> maybe_link_author()
+      |> normalize_author_rows(socket.assigns.person)
       |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
     socket =
@@ -482,50 +483,68 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   defp loaded(rows) when is_list(rows), do: rows
   defp loaded(_not_loaded), do: []
 
-  # Selecting an author in the "link an existing author" autocomplete stages an
-  # `author_people` row linking that author (unless it's already present).
-  defp maybe_link_author(%{"link_author_id" => id} = person_params) when id not in [nil, ""] do
-    author_people = person_params["author_people"] || %{}
+  # Each pen-name row is one typeahead, so a row means one of two things and
+  # the params have to say which.
+  #
+  # The resolver clears its id the moment you type, so a row carrying an id
+  # was *picked* and a row carrying only text was *typed*. What they mean
+  # differs for a row that already exists:
+  #
+  #   * picked — link this row to that author instead. The one it pointed at
+  #     is cleaned up by `delete_orphaned_authors/2` if nothing else wants
+  #     it, which is what makes relinking safe.
+  #   * typed — rename the author this row already points at. Emitting the
+  #     name without its id would read as "replace this author with a new
+  #     one", and `AuthorPerson` casts `:author` with `on_replace: :raise`,
+  #     so it raises rather than renaming.
+  #
+  # Both halves are also mutually exclusive on the way in: `cast_assoc` and
+  # a changed `author_id` in the same row is the same replace, by a longer
+  # route.
+  defp normalize_author_rows(params, person) do
+    case params["author_people"] do
+      rows when is_map(rows) ->
+        current = Map.new(loaded(person.author_people), &{to_string(&1.id), &1})
+        Map.put(params, "author_people", Map.new(rows, &normalize_row(&1, current)))
 
-    linked_ids =
-      author_people
-      |> Map.values()
-      |> Enum.flat_map(&[&1["author_id"], get_in(&1, ["author", "id"])])
-      |> Enum.reject(&is_nil/1)
-      |> Enum.map(&to_string/1)
-
-    person_params = Map.put(person_params, "link_author_id", "")
-
-    if to_string(id) in linked_ids do
-      person_params
-    else
-      next_index =
-        author_people
-        |> Map.keys()
-        |> Enum.map(&String.to_integer/1)
-        |> Enum.max(fn -> -1 end)
-        |> Kernel.+(1)
-        |> to_string()
-
-      sort = person_params["author_people_sort"] || []
-
-      person_params
-      |> Map.put("author_people", Map.put(author_people, next_index, %{"author_id" => id}))
-      |> Map.put("author_people_sort", sort ++ [next_index])
+      _absent ->
+        params
     end
   end
 
-  defp maybe_link_author(person_params), do: person_params
+  defp normalize_row({index, row}, current) do
+    author = existing_author(current, row["id"])
 
-  defp linked_author_row?(author_person_form) do
-    is_nil(author_person_form.data.id) and
-      author_person_form[:author_id].value not in [nil, ""]
+    normalized =
+      cond do
+        row["author_id"] not in [nil, ""] -> Map.delete(row, "author")
+        author -> row |> Map.delete("author_id") |> put_author_id(author.id)
+        true -> Map.delete(row, "author_id")
+      end
+
+    {index, normalized}
   end
 
-  defp linked_author_name(authors, value) do
-    Enum.find_value(authors, fn option ->
-      to_string(option.id) == to_string(value) && option.label
-    end)
+  defp existing_author(current, id) do
+    case current[to_string(id)] do
+      %{author: %Author{} = author} -> author
+      _none -> nil
+    end
+  end
+
+  defp put_author_id(row, id) do
+    Map.update(row, "author", %{"id" => to_string(id)}, &Map.put(&1, "id", to_string(id)))
+  end
+
+  # What the row's box shows. The nested author's name where the row has
+  # one; falling back to the linked author's own, for a row that links to
+  # somebody the operator picked and has not typed over.
+  defp author_row_name(author_person_form) do
+    case author_person_form[:author].value do
+      %Author{name: name} when is_binary(name) -> name
+      %Changeset{} = changeset -> Changeset.get_field(changeset, :name)
+      _none -> nil
+    end
   end
 
   defp shared_with(author_person_form, person) do

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -108,11 +108,12 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   def handle_params(_params, _url, socket), do: {:noreply, socket}
 
   @impl Phoenix.LiveView
-  def handle_event("validate", %{"person" => person_params}, socket) do
+  def handle_event("validate", %{"person" => person_params} = params, socket) do
     socket = assign(socket, reveal: reveal_after(socket.assigns.reveal, person_params))
 
     person_params =
       person_params
+      |> apply_typed_names(params["resolver"], socket.assigns.person)
       |> normalize_author_rows(socket.assigns.person)
       |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
@@ -137,9 +138,10 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
      |> refresh_chips()}
   end
 
-  def handle_event("submit", %{"person" => person_params}, socket) do
+  def handle_event("submit", %{"person" => person_params} = params, socket) do
     person_params =
       person_params
+      |> apply_typed_names(params["resolver"], socket.assigns.person)
       |> normalize_author_rows(socket.assigns.person)
       |> apply_credits(socket.assigns.person, socket.assigns.reveal)
 
@@ -483,6 +485,66 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   defp loaded(rows) when is_list(rows), do: rows
   defp loaded(_not_loaded), do: []
 
+  # What is in the box right now, which is the only fresh thing in a change
+  # event mid-typing.
+  #
+  # The resolver keeps its answer in two hidden inputs and re-renders them
+  # after its own `filter` round trip — but the parent form's `validate`
+  # fires on the same keystroke, *before* that, carrying the hidden inputs'
+  # previous values. The parent then re-renders the component from its
+  # changeset, which puts the old name back in the box the operator is
+  # typing into. Renaming "Baz" to "David Wong" therefore posted
+  # `author_id=5, name="Baz"` and saved "successfully" having changed
+  # nothing at all.
+  #
+  # The visible box is published under `resolver[<id>]` on every keystroke,
+  # so that is what a rename is read from. A *pick* is told apart by its id:
+  # the resolver sets one, and it differs from the row's own.
+  defp apply_typed_names(params, resolver, person) when is_map(resolver) do
+    case params["author_people"] do
+      rows when is_map(rows) ->
+        current = Map.new(loaded(person.author_people), &{to_string(&1.id), &1})
+
+        Map.put(
+          params,
+          "author_people",
+          Map.new(rows, fn {index, row} ->
+            {index, apply_typed_name(row, resolver["author-#{index}-resolver"], current)}
+          end)
+        )
+
+      _absent ->
+        params
+    end
+  end
+
+  defp apply_typed_names(params, _resolver, _person), do: params
+
+  defp apply_typed_name(row, typed, current) do
+    original = existing_author(current, row["id"])
+
+    cond do
+      picked?(row, original) -> row
+      typed in [nil, ""] -> row
+      original && typed == original.name -> row
+      true -> row |> Map.delete("author_id") |> put_author_name(typed)
+    end
+  end
+
+  # An id the row did not already have is the operator choosing from the
+  # list; the row's own id, still sitting in a hidden input the component
+  # has not caught up with yet, is not.
+  defp picked?(%{"author_id" => id}, nil) when id not in [nil, ""], do: true
+
+  defp picked?(%{"author_id" => id}, %Author{id: original}) when id not in [nil, ""],
+    do: to_string(id) != to_string(original)
+
+  defp picked?(_row, _original), do: false
+
+  defp put_author_name(row, name) do
+    Map.update(row, "author", %{"name" => name}, &Map.put(&1, "name", name))
+  end
+
   # Each pen-name row is one typeahead, so a row means one of two things and
   # the params have to say which.
   #
@@ -517,7 +579,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
 
     normalized =
       cond do
-        row["author_id"] not in [nil, ""] -> Map.delete(row, "author")
+        # The same test `apply_typed_names/3` uses, and it has to be: reading
+        # a stale id as a pick is what threw the typed name away.
+        picked?(row, author) -> Map.delete(row, "author")
         author -> row |> Map.delete("author_id") |> put_author_id(author.id)
         true -> Map.delete(row, "author_id")
       end

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -6,7 +6,7 @@
     <.evidence_panel
       evidence={@evidence}
       level="person"
-      title="Records of this person"
+      title="Search providers"
       hint="Tick every record of this person; check the name carefully first. Ticked records offer names, photos and bios below."
       retrying={@retrying}
     />

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -88,46 +88,73 @@
             <%!-- Revealed: the names themselves, which is the only state
                 where linking an existing author means anything specific. --%>
             <div :if={revealed?(assigns, :author)} class="space-y-2 pl-6">
-              <%!-- One control per row: type a name and it is created (or
-                  this row's author renamed), pick one and the row links to
-                  it instead. Two controls for one decision — a name box in
-                  the card and "or link an existing author" under it — is
-                  what made this cluster read as two unrelated things. --%>
               <.inputs_for :let={author_person_form} field={@form[:author_people]}>
                 <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
 
-                <div class="flex items-center gap-2">
-                  <.live_component
-                    module={EntityResolver}
-                    id={"author-#{author_person_form.index}-resolver"}
-                    name={author_person_form[:author_id].name}
-                    text_name={author_person_form[:author].name <> "[name]"}
-                    options={@authors}
-                    value={author_person_form[:author_id].value}
-                    text={author_row_name(author_person_form)}
-                    placeholder="the name books are credited to"
-                    class={input_classes("w-full")}
-                  />
-
-                  <.delete_button
-                    field={@form[:author_people_drop]}
-                    index={author_person_form.index}
-                    class="flex-none"
-                  />
-                </div>
-
-                <p
-                  :if={shared_with(author_person_form, @person) != []}
-                  class="pl-3 text-xs text-zinc-500"
-                >
-                  Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
-                </p>
+                <%= if linked_author_row?(author_person_form) do %>
+                  <div class="relative">
+                    <.input type="hidden" field={author_person_form[:author_id]} />
+                    <.input
+                      type="text"
+                      name={"linked-author-#{author_person_form.index}"}
+                      value={linked_author_name(@authors, author_person_form[:author_id].value)}
+                      disabled
+                    />
+                    <.delete_button
+                      field={@form[:author_people_drop]}
+                      index={author_person_form.index}
+                      class="absolute top-3 right-2"
+                    />
+                  </div>
+                <% else %>
+                  <.inputs_for :let={author_form} field={author_person_form[:author]}>
+                    <div class="relative">
+                      <.input field={author_form[:name]} />
+                      <.delete_button
+                        field={@form[:author_people_drop]}
+                        index={author_person_form.index}
+                        class="absolute top-3 right-2"
+                      />
+                    </div>
+                    <p
+                      :if={shared_with(author_person_form, @person) != []}
+                      class="pl-3 text-xs text-zinc-500"
+                    >
+                      Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
+                    </p>
+                  </.inputs_for>
+                <% end %>
               </.inputs_for>
 
-              <div class="flex flex-wrap items-baseline gap-x-4">
-                <.add_button field={@form[:author_people_sort]}>Add a pen name</.add_button>
-                <.delete_input field={@form[:author_people_drop]} />
+              <%!-- Two ways to add a name, side by side and each saying which
+                  it is. The boxes above are authoritative — this form is
+                  where an author's name is *decided*, so typing in one
+                  renames the record and nothing about that is a guess. The
+                  picker below only ever links a name that already exists,
+                  which is the composite case and nothing else.
 
+                  They were one control for a while, a typeahead where typing
+                  created and picking linked. It could not work: a rename and
+                  a create are the same gesture in a picker, so renaming
+                  wore the "new" badge while quietly renaming, and the two
+                  meanings fought over the same hidden inputs on every
+                  keystroke. Separate controls, separate promises. --%>
+              <div class="flex flex-wrap items-end gap-x-4 gap-y-2">
+                <div class="flex items-baseline gap-x-4">
+                  <.add_button field={@form[:author_people_sort]}>Add a pen name</.add_button>
+                  <.delete_input field={@form[:author_people_drop]} />
+                </div>
+
+                <.input
+                  field={@form[:link_author_id]}
+                  type="autocomplete"
+                  options={@authors}
+                  label="Or link one that already exists"
+                  container_class="min-w-64 grow"
+                />
+              </div>
+
+              <div class="flex flex-wrap items-baseline gap-x-4">
                 <%!-- Every way in needs a way out — but only while the data
                     still agrees, or the hatch would hide what it describes. --%>
                 <button

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -54,75 +54,183 @@
         />
       </.field_group>
 
-      <%!-- One human, two working names — the credits they appear under are
-          a different question from who they are, so they get their own
-          clusters side by side. --%>
-      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-7">
-        <.list_cluster label="Writing as">
-          <.inputs_for :let={author_person_form} field={@form[:author_people]}>
-            <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
+      <%!-- Author and Narrator are credit NAMES, not roles, and the form used
+          to say so out loud: two lists to populate, where having just typed
+          "Stephen King" you were asked to add an author and the answer was
+          "Stephen King". Two questions instead, answered by a tick, with the
+          name stated rather than typed. "Both" is two ticks, not a case. --%>
+      <.field_group label="Credited as">
+        <%!-- Unticking can be refused — `delete_orphaned_authors/2` names the
+            book still crediting them — and with the list hidden there was
+            nowhere for that to land: the save simply didn't happen and said
+            nothing. --%>
+        <.field_errors field={@form[:author_people]} />
+        <.field_errors field={@form[:narrators]} />
 
-            <%= if linked_author_row?(author_person_form) do %>
-              <div class="relative">
-                <.input type="hidden" field={author_person_form[:author_id]} />
-                <.input
-                  type="text"
-                  name={"linked-author-#{author_person_form.index}"}
-                  value={linked_author_name(@authors, author_person_form[:author_id].value)}
-                  disabled
-                />
-                <.delete_button
-                  field={@form[:author_people_drop]}
-                  index={author_person_form.index}
-                  class="absolute top-3 right-2"
-                />
+        <div class="space-y-4">
+          <%!-- ── writes ─────────────────────────────────────────────── --%>
+          <div class="space-y-2">
+            <label class="flex items-center gap-2 pl-3">
+              <input type="hidden" name="person[writes]" value="false" />
+              <input
+                type="checkbox"
+                name="person[writes]"
+                value="true"
+                checked={@writes}
+                class="text-brand-dark h-4 w-4 rounded-sm border-transparent bg-zinc-800 focus:ring-brand-dark/20 focus:ring-4"
+              />
+              <span class="text-sm text-zinc-200">Writes books</span>
+              <span :if={@writes and not revealed?(assigns, :author)} class="text-sm text-zinc-400">
+                as {@form[:name].value}
+              </span>
+            </label>
+
+            <%!-- Revealed: the names themselves, which is the only state
+                where linking an existing author means anything specific. --%>
+            <div :if={revealed?(assigns, :author)} class="space-y-2 pl-6">
+              <.inputs_for :let={author_person_form} field={@form[:author_people]}>
+                <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
+
+                <%= if linked_author_row?(author_person_form) do %>
+                  <div class="relative">
+                    <.input type="hidden" field={author_person_form[:author_id]} />
+                    <.input
+                      type="text"
+                      name={"linked-author-#{author_person_form.index}"}
+                      value={linked_author_name(@authors, author_person_form[:author_id].value)}
+                      disabled
+                    />
+                    <.delete_button
+                      field={@form[:author_people_drop]}
+                      index={author_person_form.index}
+                      class="absolute top-3 right-2"
+                    />
+                  </div>
+                <% else %>
+                  <.inputs_for :let={author_form} field={author_person_form[:author]}>
+                    <div class="relative">
+                      <.input field={author_form[:name]} />
+                      <.delete_button
+                        field={@form[:author_people_drop]}
+                        index={author_person_form.index}
+                        class="absolute top-3 right-2"
+                      />
+                    </div>
+                    <p
+                      :if={shared_with(author_person_form, @person) != []}
+                      class="pl-3 text-xs text-zinc-500"
+                    >
+                      Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
+                    </p>
+                  </.inputs_for>
+                <% end %>
+              </.inputs_for>
+
+              <.input
+                field={@form[:link_author_id]}
+                type="autocomplete"
+                options={@authors}
+                label="Link a pen name somebody else also writes under"
+              />
+
+              <div class="flex flex-wrap items-baseline gap-x-4">
+                <.add_button field={@form[:author_people_sort]}>Add a pen name</.add_button>
+                <.delete_input field={@form[:author_people_drop]} />
+
+                <%!-- Every way in needs a way out — but only while the data
+                    still agrees, or the hatch would hide what it describes. --%>
+                <button
+                  :if={not @author_diverges}
+                  type="button"
+                  phx-click="hide-credit"
+                  phx-value-kind="author"
+                  class="text-xs text-zinc-400 underline"
+                >
+                  No, they write under their own name
+                </button>
               </div>
-            <% else %>
-              <.inputs_for :let={author_form} field={author_person_form[:author]}>
+            </div>
+
+            <%!-- Offered whether or not the box is ticked: linking a
+                shared pen name is how a person becomes an author at all in
+                the composite case, and routing that through "tick, then
+                delete the author it made" is not a route. --%>
+            <button
+              :if={not revealed?(assigns, :author)}
+              type="button"
+              phx-click="reveal-credit"
+              phx-value-kind="author"
+              class="pl-6 text-xs text-zinc-400 underline"
+            >
+              Writes under a pen name?
+            </button>
+          </div>
+
+          <%!-- ── narrates ───────────────────────────────────────────── --%>
+          <%!-- No linking hatch: a Narrator belongs to exactly one Person,
+              so there is no shared-narrator case to offer. The asymmetry is
+              the model's, and stating it beats faking symmetry. --%>
+          <div class="space-y-2">
+            <label class="flex items-center gap-2 pl-3">
+              <input type="hidden" name="person[narrates]" value="false" />
+              <input
+                type="checkbox"
+                name="person[narrates]"
+                value="true"
+                checked={@narrates}
+                class="text-brand-dark h-4 w-4 rounded-sm border-transparent bg-zinc-800 focus:ring-brand-dark/20 focus:ring-4"
+              />
+              <span class="text-sm text-zinc-200">Narrates audiobooks</span>
+              <span
+                :if={@narrates and not revealed?(assigns, :narrator)}
+                class="text-sm text-zinc-400"
+              >
+                as {@form[:name].value}
+              </span>
+            </label>
+
+            <div :if={revealed?(assigns, :narrator)} class="space-y-2 pl-6">
+              <.inputs_for :let={narrator_form} field={@form[:narrators]}>
+                <.sort_input field={@form[:narrators_sort]} index={narrator_form.index} />
+
                 <div class="relative">
-                  <.input field={author_form[:name]} />
+                  <.input field={narrator_form[:name]} container_class="grow" />
                   <.delete_button
-                    field={@form[:author_people_drop]}
-                    index={author_person_form.index}
+                    field={@form[:narrators_drop]}
+                    index={narrator_form.index}
                     class="absolute top-3 right-2"
                   />
                 </div>
-                <p :if={shared_with(author_person_form, @person) != []} class="pl-3 text-xs text-zinc-500">
-                  Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
-                </p>
               </.inputs_for>
-            <% end %>
-          </.inputs_for>
 
-          <.input
-            field={@form[:link_author_id]}
-            type="autocomplete"
-            options={@authors}
-            label="Or link an existing author"
-          />
+              <div class="flex flex-wrap items-baseline gap-x-4">
+                <.add_button field={@form[:narrators_sort]}>Add a stage name</.add_button>
+                <.delete_input field={@form[:narrators_drop]} />
 
-          <:add>
-            <.add_button field={@form[:author_people_sort]}>Add author</.add_button>
-            <.delete_input field={@form[:author_people_drop]} />
-          </:add>
-        </.list_cluster>
-
-        <.list_cluster label="Narrating as">
-          <.inputs_for :let={narrator_form} field={@form[:narrators]}>
-            <.sort_input field={@form[:narrators_sort]} index={narrator_form.index} />
-
-            <div class="relative">
-              <.input field={narrator_form[:name]} container_class="grow" />
-              <.delete_button field={@form[:narrators_drop]} index={narrator_form.index} class="absolute top-3 right-2" />
+                <button
+                  :if={not @narrator_diverges}
+                  type="button"
+                  phx-click="hide-credit"
+                  phx-value-kind="narrator"
+                  class="text-xs text-zinc-400 underline"
+                >
+                  No, they narrate under their own name
+                </button>
+              </div>
             </div>
-          </.inputs_for>
 
-          <:add>
-            <.add_button field={@form[:narrators_sort]}>Add narrator</.add_button>
-            <.delete_input field={@form[:narrators_drop]} />
-          </:add>
-        </.list_cluster>
-      </div>
+            <button
+              :if={not revealed?(assigns, :narrator)}
+              type="button"
+              phx-click="reveal-credit"
+              phx-value-kind="narrator"
+              class="pl-6 text-xs text-zinc-400 underline"
+            >
+              Narrates under a stage name?
+            </button>
+          </div>
+        </div>
+      </.field_group>
 
       <.input type="hidden" field={@form[:image_type]} />
       <.input type="hidden" field={@form[:image_path]} />

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -88,50 +88,41 @@
             <%!-- Revealed: the names themselves, which is the only state
                 where linking an existing author means anything specific. --%>
             <div :if={revealed?(assigns, :author)} class="space-y-2 pl-6">
+              <%!-- One control per row: type a name and it is created (or
+                  this row's author renamed), pick one and the row links to
+                  it instead. Two controls for one decision — a name box in
+                  the card and "or link an existing author" under it — is
+                  what made this cluster read as two unrelated things. --%>
               <.inputs_for :let={author_person_form} field={@form[:author_people]}>
                 <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
 
-                <%= if linked_author_row?(author_person_form) do %>
-                  <div class="relative">
-                    <.input type="hidden" field={author_person_form[:author_id]} />
-                    <.input
-                      type="text"
-                      name={"linked-author-#{author_person_form.index}"}
-                      value={linked_author_name(@authors, author_person_form[:author_id].value)}
-                      disabled
-                    />
-                    <.delete_button
-                      field={@form[:author_people_drop]}
-                      index={author_person_form.index}
-                      class="absolute top-3 right-2"
-                    />
-                  </div>
-                <% else %>
-                  <.inputs_for :let={author_form} field={author_person_form[:author]}>
-                    <div class="relative">
-                      <.input field={author_form[:name]} />
-                      <.delete_button
-                        field={@form[:author_people_drop]}
-                        index={author_person_form.index}
-                        class="absolute top-3 right-2"
-                      />
-                    </div>
-                    <p
-                      :if={shared_with(author_person_form, @person) != []}
-                      class="pl-3 text-xs text-zinc-500"
-                    >
-                      Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
-                    </p>
-                  </.inputs_for>
-                <% end %>
-              </.inputs_for>
+                <div class="flex items-center gap-2">
+                  <.live_component
+                    module={EntityResolver}
+                    id={"author-#{author_person_form.index}-resolver"}
+                    name={author_person_form[:author_id].name}
+                    text_name={author_person_form[:author].name <> "[name]"}
+                    options={@authors}
+                    value={author_person_form[:author_id].value}
+                    text={author_row_name(author_person_form)}
+                    placeholder="the name books are credited to"
+                    class={input_classes("w-full")}
+                  />
 
-              <.input
-                field={@form[:link_author_id]}
-                type="autocomplete"
-                options={@authors}
-                label="Link a pen name somebody else also writes under"
-              />
+                  <.delete_button
+                    field={@form[:author_people_drop]}
+                    index={author_person_form.index}
+                    class="flex-none"
+                  />
+                </div>
+
+                <p
+                  :if={shared_with(author_person_form, @person) != []}
+                  class="pl-3 text-xs text-zinc-500"
+                >
+                  Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
+                </p>
+              </.inputs_for>
 
               <div class="flex flex-wrap items-baseline gap-x-4">
                 <.add_button field={@form[:author_people_sort]}>Add a pen name</.add_button>

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -70,21 +70,54 @@
         <div class="space-y-4">
           <%!-- ── writes ─────────────────────────────────────────────── --%>
           <div class="space-y-2">
-            <label class="flex items-center gap-2 pl-3">
-              <input type="hidden" name="person[writes]" value="false" />
-              <input
-                type="checkbox"
-                name="person[writes]"
-                value="true"
-                checked={@writes}
-                class="text-brand-dark h-4 w-4 rounded-sm border-transparent bg-zinc-800 focus:ring-brand-dark/20 focus:ring-4"
-              />
-              <span class="text-sm text-zinc-200">Writes books</span>
-              <span :if={@writes and not revealed?(assigns, :author)} class="text-sm text-zinc-400">
-                as {@form[:name].value}
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={to_string(@writes)}
+              phx-click="toggle-credit"
+              phx-value-kind="author"
+              class="flex items-center gap-2 pl-3"
+            >
+              <span class={[
+                "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
+                (@writes && "bg-brand-dark") || "bg-zinc-800"
+              ]}>
+                <.icon :if={@writes} name="fa-check" class="h-2.5 w-2.5 text-zinc-900" />
               </span>
-            </label>
+              <%!-- The label absorbs the "as": revealed, the names below it
+                  are what it is credited as, so the line reads into them
+                  rather than repeating the person's name beside the box. --%>
+              <span class="text-sm text-zinc-200">
+                Writes books{if revealed?(assigns, :author), do: " as"}
+              </span>
+            </button>
 
+            <%!-- Collapsed, the credits still ride along. A card that renders
+                nothing says nothing, and "said nothing" is indistinguishable
+                from "deleted them all" by the time the params arrive — so
+                ticking the box and pressing Save created no author at all.
+                Collapsed also means every credit here is their own name
+                (a pen name or a shared one forces the card open), which is
+                why the name can simply track the box above. --%>
+            <div :if={not revealed?(assigns, :author)} class="hidden">
+              <.inputs_for :let={author_person_form} field={@form[:author_people]}>
+                <input
+                  :if={author_person_form[:id].value}
+                  type="hidden"
+                  name={author_person_form[:id].name}
+                  value={author_person_form[:id].value}
+                />
+                <.inputs_for :let={author_form} field={author_person_form[:author]}>
+                  <input
+                    :if={author_form[:id].value}
+                    type="hidden"
+                    name={author_form[:id].name}
+                    value={author_form[:id].value}
+                  />
+                  <input type="hidden" name={author_form[:name].name} value={@form[:name].value} />
+                </.inputs_for>
+              </.inputs_for>
+            </div>
             <%!-- Revealed: the names themselves, which is the only state
                 where linking an existing author means anything specific. --%>
             <div :if={revealed?(assigns, :author)} class="space-y-2 pl-6">
@@ -189,24 +222,36 @@
               so there is no shared-narrator case to offer. The asymmetry is
               the model's, and stating it beats faking symmetry. --%>
           <div class="space-y-2">
-            <label class="flex items-center gap-2 pl-3">
-              <input type="hidden" name="person[narrates]" value="false" />
-              <input
-                type="checkbox"
-                name="person[narrates]"
-                value="true"
-                checked={@narrates}
-                class="text-brand-dark h-4 w-4 rounded-sm border-transparent bg-zinc-800 focus:ring-brand-dark/20 focus:ring-4"
-              />
-              <span class="text-sm text-zinc-200">Narrates audiobooks</span>
-              <span
-                :if={@narrates and not revealed?(assigns, :narrator)}
-                class="text-sm text-zinc-400"
-              >
-                as {@form[:name].value}
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={to_string(@narrates)}
+              phx-click="toggle-credit"
+              phx-value-kind="narrator"
+              class="flex items-center gap-2 pl-3"
+            >
+              <span class={[
+                "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
+                (@narrates && "bg-brand-dark") || "bg-zinc-800"
+              ]}>
+                <.icon :if={@narrates} name="fa-check" class="h-2.5 w-2.5 text-zinc-900" />
               </span>
-            </label>
+              <span class="text-sm text-zinc-200">
+                Narrates audiobooks{if revealed?(assigns, :narrator), do: " as"}
+              </span>
+            </button>
 
+            <div :if={not revealed?(assigns, :narrator)} class="hidden">
+              <.inputs_for :let={narrator_form} field={@form[:narrators]}>
+                <input
+                  :if={narrator_form[:id].value}
+                  type="hidden"
+                  name={narrator_form[:id].name}
+                  value={narrator_form[:id].value}
+                />
+                <input type="hidden" name={narrator_form[:name].name} value={@form[:name].value} />
+              </.inputs_for>
+            </div>
             <div :if={revealed?(assigns, :narrator)} class="space-y-2 pl-6">
               <.inputs_for :let={narrator_form} field={@form[:narrators]}>
                 <.sort_input field={@form[:narrators_sort]} index={narrator_form.index} />

--- a/test/ambry/images_test.exs
+++ b/test/ambry/images_test.exs
@@ -36,3 +36,70 @@ defmodule Ambry.ImagesTest do
     end
   end
 end
+
+defmodule Ambry.ImagesImportTest do
+  use ExUnit.Case, async: false
+  use Patch
+
+  alias Ambry.Images
+  alias Ambry.Paths
+
+  describe "import_url/1" do
+    # The download used to accept only an allowlisted `content-type` header,
+    # and Hardcover labels every asset `application/octet-stream` — so a photo
+    # the person picker offered failed to import, quietly.
+    test "imports an image the server labels application/octet-stream" do
+      png = encoded(".png")
+      stub_get("application/octet-stream", png)
+
+      assert {:ok, "/uploads/images/" <> filename} =
+               Images.import_url("https://assets.hardcover.app/author/1/x.png")
+
+      on_exit(fn -> File.rm(Paths.images_disk_path(filename)) end)
+
+      assert Path.extname(filename) == ".png"
+      assert File.read!(Paths.images_disk_path(filename)) == png
+    end
+
+    # The bytes name the file, so a mislabeled download can't land under an
+    # extension that lies about its contents.
+    test "the extension comes from the bytes, not the header" do
+      jpeg = encoded(".jpg")
+      stub_get("image/png", jpeg)
+
+      assert {:ok, "/uploads/images/" <> filename} =
+               Images.import_url("https://example.com/author.png")
+
+      on_exit(fn -> File.rm(Paths.images_disk_path(filename)) end)
+
+      assert Path.extname(filename) == ".jpg"
+    end
+
+    test "bytes that are not an image are still a failed download" do
+      stub_get("image/png", "<html></html>")
+
+      assert {:error, :failed_to_download_image} =
+               Images.import_url("https://example.com/not-really.png")
+    end
+
+    test "a non-200 response is a failed download" do
+      patch(Req, :get, fn _opts -> {:ok, %Req.Response{status: 404, body: "Not Found"}} end)
+
+      assert {:error, :failed_to_download_image} =
+               Images.import_url("https://example.com/gone.png")
+    end
+
+    defp stub_get(content_type, body) do
+      patch(Req, :get, fn _opts ->
+        {:ok,
+         %Req.Response{status: 200, headers: %{"content-type" => [content_type]}, body: body}}
+      end)
+    end
+
+    defp encoded(suffix) do
+      {:ok, image} = Image.new(8, 8, color: :red)
+      {:ok, binary} = Image.write(image, :memory, suffix: suffix)
+      binary
+    end
+  end
+end

--- a/test/ambry_web/controllers/admin/image_proxy_controller_test.exs
+++ b/test/ambry_web/controllers/admin/image_proxy_controller_test.exs
@@ -27,7 +27,25 @@ defmodule AmbryWeb.Admin.ImageProxyControllerTest do
     assert get_resp_header(conn, "cache-control") == ["private, max-age=86400"]
   end
 
-  test "rejects non-image content types", %{conn: conn} do
+  # Hardcover's CDN serves every asset — author photos included — as
+  # `application/octet-stream`. Gating on the header 404'd a real PNG.
+  test "serves an image the upstream labels application/octet-stream", %{conn: conn} do
+    patch(Req, :get, fn _opts ->
+      {:ok,
+       %Req.Response{
+         status: 200,
+         headers: %{"content-type" => ["application/octet-stream"]},
+         body: @jpeg_bytes
+       }}
+    end)
+
+    conn = get(conn, ~p"/admin/image-proxy?url=https://assets.hardcover.app/author/1/x.png")
+
+    assert response(conn, 200) == @jpeg_bytes
+    assert response_content_type(conn, :jpeg) =~ "image/jpeg"
+  end
+
+  test "rejects bytes that are not an image", %{conn: conn} do
     patch(Req, :get, fn _opts ->
       {:ok,
        %Req.Response{
@@ -38,6 +56,23 @@ defmodule AmbryWeb.Admin.ImageProxyControllerTest do
     end)
 
     conn = get(conn, ~p"/admin/image-proxy?url=https://example.com/page")
+
+    assert response(conn, 404)
+  end
+
+  # The other direction: trusting the header let a page claiming to be an
+  # image be echoed back under an image content type.
+  test "rejects a page whose content type claims to be an image", %{conn: conn} do
+    patch(Req, :get, fn _opts ->
+      {:ok,
+       %Req.Response{
+         status: 200,
+         headers: %{"content-type" => ["image/png"]},
+         body: "<html></html>"
+       }}
+    end)
+
+    conn = get(conn, ~p"/admin/image-proxy?url=https://example.com/not-really.png")
 
     assert response(conn, 404)
   end

--- a/test/ambry_web/live/admin/inbox_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/chapters_test.exs
@@ -81,7 +81,7 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
          %{conn: conn} do
       item = chaptered_item()
 
-      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
       assert has_element?(view, "form#chapters-form")
       # two file-boundary rows, open by default because the list is short

--- a/test/ambry_web/live/admin/inbox_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/chapters_test.exs
@@ -83,7 +83,6 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
 
       {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "one per file"
       assert has_element?(view, "form#chapters-form")
       # two file-boundary rows, open by default because the list is short
       assert view

--- a/test/ambry_web/live/admin/inbox_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/chapters_test.exs
@@ -15,6 +15,8 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
   import Phoenix.LiveViewTest
 
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.InboxItem
   alias Ambry.Metadata.Provider
   alias Ambry.Repo
@@ -124,8 +126,10 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
       patch_audnexus()
       item = chaptered_item() |> with_recording_record()
 
-      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
-      refute html =~ "chapter-title-chips"
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      # the files' own list is always on offer; a record's titles are not,
+      # until its record is ticked
+      refute has_element?(view, "button[phx-click='fetch-chapter-titles']")
 
       # tick the record — the evidence panel is the search
       view
@@ -134,7 +138,7 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
 
       assert has_element?(view, "#chapter-title-chips")
 
-      view |> element("#chapter-title-chips button") |> render_click()
+      view |> element("button[phx-click='fetch-chapter-titles']") |> render_click()
       html = render_async(view)
       # the proposed titles render into the rows, and the counts match
       assert html =~ "The Dungeon Opens"
@@ -168,7 +172,7 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
       |> element("[phx-click='toggle-source'][phx-value-id='B08BKGYQXW']")
       |> render_click()
 
-      view |> element("#chapter-title-chips button") |> render_click()
+      view |> element("button[phx-click='fetch-chapter-titles']") |> render_click()
       html = render_async(view)
 
       assert html =~ "1 title for 2 markers"
@@ -202,6 +206,95 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
       chapters = Inbox.get_item!(item.id).draft.recording.chapters
       assert chapters.chapter_marker_source == :manual
       assert chapters.curated
+    end
+  end
+
+  # The card was the one decision in the tree wearing no rail and offering no
+  # way to agree with it: an operator who wanted exactly what the files carry
+  # could only reach `:reviewed` by editing a row, so agreeing cost a
+  # pointless edit and disagreeing was the only settled state.
+  describe "taking the files' own list" do
+    test "the card wears the decision rail", %{conn: conn} do
+      item = chaptered_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # seeded approved and untouched — the machine settled it, nobody looked
+      assert has_element?(view, "#chapters .border-blue-400\\/70")
+    end
+
+    test "the files are a chip, chosen while the rows still match them", %{conn: conn} do
+      item = chaptered_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert has_element?(view, "button[phx-click='take-file-chapters']")
+
+      assert view
+             |> element("button[phx-click='take-file-chapters']")
+             |> render() =~ "fa-check"
+    end
+
+    test "taking it settles the decision without touching a row", %{conn: conn} do
+      item = chaptered_item()
+      before = Inbox.get_item!(item.id).draft.recording.chapters
+      refute before.curated
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view |> element("button[phx-click='take-file-chapters']") |> render_click()
+
+      chapters = Inbox.get_item!(item.id).draft.recording.chapters
+      assert chapters.curated
+      assert Tier.of(chapters) == :reviewed
+      # the rows are the files' own, unchanged — this is agreement, not an edit
+      assert Enum.map(chapters.chapters, & &1.title) ==
+               Enum.map(before.chapters, & &1.title)
+
+      assert has_element?(view, "#chapters .border-brand-dark\\/60")
+    end
+
+    # Taking it after a merge is the way back to the machine's value that
+    # every other decision has.
+    test "it restores the files' titles after provider ones were poured on", %{conn: conn} do
+      patch_audnexus()
+      item = chaptered_item() |> with_recording_record()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("[phx-click='toggle-source'][phx-value-id='B08BKGYQXW']")
+      |> render_click()
+
+      view |> element("button[phx-click='fetch-chapter-titles']") |> render_click()
+      render_async(view)
+      view |> element("button[phx-click='apply-chapter-titles']") |> render_click()
+
+      assert ["The Dungeon Opens" | _rest] =
+               Enum.map(Inbox.get_item!(item.id).draft.recording.chapters.chapters, & &1.title)
+
+      view |> element("button[phx-click='take-file-chapters']") |> render_click()
+
+      chapters = Inbox.get_item!(item.id).draft.recording.chapters
+      refute "The Dungeon Opens" in Enum.map(chapters.chapters, & &1.title)
+      assert chapters.curated
+    end
+  end
+
+  # The operator's question when the rail was missing: it looked like it
+  # wasn't a decision at all. It always was one, and always counted.
+  describe "the settled count" do
+    test "chapters are one of the decisions the footer counts", %{conn: conn} do
+      item = chaptered_item()
+
+      {:ok, _view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      draft = Inbox.get_item!(item.id).draft
+      with_chapters = Draft.progress(draft)
+      without = Draft.progress(put_in(draft.recording.chapters, nil))
+
+      assert with_chapters.total == without.total + 1
+      assert with_chapters.resolved == without.resolved + 1
     end
   end
 end

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -535,6 +535,79 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert %{mode: :link, person_id: id} = person_keyed(item, "brandonsanderson")
       assert id == person.id
     end
+
+    # The operator's route: say the credit is a pen name, clear the box, type
+    # a letter, pick the human out of the typeahead. The draft keeps the "j"
+    # that was typed on the way — linking must not overwrite staged curation,
+    # because unlinking has to give it back — but nothing should *render* it.
+    test "a person linked through the typeahead reads as the library's own",
+         %{conn: conn} do
+      rowling = :person |> build(name: "J.K. Rowling") |> with_thumbnails() |> insert()
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      # typing narrows the typeahead, one keystroke at a time
+      view
+      |> element("#person-brandonsanderson-identity")
+      |> render_change(%{"key" => "brandonsanderson", "name" => "j"})
+
+      # and picking sends the id the resolver holds
+      view
+      |> element("#person-brandonsanderson-identity")
+      |> render_change(%{
+        "key" => "brandonsanderson",
+        "name" => "j",
+        "person_id" => to_string(rowling.id)
+      })
+
+      assert %{mode: :link, person_id: id} = person_keyed(item, "brandonsanderson")
+      assert id == rowling.id
+
+      chips =
+        view
+        |> element("#work [data-role='credit-people']")
+        |> render()
+        |> Floki.parse_fragment!()
+
+      assert Floki.text(chips) =~ "J.K. Rowling"
+      refute Floki.text(chips) |> String.trim() == "j"
+
+      # her library portrait, not whichever candidate the half-typed name found
+      assert Floki.find(chips, "img") |> Floki.attribute("src") ==
+               [rowling.thumbnails.extra_small]
+    end
+
+    # Linking answers "who is this"; a pen name answers "whose name is on the
+    # book". The second doesn't stop being true because the first was
+    # answered from the library.
+    test "a linked pen name still says whose pen name it is", %{conn: conn} do
+      rowling = insert(:person, name: "J.K. Rowling")
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#person-brandonsanderson button[phx-click='separate-name']")
+      |> render_click()
+
+      view
+      |> element("#person-brandonsanderson-identity")
+      |> render_change(%{
+        "key" => "brandonsanderson",
+        "name" => "j",
+        "person_id" => to_string(rowling.id)
+      })
+
+      card = view |> element("#person-brandonsanderson") |> render()
+
+      assert card =~ "A pen name of"
+      refute card =~ "This import will use the person you already have."
+    end
   end
 
   describe "credits — credited as / written by" do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1133,6 +1133,32 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert person.description.source == "provider:wikidata"
     end
 
+    # The box holds the query, the way the work level's holds `query_fields`.
+    # It rendered the person's name decision instead, so a search for anything
+    # else worked and then snapped back the moment the results landed — at
+    # the one moment the operator needs to see what produced them.
+    test "the search box keeps the name that was searched for", %{conn: conn} do
+      patch_person_search()
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("form#research-person-work-0-0")
+      |> render_submit(%{"key" => "brandonsanderson", "name" => "Robert Galbraith"})
+
+      render_async(view)
+
+      assert view
+             |> render()
+             |> Floki.parse_document!()
+             |> Floki.find("form#research-person-work-0-0 input[name='name']")
+             |> Floki.attribute("value") == ["Robert Galbraith"]
+
+      # and the person is still the person: a query is not a rename
+      assert Field.value(person_keyed(item, "brandonsanderson").name) == "Brandon Sanderson"
+    end
+
     # A person the matcher doubted is seeded unapproved, and until this the
     # only control in the whole form that could approve one was linking them
     # to somebody already in the library — 96 of the operator's 344 queued

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -905,6 +905,123 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       refute render(view) =~ "Looking for The Way of Kings…"
     end
 
+    # The test above re-submits the title the item already had, so stored and
+    # submitted agreed and the bug hid. Changing the value is the case: the
+    # box and the scrim both described the PREVIOUS search until this one
+    # landed — the typed words vanished from the box at the moment of the
+    # click, and the scrim named the wrong book.
+    test "a changed search is what the box and the scrim show, immediately",
+         %{conn: conn} do
+      test_pid = self()
+
+      patch(Providers, :search_books, fn _id, _query, _opts ->
+        send(test_pid, {:searching, self()})
+        receive do: (:go -> :ok)
+        {:ok, []}
+      end)
+
+      item = probed_item() |> with_work_records()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("form#research-work")
+        |> render_submit(%{
+          "level" => "work",
+          "title" => "Oathbringer",
+          "author" => "Sanderson"
+        })
+
+      assert_receive {:searching, task}
+
+      assert html =~ "Looking for Oathbringer…"
+      refute html =~ "Looking for The Way of Kings…"
+
+      # and the words are still in the boxes that were typed into
+      assert search_values(html, "#research-work") == %{
+               "title" => "Oathbringer",
+               "author" => "Sanderson"
+             }
+
+      send(task, :go)
+      render_async(view)
+
+      # the search landed: still what was asked for, now from storage
+      assert search_values(render(view), "#research-work") == %{
+               "title" => "Oathbringer",
+               "author" => "Sanderson"
+             }
+    end
+
+    # A recording matched by its ASIN stores `%{"keywords" => "B0…"}`, which
+    # this form has no box for — so the audiobook card showed three empty
+    # boxes above a Search button that submitted a blank query and, quite
+    # correctly, did nothing whatsoever. A dead control that said nothing
+    # about why.
+    test "a level searched by ASIN still starts from something submittable",
+         %{conn: conn} do
+      item =
+        probed_item()
+        |> with_recording_records()
+        |> then(fn item ->
+          item
+          |> InboxItem.changeset(%{
+            matches:
+              Map.update!(item.matches, "recording", fn level ->
+                Map.put(level, "query_fields", %{"keywords" => "B08BKGYQXW"})
+              end)
+          })
+          |> Repo.update!()
+        end)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # the boxes hold the hints matching itself searched with
+      values = search_values(html, "#research-recording")
+      assert values["title"] == "The Way of Kings"
+      refute values["title"] == ""
+    end
+
+    # The recording level is the same form with a narrator box, and gets the
+    # same rule — the point of fixing this once.
+    test "the recording level's search behaves the same", %{conn: conn} do
+      test_pid = self()
+
+      patch(Providers, :search_books, fn _id, _query, _opts ->
+        send(test_pid, {:searching, self()})
+        receive do: (:go -> :ok)
+        {:ok, []}
+      end)
+
+      item = probed_item() |> with_recording_records()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("form#research-recording")
+        |> render_submit(%{
+          "level" => "recording",
+          "title" => "Oathbringer",
+          "author" => "Sanderson",
+          "narrator" => "Kate Reading"
+        })
+
+      assert_receive {:searching, task}
+
+      assert html =~ "Looking for Oathbringer…"
+
+      assert search_values(html, "#research-recording") == %{
+               "title" => "Oathbringer",
+               "author" => "Sanderson",
+               "narrator" => "Kate Reading"
+             }
+
+      send(task, :go)
+      render_async(view)
+    end
+
     # Which database said this is the first thing an operator checks, and at
     # the end of the facts line it was the first thing truncation took.
     test "a record's provider is a badge, not the tail of a long line", %{conn: conn} do
@@ -1157,6 +1274,45 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       # and the person is still the person: a query is not a rename
       assert Field.value(person_keyed(item, "brandonsanderson").name) == "Brandon Sanderson"
+    end
+
+    # The same rule as the work and recording levels, and the same two
+    # symptoms before it: the box fell back to the person's own name for the
+    # length of the round trip, and the scrim over it named that person while
+    # a search for somebody else was in flight.
+    test "a person search shows the searched name while it runs, not the person's",
+         %{conn: conn} do
+      test_pid = self()
+
+      patch(PersonSearch, :providers, fn -> [%{id: "wikidata", display_name: "Wikidata"}] end)
+
+      patch(PersonSearch, :matches_with_outcome, fn _provider, _query, _opts ->
+        send(test_pid, {:searching, self()})
+        receive do: (:go -> :ok)
+        {[], []}
+      end)
+
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      html =
+        view
+        |> element("form#research-person-work-0-0")
+        |> render_submit(%{"key" => "brandonsanderson", "name" => "Robert Galbraith"})
+
+      assert_receive {:searching, task}
+
+      assert html =~ "Looking for Robert Galbraith…"
+      refute html =~ "Looking for Brandon Sanderson…"
+
+      assert html
+             |> Floki.parse_document!()
+             |> Floki.find("form#research-person-work-0-0 input[name='name']")
+             |> Floki.attribute("value") == ["Robert Galbraith"]
+
+      send(task, :go)
+      render_async(view)
     end
 
     # A person the matcher doubted is seeded unapproved, and until this the
@@ -1828,6 +1984,17 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
   defp person_keyed(item, key) do
     Enum.find(Inbox.get_item!(item.id).draft.people, &(&1.key == key))
+  end
+
+  # What a search form's text boxes are actually holding, which is the whole
+  # question when a search is in flight.
+  defp search_values(html, selector) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("#{selector} input[type='text']")
+    |> Map.new(fn input ->
+      {Floki.attribute(input, "name") |> hd(), Floki.attribute(input, "value") |> hd()}
+    end)
   end
 
   defp probed_item(opts \\ []) do

--- a/test/ambry_web/live/admin/media_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_test.exs
@@ -59,8 +59,13 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
     end
   end
 
-  describe "the header" do
-    test "says where the markers came from", %{conn: conn} do
+  # The card used to open with a sentence naming the marker source and
+  # counting the title sources ("Markers one per file · titles: 1
+  # generated."). It restated what every row already shows in its own source
+  # column, so it went; the per-row labels below are where that now lives,
+  # and `chapter_marker_source` is still enforced by "editing" below.
+  describe "the marker source" do
+    test "a moved marker still records the timeline as the operator's", %{conn: conn} do
       media =
         media_with_chapters([chapter(0, "Chapter 1", :generated)],
           chapter_marker_source: :file_boundaries
@@ -68,16 +73,9 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersTest do
 
       {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
 
-      assert html =~ "one per file"
-      assert html =~ "1 generated"
-    end
-
-    test "is honest about a list that predates the field", %{conn: conn} do
-      media = media_with_chapters([chapter(0, "Prologue", nil)])
-
-      {:ok, _view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
-
-      assert html =~ "from before this was recorded"
+      # carried in the form rather than printed at the operator
+      assert html =~ ~s(name="media[chapter_marker_source]")
+      assert html =~ ~s(value="file_boundaries")
     end
   end
 

--- a/test/ambry_web/live/admin/person_live/evidence_test.exs
+++ b/test/ambry_web/live/admin/person_live/evidence_test.exs
@@ -149,6 +149,26 @@ defmodule AmbryWeb.Admin.PersonLive.EvidenceTest do
     assert html =~ ~s(value="Anthony Palmini")
   end
 
+  # This form and the import form's person cards render the same component
+  # now — the markup was hand-written in both places and had already drifted.
+  # The rule they share: the box holds the query, from the click onward, so a
+  # search for a name other than this person's own does not read as a rename
+  # and does not revert while it runs.
+  test "the box keeps the searched name, which is not the person's name", %{conn: conn} do
+    patch_providers()
+    person = insert(:person, name: "Anthony Palmini")
+
+    {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+    search(view, "Matt Dinniman")
+
+    assert view
+           |> render()
+           |> Floki.parse_document!()
+           |> Floki.find("form#research-person input[name='name']")
+           |> Floki.attribute("value") == ["Matt Dinniman"]
+  end
+
   describe "the provenance flag" do
     test "shows the recorded source in the field header", %{conn: conn} do
       person =

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -306,6 +306,28 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       assert [%{name: "Robert Galbraith"}] = People.get_person!(person.id).authors
     end
 
+    # The operator's own case: Jason Pargin credited as "Baz", with a book
+    # already crediting that author. A rename does not unlink anything, so
+    # the book is not in the way — but "does the book block it" is exactly
+    # the question the row rewrite has to answer out loud.
+    test "renaming works even when a book credits the author", %{conn: conn} do
+      person = insert(:person, name: "Jason Pargin", authors: [build(:author, name: "Baz")])
+      [baz] = Ambry.Repo.preload(person, :authors).authors
+      insert(:book, book_authors: [build(:book_author, author: baz)])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> element("#author-0-resolver-input")
+      |> render_change(%{"resolver" => %{"author-0-resolver" => "David Wong"}})
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      assert [%{name: "David Wong"}] = People.get_person!(person.id).authors
+      # the same record, renamed — not a new author with the book left behind
+      assert %{name: "David Wong"} = Ambry.Repo.get(Ambry.People.Author, baz.id)
+    end
+
     # Relinking a row is safe for the same reason unticking is: the author it
     # pointed at is deleted only if nothing else wants it.
     test "picking a different author relinks the row and cleans up behind it", %{conn: conn} do

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -166,53 +166,6 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       assert %{name: "Daniel Abraham"} = Ambry.Repo.get(Ambry.People.Author, shared.id)
     end
 
-    # Emptying the list is not the same as not rendering it. Absent params
-    # mean "leave the association alone" — Ecto's rule, and the right read
-    # while the list is collapsed — but with it open and every row deleted,
-    # absent means the operator deleted them, and the save has to say so.
-    test "deleting every credit row actually deletes them", %{conn: conn} do
-      person =
-        insert(:person,
-          name: "Foo",
-          authors: [build(:author, name: "Foo"), build(:author, name: "Bar")]
-        )
-
-      # "Bar" is not "Foo", so this person opens revealed already
-      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
-
-      # what the ✕ sends: the row's index on the drop param
-      view
-      |> element("#person-form")
-      |> render_change(%{"person" => %{"author_people_drop" => ["0", "1"]}})
-
-      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
-
-      assert People.get_person!(person.id).authors == []
-    end
-
-    # The same deletion, reached through the hatch instead of by divergence.
-    # Absent params meant two different things depending on a flag the
-    # template and the transform disagreed about, and this is the half where
-    # the save quietly did nothing.
-    test "deleting the only credit row after opening the hatch", %{conn: conn} do
-      person =
-        insert(:person, name: "Foo", authors: [build(:author, name: "Foo")])
-
-      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
-
-      view
-      |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
-      |> render_click()
-
-      view
-      |> element("#person-form")
-      |> render_change(%{"person" => %{"name" => "Foo", "author_people_drop" => ["0"]}})
-
-      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
-
-      assert People.get_person!(person.id).authors == []
-    end
-
     # A person whose data already disagrees with "their own name" opens with
     # the list showing: a pen name behind a control nobody clicked is a pen
     # name the operator cannot see.
@@ -227,11 +180,64 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
     end
   end
 
+  describe "renaming a pen name" do
+    # The hatch used to be *derived* — open whenever the credit name differed
+    # from the person's. So renaming "Bar" to "Alastair Reynolds" made it
+    # stop differing, the card collapsed on the keystroke that finished the
+    # word, the rows stopped rendering, and the save had nothing to save. A
+    # disclosure may not close itself because of what was just typed into it.
+    test "renaming a pen name to the person's own name still saves", %{conn: conn} do
+      person =
+        insert(:person, name: "Alastair Reynolds", authors: [build(:author, name: "Bar")])
+
+      [author] = Ambry.Repo.preload(person, :authors).authors
+
+      {:ok, view, html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      # diverging data opens revealed
+      assert html =~ ~s(name="person[author_people][0][author][name]")
+
+      typed =
+        view
+        |> form("#person-form", %{
+          "person" => %{
+            "author_people" => %{"0" => %{"author" => %{"name" => "Alastair Reynolds"}}}
+          }
+        })
+        |> render_change()
+
+      # the box is still there — the card did not close under the operator
+      assert typed =~ ~s(name="person[author_people][0][author][name]")
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      assert %{name: "Alastair Reynolds"} = Ambry.Repo.get(Ambry.People.Author, author.id)
+      assert [%{name: "Alastair Reynolds"}] = People.get_person!(person.id).authors
+    end
+
+    # The authoritative half of the pair: this form is where an author's name
+    # is decided, so the box renames the record rather than proposing a new
+    # one. A book already crediting them is not in the way — a rename unlinks
+    # nothing.
+    test "the name box renames the record, even when a book credits it", %{conn: conn} do
+      person = insert(:person, name: "Jason Pargin", authors: [build(:author, name: "Baz")])
+      [baz] = Ambry.Repo.preload(person, :authors).authors
+      insert(:book, book_authors: [build(:book_author, author: baz)])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> form("#person-form", %{
+        "person" => %{"author_people" => %{"0" => %{"author" => %{"name" => "David Wong"}}}}
+      })
+      |> render_submit()
+
+      assert %{name: "David Wong"} = Ambry.Repo.get(Ambry.People.Author, baz.id)
+    end
+  end
+
   describe "linking an existing author (composite pen names)" do
-    # One control per row now: typing names a pen name, picking links this
-    # row to one that already exists. The separate "or link an existing
-    # author" box is gone — it was the same decision in a second costume.
-    test "picking an existing author in a row links it", %{conn: conn} do
+    test "links a shared author through the autocomplete", %{conn: conn} do
       abraham =
         insert(:person,
           name: "Daniel Abraham",
@@ -243,24 +249,28 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
-      # the hatch, then a row to put it in
+      # Linking lives behind the pen-name hatch now: it is the composite
+      # case, not the ordinary one. Offered while unticked too, because this
+      # is how a person who is not yet an author becomes one.
       view
       |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
       |> render_click()
 
-      view
-      |> element("#person-form")
-      |> render_change(%{"person" => %{"name" => "Ty Franck", "author_people_sort" => ["new"]}})
-
+      # type to filter, then pick the option; in the browser the value-change
+      # hook then fires a form change event
       html =
         view
-        |> element("#author-0-resolver-input")
-        |> render_change(%{"resolver" => %{"author-0-resolver" => "James"}})
+        |> element("#person_link_author_id-input")
+        |> render_change(%{"resolver" => %{"person_link_author_id" => "James"}})
 
-      # an edit form is a picker and a namer, so both outcomes are offered
+      # an edit form is a pure picker — no new-record support
+      refute html =~ "Create “"
+
+      view |> element("#person_link_author_id-option-#{corey.id}") |> render_click()
+
+      html = view |> form("#person-form", %{"person" => %{}}) |> render_change()
       assert html =~ "James S.A. Corey"
 
-      view |> element("#author-0-resolver-option-#{corey.id}") |> render_click()
       view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       person = People.get_person!(person.id)
@@ -285,142 +295,36 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       assert html =~ "Shared pen name with Ty Franck"
     end
 
-    # Typing over a saved row renames the author it points at. Emitting the
-    # name without its id reads as "replace this author", which
-    # `on_replace: :raise` turns into a crash rather than a rename.
-    test "typing over a saved row renames that author", %{conn: conn} do
-      person =
-        insert(:person, name: "J.K. Rowling", authors: [build(:author, name: "Robert Galbrait")])
+    test "linking the same author twice adds only one row", %{conn: conn} do
+      abraham =
+        insert(:person,
+          name: "Daniel Abraham",
+          authors: [build(:author, name: "James S.A. Corey")]
+        )
 
-      [author] = Ambry.Repo.preload(person, :authors).authors
-
-      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
-
-      view
-      |> element("#author-0-resolver-input")
-      |> render_change(%{"resolver" => %{"author-0-resolver" => "Robert Galbraith"}})
-
-      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
-
-      assert %{name: "Robert Galbraith"} = Ambry.Repo.get(Ambry.People.Author, author.id)
-      assert [%{name: "Robert Galbraith"}] = People.get_person!(person.id).authors
-    end
-
-    # THE ONE THAT MATTERED. Driving the resolver's own input in a test
-    # exercises the component alone, and it dutifully clears its id and
-    # keeps the typed text. A browser does something else: the parent form's
-    # `validate` fires on the same keystroke, *before* the component's
-    # round trip, so it arrives carrying the hidden inputs' PREVIOUS values
-    # — and the parent then re-renders the component from its changeset,
-    # putting the old name back in the box being typed into.
-    #
-    # So this sends what Chrome actually sends: stale id, stale name, and
-    # the live text under `resolver[...]`. Before the fix it saved
-    # "successfully" and changed nothing.
-    test "renaming works from the params a browser really posts", %{conn: conn} do
-      person = insert(:person, name: "Jason Pargin", authors: [build(:author, name: "Baz")])
-      [baz] = Ambry.Repo.preload(person, :authors).authors
-      [ap] = Ambry.Repo.preload(person, :author_people).author_people
-
-      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
-
-      stale = %{
-        "person" => %{
-          "name" => "Jason Pargin",
-          "writes" => "true",
-          "author_people" => %{
-            "0" => %{
-              "id" => to_string(ap.id),
-              "author_id" => to_string(baz.id),
-              "author" => %{"name" => "Baz"}
-            }
-          }
-        },
-        "resolver" => %{"author-0-resolver" => "David Wong"}
-      }
-
-      view |> element("#person-form") |> render_change(stale)
-      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
-
-      assert %{name: "David Wong"} = Ambry.Repo.get(Ambry.People.Author, baz.id)
-    end
-
-    # …and the other half of the same params: an id the row did NOT have is
-    # the operator picking from the list, which links rather than renames.
-    # Told apart by the id alone, because the visible text says the picked
-    # author's name either way.
-    test "picking is told apart from typing by the id, not the text", %{conn: conn} do
-      person = insert(:person, name: "Ty Franck", authors: [build(:author, name: "Typo")])
-      [typo] = Ambry.Repo.preload(person, :authors).authors
-      [ap] = Ambry.Repo.preload(person, :author_people).author_people
-      corey = insert(:author, name: "James S.A. Corey")
-
-      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
-
-      picked = %{
-        "person" => %{
-          "name" => "Ty Franck",
-          "writes" => "true",
-          "author_people" => %{
-            "0" => %{
-              "id" => to_string(ap.id),
-              "author_id" => to_string(corey.id),
-              "author" => %{"name" => "Typo"}
-            }
-          }
-        },
-        "resolver" => %{"author-0-resolver" => "James S.A. Corey"}
-      }
-
-      view |> element("#person-form") |> render_change(picked)
-      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
-
-      # linked to Corey, and "Typo" — wanted by nobody now — is gone
-      assert [%{name: "James S.A. Corey"}] = People.get_person!(person.id).authors
-      assert %{name: "James S.A. Corey"} = Ambry.Repo.get(Ambry.People.Author, corey.id)
-      refute Ambry.Repo.get(Ambry.People.Author, typo.id)
-    end
-
-    # The operator's own case: Jason Pargin credited as "Baz", with a book
-    # already crediting that author. A rename does not unlink anything, so
-    # the book is not in the way — but "does the book block it" is exactly
-    # the question the row rewrite has to answer out loud.
-    test "renaming works even when a book credits the author", %{conn: conn} do
-      person = insert(:person, name: "Jason Pargin", authors: [build(:author, name: "Baz")])
-      [baz] = Ambry.Repo.preload(person, :authors).authors
-      insert(:book, book_authors: [build(:book_author, author: baz)])
+      [corey] = Ambry.Repo.preload(abraham, :authors).authors
+      person = insert(:person, name: "Ty Franck")
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
       view
-      |> element("#author-0-resolver-input")
-      |> render_change(%{"resolver" => %{"author-0-resolver" => "David Wong"}})
+      |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
+      |> render_click()
+
+      for _try <- 1..2 do
+        view
+        |> element("#person_link_author_id-input")
+        |> render_change(%{"resolver" => %{"person_link_author_id" => "James"}})
+
+        view |> element("#person_link_author_id-option-#{corey.id}") |> render_click()
+
+        view |> form("#person-form", %{"person" => %{}}) |> render_change()
+      end
 
       view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
-      assert [%{name: "David Wong"}] = People.get_person!(person.id).authors
-      # the same record, renamed — not a new author with the book left behind
-      assert %{name: "David Wong"} = Ambry.Repo.get(Ambry.People.Author, baz.id)
-    end
-
-    # Relinking a row is safe for the same reason unticking is: the author it
-    # pointed at is deleted only if nothing else wants it.
-    test "picking a different author relinks the row and cleans up behind it", %{conn: conn} do
-      person = insert(:person, name: "Ty Franck", authors: [build(:author, name: "Typo Name")])
-      [typo] = Ambry.Repo.preload(person, :authors).authors
-      other = insert(:author, name: "James S.A. Corey")
-
-      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
-
-      view
-      |> element("#author-0-resolver-input")
-      |> render_change(%{"resolver" => %{"author-0-resolver" => "James"}})
-
-      view |> element("#author-0-resolver-option-#{other.id}") |> render_click()
-      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
-
-      assert [%{name: "James S.A. Corey"}] = People.get_person!(person.id).authors
-      refute Ambry.Repo.get(Ambry.People.Author, typo.id)
+      person = People.get_person!(person.id)
+      assert [%{author: %{name: "James S.A. Corey"}}] = person.author_people
     end
   end
 end

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -166,6 +166,53 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       assert %{name: "Daniel Abraham"} = Ambry.Repo.get(Ambry.People.Author, shared.id)
     end
 
+    # Emptying the list is not the same as not rendering it. Absent params
+    # mean "leave the association alone" — Ecto's rule, and the right read
+    # while the list is collapsed — but with it open and every row deleted,
+    # absent means the operator deleted them, and the save has to say so.
+    test "deleting every credit row actually deletes them", %{conn: conn} do
+      person =
+        insert(:person,
+          name: "Foo",
+          authors: [build(:author, name: "Foo"), build(:author, name: "Bar")]
+        )
+
+      # "Bar" is not "Foo", so this person opens revealed already
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      # what the ✕ sends: the row's index on the drop param
+      view
+      |> element("#person-form")
+      |> render_change(%{"person" => %{"author_people_drop" => ["0", "1"]}})
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      assert People.get_person!(person.id).authors == []
+    end
+
+    # The same deletion, reached through the hatch instead of by divergence.
+    # Absent params meant two different things depending on a flag the
+    # template and the transform disagreed about, and this is the half where
+    # the save quietly did nothing.
+    test "deleting the only credit row after opening the hatch", %{conn: conn} do
+      person =
+        insert(:person, name: "Foo", authors: [build(:author, name: "Foo")])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
+      |> render_click()
+
+      view
+      |> element("#person-form")
+      |> render_change(%{"person" => %{"name" => "Foo", "author_people_drop" => ["0"]}})
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      assert People.get_person!(person.id).authors == []
+    end
+
     # A person whose data already disagrees with "their own name" opens with
     # the list showing: a pen name behind a control nobody clicked is a pen
     # name the operator cannot see.
@@ -181,7 +228,10 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
   end
 
   describe "linking an existing author (composite pen names)" do
-    test "links a shared author through the autocomplete", %{conn: conn} do
+    # One control per row now: typing names a pen name, picking links this
+    # row to one that already exists. The separate "or link an existing
+    # author" box is gone — it was the same decision in a second costume.
+    test "picking an existing author in a row links it", %{conn: conn} do
       abraham =
         insert(:person,
           name: "Daniel Abraham",
@@ -193,28 +243,24 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
-      # Linking lives behind the pen-name hatch now: it is the composite
-      # case, not the ordinary one. Offered while unticked too, because this
-      # is how a person who is not yet an author becomes one.
+      # the hatch, then a row to put it in
       view
       |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
       |> render_click()
 
-      # type to filter, then pick the option; in the browser the value-change
-      # hook then fires a form change event
+      view
+      |> element("#person-form")
+      |> render_change(%{"person" => %{"name" => "Ty Franck", "author_people_sort" => ["new"]}})
+
       html =
         view
-        |> element("#person_link_author_id-input")
-        |> render_change(%{"resolver" => %{"person_link_author_id" => "James"}})
+        |> element("#author-0-resolver-input")
+        |> render_change(%{"resolver" => %{"author-0-resolver" => "James"}})
 
-      # an edit form is a pure picker — no new-record support
-      refute html =~ "Create “"
-
-      view |> element("#person_link_author_id-option-#{corey.id}") |> render_click()
-
-      html = view |> form("#person-form", %{"person" => %{}}) |> render_change()
+      # an edit form is a picker and a namer, so both outcomes are offered
       assert html =~ "James S.A. Corey"
 
+      view |> element("#author-0-resolver-option-#{corey.id}") |> render_click()
       view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       person = People.get_person!(person.id)
@@ -239,36 +285,45 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       assert html =~ "Shared pen name with Ty Franck"
     end
 
-    test "linking the same author twice adds only one row", %{conn: conn} do
-      abraham =
-        insert(:person,
-          name: "Daniel Abraham",
-          authors: [build(:author, name: "James S.A. Corey")]
-        )
+    # Typing over a saved row renames the author it points at. Emitting the
+    # name without its id reads as "replace this author", which
+    # `on_replace: :raise` turns into a crash rather than a rename.
+    test "typing over a saved row renames that author", %{conn: conn} do
+      person =
+        insert(:person, name: "J.K. Rowling", authors: [build(:author, name: "Robert Galbrait")])
 
-      [corey] = Ambry.Repo.preload(abraham, :authors).authors
-      person = insert(:person, name: "Ty Franck")
+      [author] = Ambry.Repo.preload(person, :authors).authors
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
       view
-      |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
-      |> render_click()
-
-      for _try <- 1..2 do
-        view
-        |> element("#person_link_author_id-input")
-        |> render_change(%{"resolver" => %{"person_link_author_id" => "James"}})
-
-        view |> element("#person_link_author_id-option-#{corey.id}") |> render_click()
-
-        view |> form("#person-form", %{"person" => %{}}) |> render_change()
-      end
+      |> element("#author-0-resolver-input")
+      |> render_change(%{"resolver" => %{"author-0-resolver" => "Robert Galbraith"}})
 
       view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
-      person = People.get_person!(person.id)
-      assert [%{author: %{name: "James S.A. Corey"}}] = person.author_people
+      assert %{name: "Robert Galbraith"} = Ambry.Repo.get(Ambry.People.Author, author.id)
+      assert [%{name: "Robert Galbraith"}] = People.get_person!(person.id).authors
+    end
+
+    # Relinking a row is safe for the same reason unticking is: the author it
+    # pointed at is deleted only if nothing else wants it.
+    test "picking a different author relinks the row and cleans up behind it", %{conn: conn} do
+      person = insert(:person, name: "Ty Franck", authors: [build(:author, name: "Typo Name")])
+      [typo] = Ambry.Repo.preload(person, :authors).authors
+      other = insert(:author, name: "James S.A. Corey")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> element("#author-0-resolver-input")
+      |> render_change(%{"resolver" => %{"author-0-resolver" => "James"}})
+
+      view |> element("#author-0-resolver-option-#{other.id}") |> render_click()
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      assert [%{name: "James S.A. Corey"}] = People.get_person!(person.id).authors
+      refute Ambry.Repo.get(Ambry.People.Author, typo.id)
     end
   end
 end

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -8,6 +8,14 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
   setup :register_and_log_in_admin_user
 
+  # The credit toggle is a named event, not form data — so tests press it
+  # rather than posting a value the form no longer carries.
+  defp tick(view, kind) do
+    view
+    |> element("button[phx-click='toggle-credit'][phx-value-kind='#{kind}']")
+    |> render_click()
+  end
+
   describe "field-level provenance" do
     # Display, lock-toggling and pending previews live with the inline
     # provenance flag now â covered in evidence_test.exs.
@@ -39,9 +47,8 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       # nothing to fill in: the name is stated, not asked for
       refute html =~ "Writing as"
 
-      view
-      |> form("#person-form", %{"person" => %{"writes" => "true"}})
-      |> render_submit()
+      tick(view, "author")
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       assert [%{name: "Stephen King"}] = People.get_person!(person.id).authors
     end
@@ -51,9 +58,8 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
-      view
-      |> form("#person-form", %{"person" => %{"narrates" => "true"}})
-      |> render_submit()
+      tick(view, "narrator")
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       assert [%{name: "Stephen King"}] = People.get_person!(person.id).narrators
     end
@@ -63,9 +69,9 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
-      view
-      |> form("#person-form", %{"person" => %{"writes" => "true", "narrates" => "true"}})
-      |> render_submit()
+      tick(view, "author")
+      tick(view, "narrator")
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       person = People.get_person!(person.id)
       assert [%{name: "Stephen King"}] = person.authors
@@ -82,9 +88,8 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
-      view
-      |> form("#person-form", %{"person" => %{"writes" => "false"}})
-      |> render_submit()
+      tick(view, "author")
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       assert People.get_person!(person.id).authors == []
       refute Ambry.Repo.get(Ambry.People.Author, author.id)
@@ -101,10 +106,8 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
-      html =
-        view
-        |> form("#person-form", %{"person" => %{"writes" => "false"}})
-        |> render_submit()
+      tick(view, "author")
+      html = view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       assert html =~ "in use by one or more books"
       assert [%{name: "Stephen King"}] = People.get_person!(person.id).authors
@@ -122,9 +125,13 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
 
+      # a browser validates on every keystroke, which is what keeps the
+      # collapsed credits tracking the name box
       view
       |> form("#person-form", %{"person" => %{"name" => "Richard Bachman"}})
-      |> render_submit()
+      |> render_change()
+
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
 
       person = People.get_person!(person.id)
       assert [%{name: "Richard Bachman"}] = person.authors

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -26,6 +26,160 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
     end
   end
 
+  # `Author` and `Narrator` are credit NAMES, not roles. The form used to say
+  # so out loud — two lists to populate, where having typed "Stephen King"
+  # you were asked to add an author and the answer was "Stephen King" — so
+  # the ordinary person now answers two checkboxes and types nothing.
+  describe "credited as" do
+    test "ticking writes creates an author under the person's own name", %{conn: conn} do
+      person = insert(:person, name: "Stephen King")
+
+      {:ok, view, html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      # nothing to fill in: the name is stated, not asked for
+      refute html =~ "Writing as"
+
+      view
+      |> form("#person-form", %{"person" => %{"writes" => "true"}})
+      |> render_submit()
+
+      assert [%{name: "Stephen King"}] = People.get_person!(person.id).authors
+    end
+
+    test "ticking narrates creates a narrator the same way", %{conn: conn} do
+      person = insert(:person, name: "Stephen King")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> form("#person-form", %{"person" => %{"narrates" => "true"}})
+      |> render_submit()
+
+      assert [%{name: "Stephen King"}] = People.get_person!(person.id).narrators
+    end
+
+    test "both is two ticks, not a special case", %{conn: conn} do
+      person = insert(:person, name: "Stephen King")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> form("#person-form", %{"person" => %{"writes" => "true", "narrates" => "true"}})
+      |> render_submit()
+
+      person = People.get_person!(person.id)
+      assert [%{name: "Stephen King"}] = person.authors
+      assert [%{name: "Stephen King"}] = person.narrators
+    end
+
+    # The operator's call: nothing credits them, so nothing is protected, and
+    # putting it back is a tick.
+    test "unticking deletes the credit nothing is using", %{conn: conn} do
+      person =
+        insert(:person, name: "Stephen King", authors: [build(:author, name: "Stephen King")])
+
+      [author] = Ambry.Repo.preload(person, :authors).authors
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> form("#person-form", %{"person" => %{"writes" => "false"}})
+      |> render_submit()
+
+      assert People.get_person!(person.id).authors == []
+      refute Ambry.Repo.get(Ambry.People.Author, author.id)
+    end
+
+    # …but a credit a book is using is not the operator's to drop by
+    # accident, and `delete_orphaned_authors/2` says so by name.
+    test "unticking is refused while a book still credits them", %{conn: conn} do
+      person =
+        insert(:person, name: "Stephen King", authors: [build(:author, name: "Stephen King")])
+
+      [author] = Ambry.Repo.preload(person, :authors).authors
+      insert(:book, book_authors: [build(:book_author, author: author)])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      html =
+        view
+        |> form("#person-form", %{"person" => %{"writes" => "false"}})
+        |> render_submit()
+
+      assert html =~ "in use by one or more books"
+      assert [%{name: "Stephen King"}] = People.get_person!(person.id).authors
+    end
+
+    # Renaming Stephen King used to leave an author called Stephen King
+    # behind, credited on every one of his books.
+    test "renaming the person renames the credit that is their own name", %{conn: conn} do
+      person =
+        insert(:person,
+          name: "Stephen King",
+          authors: [build(:author, name: "Stephen King")],
+          narrators: [build(:narrator, name: "Stephen King")]
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> form("#person-form", %{"person" => %{"name" => "Richard Bachman"}})
+      |> render_submit()
+
+      person = People.get_person!(person.id)
+      assert [%{name: "Richard Bachman"}] = person.authors
+      assert [%{name: "Richard Bachman"}] = person.narrators
+    end
+
+    # A pen name is not their name, so it does not follow.
+    test "a pen name is left alone when the person is renamed", %{conn: conn} do
+      person =
+        insert(:person, name: "J.K. Rowling", authors: [build(:author, name: "Robert Galbraith")])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> form("#person-form", %{"person" => %{"name" => "Joanne Rowling"}})
+      |> render_submit()
+
+      assert [%{name: "Robert Galbraith"}] = People.get_person!(person.id).authors
+    end
+
+    # One of James S.A. Corey's two humans renaming themselves must not
+    # rename James S.A. Corey.
+    test "a shared pen name is never renamed by one of its people", %{conn: conn} do
+      abraham =
+        insert(:person, name: "Daniel Abraham", authors: [build(:author, name: "Daniel Abraham")])
+
+      [shared] = Ambry.Repo.preload(abraham, :authors).authors
+      franck = insert(:person, name: "Ty Franck")
+      {:ok, _} = People.update_person(franck, %{author_people: [%{author_id: shared.id}]})
+
+      abraham = People.get_person!(abraham.id)
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{abraham.id}/edit")
+
+      view
+      |> form("#person-form", %{"person" => %{"name" => "Daniel James Abraham"}})
+      |> render_submit()
+
+      # the credit keeps its name, because it is not only his
+      assert %{name: "Daniel Abraham"} = Ambry.Repo.get(Ambry.People.Author, shared.id)
+    end
+
+    # A person whose data already disagrees with "their own name" opens with
+    # the list showing: a pen name behind a control nobody clicked is a pen
+    # name the operator cannot see.
+    test "an existing pen name reveals itself without being asked", %{conn: conn} do
+      person =
+        insert(:person, name: "J.K. Rowling", authors: [build(:author, name: "Robert Galbraith")])
+
+      {:ok, _view, html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      assert html =~ "Robert Galbraith"
+      refute html =~ "Writes under a pen name?"
+    end
+  end
+
   describe "linking an existing author (composite pen names)" do
     test "links a shared author through the autocomplete", %{conn: conn} do
       abraham =
@@ -38,6 +192,13 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       person = insert(:person, name: "Ty Franck")
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      # Linking lives behind the pen-name hatch now: it is the composite
+      # case, not the ordinary one. Offered while unticked too, because this
+      # is how a person who is not yet an author becomes one.
+      view
+      |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
+      |> render_click()
 
       # type to filter, then pick the option; in the browser the value-change
       # hook then fires a form change event
@@ -89,6 +250,10 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       person = insert(:person, name: "Ty Franck")
 
       {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      view
+      |> element("button[phx-value-kind='author'][phx-click='reveal-credit']")
+      |> render_click()
 
       for _try <- 1..2 do
         view

--- a/test/ambry_web/live/admin/person_live/form_test.exs
+++ b/test/ambry_web/live/admin/person_live/form_test.exs
@@ -306,6 +306,81 @@ defmodule AmbryWeb.Admin.PersonLive.FormTest do
       assert [%{name: "Robert Galbraith"}] = People.get_person!(person.id).authors
     end
 
+    # THE ONE THAT MATTERED. Driving the resolver's own input in a test
+    # exercises the component alone, and it dutifully clears its id and
+    # keeps the typed text. A browser does something else: the parent form's
+    # `validate` fires on the same keystroke, *before* the component's
+    # round trip, so it arrives carrying the hidden inputs' PREVIOUS values
+    # — and the parent then re-renders the component from its changeset,
+    # putting the old name back in the box being typed into.
+    #
+    # So this sends what Chrome actually sends: stale id, stale name, and
+    # the live text under `resolver[...]`. Before the fix it saved
+    # "successfully" and changed nothing.
+    test "renaming works from the params a browser really posts", %{conn: conn} do
+      person = insert(:person, name: "Jason Pargin", authors: [build(:author, name: "Baz")])
+      [baz] = Ambry.Repo.preload(person, :authors).authors
+      [ap] = Ambry.Repo.preload(person, :author_people).author_people
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      stale = %{
+        "person" => %{
+          "name" => "Jason Pargin",
+          "writes" => "true",
+          "author_people" => %{
+            "0" => %{
+              "id" => to_string(ap.id),
+              "author_id" => to_string(baz.id),
+              "author" => %{"name" => "Baz"}
+            }
+          }
+        },
+        "resolver" => %{"author-0-resolver" => "David Wong"}
+      }
+
+      view |> element("#person-form") |> render_change(stale)
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      assert %{name: "David Wong"} = Ambry.Repo.get(Ambry.People.Author, baz.id)
+    end
+
+    # …and the other half of the same params: an id the row did NOT have is
+    # the operator picking from the list, which links rather than renames.
+    # Told apart by the id alone, because the visible text says the picked
+    # author's name either way.
+    test "picking is told apart from typing by the id, not the text", %{conn: conn} do
+      person = insert(:person, name: "Ty Franck", authors: [build(:author, name: "Typo")])
+      [typo] = Ambry.Repo.preload(person, :authors).authors
+      [ap] = Ambry.Repo.preload(person, :author_people).author_people
+      corey = insert(:author, name: "James S.A. Corey")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/people/#{person.id}/edit")
+
+      picked = %{
+        "person" => %{
+          "name" => "Ty Franck",
+          "writes" => "true",
+          "author_people" => %{
+            "0" => %{
+              "id" => to_string(ap.id),
+              "author_id" => to_string(corey.id),
+              "author" => %{"name" => "Typo"}
+            }
+          }
+        },
+        "resolver" => %{"author-0-resolver" => "James S.A. Corey"}
+      }
+
+      view |> element("#person-form") |> render_change(picked)
+      view |> form("#person-form", %{"person" => %{}}) |> render_submit()
+
+      # linked to Corey, and "Typo" — wanted by nobody now — is gone
+      assert [%{name: "James S.A. Corey"}] = People.get_person!(person.id).authors
+      assert %{name: "James S.A. Corey"} = Ambry.Repo.get(Ambry.People.Author, corey.id)
+      refute Ambry.Repo.get(Ambry.People.Author, typo.id)
+    end
+
     # The operator's own case: Jason Pargin credited as "Baz", with a book
     # already crediting that author. A rename does not unlink anything, so
     # the book is not in the way — but "does the book block it" is exactly


### PR DESCRIPTION
A run of fixes and tweaks from using the import and edit forms, in the order the operator found them.

## Fixes

**The image proxy 404'd on real images.** Hardcover's CDN labels every asset `application/octet-stream`, and both the proxy and `Images.download/1` gated on a `content-type` allowlist — so a valid PNG was refused, and the *import* refused it silently (a failed cover isn't fatal). Both sniff the bytes now, through the same `browser_safe/1` the embedded-art path uses.

**Every provider search showed the previous query while running.** The staged form rendered the *stored* query, which is only written when results land — so typed words vanished from the box at the click and the scrim named the wrong book. The edit forms never had this (`Evidence.begin/2` records the submitted fields); the import form does the same now, at all three levels. The person scrim also named the person rather than the name being searched.

Also found in that audit: the person search form existed twice (the import form's component and a hand-written copy that had already drifted) — now one component; and a recording matched by ASIN stores `%{"keywords" => …}`, a shape the form has no box for, so its Search button submitted a blank query and silently did nothing.

**A linked person rendered the name typed on the way to finding them.** Type "j", pick J.K. Rowling, and the credit chip read "j" beside a stranger's portrait. Linking must not overwrite staged curation (unlinking has to give it back), so the resolution is at render.

**The chapters card wore no rail and offered no way to agree with it.** It was the one decision in the tree with no rail, and `:reviewed` was reachable only by editing a row — so agreeing with the files cost a pointless edit. It has a rail, and the files are a proposal chip like any other.

## The person form

`Author` and `Narrator` are credit *names*, not roles, and the form said so out loud: two lists to populate, where having typed "Stephen King" you were asked to add an author and the answer was "Stephen King". It's two checkboxes now, credited under the person's own name, with pen names and shared pen names behind escape hatches in the import form's vocabulary. Renaming a person renames an own-name credit — guarded so a pen name doesn't follow and a shared one is never renamed by one of its people.

A typeahead-per-row experiment is in here and reverted in the same PR: a rename and a create are the same gesture in a picker, and this form is the *authority* on author names. The commits are kept because the reverting commit explains why.

## Tweaks

Fold labels are "Search providers"; the audiobook form's redundant opening heading is gone; supplemental files is a card and its dropzone sits inside it; the upload control was rebuilt to the current design language (it was the last pre-redesign control in the admin); the chapters card's "Markers read from…" line is gone.

## Verification

`mix check` clean, 1601 tests passing. The interactive work was driven in real Chrome, not only in tests — two bugs here were invisible to LiveView tests because driving a component's input directly isn't what a browser does.