### PR TITLE
One library, four doors: root-relative paths and the removal of custody

### DIFF
--- a/lib/ambry/images.ex
+++ b/lib/ambry/images.ex
@@ -10,8 +10,8 @@ defmodule Ambry.Images do
   that drift.
 
   Everything written here is Ambry's own, under the uploads path — never a
-  file the library references in place. That distinction is what makes these
-  safe to delete with a record regardless of its custody.
+  file inside a library root. That distinction is what makes these safe to
+  delete with a record unconditionally.
   """
 
   import Ambry.Paths

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -692,6 +692,10 @@ defmodule Ambry.Inbox do
   defp policy_summary(:hardlink, root),
     do: "Hardlinked into #{root.path} — one copy of the bytes, the download keeps seeding."
 
+  defp policy_summary(:symlink, root),
+    do:
+      "Symlinked into #{root.path} — a pointer to the original, which dangles if the original ever moves or is deleted."
+
   defp policy_summary(:copy, root), do: "Copied into #{root.path}, duplicating the bytes."
 
   defp policy_summary(:move, root),

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -1106,9 +1106,22 @@ defmodule Ambry.Inbox do
   defp owner_of(file, ledger) do
     cond do
       item = ledger.by_file[file] -> item
-      MapSet.member?(ledger.library, file) -> :library
+      MapSet.member?(ledger.library, library_coordinates(file, ledger.roots)) -> :library
       item = nearest_owner(file, ledger.by_path) -> item
       true -> nil
+    end
+  end
+
+  # A scanned absolute path in the same coordinates the library stores: the
+  # root it falls in plus its relative form. A file under no root can only
+  # be claimed by an item, never by the library.
+  defp library_coordinates(file, roots) do
+    roots
+    |> Enum.filter(&String.starts_with?(file, &1.path <> "/"))
+    |> Enum.max_by(&String.length(&1.path), fn -> nil end)
+    |> case do
+      nil -> {nil, file}
+      root -> {root.id, Path.relative_to(file, root.path)}
     end
   end
 
@@ -1204,17 +1217,25 @@ defmodule Ambry.Inbox do
     %{
       by_file: for(item <- items, file <- item.files, into: %{}, do: {file, item}),
       by_path: Map.new(items, &{&1.path, &1}),
-      library: imported_files()
+      library: imported_files(),
+      roots: Library.list_roots()
     }
   end
 
   # Files the library already has, by either route: a direct-play track or a
-  # legacy media's recorded source files.
+  # recording's recorded source files. Compared as `{root_id, relative}`
+  # tuples rather than strings — two roots may legitimately hold the same
+  # relative path, and the stored columns are relative now. A scanned file
+  # only matches once `locate/1`d into the same coordinates, which happens
+  # in `owner_of/2`.
   defp imported_files do
-    track_paths = MediaTrack |> select([t], t.path) |> Repo.all()
+    track_paths = MediaTrack |> select([t], {t.library_root_id, t.path}) |> Repo.all()
 
     source_files =
-      Media |> select([m], m.source_files) |> Repo.all() |> List.flatten()
+      Media
+      |> select([m], {m.library_root_id, m.source_files})
+      |> Repo.all()
+      |> Enum.flat_map(fn {root_id, files} -> Enum.map(files || [], &{root_id, &1}) end)
 
     MapSet.new(track_paths ++ source_files)
   end

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -1278,7 +1278,18 @@ defmodule Ambry.Inbox do
       |> Repo.all()
       |> Enum.flat_map(fn {root_id, files} -> Enum.map(files || [], &{root_id, &1}) end)
 
-    MapSet.new(track_paths ++ source_files)
+    # Pre-refactor provenance: the absolute downloads paths a legacy media
+    # was transcoded from. They live under no root, so they compare in the
+    # same `{nil, absolute}` coordinates an unrooted scan file gets — and
+    # without them, every legacy recording's source would resurface as new.
+    legacy_files =
+      Media
+      |> select([m], m.legacy_source_files)
+      |> Repo.all()
+      |> Enum.reject(&is_nil/1)
+      |> Enum.flat_map(fn files -> Enum.map(files, &{nil, &1}) end)
+
+    MapSet.new(track_paths ++ source_files ++ legacy_files)
   end
 
   # The whole release, measured as the one recording it will become: the

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -233,10 +233,12 @@ defmodule Ambry.Inbox do
   needs to see it to act on it.
   """
   def probe_item(%InboxItem{} = item, opts \\ []) do
+    item = Repo.preload(item, :source)
+
     attrs =
       case item.files do
         [] -> %{issue: "no audio files found"}
-        files -> probe_recording(files)
+        _files -> probe_recording(InboxItem.disk_files(item))
       end
 
     with {:ok, item} <- update_item(item, attrs) do
@@ -298,17 +300,26 @@ defmodule Ambry.Inbox do
   #
   # Left alone when the walk comes back empty: an NFS mount that is briefly
   # away must not be recorded as "this release has no audio in it", and a
-  # genuinely empty folder is reported by probing instead.
-  defp refresh_files(%InboxItem{path: path} = item) do
-    case candidate(path) do
-      [{_path, files}] when files != [] and files != item.files ->
-        with {:ok, item} <- update_item(item, %{files: files}) do
-          # the draft describes files that just moved under it
-          mark_draft_stale(item)
+  # genuinely empty folder is reported by probing instead. The walk speaks
+  # absolutes; what gets stored is the source-relative form.
+  defp refresh_files(%InboxItem{} = item) do
+    item = Repo.preload(item, :source)
+
+    case candidate(InboxItem.disk_path(item)) do
+      [{_path, [_ | _] = files}] ->
+        stored = Enum.map(files, &stored_form(&1, item.source))
+
+        if stored == item.files do
           {:ok, item}
+        else
+          with {:ok, item} <- update_item(item, %{files: stored}) do
+            # the draft describes files that just moved under it
+            mark_draft_stale(item)
+            {:ok, item}
+          end
         end
 
-      _unchanged_or_unreachable ->
+      _empty_or_unreachable ->
         {:ok, item}
     end
   end
@@ -317,6 +328,14 @@ defmodule Ambry.Inbox do
     item
     |> InboxItem.changeset(attrs)
     |> Repo.update()
+  end
+
+  @doc """
+  An item's files as absolute disk paths, for callers holding an item whose
+  source may not be loaded.
+  """
+  def disk_files(%InboxItem{} = item) do
+    item |> Repo.preload(:source) |> InboxItem.disk_files()
   end
 
   @doc """
@@ -636,6 +655,7 @@ defmodule Ambry.Inbox do
   will work.
   """
   def destination_preflight(%InboxItem{} = item) do
+    item = Repo.preload(item, :source)
     base = %{blocker: nil, summary: nil}
     policy = chosen_policy(item)
 
@@ -654,16 +674,11 @@ defmodule Ambry.Inbox do
 
   # The draft's choice, which the seed filled from the source. Falling back
   # to the source covers a preflight taken before any draft exists.
-  defp chosen_policy(%InboxItem{} = item) do
-    case item do
-      %InboxItem{draft: %{destination: %{policy: policy}}} when not is_nil(policy) ->
-        policy
+  defp chosen_policy(%InboxItem{draft: %{destination: %{policy: policy}}})
+       when not is_nil(policy), do: policy
 
-      _no_draft_choice ->
-        item = Repo.preload(item, :source)
-        item.source && item.source.import_policy
-    end
-  end
+  defp chosen_policy(%InboxItem{source: %Source{import_policy: policy}}), do: policy
+  defp chosen_policy(%InboxItem{}), do: nil
 
   # The root the draft settled on, not one derived from the source: inputs
   # and outputs are independent, so this is a decision rather than a lookup.
@@ -702,7 +717,9 @@ defmodule Ambry.Inbox do
   # filesystem, and silently copying instead is the storage doubling the
   # roadmap set out to eliminate. Worth knowing before the click, not after.
   # Symlink deliberately gets no blocker: it has no precondition to fail.
-  defp hardlink_blocker(%InboxItem{files: [file | _rest]}, :hardlink, root) do
+  defp hardlink_blocker(%InboxItem{files: [_ | _]} = item, :hardlink, root) do
+    [file | _rest] = InboxItem.disk_files(item)
+
     case Library.same_filesystem?(Path.dirname(file), root.path) do
       {:ok, true} -> nil
       {:ok, false} -> describe_error({:cross_filesystem, file, root.path})
@@ -1156,14 +1173,21 @@ defmodule Ambry.Inbox do
   #
   # An item found under a source adopts it if it had none — that's a fact
   # the scan just established, not a guess — but a source is never swapped
-  # out from under an item that already has one.
+  # out from under an item that already has one. Adopting rewrites the
+  # stored path and files into the source's coordinates, so the columns
+  # always agree with the FK.
   defp refresh_known(%InboxItem{} = item, files, source) do
+    item = Repo.preload(item, :source)
     adopts_source? = is_nil(item.source_id) and not is_nil(source)
+    owner = if adopts_source?, do: source, else: item.source
+
+    stored_files = Enum.map(files, &stored_form(&1, owner))
 
     changes =
       %{}
-      |> put_if(:files, files, item.files != files)
+      |> put_if(:files, stored_files, item.files != stored_files)
       |> put_if(:source_id, adopts_source? && source.id, adopts_source?)
+      |> put_if(:path, stored_form(InboxItem.disk_path(item), owner), adopts_source?)
 
     if changes == %{} do
       :skipped
@@ -1191,9 +1215,22 @@ defmodule Ambry.Inbox do
   defp put_if(map, _key, _value, false), do: map
   defp put_if(map, key, value, _truthy), do: Map.put(map, key, value)
 
+  # The stored form of an absolute path the walk produced: source-relative
+  # when the item has a source, absolute for the ad-hoc case.
+  defp stored_form(path, nil), do: path
+
+  defp stored_form(path, %Source{} = source) do
+    {:ok, relative} = Library.relativize(source, path)
+    relative
+  end
+
   defp create_item(path, files, source) do
     %InboxItem{}
-    |> InboxItem.changeset(%{path: path, files: files, source_id: source && source.id})
+    |> InboxItem.changeset(%{
+      path: stored_form(path, source),
+      files: Enum.map(files, &stored_form(&1, source)),
+      source_id: source && source.id
+    })
     |> Repo.insert()
     |> case do
       {:ok, item} ->
@@ -1211,12 +1248,16 @@ defmodule Ambry.Inbox do
   # `by_file` is the authority — an item's own list of files — and `by_path`
   # only answers for files nothing has claimed yet, so a new file in a known
   # folder joins the item that holds the folder.
+  # The walk speaks absolutes, so the ledger's keys are the items' resolved
+  # paths — the stored source-relative forms never meet a scanned path
+  # directly.
   defp ledger do
-    items = Repo.all(InboxItem)
+    items = InboxItem |> Repo.all() |> Repo.preload(:source)
 
     %{
-      by_file: for(item <- items, file <- item.files, into: %{}, do: {file, item}),
-      by_path: Map.new(items, &{&1.path, &1}),
+      by_file:
+        for(item <- items, file <- InboxItem.disk_files(item), into: %{}, do: {file, item}),
+      by_path: Map.new(items, &{InboxItem.disk_path(&1), &1}),
       library: imported_files(),
       roots: Library.list_roots()
     }

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -175,8 +175,8 @@ defmodule Ambry.Inbox do
   Scans one source, or one bare path.
 
   The bare-path form is for ad-hoc scans and for exercising the walk itself;
-  items it creates have no source, so import can't know what custody they
-  imply.
+  items it creates have no source, so they carry no default placement policy
+  and the operator chooses one at approval.
   """
   def discover(%Source{} = source) do
     with {:ok, counts} <- scan(source.path, source) do
@@ -494,24 +494,33 @@ defmodule Ambry.Inbox do
     heal_destination(item)
   end
 
-  # Custody is *derived* — from where the files sit and what the item's
-  # source promises — never chosen by the operator, so re-deriving it
-  # un-answers nothing. It can change under a draft: an ad-hoc-scanned item
-  # adopts its source when the source's own scan next sees it, at which point
-  # a draft that sealed an external destination leaves the operator staring
-  # at "no library root" with no root picker rendered (the picker keys off
-  # the draft's custody). A changed custody replaces the destination with a
-  # fresh seed; an unchanged one leaves the operator's root choice alone.
+  # A destination's *defaults* are derived — from the item's source — while
+  # its root and policy are the operator's to choose, so healing fills gaps
+  # without un-answering anything. The gap it exists for: an ad-hoc-scanned
+  # item adopts its source when the source's own scan next sees it, at which
+  # point the draft's sealed destination has no policy and the source now
+  # knows one. That's a fact the scan established, not a choice to preserve.
   defp heal_destination(%InboxItem{} = item) do
+    stored = item.draft.destination
     fresh = Seed.destination(item)
 
-    if item.draft.destination && item.draft.destination.custody == fresh.custody do
-      {:ok, item}
-    else
-      item
-      |> InboxItem.put_draft(dump(%{item.draft | destination: fresh}))
-      |> Repo.update()
+    cond do
+      is_nil(stored) ->
+        put_destination(item, fresh)
+
+      is_nil(stored.policy) and not is_nil(fresh.policy) ->
+        healed = %{stored | policy: fresh.policy, root_id: stored.root_id || fresh.root_id}
+        put_destination(item, %{healed | approved: not is_nil(healed.root_id)})
+
+      true ->
+        {:ok, item}
     end
+  end
+
+  defp put_destination(item, destination) do
+    item
+    |> InboxItem.put_draft(dump(%{item.draft | destination: destination}))
+    |> Repo.update()
   end
 
   @doc """
@@ -623,39 +632,12 @@ defmodule Ambry.Inbox do
   lets the form refuse to offer a button that fails, and it tells the
   operator *where the file is going* before they commit to it.
 
-  Returns a map with `:custody`, a human `:summary`, and `:blocker` — nil when
-  placement will work.
+  Returns a map with a human `:summary` and a `:blocker` — nil when placement
+  will work.
   """
   def destination_preflight(%InboxItem{} = item) do
-    item = Repo.preload(item, :source)
-
-    cond do
-      # Derived, never declared: bringing a file in from inside a root would
-      # be copying it to where it already is.
-      Library.inside_root?(item.path) ->
-        adopt_preflight("It's already inside a library root.")
-
-      is_nil(item.source) ->
-        adopt_preflight("It came from an ad-hoc scan with no source.")
-
-      item.source.on_import == :leave_in_place ->
-        adopt_preflight("Its source is trusted to keep its files.")
-
-      true ->
-        bring_in_preflight(item, item.source)
-    end
-  end
-
-  defp adopt_preflight(why) do
-    %{
-      custody: :external,
-      summary: "Referenced where it lies — #{why} Ambry will never move, rename or delete it.",
-      blocker: nil
-    }
-  end
-
-  defp bring_in_preflight(item, source) do
-    base = %{custody: :managed, blocker: nil, summary: nil}
+    base = %{blocker: nil, summary: nil}
+    policy = chosen_policy(item)
 
     case chosen_root(item) do
       {:error, reason} ->
@@ -664,9 +646,22 @@ defmodule Ambry.Inbox do
       {:ok, root} ->
         %{
           base
-          | summary: policy_summary(source.import_policy, root),
-            blocker: hardlink_blocker(item, source, root)
+          | summary: policy_summary(policy, root),
+            blocker: hardlink_blocker(item, policy, root)
         }
+    end
+  end
+
+  # The draft's choice, which the seed filled from the source. Falling back
+  # to the source covers a preflight taken before any draft exists.
+  defp chosen_policy(%InboxItem{} = item) do
+    case item do
+      %InboxItem{draft: %{destination: %{policy: policy}}} when not is_nil(policy) ->
+        policy
+
+      _no_draft_choice ->
+        item = Repo.preload(item, :source)
+        item.source && item.source.import_policy
     end
   end
 
@@ -706,11 +701,8 @@ defmodule Ambry.Inbox do
   # The refusal this whole phase exists for: a hardlink cannot cross a
   # filesystem, and silently copying instead is the storage doubling the
   # roadmap set out to eliminate. Worth knowing before the click, not after.
-  defp hardlink_blocker(
-         %InboxItem{files: [file | _rest]},
-         %Source{import_policy: :hardlink},
-         root
-       ) do
+  # Symlink deliberately gets no blocker: it has no precondition to fail.
+  defp hardlink_blocker(%InboxItem{files: [file | _rest]}, :hardlink, root) do
     case Library.same_filesystem?(Path.dirname(file), root.path) do
       {:ok, true} -> nil
       {:ok, false} -> describe_error({:cross_filesystem, file, root.path})
@@ -718,7 +710,7 @@ defmodule Ambry.Inbox do
     end
   end
 
-  defp hardlink_blocker(_item, _source, _root), do: nil
+  defp hardlink_blocker(_item, _policy, _root), do: nil
 
   @doc """
   A draft as params, for staging it back onto an item.

--- a/lib/ambry/inbox/draft.ex
+++ b/lib/ambry/inbox/draft.ex
@@ -104,8 +104,8 @@ defmodule Ambry.Inbox.Draft do
     )
   end
 
-  # Absent means nothing was staged about the bytes, which for an adopt-in-
-  # place item is the normal case rather than an omission.
+  # Absent only on drafts that predate the destination decision (an imported
+  # item's draft is frozen history); a live draft always stages one.
   defp destination(%__MODULE__{destination: nil}), do: []
 
   defp destination(%__MODULE__{destination: destination}) do
@@ -114,7 +114,7 @@ defmodule Ambry.Inbox.Draft do
       else: [
         %{
           section: :destination,
-          label: "Which library root to import into",
+          label: "Where the files go",
           state: Destination.state(destination)
         }
       ]
@@ -335,7 +335,6 @@ defmodule Ambry.Inbox.Draft do
   end
 
   defp destination_total(nil), do: 0
-  defp destination_total(%Destination{custody: :external}), do: 0
   defp destination_total(%Destination{}), do: 1
 
   defp work_total(nil), do: 1

--- a/lib/ambry/inbox/draft/destination.ex
+++ b/lib/ambry/inbox/draft/destination.ex
@@ -36,7 +36,7 @@ defmodule Ambry.Inbox.Draft.Destination do
     # there is no destination to choose.
     field :custody, Ecto.Enum, values: [:managed, :external], default: :external
     field :root_id, :id
-    field :policy, Ecto.Enum, values: [:hardlink, :copy, :move]
+    field :policy, Ecto.Enum, values: [:hardlink, :symlink, :copy, :move]
     field :approved, :boolean, default: false
 
     # Filled in at render time from the registry rather than stored: roots are

--- a/lib/ambry/inbox/draft/destination.ex
+++ b/lib/ambry/inbox/draft/destination.ex
@@ -2,6 +2,10 @@ defmodule Ambry.Inbox.Draft.Destination do
   @moduledoc """
   Where this import's files are going, and what will be done to them.
 
+  Every import places into a library root — there is no other place Ambry
+  serves from — so a destination is two choices: **which root**, and **which
+  policy** (hardlink, symlink, copy or move) brings the files in.
+
   ## Inputs and outputs are independent
 
   A watched folder is an *input*; a library root is an *output*. Any input may
@@ -16,13 +20,15 @@ defmodule Ambry.Inbox.Draft.Destination do
   location may still name a *preferred* root, which seeds the choice without
   binding it.
 
-  ## Policy belongs to the input; feasibility belongs to the pair
+  ## Policy is seeded by the input; feasibility belongs to the pair
 
-  `hardlink | copy | move` describes what you want done with the *source* —
-  preserve it for seeding, or clear it out — so it's a property of where the
-  files came from. Whether a hardlink is actually possible depends on the
-  input and output being on one filesystem, which is a fact about the
-  *pairing* and can only be checked once both ends are known.
+  `hardlink | symlink | copy | move` describes what happens to the *source* —
+  preserve it for seeding, reference it in place, or clear it out — so its
+  default comes from where the files came from (`Source.import_policy`). An
+  item with no source has no default and the policy is a real outstanding
+  decision. Whether a hardlink is actually possible depends on the input and
+  output being on one filesystem, which is a fact about the *pairing* and can
+  only be checked once both ends are known.
   """
 
   use Ecto.Schema
@@ -32,9 +38,6 @@ defmodule Ambry.Inbox.Draft.Destination do
   @primary_key false
 
   embedded_schema do
-    # :external adopts the files where they lie and is settled by definition —
-    # there is no destination to choose.
-    field :custody, Ecto.Enum, values: [:managed, :external], default: :external
     field :root_id, :id
     field :policy, Ecto.Enum, values: [:hardlink, :symlink, :copy, :move]
     field :approved, :boolean, default: false
@@ -47,32 +50,35 @@ defmodule Ambry.Inbox.Draft.Destination do
   @doc false
   def changeset(destination, attrs) do
     destination
-    |> cast(attrs, [:custody, :root_id, :policy, :approved])
-    |> validate_managed_has_root()
+    |> cast(attrs, [:root_id, :policy, :approved])
+    |> validate_approved_is_placeable()
   end
 
-  # An approved managed import with no root is not a decision — it's one that
-  # would fail at the moment of placement, which is precisely what the
+  # An approved import with no root or no policy is not a decision — it's one
+  # that would fail at the moment of placement, which is precisely what the
   # invariant exists to prevent.
-  defp validate_managed_has_root(changeset) do
-    approved? = get_field(changeset, :approved)
-    managed? = get_field(changeset, :custody) == :managed
-
-    if approved? and managed? and is_nil(get_field(changeset, :root_id)) do
-      add_error(changeset, :root_id, "needs a library root to import into")
+  defp validate_approved_is_placeable(changeset) do
+    if get_field(changeset, :approved) do
+      changeset
+      |> validate_present(:root_id, "needs a library root to import into")
+      |> validate_present(:policy, "needs a placement policy")
     else
       changeset
     end
   end
 
+  defp validate_present(changeset, field, message) do
+    if is_nil(get_field(changeset, field)),
+      do: add_error(changeset, field, message),
+      else: changeset
+  end
+
   @doc """
   Whether the destination still needs a human.
-
-  External custody is settled by construction: the files stay exactly where
-  they are, so there is nothing to decide.
   """
-  def resolved?(%__MODULE__{custody: :external}), do: true
-  def resolved?(%__MODULE__{approved: true, root_id: id}), do: not is_nil(id)
+  def resolved?(%__MODULE__{approved: true, root_id: root_id, policy: policy}),
+    do: not is_nil(root_id) and not is_nil(policy)
+
   def resolved?(%__MODULE__{}), do: false
 
   def state(%__MODULE__{} = destination) do

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -963,12 +963,13 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   # Embedded art and a provider cover are both real answers, so two of them is
   # a choice rather than a winner. The embedded candidate carries the audio
-  # file to extract from; approval does the extracting.
+  # file to extract from — resolved to a disk path, because approval hands
+  # the value straight to the extractor.
   defp cover_field(sources, tags, item) do
     embedded =
       if tags["has_cover_art"] && item.files != [] do
         %Candidate{
-          value: List.first(item.files),
+          value: item |> Repo.preload(:source) |> InboxItem.disk_files() |> List.first(),
           source: "embedded",
           label: "Embedded in the file",
           key: "embedded"

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -284,43 +284,34 @@ defmodule Ambry.Inbox.Draft.Seed do
   # Any input may feed any output, so the root is chosen per import rather
   # than fixed on the source. The single-root case — which is nearly all of
   # them — resolves silently: being asked to pick from a list of one is not a
-  # decision, it's an interruption.
+  # decision, it's an interruption. The policy is seeded from the source the
+  # same way; an item with no source (ad-hoc scan) has no default and the
+  # policy stays an outstanding decision.
   def destination(%InboxItem{} = item) do
     item = Repo.preload(item, :source)
 
-    cond do
-      # Derived, never declared: a file already inside a root is already
-      # home, whatever its source promised.
-      Library.inside_root?(item.path) ->
-        %Destination{custody: :external, approved: true}
+    policy =
+      case item.source do
+        %Source{import_policy: policy} -> policy
+        nil -> nil
+      end
 
-      match?(%Source{on_import: :bring_in}, item.source) ->
-        managed_destination(item.source)
-
-      true ->
-        %Destination{custody: :external, approved: true}
-    end
-  end
-
-  defp managed_destination(source) do
     roots = Library.list_roots()
 
     # A source may still *prefer* a root; it just doesn't bind to one.
-    preferred = Enum.find(roots, &(&1.id == source.target_root_id))
+    preferred = item.source && Enum.find(roots, &(&1.id == item.source.target_root_id))
 
-    case {preferred, roots} do
-      {%Root{} = root, _several} -> settled(root, source)
-      {nil, [only]} -> settled(only, source)
-      {nil, _none_or_several} -> %Destination{custody: :managed, policy: source.import_policy}
-    end
-  end
+    root =
+      case {preferred, roots} do
+        {%Root{} = root, _several} -> root
+        {nil, [only]} -> only
+        {nil, _none_or_several} -> nil
+      end
 
-  defp settled(root, source) do
     %Destination{
-      custody: :managed,
-      root_id: root.id,
-      policy: source.import_policy,
-      approved: true
+      root_id: root && root.id,
+      policy: policy,
+      approved: not is_nil(root) and not is_nil(policy)
     }
   end
 

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -22,17 +22,13 @@ defmodule Ambry.Inbox.Importer do
   with a guess — and inventing a series number or a publication date is
   exactly the confidently-wrong data the inbox exists to prevent.
 
-  ## Custody
+  ## Placement
 
-  Where an item came from decides what happens to its bytes:
-
-    * from a **bring-in** source, the file is placed into a library root
-      under the naming template — hardlinked, copied or moved per the
-      source's policy — and the recording becomes **managed**.
-    * from a **trusted** source, from inside a library root, or from an item
-      with no source at all, the file is referenced exactly where it lies
-      and the recording is **external**. Ambry never moves, copies, renames
-      or deletes it.
+  Every import places its files into a library root under the naming
+  template, by the policy the draft settled — hardlink, symlink, copy or
+  move. The original is untouched by construction for the first three and
+  deliberately gone for the last; there is no import that leaves the
+  library referencing a path outside a root.
 
   A hardlink cannot cross a filesystem, and here the downloads folder and the
   library can easily be on different NAS boxes. Import **refuses** in that
@@ -143,7 +139,7 @@ defmodule Ambry.Inbox.Importer do
       with {:ok, item} <- claim(item),
            {:ok, people} <- resolve_people(item.draft),
            {:ok, book} <- resolve_book(item.draft.work, people),
-           {:ok, media} <- create_media(item, book, probes, people),
+           {:ok, media} <- create_media(item, book, probes, people, destination),
            {:ok, _item} <- link(item, media),
            {:ok, media, placements} <- place(destination, book, media, files),
            {:ok, media} <- publish(media) do
@@ -316,11 +312,11 @@ defmodule Ambry.Inbox.Importer do
 
   ## the recording
 
-  defp create_media(item, book, probes, people) do
+  defp create_media(item, book, probes, people, {root, _policy}) do
     recording = item.draft.recording
 
     with {:ok, group} <- resolve_group(recording.recording_group, book) do
-      do_create_media(item, book, probes, people, recording, group)
+      do_create_media(item, book, probes, people, recording, group, root)
     end
   end
 
@@ -342,15 +338,19 @@ defmodule Ambry.Inbox.Importer do
         parts_total: link.parts_total
       })
 
-  defp do_create_media(item, book, probes, people, recording, group) do
+  defp do_create_media(item, book, probes, people, recording, group, root) do
     {chapters, marker_source} = chapters(recording.chapters, probes)
 
     %{
       book_id: book.id,
-      # the item's own paths until placement repoints them to the library
-      # copies below
-      source_path: item.path,
-      source_files: item.files,
+      # Created in the destination root's coordinates from the start: the
+      # path columns are CHECK-constrained to hold a resolvable stored form,
+      # and a CHECK cannot wait for the commit. These are placeholders in
+      # valid form — basenames under the right root — that placement
+      # rewrites to the real relative paths inside this same transaction.
+      library_root_id: root.id,
+      source_path: Path.basename(item.path),
+      source_files: Enum.map(item.files, &Path.basename/1),
       status: :pending,
       # The recording's settled place in its part set, if any.
       part_number: part_number(recording.recording_group),
@@ -358,7 +358,11 @@ defmodule Ambry.Inbox.Importer do
       duration: Scanner.total_duration(probes),
       chapters: chapters,
       chapter_marker_source: marker_source,
-      media_tracks: Scanner.track_attrs(probes),
+      media_tracks:
+        probes
+        |> Scanner.track_attrs()
+        |> Enum.map(&%{&1 | path: Path.basename(&1.path)})
+        |> Enum.map(&Map.put(&1, :library_root_id, root.id)),
       title: Field.value(recording.title),
       published: Field.date(recording.published),
       published_format: Field.format_atom(recording.published, :full),

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -60,6 +60,7 @@ defmodule Ambry.Inbox.Importer do
   alias Ambry.Inbox.Draft.PersonDecision
   alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library
   alias Ambry.Library.NamingTemplate
   alias Ambry.Library.Placement
   alias Ambry.Library.Root
@@ -520,7 +521,7 @@ defmodule Ambry.Inbox.Importer do
          {:ok, filenames} <- NamingTemplate.filenames(values, files, filename_recording(media)),
          paths = Enum.map(filenames, &Path.join([root.path, folder, &1])),
          {:ok, placements} <- Placement.place_all(Enum.zip(files, paths), policy),
-         {:ok, media} <- record_placement(media, paths) do
+         {:ok, media} <- record_placement(media, root, paths) do
       {:ok, media, placements}
     end
   end
@@ -549,27 +550,35 @@ defmodule Ambry.Inbox.Importer do
   # names. `source_path` is the folder those copies share, which for a
   # multi-file recording is the subfolder of its own that placement gave it,
   # not the book folder it sits in.
-  defp record_placement(media, paths) do
-    with {:ok, _tracks} <- repoint_tracks(media, paths) do
+  defp record_placement(media, root, paths) do
+    with {:ok, _tracks} <- repoint_tracks(media, root, paths) do
       media
       |> Ecto.Changeset.change(%{
-        source_path: paths |> hd() |> Path.dirname(),
-        source_files: paths
+        library_root_id: root.id,
+        source_path: relativize!(root, paths |> hd() |> Path.dirname()),
+        source_files: Enum.map(paths, &relativize!(root, &1))
       })
       |> Repo.update()
     end
   end
 
+  # Placement just wrote these under the root, so being outside it is a bug
+  # worth crashing on rather than recording.
+  defp relativize!(root, absolute) do
+    {:ok, relative} = Library.relativize(root, absolute)
+    relative
+  end
+
   # Zipped by position, and the positions are the same order everywhere: the
   # probes were taken in it, the tracks were written in it, and the
   # destination names were rendered from it.
-  defp repoint_tracks(%{media_tracks: [_ | _] = tracks}, paths) do
+  defp repoint_tracks(%{media_tracks: [_ | _] = tracks}, root, paths) do
     tracks
     |> Enum.sort_by(& &1.index)
     |> Enum.zip(paths)
     |> Enum.reduce_while({:ok, []}, fn {track, path}, {:ok, acc} ->
       track
-      |> Ecto.Changeset.change(%{path: path})
+      |> Ecto.Changeset.change(%{path: relativize!(root, path), library_root_id: root.id})
       |> Repo.update()
       |> case do
         {:ok, track} -> {:cont, {:ok, [track | acc]}}
@@ -578,7 +587,7 @@ defmodule Ambry.Inbox.Importer do
     end)
   end
 
-  defp repoint_tracks(_no_tracks, _paths), do: {:error, :no_tracks}
+  defp repoint_tracks(_no_tracks, _root, _paths), do: {:error, :no_tracks}
 
   # A source that couldn't be removed is untidy, not broken: the library copy
   # exists and is recorded. Failing the import here would be worse than

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -346,9 +346,8 @@ defmodule Ambry.Inbox.Importer do
 
     %{
       book_id: book.id,
-      # external until placement says otherwise; a downloads item is
-      # repointed to its library copy below
-      custody: :external,
+      # the item's own paths until placement repoints them to the library
+      # copies below
       source_path: item.path,
       source_files: item.files,
       status: :pending,
@@ -490,23 +489,21 @@ defmodule Ambry.Inbox.Importer do
 
   ## placement
 
-  # What import should do with the bytes, decided by the draft's custody:
-  # only a bring-in source's item is placed; a trusted source's files are
-  # adopted exactly where they lie (that is the entire promise of external
-  # custody). Read off the draft rather than re-derived from the source: any
-  # input may feed any output, so which root this import goes to is a
-  # decision the operator made (or that resolved silently because there was
-  # only one), not a property of where the files were found.
-  defp destination(%InboxItem{draft: %{destination: %{custody: :managed} = destination}}) do
-    case Repo.get(Root, destination.root_id) do
-      %Root{} = root -> {:ok, {root, destination.policy}}
+  # Where import puts the bytes. Every import places into a root — there is
+  # no other place Ambry serves from. Read off the draft rather than
+  # re-derived from the source: any input may feed any output, so which root
+  # this import goes to and how the files come in are decisions the operator
+  # made (or that resolved silently because there was only one root and the
+  # source carried a policy), not properties of where the files were found.
+  defp destination(%InboxItem{draft: %{destination: %{root_id: root_id, policy: policy}}})
+       when is_integer(root_id) and not is_nil(policy) do
+    case Repo.get(Root, root_id) do
+      %Root{} = root -> {:ok, {root, policy}}
       nil -> {:error, :no_library_root}
     end
   end
 
-  defp destination(%InboxItem{}), do: {:ok, :adopt}
-
-  defp place(:adopt, _book, media, _files), do: {:ok, media, []}
+  defp destination(%InboxItem{}), do: {:error, :no_library_root}
 
   defp place({root, policy}, book, media, files) do
     # Forced: a freshly-created book carries its `book_authors` as insert
@@ -523,7 +520,7 @@ defmodule Ambry.Inbox.Importer do
          {:ok, filenames} <- NamingTemplate.filenames(values, files, filename_recording(media)),
          paths = Enum.map(filenames, &Path.join([root.path, folder, &1])),
          {:ok, placements} <- Placement.place_all(Enum.zip(files, paths), policy),
-         {:ok, media} <- adopt_managed(media, paths) do
+         {:ok, media} <- record_placement(media, paths) do
       {:ok, media, placements}
     end
   end
@@ -549,14 +546,13 @@ defmodule Ambry.Inbox.Importer do
   defp part_number(_absent_or_removed), do: nil
 
   # The recording now points at the library copies and Ambry owns those
-  # bytes. `source_path` is the folder those copies share, which for a
+  # names. `source_path` is the folder those copies share, which for a
   # multi-file recording is the subfolder of its own that placement gave it,
   # not the book folder it sits in.
-  defp adopt_managed(media, paths) do
+  defp record_placement(media, paths) do
     with {:ok, _tracks} <- repoint_tracks(media, paths) do
       media
       |> Ecto.Changeset.change(%{
-        custody: :managed,
         source_path: paths |> hd() |> Path.dirname(),
         source_files: paths
       })

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -615,12 +615,13 @@ defmodule Ambry.Inbox.Importer do
 
   defp chapters(_decision, probes), do: Scanner.chapters(probes)
 
-  # An item's files, in the order discovery recorded them — which is natural
-  # sort, and therefore the play order the operator saw listed on the form.
-  # A release the operator has decided is really two books is split into
-  # separate items first; this is the one they've said is one recording.
+  # An item's files as absolute disk paths, in the order discovery recorded
+  # them — which is natural sort, and therefore the play order the operator
+  # saw listed on the form. A release the operator has decided is really two
+  # books is split into separate items first; this is the one they've said
+  # is one recording.
   defp audio_files(%InboxItem{files: []}), do: {:error, :no_audio_files}
-  defp audio_files(%InboxItem{files: files}), do: {:ok, files}
+  defp audio_files(%InboxItem{} = item), do: {:ok, InboxItem.disk_files(item)}
 
   # Re-probed rather than trusting what discovery recorded: it costs one
   # ffprobe per file and buys current track data, plus a file that vanished

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -6,6 +6,13 @@ defmodule Ambry.Inbox.InboxItem do
   organized until it's imported. `path` is the item's identity (the release
   folder, or a loose file), which is what makes rescans idempotent and keeps
   ignored items ignored.
+
+  `path` and `files` are stored relative to the item's source, so a source
+  whose mount point changes is a one-row edit and every queued item — and
+  the operator decisions staged on it — survives the move. An ad-hoc item
+  with no source stores absolute paths; that exception stays inside the
+  inbox, whose rows are transient. Resolve through `disk_path/1` and
+  `disk_files/1`, never by joining the columns against anything directly.
   """
 
   use Ecto.Schema
@@ -14,8 +21,10 @@ defmodule Ambry.Inbox.InboxItem do
 
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.ReleaseName
+  alias Ambry.Library
   alias Ambry.Library.Source
   alias Ambry.Media.Media
+  alias Ambry.Repo
 
   @statuses [:pending, :ignored, :imported]
 
@@ -96,4 +105,30 @@ defmodule Ambry.Inbox.InboxItem do
       do: Path.join(Path.basename(Path.dirname(path)), base),
       else: base
   end
+
+  @doc """
+  The item's absolute path on disk.
+  """
+  def disk_path(%__MODULE__{path: path} = item), do: resolve!(item, path)
+
+  @doc """
+  The item's files as absolute disk paths, in discovery order.
+  """
+  def disk_files(%__MODULE__{files: files} = item), do: Enum.map(files, &resolve!(item, &1))
+
+  # An ad-hoc item's paths are already absolute; a sourced item resolves
+  # against its source. Raising on anything else is deliberate: these paths
+  # get probed, placed and (on undo) checked before deletion, and a path
+  # that can't resolve must never quietly become a relative one.
+  defp resolve!(%__MODULE__{source_id: nil}, path), do: path
+
+  defp resolve!(%__MODULE__{} = item, path) do
+    case Library.resolve(item_source(item), path) do
+      {:ok, absolute} -> absolute
+      {:error, reason} -> raise "unresolvable inbox path: #{inspect(reason)}"
+    end
+  end
+
+  defp item_source(%__MODULE__{source: %Source{} = source}), do: source
+  defp item_source(%__MODULE__{source_id: id}), do: Repo.get!(Source, id)
 end

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -22,9 +22,10 @@ defmodule Ambry.Inbox.InboxItem do
   schema "inbox_items" do
     belongs_to :media, Media
 
-    # Where this was found, which is what says whether importing it should
-    # bring the files into a library root or adopt them where they lie.
-    # Nullable: items from an ad-hoc scan have no source to speak for them.
+    # Where this was found, which seeds the placement policy import brings
+    # its files into a library root with. Nullable: items from an ad-hoc
+    # scan have no source to speak for them, so the operator picks the
+    # policy at approval.
     belongs_to :source, Source
 
     field :path, :string

--- a/lib/ambry/inbox/undo.ex
+++ b/lib/ambry/inbox/undo.ex
@@ -105,11 +105,13 @@ defmodule Ambry.Inbox.Undo do
 
   # The check that makes this safe to offer. A `move` policy leaves the
   # library copy as the only copy, and `Media.delete_media/1` deletes a
-  # managed recording's files — so without the source on disk, "undo" would
-  # delete the release.
+  # recording's files — so without the source on disk, "undo" would delete
+  # the release.
   defp source_intact(%InboxItem{files: []}), do: :ok
 
-  defp source_intact(%InboxItem{files: files}) do
+  defp source_intact(%InboxItem{} = item) do
+    files = item |> Repo.preload(:source) |> InboxItem.disk_files()
+
     if Enum.all?(files, &File.exists?/1), do: :ok, else: {:error, :source_files_missing}
   end
 

--- a/lib/ambry/inbox/undo.ex
+++ b/lib/ambry/inbox/undo.ex
@@ -118,9 +118,10 @@ defmodule Ambry.Inbox.Undo do
   defp drop_media(summary, nil), do: note(summary, :kept, "no audiobook: the item had none")
 
   defp drop_media(summary, %Media.Media{} = media) do
-    # Custody decides the bytes, as everywhere else: a managed recording's
-    # library copies go with it, an adopted one's files are somebody else's
-    # and are only ever dereferenced.
+    # The recording's library copies go with it. The originals they were
+    # placed from are untouched by construction — which is exactly why
+    # `source_intact/1` refused already if a move made the library copy the
+    # only one.
     case Media.delete_media(media) do
       {:ok, _media} -> note(summary, :deleted, "the audiobook")
       {:error, reason} -> note(summary, :kept, "the audiobook: #{inspect(reason)}")

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -41,6 +41,7 @@ defmodule Ambry.Library do
 
   import Ecto.Query
 
+  alias Ambry.Library.Mounts
   alias Ambry.Library.Root
   alias Ambry.Library.Source
   alias Ambry.Paths
@@ -53,8 +54,12 @@ defmodule Ambry.Library do
     Deliberately not stored: a NAS that was mounted when the row was written
     tells you nothing about whether it's mounted now, and a stale "healthy"
     is worse than no answer.
+
+    `device` and `mount` together identify what a path can be hardlinked
+    with — see `Ambry.Library.same_filesystem?/2` for why it takes both.
+    `mount` is nil where the system offers no mount table.
     """
-    defstruct [:exists?, :directory?, :writable?, :device]
+    defstruct [:exists?, :directory?, :writable?, :device, :mount]
   end
 
   ## sources
@@ -277,17 +282,38 @@ defmodule Ambry.Library do
           exists?: true,
           directory?: stat.type == :directory,
           writable?: stat.access in [:write, :read_write],
-          device: stat.major_device
+          device: stat.major_device,
+          mount: mount_id(path)
         }
 
       {:error, _reason} ->
-        %Status{exists?: false, directory?: false, writable?: false, device: nil}
+        %Status{exists?: false, directory?: false, writable?: false, device: nil, mount: nil}
+    end
+  end
+
+  defp mount_id(path) do
+    with {:ok, mounts} <- Mounts.read(),
+         {:ok, mount} <- Mounts.mount_of(path, mounts) do
+      mount.id
+    else
+      _unavailable -> nil
     end
   end
 
   @doc """
-  Whether two paths sit on the same filesystem, and can therefore be
-  hardlinked between.
+  Whether two paths can be hardlinked between.
+
+  Two checks, because `link(2)` refuses in two different ways and each one
+  is invisible to the other check:
+
+    * **different `st_dev`** — different filesystems, and also btrfs
+      subvolumes, which share a mount but carry their own device and refuse
+      cross-subvolume links;
+    * **same `st_dev`, different mounts** — two mounts of one NFS export
+      share a superblock and the kernel still refuses to link across them.
+      This is the case a device comparison alone gets confidently wrong,
+      and it matters here because in production the same export can be
+      mounted more than once.
 
   Returns `{:error, reason}` rather than `false` when the question can't be
   answered — a missing mount must not read as "different filesystem, fall
@@ -297,7 +323,24 @@ defmodule Ambry.Library do
   def same_filesystem?(source, destination) do
     with {:ok, source_device} <- device(source),
          {:ok, destination_device} <- device(destination) do
-      {:ok, source_device == destination_device}
+      if source_device == destination_device,
+        do: same_mount?(source, destination),
+        else: {:ok, false}
+    end
+  end
+
+  defp same_mount?(source, destination) do
+    case Mounts.read() do
+      {:ok, mounts} ->
+        with {:ok, source_mount} <- Mounts.mount_of(source, mounts),
+             {:ok, destination_mount} <- Mounts.mount_of(destination, mounts) do
+          {:ok, source_mount.id == destination_mount.id}
+        end
+
+      # No mountinfo (not Linux): device equality is the best available
+      # answer, which is exactly what this check was before mounts existed.
+      :unavailable ->
+        {:ok, true}
     end
   end
 

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -5,11 +5,12 @@ defmodule Ambry.Library do
   Two registries, deliberately separate because they are separate concepts:
 
     * **Sources** (`Ambry.Library.Source`) — watched folders audiobooks
-      arrive from. Read, never written. Each carries one promise: whether
-      its files can be trusted to stay (`on_import`).
-    * **Library roots** (`Ambry.Library.Root`) — the folders managed audio
-      is organized into. Written, never watched. Optional: a setup whose
-      sources are all trusted imports nothing into a root.
+      arrive from. Read, never written. Each carries a default placement
+      policy (`import_policy`) naming how import brings its files into a
+      root.
+    * **Library roots** (`Ambry.Library.Root`) — the folders the library's
+      audio is organized into, and the only place Ambry serves from.
+      Written, never watched. At least one is required to import anything.
 
   This module is also the place that answers "can these two paths share a
   hardlink?".
@@ -126,20 +127,6 @@ defmodule Ambry.Library do
   def delete_root(%Root{} = root), do: Repo.delete(root)
 
   def change_root(%Root{} = root, attrs \\ %{}), do: Root.changeset(root, attrs)
-
-  @doc """
-  Whether a path lies inside a registered library root.
-
-  This is derived, never declared: nobody should have to *tell* the system a
-  folder is inside the library. Import uses it to notice that bringing a
-  file in would be copying it to where it already is, and adopts in place
-  instead.
-  """
-  def inside_root?(path) when is_binary(path) do
-    Enum.any?(list_roots(), fn root ->
-      String.starts_with?(path <> "/", root.path <> "/")
-    end)
-  end
 
   @doc """
   Every registered path, source or root.

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -88,8 +88,24 @@ defmodule Ambry.Library do
 
   @doc """
   Removes a source from the registry. Never touches the files it points at.
+
+  Refused with `{:error, {:referenced, %{inbox_items: n}}}` while inbox
+  items still resolve their paths through it — the database would refuse
+  too (`on_delete: :restrict`), but a count is an explanation and a
+  constraint violation is not.
   """
-  def delete_source(%Source{} = source), do: Repo.delete(source)
+  def delete_source(%Source{} = source) do
+    case references_to(source) do
+      %{inbox_items: 0} -> Repo.delete(source)
+      counts -> {:error, {:referenced, counts}}
+    end
+  end
+
+  defp references_to(%Source{id: id}) do
+    %{
+      inbox_items: Repo.aggregate(from(i in "inbox_items", where: i.source_id == ^id), :count)
+    }
+  end
 
   def change_source(%Source{} = source, attrs \\ %{}), do: Source.changeset(source, attrs)
 
@@ -123,9 +139,26 @@ defmodule Ambry.Library do
   Removes a root from the registry.
 
   This never touches the files it points at — deleting a row is not how an
-  operator says "delete my library".
+  operator says "delete my library". Refused with
+  `{:error, {:referenced, %{media: n, media_tracks: n}}}` while recordings
+  still resolve their paths through it; the database's
+  `on_delete: :restrict` backs the same rule, but a count is an
+  explanation and a constraint violation is not.
   """
-  def delete_root(%Root{} = root), do: Repo.delete(root)
+  def delete_root(%Root{} = root) do
+    case root_references(root) do
+      %{media: 0, media_tracks: 0} -> Repo.delete(root)
+      counts -> {:error, {:referenced, counts}}
+    end
+  end
+
+  defp root_references(%Root{id: id}) do
+    %{
+      media: Repo.aggregate(from(m in "media", where: m.library_root_id == ^id), :count),
+      media_tracks:
+        Repo.aggregate(from(t in "media_tracks", where: t.library_root_id == ^id), :count)
+    }
+  end
 
   def change_root(%Root{} = root, attrs \\ %{}), do: Root.changeset(root, attrs)
 

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -36,13 +36,14 @@ defmodule Ambry.Library do
   """
 
   use Boundary,
-    deps: [Ambry.Repo],
+    deps: [Ambry.Paths, Ambry.Repo],
     exports: [Source, Root, NamingTemplate, Placement]
 
   import Ecto.Query
 
   alias Ambry.Library.Root
   alias Ambry.Library.Source
+  alias Ambry.Paths
   alias Ambry.Repo
 
   defmodule Status do
@@ -127,6 +128,86 @@ defmodule Ambry.Library do
   def delete_root(%Root{} = root), do: Repo.delete(root)
 
   def change_root(%Root{} = root, attrs \\ %{}), do: Root.changeset(root, attrs)
+
+  ## stored-path resolution
+  #
+  # A stored path is either relative to a library root (the FK says which)
+  # or a legacy `/uploads/...` path with a null FK, resolved through
+  # `Ambry.Paths`. These are the only two cases; anything else is refused
+  # rather than guessed at.
+
+  @doc """
+  Resolves a stored path to an absolute disk path.
+
+  Takes the root (record, id, or `nil` for the legacy uploads case) and the
+  stored string. Rejects a relative path containing `..` or starting with
+  `/` **before anything else** — `Path.join/2` traverses upward happily and
+  discards a joined-on absolute path entirely, and resolved paths feed
+  `File.rm_rf`.
+  """
+  def resolve(nil, "/uploads/" <> _rest = web_path), do: {:ok, Paths.web_to_disk(web_path)}
+  def resolve(nil, path), do: {:error, {:unresolvable, path}}
+
+  def resolve(%Root{} = root, relative) do
+    cond do
+      Path.type(relative) != :relative -> {:error, {:not_relative, relative}}
+      ".." in Path.split(relative) -> {:error, {:traversal, relative}}
+      true -> {:ok, Path.join(root.path, relative)}
+    end
+  end
+
+  def resolve(root_id, relative) when is_integer(root_id) do
+    case fetch_root(root_id) do
+      {:ok, root} -> resolve(root, relative)
+      {:error, :not_found} -> {:error, {:no_root, root_id}}
+    end
+  end
+
+  @doc """
+  Same, raising on anything unresolvable.
+
+  For invariants the schema is meant to guarantee — a caller that has no
+  better answer than crashing should crash here, before the bad path
+  reaches the filesystem.
+  """
+  def resolve!(root, path) do
+    case resolve(root, path) do
+      {:ok, absolute} -> absolute
+      {:error, reason} -> raise "unresolvable stored path: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  The stored (relative) form of an absolute path inside a location.
+
+  Refuses a path outside the location rather than emitting `../..`.
+  """
+  def relativize(%Root{path: base}, absolute), do: do_relativize(base, absolute)
+  def relativize(%Source{path: base}, absolute), do: do_relativize(base, absolute)
+
+  defp do_relativize(base, absolute) do
+    if String.starts_with?(absolute, base <> "/"),
+      do: {:ok, Path.relative_to(absolute, base)},
+      else: {:error, :outside_location}
+  end
+
+  @doc """
+  The root an absolute path lives in, with its relative form.
+
+  Longest-prefix match, matched on a path-segment boundary, so nested
+  locations resolve deterministically. For the backfill and the import
+  boundary only — runtime code reads the FK rather than inferring a
+  location.
+  """
+  def locate(absolute) when is_binary(absolute) do
+    list_roots()
+    |> Enum.filter(&String.starts_with?(absolute, &1.path <> "/"))
+    |> Enum.max_by(&String.length(&1.path), fn -> nil end)
+    |> case do
+      nil -> {:error, :no_location}
+      root -> {:ok, {root, Path.relative_to(absolute, root.path)}}
+    end
+  end
 
   @doc """
   Every registered path, source or root.

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -148,18 +148,24 @@ defmodule Ambry.Library do
   def resolve(nil, "/uploads/" <> _rest = web_path), do: {:ok, Paths.web_to_disk(web_path)}
   def resolve(nil, path), do: {:error, {:unresolvable, path}}
 
-  def resolve(%Root{} = root, relative) do
-    cond do
-      Path.type(relative) != :relative -> {:error, {:not_relative, relative}}
-      ".." in Path.split(relative) -> {:error, {:traversal, relative}}
-      true -> {:ok, Path.join(root.path, relative)}
-    end
-  end
+  def resolve(%Root{path: base}, relative), do: resolve_in(base, relative)
+
+  # Inbox item paths are relative to the *source* they were discovered in —
+  # a source is a location too, it's just never a place media lives.
+  def resolve(%Source{path: base}, relative), do: resolve_in(base, relative)
 
   def resolve(root_id, relative) when is_integer(root_id) do
     case fetch_root(root_id) do
       {:ok, root} -> resolve(root, relative)
       {:error, :not_found} -> {:error, {:no_root, root_id}}
+    end
+  end
+
+  defp resolve_in(base, relative) do
+    cond do
+      Path.type(relative) != :relative -> {:error, {:not_relative, relative}}
+      ".." in Path.split(relative) -> {:error, {:traversal, relative}}
+      true -> {:ok, Path.join(base, relative)}
     end
   end
 

--- a/lib/ambry/library/mounts.ex
+++ b/lib/ambry/library/mounts.ex
@@ -1,0 +1,95 @@
+defmodule Ambry.Library.Mounts do
+  @moduledoc """
+  Which mount a path lives under, read live from `/proc/self/mountinfo`.
+
+  This exists because "same filesystem" and "can be hardlinked between" are
+  different questions, and `link(2)` answers the second one in terms of
+  *mounts*:
+
+    * Two mounts of one NFS export share a superblock — one `st_dev` — and
+      the kernel still refuses to link across them (`EXDEV`). A device
+      comparison alone says "fine" and the refusal arrives later, after the
+      destination folder has already been created.
+    * The inverse on btrfs: one mount holds many subvolumes, each with its
+      own anonymous `st_dev`, and links across subvolumes are refused too.
+      There the device comparison is the one that catches it, and the mount
+      table would wrongly say "same".
+
+  So the hardlink question is device equality *refined by* mount identity,
+  never one or the other — see `Ambry.Library.same_filesystem?/2`.
+
+  Read live rather than captured into a column: mount tables change with
+  every remount and autofs event, and the doctrine of `Ambry.Library.Status`
+  applies — a stale answer is worse than none. The file is tiny and the
+  check runs at preflight frequency, not per request.
+
+  ## Known limit
+
+  Matching is by literal path prefix, so a registered path that is itself a
+  symlink into another mount is attributed to the symlink's mount, not the
+  target's. Registered locations are mount-point-shaped in practice; if one
+  ever isn't, the worst case is the pre-existing one — placement's own loud
+  `EXDEV` refusal at link time.
+  """
+
+  @mountinfo "/proc/self/mountinfo"
+
+  @doc """
+  The mount table, as `%{id, mount_point}` entries in table order.
+
+  `:unavailable` on systems without `#{@mountinfo}` — macOS has no
+  equivalent, and there the device comparison is the best answer available.
+  """
+  def read(path \\ @mountinfo) do
+    case File.read(path) do
+      {:ok, content} -> {:ok, parse(content)}
+      {:error, _reason} -> :unavailable
+    end
+  end
+
+  @doc """
+  Parses mountinfo content.
+
+  Fields are space-separated with octal escapes inside the mount point
+  (`\\040` for the space in "/mnt/my nas"), so a plain split is safe and
+  the escapes are undone afterwards.
+  """
+  def parse(content) do
+    for line <- String.split(content, "\n", trim: true),
+        [id, _parent, _dev, _root, mount_point | _rest] = String.split(line, " ") do
+      %{id: String.to_integer(id), mount_point: unescape(mount_point)}
+    end
+  end
+
+  @doc """
+  The mount a path lives under: longest mount-point prefix, matched on a
+  path-segment boundary so `/mnt/nas-a` never claims `/mnt/nas-abc`.
+
+  Overmounts shadow: when two entries claim the same mount point, the later
+  one is the visible mount, so among equal-length matches table order wins.
+  """
+  def mount_of(path, mounts) do
+    mounts
+    |> Enum.with_index()
+    |> Enum.filter(fn {mount, _index} -> covers?(mount.mount_point, path) end)
+    |> Enum.max_by(fn {mount, index} -> {byte_size(mount.mount_point), index} end, fn -> nil end)
+    |> case do
+      # Every absolute path is under "/" at minimum; nil means the path (or
+      # the table) wasn't absolute-shaped, and guessing helps nobody.
+      nil -> {:error, :no_mount}
+      {mount, _index} -> {:ok, mount}
+    end
+  end
+
+  defp covers?("/", path), do: String.starts_with?(path, "/")
+
+  defp covers?(mount_point, path),
+    do: path == mount_point or String.starts_with?(path, mount_point <> "/")
+
+  defp unescape(mount_point) do
+    ~r/\\([0-7]{3})/
+    |> Regex.replace(mount_point, fn _whole, octal ->
+      <<String.to_integer(octal, 8)>>
+    end)
+  end
+end

--- a/lib/ambry/library/placement.ex
+++ b/lib/ambry/library/placement.ex
@@ -131,9 +131,6 @@ defmodule Ambry.Library.Placement do
 
   def finalize(%__MODULE__{}), do: :ok
 
-  # An adopted item was never placed, so there's nothing to finish.
-  def finalize(nil), do: :ok
-
   @doc """
   Removes a placement, for when the surrounding transaction failed.
 

--- a/lib/ambry/library/placement.ex
+++ b/lib/ambry/library/placement.ex
@@ -2,14 +2,36 @@ defmodule Ambry.Library.Placement do
   @moduledoc """
   Bringing a file into a library root.
 
-  Three policies, set per bring-in source:
+  Four policies, set per source. They are exhaustive: a file either shares
+  its bytes with the original (hard or soft), duplicates them, or relocates
+  them — there is no fifth door.
 
     * `:hardlink` — **same filesystem required**. One inode, two names, no
       extra bytes. This is the point of the whole exercise: the torrent keeps
       seeding from the downloads folder while the library serves the same
       bytes.
+    * `:symlink` — the cross-filesystem answer to the same question, with
+      real burdens the operator accepts by choosing it (below).
     * `:copy` — duplicates. Honest and always possible.
     * `:move` — the library gets the file and the source folder is left clean.
+
+  ## What choosing symlink takes on
+
+  A symlink stores a path *string*, not a reference to the bytes, so the
+  library entry dangles if the target is moved or deleted — reconciliation
+  reports the recording missing, which is the honest answer, and recreating
+  the link is the only repair. Links are written **absolute**: a relative
+  link survives only when link and target move as one tree, and that is
+  exactly the shared-filesystem case where `:hardlink` is available and
+  strictly better. Two consequences worth telling the operator at the point
+  of choosing: the link breaks if either mount path changes, and a link
+  written from inside a container encodes the *container's* view of the
+  path — the same tree read from the NAS host sees dangling links. Not a
+  data-loss risk; the bytes are untouched. But the library tree stops being
+  self-describing outside Ambry.
+
+  Unlike `:hardlink`, symlink has no precondition to fail — that is the
+  point of having it — so it gets no feasibility blocker.
 
   ## Why hardlink refuses instead of falling back
 
@@ -43,7 +65,7 @@ defmodule Ambry.Library.Placement do
   `finalize/1` once the surrounding transaction commits, or to `undo/1` if it
   doesn't.
   """
-  def place(source, destination, policy) when policy in [:hardlink, :copy, :move] do
+  def place(source, destination, policy) when policy in [:hardlink, :symlink, :copy, :move] do
     with :ok <- readable(source),
          :ok <- vacant(destination),
          :ok <- File.mkdir_p(Path.dirname(destination)),
@@ -142,6 +164,16 @@ defmodule Ambry.Library.Placement do
     Library.same_filesystem?(source, root_path)
   end
 
+  # Absolute target, deliberately — see the moduledoc. `source` is already
+  # absolute everywhere placement is reached (sources and roots both validate
+  # it), so this writes the link content as given rather than re-deriving it.
+  defp transfer(source, destination, :symlink) do
+    case File.ln_s(source, destination) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:symlink_failed, reason}}
+    end
+  end
+
   defp transfer(source, destination, :copy) do
     case File.cp(source, destination) do
       :ok -> :ok
@@ -175,9 +207,13 @@ defmodule Ambry.Library.Placement do
 
   # Never clobber. A collision means two recordings rendered to the same
   # path, which is a curation problem the operator has to see, not something
-  # to paper over with " (2)".
+  # to paper over with " (2)". `lstat` rather than `exists?`: a dangling
+  # symlink occupies the name too, and `exists?` follows links.
   defp vacant(destination) do
-    if File.exists?(destination), do: {:error, {:destination_exists, destination}}, else: :ok
+    case File.lstat(destination) do
+      {:ok, _occupied} -> {:error, {:destination_exists, destination}}
+      {:error, _absent} -> :ok
+    end
   end
 
   # An undone placement shouldn't leave "Brandon Sanderson/The Stormlight

--- a/lib/ambry/library/root.ex
+++ b/lib/ambry/library/root.ex
@@ -1,19 +1,20 @@
 defmodule Ambry.Library.Root do
   @moduledoc """
-  A folder the library's managed audio lives in, organized by the naming
-  template. Ambry writes here and nowhere else.
+  A folder the library's audio lives in, organized by the naming template.
+  Ambry writes here and nowhere else — a root is the only place it serves
+  from, so **at least one root is required to import anything**. The inbox
+  surfaces `:no_library_root` as "create a library root first" rather than
+  offering an import that cannot place.
 
   Roots are destinations, not sources: they aren't watched, and files only
-  arrive in one by being imported into it. An operator who wants a root's
-  tree watched — hand-placed files surfacing in the inbox — points a
-  `Ambry.Library.Source` at the same path; import notices the files are
-  already inside a root and adopts them where they lie.
+  arrive in one by being imported into it. An operator with hand-placed
+  files points an `Ambry.Library.Source` at them and imports like anything
+  else — a `:move` policy organizes them into template shape without
+  copying a byte when source and root share a filesystem.
 
-  Roots are optional by design. A setup whose sources are all
-  `leave_in_place` imports nothing into the library tree and needs no root
-  at all. Images (covers, person photos) never live in a root either —
-  they're derived, re-fetchable artifacts and keep to Ambry's internal
-  uploads storage (`Ambry.Paths`); roots hold audio only.
+  Images (covers, person photos) never live in a root — they're derived,
+  re-fetchable artifacts and keep to Ambry's internal uploads storage
+  (`Ambry.Paths`); roots hold audio only.
 
   Several roots is a first-class arrangement, not a fallback: a hardlink
   can't cross a filesystem, so each disk that receives imports needs a root

--- a/lib/ambry/library/source.ex
+++ b/lib/ambry/library/source.ex
@@ -1,22 +1,17 @@
 defmodule Ambry.Library.Source do
   @moduledoc """
-  A watched folder audiobooks arrive from.
+  A watched folder audiobooks arrive from. Read, never written.
 
-  A source carries exactly one promise, made by the operator: whether these
-  files can be trusted to stay. `on_import` names what import does about it:
-
-    * `:bring_in` — the folder belongs to something that may delete from it
-      (a download client, usually), so import protects the library by
-      placing its own copy of the bytes into a library root, per
-      `import_policy`, and the recording becomes **managed**.
-    * `:leave_in_place` — the files are staying put, so import references
-      them exactly where they are and the recording becomes **external**.
-      Ambry never writes here.
+  Import always places a source's files into a library root; the source
+  carries the default `import_policy` naming how — hardlink, symlink, copy
+  or move. The durability question the operator used to answer separately
+  ("can these files be trusted to stay?") is answered by the choice itself:
+  pick `:symlink` if they'll stay, `:hardlink`/`:copy`/`:move` if they
+  might not.
 
   How organized the folder is doesn't matter and isn't asked: discovery
   measures release boundaries from the tree itself, and a messy downloads
   folder and a meticulously curated collection are the same thing to it.
-  The one distinction that changes behavior is the durability promise.
   """
 
   use Ecto.Schema
@@ -25,27 +20,24 @@ defmodule Ambry.Library.Source do
 
   alias Ambry.Library.Root
 
-  @on_import [:bring_in, :leave_in_place]
   @import_policies [:hardlink, :symlink, :copy, :move]
 
   schema "sources" do
     # A *preferred* root, not a binding one: any source may feed any root,
     # and which one an import uses is a per-import decision this only seeds.
-    # Pairing each bring-in source with a same-filesystem root is what makes
+    # Pairing each source with a same-filesystem root is what makes
     # hardlinking possible, so complex setups pair them explicitly.
     belongs_to :target_root, Root
 
     field :name, :string
     field :path, :string
-    field :on_import, Ecto.Enum, values: @on_import
-    field :import_policy, Ecto.Enum, values: @import_policies
+    field :import_policy, Ecto.Enum, values: @import_policies, default: :hardlink
     field :enabled, :boolean, default: true
     field :last_scanned_at, :utc_datetime
 
     timestamps(type: :utc_datetime)
   end
 
-  def on_import_choices, do: @on_import
   def import_policies, do: @import_policies
 
   @doc false
@@ -54,16 +46,14 @@ defmodule Ambry.Library.Source do
     |> cast(attrs, [
       :name,
       :path,
-      :on_import,
       :import_policy,
       :enabled,
       :last_scanned_at,
       :target_root_id
     ])
     |> update_change(:path, &normalize_path/1)
-    |> validate_required([:name, :path, :on_import])
+    |> validate_required([:name, :path, :import_policy])
     |> validate_absolute_path()
-    |> put_import_policy()
     |> foreign_key_constraint(:target_root_id)
     |> unique_constraint(:path)
     |> unique_constraint(:name)
@@ -90,28 +80,5 @@ defmodule Ambry.Library.Source do
         do: [],
         else: [path: "must be an absolute path"]
     end)
-  end
-
-  # The policy and the preferred root only mean anything when import brings
-  # files in, so a leave-in-place source doesn't get to carry stale ones.
-  # Bring-in defaults to hardlinking: it's the 1x-storage case this whole
-  # phase exists for, and the operator can pick something else deliberately.
-  defp put_import_policy(changeset) do
-    case get_field(changeset, :on_import) do
-      :bring_in ->
-        update_change_default(changeset, :import_policy, :hardlink)
-
-      _leave_in_place ->
-        changeset
-        |> put_change(:import_policy, nil)
-        |> put_change(:target_root_id, nil)
-    end
-  end
-
-  defp update_change_default(changeset, field, default) do
-    case get_field(changeset, field) do
-      nil -> put_change(changeset, field, default)
-      _set -> changeset
-    end
   end
 end

--- a/lib/ambry/library/source.ex
+++ b/lib/ambry/library/source.ex
@@ -26,7 +26,7 @@ defmodule Ambry.Library.Source do
   alias Ambry.Library.Root
 
   @on_import [:bring_in, :leave_in_place]
-  @import_policies [:hardlink, :copy, :move]
+  @import_policies [:hardlink, :symlink, :copy, :move]
 
   schema "sources" do
     # A *preferred* root, not a binding one: any source may feed any root,

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -414,15 +414,23 @@ defmodule Ambry.Media do
   # goes with its last part.
   defp source_deletions(%Media{source_path: path} = media) when is_binary(path) do
     if shared_source_path?(media),
-      do: {[], media.source_files || []},
-      else: {[path], []}
+      do: {[], Media.source_file_paths(media)},
+      else: {[Media.source_path(media)], []}
   end
 
   defp source_deletions(%Media{}), do: {[], []}
 
-  defp shared_source_path?(%Media{id: id, source_path: path}) do
-    Repo.exists?(from(m in Media, where: m.source_path == ^path and m.id != ^id))
+  # Compared as {root, relative} rather than as strings: two roots may
+  # legitimately hold the same relative path, and they are different folders.
+  defp shared_source_path?(%Media{id: id, source_path: path, library_root_id: root_id}) do
+    Media
+    |> where([m], m.source_path == ^path and m.id != ^id)
+    |> same_root(root_id)
+    |> Repo.exists?()
   end
+
+  defp same_root(query, nil), do: where(query, [m], is_nil(m.library_root_id))
+  defp same_root(query, root_id), do: where(query, [m], m.library_root_id == ^root_id)
 
   defp all_file_paths(%Media{} = media) do
     %Media{
@@ -544,7 +552,8 @@ defmodule Ambry.Media do
         source_files: source_files,
         processor: processor
       }) do
-    old_source_path = media.source_path
+    old_stored = media.source_path
+    old_disk = old_stored && Media.source_path(media)
 
     with {:ok, updated_media} <-
            update_media(media, %{
@@ -553,19 +562,19 @@ defmodule Ambry.Media do
              status: :pending
            }),
          {:ok, _job} <- run_processor_async(updated_media, processor) do
-      delete_old_source_folder_async(old_source_path, source_path)
+      delete_old_source_folder_async(old_stored, old_disk, source_path)
       {:ok, updated_media}
     end
   end
 
   # Same rule as deletion: the old folder is Ambry's name for the bytes and
   # goes with the replacement; any original it was placed from is untouched
-  # by construction.
-  defp delete_old_source_folder_async(old_source_path, new_source_path)
-       when old_source_path in [nil, new_source_path], do: {:ok, :noop}
+  # by construction. Compared in stored form, deleted in resolved form.
+  defp delete_old_source_folder_async(old_stored, _old_disk, new_source_path)
+       when old_stored in [nil, new_source_path], do: {:ok, :noop}
 
-  defp delete_old_source_folder_async(old_source_path, _new_source_path),
-    do: try_delete_files_async([], [old_source_path])
+  defp delete_old_source_folder_async(_old_stored, old_disk, _new_source_path),
+    do: try_delete_files_async([], [old_disk])
 
   defdelegate available_processors(media_or_filenames), to: Processor, as: :matched_processors
 

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -392,30 +392,27 @@ defmodule Ambry.Media do
     Library.registered_paths()
   end
 
-  # Deletion semantics by custody (roadmap 3a).
+  # Deletion semantics (roadmap 3a, custody collapsed by the paths refactor).
   #
-  # `managed` means Ambry owns the bytes — the legacy transcoded library, or
-  # a file placed into a library root — and removing the recording removes
-  # them. If that file is a hardlink, only this name goes; the seeding copy
-  # in the downloads folder is a separate name for the same inode and is
-  # untouched, which is exactly why hardlinking is safe to delete from.
+  # Every recording's files are Ambry's own name for the bytes — a file
+  # placed into a library root, or the legacy transcoded workspace — and
+  # removing the recording removes that name. The original a placement was
+  # made from is untouched by construction: a hardlink is a separate name
+  # for the same inode, a symlink is unlinked without being followed, a
+  # copy never knew its original, and a move's original is already gone.
   #
-  # `external` means the files belong to someone else's workflow and are
-  # merely referenced. Removal deletes records only.
-  #
-  # This is not a nicety. `source_path` for an inbox-approved external
-  # recording is the operator's own downloads folder, and the deletion worker
-  # runs `File.rm_rf` on every folder it's given.
+  # This is still worth care: the deletion worker runs `File.rm_rf` on
+  # every folder it's given, so `source_path` must always be a folder that
+  # is Ambry's to remove.
   #
   # Transcoded outputs, images and thumbnails are always Ambry's own, under
-  # the uploads path, so they're removed regardless of custody.
+  # the uploads path, so they're removed too.
   # A folder shared with a sibling is not this media's to remove: a
   # multi-part recording places every part in one book folder, so deleting
   # part 1 with an rm_rf of `source_path` would take part 2's file with it.
   # A shared folder yields only the media's own files; the folder itself
   # goes with its last part.
-  defp source_deletions(%Media{custody: :managed, source_path: path} = media)
-       when is_binary(path) do
+  defp source_deletions(%Media{source_path: path} = media) when is_binary(path) do
     if shared_source_path?(media),
       do: {[], media.source_files || []},
       else: {[path], []}
@@ -548,7 +545,6 @@ defmodule Ambry.Media do
         processor: processor
       }) do
     old_source_path = media.source_path
-    old_custody = media.custody
 
     with {:ok, updated_media} <-
            update_media(media, %{
@@ -557,22 +553,19 @@ defmodule Ambry.Media do
              status: :pending
            }),
          {:ok, _job} <- run_processor_async(updated_media, processor) do
-      delete_old_source_folder_async(old_custody, old_source_path, source_path)
+      delete_old_source_folder_async(old_source_path, source_path)
       {:ok, updated_media}
     end
   end
 
-  # Same custody rule as deletion: the old folder is only Ambry's to remove
-  # if it was managed. Replacing the files of an external recording must not
-  # take the original source folder with it.
-  defp delete_old_source_folder_async(_custody, old_source_path, new_source_path)
+  # Same rule as deletion: the old folder is Ambry's name for the bytes and
+  # goes with the replacement; any original it was placed from is untouched
+  # by construction.
+  defp delete_old_source_folder_async(old_source_path, new_source_path)
        when old_source_path in [nil, new_source_path], do: {:ok, :noop}
 
-  defp delete_old_source_folder_async(:managed, old_source_path, _new_source_path),
+  defp delete_old_source_folder_async(old_source_path, _new_source_path),
     do: try_delete_files_async([], [old_source_path])
-
-  defp delete_old_source_folder_async(_external, _old_source_path, _new_source_path),
-    do: {:ok, :noop}
 
   defdelegate available_processors(media_or_filenames), to: Processor, as: :matched_processors
 

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -64,16 +64,16 @@ defmodule Ambry.Media do
   defdelegate orphaned_files_audit(), to: Audit
 
   @doc """
-  Brings a recording's managed files back in line with the naming template.
+  Brings a recording's files back in line with the naming template.
 
   Asynchronous because it touches the filesystem, and safe to call after any
-  edit: a recording that is already where it belongs, external, or outside a
-  library root is a no-op.
+  edit: a recording that is already where it belongs, or that lives in the
+  legacy uploads tree rather than a library root, is a no-op.
   """
   def organize_async(%Media{id: id}), do: enqueue_organize(%{"media_id" => id})
 
   @doc """
-  The same, for every managed recording of a book.
+  The same, for every recording of a book.
 
   A book's title, primary author and primary series all appear in the path of
   every recording of it, so editing the book moves its files, not just its

--- a/lib/ambry/media/audit.ex
+++ b/lib/ambry/media/audit.ex
@@ -31,13 +31,17 @@ defmodule Ambry.Media.Audit do
   defp unwrap(nil), do: nil
   defp unwrap([single]), do: single
 
+  # `Media.source_path/2` resolves the stored root-relative (or
+  # `/uploads/...`) path to a real folder on disk.
   defp source_file_stats(media) do
-    case File.ls(media.source_path) do
+    base = Media.source_path(media)
+
+    case File.ls(base) do
       {:ok, relative_paths} ->
         relative_paths
         |> Enum.sort(NaturalOrder)
         |> Enum.flat_map(fn path ->
-          file_stat(Path.join([media.source_path, path]))
+          file_stat(Path.join([base, path]))
         end)
 
       {:error, posix} ->

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -10,6 +10,8 @@ defmodule Ambry.Media.Media do
 
   alias Ambry.Books.Book
   alias Ambry.Hashids
+  alias Ambry.Library
+  alias Ambry.Library.Root
   alias Ambry.Media.Media
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaNarrator
@@ -74,8 +76,21 @@ defmodule Ambry.Media.Media do
     # set is nonsense, enforced by CHECK); the set's total lives on the group
     field :part_number, :integer
 
+    # Which library root the recording's files live in. Null means the
+    # legacy uploads tree, where `source_path` is a `/uploads/...` path —
+    # the same convention the transcoded-output columns below always used.
+    belongs_to :library_root, Root
+
+    # Root-relative (or `/uploads/...`) — resolve through `source_path/2`
+    # and `files/2`, never join these against anything directly.
     field :source_path, :string
     field :source_files, {:array, :string}, default: []
+
+    # Absolute paths a pre-refactor recording was transcoded from, pointing
+    # into a downloads folder that is a source, not a root. Provenance for
+    # Phase 4's relink, never served and never deleted.
+    field :legacy_source_files, {:array, :string}
+
     field :mpd_path, :string
     field :hls_path, :string
     field :mp4_path, :string
@@ -114,6 +129,7 @@ defmodule Ambry.Media.Media do
       :recording_group_id,
       :source_path,
       :source_files,
+      :library_root_id,
       :published,
       :published_format,
       :notes,
@@ -412,8 +428,16 @@ defmodule Ambry.Media.Media do
   def source_id(%Media{source_path: nil}), do: Ecto.UUID.generate()
   def source_id(%Media{source_path: source_path}), do: Path.basename(source_path)
 
-  def source_path(%Media{source_path: source_path}, file \\ "") when is_binary(source_path) do
-    Path.join([source_path, file])
+  @doc """
+  The absolute disk path of the recording's source folder, or of a file in
+  it.
+
+  The stored column is root-relative (or `/uploads/...` for legacy rows);
+  this is the one place it becomes a real path.
+  """
+  def source_path(%Media{source_path: source_path} = media, file \\ "")
+      when is_binary(source_path) do
+    Path.join([resolve!(media, source_path), file])
   end
 
   def output_id(media) do
@@ -432,26 +456,49 @@ defmodule Ambry.Media.Media do
     end
   end
 
-  def out_path(%Media{source_path: source_path}, file \\ "") when is_binary(source_path) do
-    Path.join([source_path, "_out", file])
+  def out_path(%Media{source_path: source_path} = media, file \\ "")
+      when is_binary(source_path) do
+    Path.join([resolve!(media, source_path), "_out", file])
   end
 
-  def files(%Media{source_files: [_ | _] = source_files}, extensions) do
-    Processor.Shared.filter_filenames(source_files, extensions)
+  @doc """
+  The recording's audio files as absolute disk paths, filtered by extension.
+  """
+  def files(%Media{source_files: [_ | _] = source_files} = media, extensions) do
+    source_files
+    |> Processor.Shared.filter_filenames(extensions)
+    |> Enum.map(&resolve!(media, &1))
   end
 
   # DEPRECATED but still used by any older media that didn't set source_files
-  def files(%Media{source_path: source_path}, extensions) when is_binary(source_path) do
-    case File.ls(source_path) do
+  def files(%Media{source_path: source_path} = media, extensions) when is_binary(source_path) do
+    base = resolve!(media, source_path)
+
+    case File.ls(base) do
       {:ok, paths} ->
         paths
         |> Processor.Shared.filter_filenames(extensions)
-        |> Enum.map(&Path.join(source_path, &1))
+        |> Enum.map(&Path.join(base, &1))
 
       {:error, _posix} ->
         []
     end
   end
+
+  @doc """
+  Every recorded source file as an absolute disk path, in play order.
+  """
+  def source_file_paths(%Media{source_files: files} = media) when is_list(files) do
+    Enum.map(files, &resolve!(media, &1))
+  end
+
+  def source_file_paths(%Media{}), do: []
+
+  # The `/uploads/...` case carries its location in the string itself, so it
+  # resolves the same whether or not the row also names a root.
+  defp resolve!(_media, "/uploads/" <> _rest = web_path), do: Library.resolve!(nil, web_path)
+  defp resolve!(%Media{library_root: %Root{} = root}, path), do: Library.resolve!(root, path)
+  defp resolve!(%Media{library_root_id: root_id}, path), do: Library.resolve!(root_id, path)
 
   # if the image_path changes, clear the thumbnails embed
   # Moving a marker makes the timeline the operator's, wherever it started

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -21,7 +21,6 @@ defmodule Ambry.Media.Media do
   alias Ambry.Thumbnails
 
   @statuses [:pending, :processing, :error, :ready]
-  @custodies [:managed, :external]
 
   # Where this recording's chapter *markers* came from. One value for the
   # whole list, because markers arrive as a timeline from a single extractor
@@ -64,10 +63,6 @@ defmodule Ambry.Media.Media do
     # unplugged disk doesn't destroy what each recording's status used to be.
     field :missing_since, :utc_datetime
 
-    # what Ambry may do to these bytes: `managed` files are its own to
-    # organize and delete, `external` files are read where they lie and never
-    # touched (roadmap 3a)
-    field :custody, Ecto.Enum, values: @custodies, default: :managed
     field :abridged, :boolean, default: false
 
     # display-title override: how this recording's title differs from the
@@ -103,8 +98,6 @@ defmodule Ambry.Media.Media do
 
   def statuses, do: @statuses
 
-  def custodies, do: @custodies
-
   def marker_sources, do: @marker_sources
 
   def provenance_fields, do: @provenance_fields
@@ -121,7 +114,6 @@ defmodule Ambry.Media.Media do
       :recording_group_id,
       :source_path,
       :source_files,
-      :custody,
       :published,
       :published_format,
       :notes,

--- a/lib/ambry/media/media_track.ex
+++ b/lib/ambry/media/media_track.ex
@@ -19,6 +19,8 @@ defmodule Ambry.Media.MediaTrack do
   import Ecto.Changeset
 
   alias Ambry.Hashids
+  alias Ambry.Library
+  alias Ambry.Library.Root
   alias Ambry.Media.Media
   alias Ambry.Media.MediaTrack
 
@@ -26,6 +28,10 @@ defmodule Ambry.Media.MediaTrack do
 
   schema "media_tracks" do
     belongs_to :media, Media
+
+    # Which library root the file lives in; null means a legacy
+    # `/uploads/...` path. Resolve through `disk_path/1`.
+    belongs_to :library_root, Root
 
     field :index, :integer
     field :path, :string
@@ -48,6 +54,7 @@ defmodule Ambry.Media.MediaTrack do
     |> cast(attrs, [
       :index,
       :path,
+      :library_root_id,
       :size,
       :mime,
       :format,
@@ -67,14 +74,25 @@ defmodule Ambry.Media.MediaTrack do
   @doc """
   The URL clients fetch this track from.
 
-  The track's own path is a disk path that may be anywhere — the uploads
-  tree, a folder referenced in place, or a library root — so the URL is keyed
-  on the track instead, and ends in the file's real name so downloads keep
-  their real extension.
+  The track's own path is a stored path relative to its library root (or a
+  legacy `/uploads/...` path), so the URL is keyed on the track instead,
+  and ends in the file's real name so downloads keep their real extension.
   """
   def web_path(%MediaTrack{id: id, path: path}) do
     "/files/track/#{Hashids.encode(id)}/#{Path.basename(path)}"
   end
+
+  @doc """
+  The absolute disk path this track is served from.
+  """
+  def disk_path(%MediaTrack{path: "/uploads/" <> _rest = web_path}),
+    do: Library.resolve(nil, web_path)
+
+  def disk_path(%MediaTrack{library_root: %Root{} = root, path: path}),
+    do: Library.resolve(root, path)
+
+  def disk_path(%MediaTrack{library_root_id: root_id, path: path}),
+    do: Library.resolve(root_id, path)
 
   @doc """
   The absolute book-seconds range this track covers, as `{start, end}`.

--- a/lib/ambry/media/organization.ex
+++ b/lib/ambry/media/organization.ex
@@ -30,7 +30,9 @@ defmodule Ambry.Media.Organization do
   alias Ambry.Books
   alias Ambry.Library
   alias Ambry.Library.NamingTemplate
+  alias Ambry.Library.Root
   alias Ambry.Media.Media
+  alias Ambry.Media.MediaTrack
   alias Ambry.Repo
   alias Ambry.Settings
   alias Ambry.Utils
@@ -49,6 +51,7 @@ defmodule Ambry.Media.Organization do
       Repo.preload(media, [
         :media_tracks,
         :recording_group,
+        :library_root,
         book: [book_authors: :author, series_books: :series]
       ])
 
@@ -57,7 +60,7 @@ defmodule Ambry.Media.Organization do
          {:ok, destinations} <- destinations(media, root, files) do
       if destinations == files,
         do: {:ok, :noop},
-        else: move(media, Enum.zip(files, destinations))
+        else: move(media, root, Enum.zip(files, destinations))
     else
       :noop -> {:ok, :noop}
       {:error, reason} -> {:error, reason}
@@ -98,32 +101,25 @@ defmodule Ambry.Media.Organization do
     |> Repo.all()
   end
 
-  # The root the file already lives in. Not the location's *target* root —
-  # this is about where the bytes are now, and a rename never moves a
-  # recording between roots.
-  defp root_for(%Media{source_path: path}) when is_binary(path) do
-    case Enum.find(Library.list_roots(), &inside?(path, &1.path)) do
-      nil -> :noop
-      root -> {:ok, root}
-    end
-  end
-
+  # The FK, never an inferred prefix: the recording says which root its
+  # files live in. A null FK is the legacy uploads tree, which isn't
+  # template-organized and belongs to Phase 4.
+  defp root_for(%Media{library_root: %Root{} = root}), do: {:ok, root}
   defp root_for(%Media{}), do: :noop
 
-  # Prefix-matching on a separator boundary, so `/data/library-old` is not
-  # treated as living inside `/data/library`.
-  defp inside?(path, root_path) do
-    String.starts_with?(path, root_path <> "/")
-  end
-
-  # Where the recording's files are now, in play order. Track order is the
-  # order the destination names are rendered in, so a multi-file recording's
-  # file 003 stays file 003 across a rename.
+  # Where the recording's files are now, absolute and in play order. Track
+  # order is the order the destination names are rendered in, so a
+  # multi-file recording's file 003 stays file 003 across a rename.
   defp current_files(%Media{media_tracks: [_ | _] = tracks}) do
-    {:ok, tracks |> Enum.sort_by(& &1.index) |> Enum.map(& &1.path)}
+    {:ok, tracks |> Enum.sort_by(& &1.index) |> Enum.map(&track_disk_path!/1)}
   end
 
   defp current_files(%Media{}), do: :noop
+
+  defp track_disk_path!(track) do
+    {:ok, path} = MediaTrack.disk_path(track)
+    path
+  end
 
   defp destinations(media, root, current_files) do
     values = Books.naming_values(media.book, media)
@@ -151,11 +147,11 @@ defmodule Ambry.Media.Organization do
   # one file to a forty-file recording renames only the forty-first: the rest
   # map to themselves, and treating "it's already there" as a collision would
   # fail every such re-organize.
-  defp move(media, pairs) do
+  defp move(media, root, pairs) do
     pairs = Enum.reject(pairs, fn {from, to} -> from == to end)
 
     case Enum.find_value(pairs, &blocker/1) do
-      nil -> do_move(media, pairs)
+      nil -> do_move(media, root, pairs)
       reason -> {:error, reason}
     end
   end
@@ -174,9 +170,9 @@ defmodule Ambry.Media.Organization do
     end
   end
 
-  defp do_move(media, pairs) do
+  defp do_move(media, root, pairs) do
     with :ok <- rename_all(pairs),
-         {:ok, _media} <- repoint(media, pairs) do
+         {:ok, _media} <- repoint(media, root, pairs) do
       pairs |> Enum.map(&elem(&1, 0)) |> prune()
       {:ok, :moved}
     else
@@ -195,27 +191,30 @@ defmodule Ambry.Media.Organization do
     end)
   end
 
-  defp repoint(media, pairs) do
+  # File operations happen in absolutes; what gets *written back* is the
+  # stored form — relative to the root the rename stayed inside.
+  defp repoint(media, root, pairs) do
     moved = Map.new(pairs)
 
     Repo.transact(fn ->
-      with {:ok, _tracks} <- repoint_tracks(media, moved) do
+      with {:ok, _tracks} <- repoint_tracks(media, root, moved) do
         media
         |> Ecto.Changeset.change(%{
-          source_path: pairs |> List.last() |> elem(1) |> Path.dirname(),
-          source_files: replace_paths(media.source_files, moved, media.media_tracks)
+          source_path: relativize!(root, pairs |> List.last() |> elem(1) |> Path.dirname()),
+          source_files: media |> replace_paths(moved) |> Enum.map(&relativize!(root, &1))
         })
         |> Repo.update()
       end
     end)
   end
 
-  defp repoint_tracks(%Media{media_tracks: tracks}, moved) do
+  defp repoint_tracks(%Media{media_tracks: tracks}, root, moved) do
     tracks
-    |> Enum.filter(&Map.has_key?(moved, &1.path))
-    |> Enum.reduce_while({:ok, []}, fn track, {:ok, acc} ->
+    |> Enum.map(&{&1, Map.get(moved, track_disk_path!(&1))})
+    |> Enum.filter(fn {_track, new_path} -> new_path end)
+    |> Enum.reduce_while({:ok, []}, fn {track, new_path}, {:ok, acc} ->
       track
-      |> Ecto.Changeset.change(%{path: moved[track.path]})
+      |> Ecto.Changeset.change(%{path: relativize!(root, new_path), library_root_id: root.id})
       |> Repo.update()
       |> case do
         {:ok, track} -> {:cont, {:ok, [track | acc]}}
@@ -224,14 +223,21 @@ defmodule Ambry.Media.Organization do
     end)
   end
 
-  defp replace_paths(source_files, moved, _tracks) when is_list(source_files) do
-    Enum.map(source_files, fn path -> Map.get(moved, path, path) end)
+  defp replace_paths(%Media{source_files: [_ | _]} = media, moved) do
+    media |> Media.source_file_paths() |> Enum.map(&Map.get(moved, &1, &1))
   end
 
   # A recording old enough to have no `source_files` gets the one thing that
   # is certainly true afterwards: where its tracks are now.
-  defp replace_paths(_source_files, moved, tracks) do
-    tracks |> Enum.sort_by(& &1.index) |> Enum.map(&Map.get(moved, &1.path, &1.path))
+  defp replace_paths(%Media{media_tracks: tracks}, moved) do
+    tracks
+    |> Enum.sort_by(& &1.index)
+    |> Enum.map(&Map.get(moved, track_disk_path!(&1), track_disk_path!(&1)))
+  end
+
+  defp relativize!(root, absolute) do
+    {:ok, relative} = Library.relativize(root, absolute)
+    relative
   end
 
   # The folders the files just left, and any parent left empty by them.

--- a/lib/ambry/media/organization.ex
+++ b/lib/ambry/media/organization.ex
@@ -1,6 +1,6 @@
 defmodule Ambry.Media.Organization do
   @moduledoc """
-  Keeping a managed recording's files where the naming template says.
+  Keeping a recording's files where the naming template says.
 
   A library tree organized once at import drifts the moment anything is
   corrected: fix a misspelled title, reorder a book's authors, add the series
@@ -9,13 +9,11 @@ defmodule Ambry.Media.Organization do
 
   ## What it will and won't touch
 
-  Only `managed` recordings whose files sit inside a **registered library
-  root**. That's two separate guards doing two separate jobs:
-
-    * custody keeps it away from external files, which Ambry has promised
-      never to write to;
-    * the root check keeps it away from the legacy uploads library, which is
-      `managed` but isn't template-organized and belongs to Phase 4.
+  Only files inside a **registered library root** — which keeps it away from
+  the legacy uploads library, which isn't template-organized and belongs to
+  Phase 4. Every recording in a root is organizable: what lives there is
+  always Ambry's own name for the bytes (a hardlink, a symlink, a copy), and
+  renaming a name never touches an original.
 
   A rename stays inside the root the file already lives in, so it's always a
   move within one filesystem — never a copy, never a cross-device problem.
@@ -67,14 +65,13 @@ defmodule Ambry.Media.Organization do
   end
 
   @doc """
-  Organizes every managed recording.
+  Organizes every recording.
 
   The backstop for everything an edit-time trigger can't see — most obviously
   a change to the template itself, which invalidates every path at once.
   """
   def organize_all do
     Media
-    |> where([m], m.custody == :managed)
     |> Repo.all()
     |> Enum.reduce(%{moved: 0, noop: 0, failed: 0}, fn media, counts ->
       case organize(media) do
@@ -93,18 +90,18 @@ defmodule Ambry.Media.Organization do
   end
 
   @doc """
-  The managed recordings of one book, for after its metadata changed.
+  The recordings of one book, for after its metadata changed.
   """
   def book_media(book_id) do
     Media
-    |> where([m], m.book_id == ^book_id and m.custody == :managed)
+    |> where([m], m.book_id == ^book_id)
     |> Repo.all()
   end
 
   # The root the file already lives in. Not the location's *target* root —
   # this is about where the bytes are now, and a rename never moves a
   # recording between roots.
-  defp root_for(%Media{custody: :managed, source_path: path}) when is_binary(path) do
+  defp root_for(%Media{source_path: path}) when is_binary(path) do
     case Enum.find(Library.list_roots(), &inside?(path, &1.path)) do
       nil -> :noop
       root -> {:ok, root}

--- a/lib/ambry/media/reconciliation.ex
+++ b/lib/ambry/media/reconciliation.ex
@@ -32,6 +32,7 @@ defmodule Ambry.Media.Reconciliation do
   import Ecto.Query
 
   alias Ambry.Media.Media
+  alias Ambry.Media.MediaTrack
   alias Ambry.Paths
   alias Ambry.Repo
 
@@ -86,12 +87,15 @@ defmodule Ambry.Media.Reconciliation do
   end
 
   @doc """
-  The files a recording is served from.
+  The files a recording is served from, as absolute disk paths.
   """
   def playable_files(%Media{media_tracks: tracks} = media) when is_list(tracks) do
-    case Enum.map(tracks, & &1.path) do
+    case Enum.map(tracks, &MediaTrack.disk_path/1) do
       [] -> legacy_outputs(media)
-      track_paths -> track_paths
+      # A stored path that cannot resolve cannot be served either; raising
+      # here keeps a broken invariant loud instead of letting a sweep read
+      # it as one more missing file.
+      resolved -> Enum.map(resolved, fn {:ok, path} -> path end)
     end
   end
 

--- a/lib/ambry/media/scanner.ex
+++ b/lib/ambry/media/scanner.ex
@@ -34,10 +34,12 @@ defmodule Ambry.Media.Scanner do
   finding in the roadmap's 1b.
   """
 
+  alias Ambry.Library
   alias Ambry.Media, as: MediaContext
   alias Ambry.Media.Chapters.FromFiles
   alias Ambry.Media.Media
   alias Ambry.Media.Scanner.Probe
+  alias Ambry.Paths
 
   @extensions ~w(.mp3 .mp4 .m4a .m4b .flac .ogg .opus .wav)
 
@@ -95,17 +97,13 @@ defmodule Ambry.Media.Scanner do
     end
   end
 
-  # `Media.files/2` yields names relative to the source folder for media that
-  # recorded `source_files`, and absolute paths for the older ones that
-  # didn't. The sort matters for the second kind: `File.ls/1` returns
-  # whatever order the filesystem felt like, which for a 40-file book is a
-  # shuffled audiobook.
+  # `Media.files/2` resolves to absolute disk paths. The sort matters for
+  # media without recorded `source_files`: `File.ls/1` returns whatever
+  # order the filesystem felt like, which for a 40-file book is a shuffled
+  # audiobook.
   defp files(media) do
     media
     |> Media.files(@extensions)
-    |> Enum.map(fn file ->
-      if Path.type(file) == :absolute, do: file, else: Media.source_path(media, file)
-    end)
     |> Enum.sort(NaturalOrder)
   end
 
@@ -131,15 +129,57 @@ defmodule Ambry.Media.Scanner do
     end
   end
 
+  # Tracks store {root FK, relative path}, never the absolute the probe ran
+  # on — a file outside the media's root and the uploads tree has no stored
+  # form, and the scan refuses rather than writing an unservable path.
   defp write_tracks(media, probes) do
-    attrs =
-      %{
-        media_tracks: track_attrs(probes),
-        duration: total_duration(probes)
-      }
-      |> maybe_put_chapters(media, probes)
+    with {:ok, tracks} <- stored_tracks(media, probes) do
+      attrs =
+        %{
+          media_tracks: tracks,
+          duration: total_duration(probes)
+        }
+        |> maybe_put_chapters(media, probes)
 
-    MediaContext.update_media(media, attrs)
+      MediaContext.update_media(media, attrs)
+    end
+  end
+
+  defp stored_tracks(media, probes) do
+    probes
+    |> track_attrs()
+    |> Enum.reduce_while({:ok, []}, fn attrs, {:ok, acc} ->
+      case stored_track_path(media, attrs.path) do
+        {:ok, {root_id, stored}} ->
+          attrs = attrs |> Map.put(:path, stored) |> Map.put(:library_root_id, root_id)
+          {:cont, {:ok, [attrs | acc]}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, tracks} -> {:ok, Enum.reverse(tracks)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp stored_track_path(%Media{library_root_id: root_id}, absolute) when is_integer(root_id) do
+    {:ok, root} = Library.fetch_root(root_id)
+
+    case Library.relativize(root, absolute) do
+      {:ok, relative} -> {:ok, {root_id, relative}}
+      {:error, :outside_location} -> uploads_stored_form(absolute)
+    end
+  end
+
+  defp stored_track_path(%Media{}, absolute), do: uploads_stored_form(absolute)
+
+  defp uploads_stored_form(absolute) do
+    case Paths.disk_to_web(absolute) do
+      "/uploads/" <> _rest = web_path -> {:ok, {nil, web_path}}
+      _outside -> {:error, {:outside_library, absolute}}
+    end
   end
 
   @doc """

--- a/lib/ambry_web/controllers/admin/inbox_cover_controller.ex
+++ b/lib/ambry_web/controllers/admin/inbox_cover_controller.ex
@@ -21,7 +21,7 @@ defmodule AmbryWeb.Admin.InboxCoverController do
   def show(conn, %{"id" => id}) do
     # The path comes from the item's own files, never from a parameter.
     with {:ok, item} <- Inbox.fetch_item(id),
-         [path | _rest] <- item.files,
+         [path | _rest] <- Inbox.disk_files(item),
          {:ok, binary, mime} <- Images.read_embedded(path) do
       conn
       |> put_resp_content_type(mime, nil)

--- a/lib/ambry_web/controllers/track_controller.ex
+++ b/lib/ambry_web/controllers/track_controller.ex
@@ -2,23 +2,25 @@ defmodule AmbryWeb.TrackController do
   @moduledoc """
   Serves direct-play audio files to authenticated clients.
 
-  The file is served from wherever it actually lives — the uploads tree, a
-  local-import folder referenced in place, or (Phase 3) a library root — so
-  the lookup goes through the track record rather than through a path the
-  client supplies.
+  A track's stored path is relative to its library root (legacy rows keep a
+  `/uploads/...` path), so the lookup goes through the track record and its
+  root — never through a path the client supplies, and never through a
+  stored absolute.
   """
 
   use AmbryWeb, :controller
 
   alias Ambry.Hashids
   alias Ambry.Media
+  alias Ambry.Media.MediaTrack
   alias AmbryWeb.FileResponse
 
   def show(conn, params) do
     with {:ok, [track_id]} <- Hashids.decode(params["id"]),
          {:ok, track} <- Media.fetch_media_track(track_id),
+         {:ok, disk_path} <- MediaTrack.disk_path(track),
          %Plug.Conn{state: state} = conn when state != :unset <-
-           FileResponse.send(conn, track.path, track.mime) do
+           FileResponse.send(conn, disk_path, track.mime) do
       conn
     else
       _else -> not_found(conn)

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -49,6 +49,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library.Source
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
   alias Ambry.People
@@ -770,7 +771,16 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      edit(socket, fn draft ->
-       update_in(draft.destination, &%{&1 | root_id: id, approved: not is_nil(id)})
+       update_in(draft.destination, &approve_destination(%{&1 | root_id: id}))
+     end)}
+  end
+
+  def handle_event("choose-policy", %{"policy" => policy}, socket) do
+    policy = to_policy(policy)
+
+    {:noreply,
+     edit(socket, fn draft ->
+       update_in(draft.destination, &approve_destination(%{&1 | policy: policy}))
      end)}
   end
 
@@ -1017,6 +1027,29 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       {int, ""} -> int
       _other -> nil
     end
+  end
+
+  # Approved is not a separate gesture: choosing the last missing half is
+  # the approval. Un-choosing either half un-approves.
+  defp approve_destination(destination) do
+    %{destination | approved: not is_nil(destination.root_id) and not is_nil(destination.policy)}
+  end
+
+  @placement_policies Source.import_policies()
+
+  defp to_policy(value) do
+    Enum.find(@placement_policies, &(to_string(&1) == value))
+  end
+
+  # The same four doors the location form offers, worded for one import
+  # rather than a standing default.
+  defp placement_policies do
+    [
+      {"Hardlink (same filesystem only, no extra storage)", :hardlink},
+      {"Symlink (crosses filesystems; dangles if the source ever moves)", :symlink},
+      {"Copy (duplicates the files)", :copy},
+      {"Move (empties the source folder)", :move}
+    ]
   end
 
   ## rendering helpers

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -755,14 +755,11 @@
           Files &amp; destination
         </h2>
 
-        <p class="text-sm">
-          <span class="font-bold">Custody:</span> {@destination.custody}
-        </p>
-
-        <%!-- Any input may feed any output, so the root is chosen here rather
-            than fixed on the watched folder. With one root this never asks. --%>
+        <%!-- Any input may feed any output, so the root and the policy are
+            chosen here rather than fixed on the watched folder. With one root
+            and a sourced item this never asks — both resolve silently. --%>
         <div
-          :if={@item.draft.destination && @item.draft.destination.custody == :managed}
+          :if={@item.draft.destination}
           class={["space-y-2 rounded-lg border-l-4 bg-zinc-900 p-4", state_rail(Tier.of(@item.draft.destination))]}
         >
           <div class="flex items-baseline gap-2 pl-3">
@@ -781,6 +778,26 @@
                 selected={@item.draft.destination.root_id == root.id}
               >
                 {root.name} ({root.path})
+              </option>
+            </select>
+          </form>
+
+          <div class="flex items-baseline gap-2 pl-3">
+            <.label>How the files come in</.label>
+          </div>
+
+          <form id="destination-policy" phx-change="choose-policy" class="mt-1">
+            <select
+              name="policy"
+              class={input_classes("w-full max-w-md")}
+            >
+              <option value="">Choose a placement policy…</option>
+              <option
+                :for={{label, policy} <- placement_policies()}
+                value={policy}
+                selected={@item.draft.destination.policy == policy}
+              >
+                {label}
               </option>
             </select>
           </form>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -329,18 +329,19 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp rail_class(%{status: :imported}), do: "border-brand-dark/40 border-l-4"
   defp rail_class(_item), do: "border-l-4 border-zinc-700"
 
-  # Where an item came from is what decides its custody at import — whether
-  # the file gets brought into the library or referenced where it lies — so
-  # it's worth reading off the row.
-  defp source_label(%Source{name: name, on_import: on_import}),
-    do: "#{name} · #{custody_word(on_import)}"
+  # Where an item came from seeds how its files reach the library, so it's
+  # worth reading off the row.
+  defp source_label(%Source{name: name, import_policy: policy}),
+    do: "#{name} · #{policy_word(policy)}"
 
-  defp source_label(nil), do: "ad-hoc scan · adopted in place"
+  defp source_label(nil), do: "ad-hoc scan"
 
-  defp custody_word(:bring_in), do: "brought in on import"
-  defp custody_word(:leave_in_place), do: "referenced in place"
+  defp policy_word(:hardlink), do: "hardlinked in on import"
+  defp policy_word(:symlink), do: "symlinked in on import"
+  defp policy_word(:copy), do: "copied in on import"
+  defp policy_word(:move), do: "moved in on import"
 
-  defp source_color(%Source{on_import: :bring_in}), do: "bg-blue-400/15 text-blue-300"
+  defp source_color(%Source{}), do: "bg-blue-400/15 text-blue-300"
 
   defp source_color(_other), do: "bg-white/10 text-zinc-300"
 

--- a/lib/ambry_web/live/admin/location_live/form.ex
+++ b/lib/ambry_web/live/admin/location_live/form.ex
@@ -147,6 +147,7 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
   defp policy_options do
     [
       {"Hardlink (same filesystem only, no extra storage)", :hardlink},
+      {"Symlink (crosses filesystems; dangles if the source ever moves)", :symlink},
       {"Copy (duplicates the files)", :copy},
       {"Move (empties the source folder)", :move}
     ]

--- a/lib/ambry_web/live/admin/location_live/form.ex
+++ b/lib/ambry_web/live/admin/location_live/form.ex
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
   end
 
   defp apply_action(socket, :new_source, _params) do
-    source = %Source{on_import: :bring_in, import_policy: :hardlink}
+    source = %Source{import_policy: :hardlink}
 
     socket
     |> assign(page_title: "New Source", entity: source)
@@ -103,7 +103,6 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
     socket
     |> assign(:form, to_form(changeset))
     |> assign(:type, :source)
-    |> assign(:on_import, Changeset.get_field(changeset, :on_import))
     |> assign(:status, path_status(Changeset.get_field(changeset, :path)))
     |> assign(:root_options, root_options())
   end
@@ -112,7 +111,6 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
     socket
     |> assign(:form, to_form(changeset))
     |> assign(:type, :root)
-    |> assign(:on_import, nil)
     |> assign(:status, path_status(Changeset.get_field(changeset, :path)))
     |> assign(:root_options, [])
   end
@@ -134,16 +132,10 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
 
   defp path_status(_blank), do: nil
 
-  # The one question a source answers, asked in the operator's terms. What
-  # the folder is called or how tidy it looks never mattered; whether its
-  # files can be trusted to stay is the whole distinction.
-  defp on_import_options do
-    [
-      {"Bring the files in (this folder's files might not stay)", :bring_in},
-      {"Leave them where they are (these files are trusted to stay)", :leave_in_place}
-    ]
-  end
-
+  # The one question a source answers, asked in the operator's terms: what
+  # import does with these files. The old durability question ("can they be
+  # trusted to stay?") is answered by the choice — symlink if they'll stay,
+  # anything else if they might not.
   defp policy_options do
     [
       {"Hardlink (same filesystem only, no extra storage)", :hardlink},

--- a/lib/ambry_web/live/admin/location_live/form.html.heex
+++ b/lib/ambry_web/live/admin/location_live/form.html.heex
@@ -44,21 +44,10 @@
       </.field_group>
 
       <.field_group :if={@type == :source}>
-        <.input
-          field={@form[:on_import]}
-          type="select"
-          label="On import"
-          options={on_import_options()}
-        />
-        <p class="max-w-prose pl-3 text-sm text-zinc-400">
-          Whether import copies these files into the library or references them where they
-          are.
-        </p>
-
         <.input field={@form[:enabled]} type="checkbox" label="Watched" />
       </.field_group>
 
-      <.field_group :if={@type == :source and @on_import == :bring_in} label="Bringing files in">
+      <.field_group :if={@type == :source} label="Bringing files in">
         <div>
           <.input
             field={@form[:import_policy]}
@@ -68,7 +57,8 @@
           />
           <p class="max-w-prose pl-3 text-sm text-zinc-400">
             Hardlinking only works within a single filesystem. Import refuses across
-            filesystems instead of silently copying.
+            filesystems instead of silently copying. Symlinking crosses filesystems, but
+            the library entry breaks if these files ever move.
           </p>
         </div>
 

--- a/lib/ambry_web/live/admin/location_live/index.ex
+++ b/lib/ambry_web/live/admin/location_live/index.ex
@@ -93,22 +93,21 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
     |> Map.new(fn {device, index} -> {device, <<?A + index>>} end)
   end
 
-  defp on_import_label(:bring_in), do: "brings files in"
-  defp on_import_label(:leave_in_place), do: "leaves files in place"
-
-  defp on_import_blurb(:bring_in),
-    do: "Its files could vanish, so import places the library's own copy into a root."
-
-  defp on_import_blurb(:leave_in_place),
-    do: "Its files are trusted to stay. Imports reference them; Ambry never writes here."
-
-  defp on_import_class(:bring_in), do: "bg-blue-400/15 text-blue-300"
-  defp on_import_class(:leave_in_place), do: "bg-white/10 text-zinc-300"
-
   defp policy_label(:hardlink), do: "hardlink"
+  defp policy_label(:symlink), do: "symlink"
   defp policy_label(:copy), do: "copy"
   defp policy_label(:move), do: "move"
-  defp policy_label(nil), do: nil
+
+  defp policy_blurb(:hardlink),
+    do: "Import hardlinks its files into a root — one copy of the bytes, seeding untouched."
+
+  defp policy_blurb(:symlink),
+    do:
+      "Import symlinks its files into a root. They're trusted to stay; the link dangles if they don't."
+
+  defp policy_blurb(:copy), do: "Import copies its files into a root, duplicating the bytes."
+
+  defp policy_blurb(:move), do: "Import moves its files into a root, leaving this folder clean."
 
   defp source_problem(status) do
     cond do

--- a/lib/ambry_web/live/admin/location_live/index.ex
+++ b/lib/ambry_web/live/admin/location_live/index.ex
@@ -105,18 +105,24 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
     )
   end
 
-  # Raw device numbers mean nothing to anyone, but "these two are on the same
-  # one" means everything here, so distinct devices get short labels in the
-  # order they're first seen.
+  # Raw device numbers mean nothing to anyone, but "these two can hardlink
+  # between each other" means everything here, so each distinct
+  # {device, mount} pair gets a short label in the order it's first seen.
+  # Both halves, because that is what `link(2)` actually requires — see
+  # `Ambry.Library.same_filesystem?/2`.
   defp label_filesystems(statuses) do
     statuses
     |> Map.values()
-    |> Enum.map(& &1.device)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.reject(&is_nil(&1.device))
+    |> Enum.map(&{&1.device, &1.mount})
     |> Enum.uniq()
     |> Enum.with_index()
-    |> Map.new(fn {device, index} -> {device, <<?A + index>>} end)
+    |> Map.new(fn {key, index} -> {key, <<?A + index>>} end)
   end
+
+  # The tag for one row, or nil for an unreachable path.
+  defp filesystem_tag(_filesystems, %{device: nil}), do: nil
+  defp filesystem_tag(filesystems, status), do: filesystems[{status.device, status.mount}]
 
   defp policy_label(:hardlink), do: "hardlink"
   defp policy_label(:symlink), do: "symlink"

--- a/lib/ambry_web/live/admin/location_live/index.ex
+++ b/lib/ambry_web/live/admin/location_live/index.ex
@@ -44,23 +44,48 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
 
   def handle_event("delete-source", %{"id" => id}, socket) do
     source = Library.get_source!(id)
-    {:ok, _source} = Library.delete_source(source)
 
-    {:noreply,
-     socket
-     |> put_flash(:info, "Removed #{source.name}. Its files were left alone.")
-     |> load()}
+    case Library.delete_source(source) do
+      {:ok, _source} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Removed #{source.name}. Its files were left alone.")
+         |> load()}
+
+      {:error, {:referenced, %{inbox_items: items}}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "#{source.name} still has #{items} inbox item#{plural(items)} resolving through it. " <>
+             "Import or remove them first."
+         )}
+    end
   end
 
   def handle_event("delete-root", %{"id" => id}, socket) do
     root = Library.get_root!(id)
-    {:ok, _root} = Library.delete_root(root)
 
-    {:noreply,
-     socket
-     |> put_flash(:info, "Removed #{root.name}. Its files were left alone.")
-     |> load()}
+    case Library.delete_root(root) do
+      {:ok, _root} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Removed #{root.name}. Its files were left alone.")
+         |> load()}
+
+      {:error, {:referenced, %{media: media}}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "#{root.name} still holds #{media} recording#{plural(media)}. " <>
+             "The library serves them from there, so the root has to outlive them."
+         )}
+    end
   end
+
+  defp plural(1), do: ""
+  defp plural(_many), do: "s"
 
   defp load(socket) do
     sources = Library.list_sources()

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -37,9 +37,9 @@
               </span>
 
               <span
-                :if={fs = @filesystems[@statuses[{:source, source.id}].device]}
+                :if={fs = filesystem_tag(@filesystems, @statuses[{:source, source.id}])}
                 class="bg-white/10 rounded-sm px-1.5 text-xs text-zinc-300"
-                title="Paths sharing this tag are on the same filesystem and can be hardlinked between"
+                title="Paths sharing this tag can be hardlinked between"
                 data-role="source-filesystem"
               >
                 <.icon name="fa-hard-drive" class="h-3 w-3 text-current" /> {fs}
@@ -132,9 +132,9 @@
               <h3 class="font-semibold" data-role="root-name">{root.name}</h3>
 
               <span
-                :if={fs = @filesystems[@statuses[{:root, root.id}].device]}
+                :if={fs = filesystem_tag(@filesystems, @statuses[{:root, root.id}])}
                 class="bg-white/10 rounded-sm px-1.5 text-xs text-zinc-300"
-                title="Paths sharing this tag are on the same filesystem and can be hardlinked between"
+                title="Paths sharing this tag can be hardlinked between"
                 data-role="root-filesystem"
               >
                 <.icon name="fa-hard-drive" class="h-3 w-3 text-current" /> {fs}

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -29,14 +29,9 @@
             <div class="flex flex-wrap items-baseline gap-2">
               <h3 class="font-semibold" data-role="source-name">{source.name}</h3>
 
-              <span class={["rounded-sm px-1.5 text-xs", on_import_class(source.on_import)]}>
-                {on_import_label(source.on_import)}
-              </span>
-
               <span
-                :if={policy_label(source.import_policy)}
-                class="bg-white/10 rounded-sm px-1.5 text-xs text-zinc-300"
-                title="How import brings the files in"
+                class="bg-blue-400/15 rounded-sm px-1.5 text-xs text-blue-300"
+                title="How import brings the files into a library root"
               >
                 {policy_label(source.import_policy)}
               </span>
@@ -59,7 +54,7 @@
               {source.path}
             </p>
 
-            <p class="mt-1 text-sm text-zinc-400">{on_import_blurb(source.on_import)}</p>
+            <p class="mt-1 text-sm text-zinc-400">{policy_blurb(source.import_policy)}</p>
 
             <p
               :if={problem = source_problem(@statuses[{:source, source.id}])}
@@ -119,11 +114,11 @@
         only here. A source can only hardlink into a root sharing its <span class="font-semibold">filesystem</span> tag.
       </p>
 
-      <%!-- Roots are optional by design: a setup whose sources all leave
-          files in place imports nothing into a tree of its own. --%>
+      <%!-- Roots are mandatory: every import places into one, so an empty
+          section is a blocker, not a fine choice. --%>
       <div :if={@roots == []} class="rounded-lg bg-zinc-900 p-8 text-center">
         <p class="mx-auto max-w-prose text-zinc-400">
-          No roots yet. Add one when a source needs to bring files in.
+          No roots yet. Nothing can be imported until there is one.
         </p>
         <.add_button navigate={~p"/admin/locations/roots/new"} class="mx-auto mt-3">
           Add a root

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -621,6 +621,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     folder_id = Media.Media.source_id(socket.assigns.media)
     source_folder = source_media_disk_path(folder_id)
 
+    # Stored in `/uploads/...` form: paths in the database are root-relative
+    # or uploads-relative, never absolute.
     audio_files =
       consume_uploaded_entries(socket, name, fn %{path: path}, entry ->
         File.mkdir_p!(source_folder)
@@ -628,7 +630,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
         dest = Path.join([source_folder, entry.client_name])
         File.cp!(path, dest)
 
-        {:ok, dest}
+        {:ok, Ambry.Paths.disk_to_web(dest)}
       end)
 
     existing_source_files = socket.assigns.media.source_files
@@ -638,7 +640,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
         media_params
       else
         Map.merge(media_params, %{
-          "source_path" => source_folder,
+          "source_path" => Ambry.Paths.disk_to_web(source_folder),
           "source_files" => Enum.sort(existing_source_files ++ audio_files, NaturalOrder)
         })
       end
@@ -650,17 +652,35 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     {:ok, media_params}
   end
 
+  # The selected files live in the local-import folder, which is nowhere the
+  # database may point any more — so they're brought into the media's own
+  # uploads workspace first, exactly like an upload. A hardlink when the two
+  # share a filesystem, a copy otherwise: this is transcode input, not the
+  # library's copy of the bytes.
   defp handle_audio_files_import(socket, %{"source_type" => "local_import"} = media_params) do
     folder_id = Media.Media.source_id(socket.assigns.media)
     source_folder = source_media_disk_path(folder_id)
 
+    imported_files =
+      for file <- socket.assigns.selected_files do
+        File.mkdir_p!(source_folder)
+        dest = Path.join(source_folder, Path.basename(file))
+
+        case File.ln(file, dest) do
+          :ok -> :ok
+          {:error, :eexist} -> :ok
+          {:error, _reason} -> File.cp!(file, dest)
+        end
+
+        Ambry.Paths.disk_to_web(dest)
+      end
+
     existing_source_files = socket.assigns.media.source_files
-    selected_files = Enum.to_list(socket.assigns.selected_files)
-    new_source_files = Enum.sort(existing_source_files ++ selected_files, NaturalOrder)
+    new_source_files = Enum.sort(existing_source_files ++ imported_files, NaturalOrder)
 
     {:ok,
      Map.merge(media_params, %{
-       "source_path" => source_folder,
+       "source_path" => Ambry.Paths.disk_to_web(source_folder),
        "source_files" => new_source_files
      })}
   end

--- a/lib/ambry_web/live/admin/media_live/replace.ex
+++ b/lib/ambry_web/live/admin/media_live/replace.ex
@@ -89,17 +89,33 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
      |> push_patch(to: ~p"/admin/audiobooks/#{socket.assigns.media}/replace", replace: true)}
   end
 
-  # Consumes browser uploads into a fresh source folder, or references the
-  # server-side files selected via the file browser, returning the new
-  # source_path and the sorted list of source files for the replacement.
+  # Consumes browser uploads into a fresh source folder — or brings the
+  # server-side files selected via the file browser into one, since the
+  # database no longer stores absolute paths. Returns the new source_path
+  # and sorted source files in `/uploads/...` form.
   defp consume_audio_files(socket, %{"source_type" => "local_import"}) do
     case Enum.to_list(socket.assigns.selected_files) do
       [] ->
         {:error, :no_files}
 
       selected_files ->
-        {:ok, source_media_disk_path(Ecto.UUID.generate()),
-         Enum.sort(selected_files, NaturalOrder)}
+        source_path = source_media_disk_path(Ecto.UUID.generate())
+
+        files =
+          for file <- selected_files do
+            File.mkdir_p!(source_path)
+            dest = Path.join(source_path, Path.basename(file))
+
+            case File.ln(file, dest) do
+              :ok -> :ok
+              {:error, :eexist} -> :ok
+              {:error, _reason} -> File.cp!(file, dest)
+            end
+
+            Ambry.Paths.disk_to_web(dest)
+          end
+
+        {:ok, Ambry.Paths.disk_to_web(source_path), Enum.sort(files, NaturalOrder)}
     end
   end
 
@@ -112,12 +128,12 @@ defmodule AmbryWeb.Admin.MediaLive.Replace do
         dest = Path.join([source_path, entry.client_name])
         File.cp!(path, dest)
 
-        {:ok, dest}
+        {:ok, Ambry.Paths.disk_to_web(dest)}
       end)
 
     case audio_files do
       [] -> {:error, :no_files}
-      files -> {:ok, source_path, Enum.sort(files, NaturalOrder)}
+      files -> {:ok, Ambry.Paths.disk_to_web(source_path), Enum.sort(files, NaturalOrder)}
     end
   end
 

--- a/priv/repo/migrations/20260814172704_collapse_custody.exs
+++ b/priv/repo/migrations/20260814172704_collapse_custody.exs
@@ -15,16 +15,23 @@ defmodule Ambry.Repo.Migrations.CollapseCustody do
       becomes a `symlink` one, which references the files where they lie
       exactly as before, via a link the library owns.
 
-  Inbox items are derived state and their drafts embed both a destination
-  `custody` and the old shape of these decisions, so they are deleted
-  wholesale and discovery repopulates them (operator-confirmed).
+  Queued inbox items are derived state and their drafts embed both a
+  destination `custody` and the old shape of these decisions, so they are
+  deleted and discovery repopulates them (operator-confirmed). **Imported
+  items survive**: an imported item is the record of what was imported and
+  the only thing standing between an already-imported release and its
+  resurfacing as a new candidate on the next scan — the library's copies
+  are placed in a root, so the ledger cannot recognize the originals.
+  Their frozen drafts still carry the old embedded shape, which Ecto
+  ignores on load.
   """
 
   use Ecto.Migration
 
   def up do
-    # Derived state; discovery rebuilds it on the next scan.
-    execute("DELETE FROM inbox_items")
+    # Derived state; discovery rebuilds it on the next scan. Imported items
+    # are history, not derived state, and stay.
+    execute("DELETE FROM inbox_items WHERE status != 'imported'")
 
     alter table(:media) do
       remove :custody

--- a/priv/repo/migrations/20260814172704_collapse_custody.exs
+++ b/priv/repo/migrations/20260814172704_collapse_custody.exs
@@ -1,0 +1,58 @@
+defmodule Ambry.Repo.Migrations.CollapseCustody do
+  @moduledoc """
+  Collapses the custody model (PATHS_REFACTOR_PLAN §5.2).
+
+  Ambry now serves from library roots only, and every import places into one
+  via a policy (hardlink | symlink | copy | move). That deletes the two
+  columns that expressed the old distinction:
+
+    * `media.custody` — "may Ambry touch these files?" is now uniformly
+      "yes for the name in my root, never for anything outside it",
+      enforced structurally. There are zero `external` rows anywhere this
+      migration will run, so nothing is converted.
+    * `sources.on_import` — the durability promise (`leave_in_place`) is
+      answered by choosing a policy instead: a leave-in-place source
+      becomes a `symlink` one, which references the files where they lie
+      exactly as before, via a link the library owns.
+
+  Inbox items are derived state and their drafts embed both a destination
+  `custody` and the old shape of these decisions, so they are deleted
+  wholesale and discovery repopulates them (operator-confirmed).
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # Derived state; discovery rebuilds it on the next scan.
+    execute("DELETE FROM inbox_items")
+
+    alter table(:media) do
+      remove :custody
+    end
+
+    # The faithful translation of the old promise, then a default for
+    # anything left unset (bring_in sources always carried a policy).
+    execute("UPDATE sources SET import_policy = 'symlink' WHERE on_import = 'leave_in_place'")
+    execute("UPDATE sources SET import_policy = 'hardlink' WHERE import_policy IS NULL")
+
+    alter table(:sources) do
+      remove :on_import
+      modify :import_policy, :string, null: false, default: "hardlink"
+    end
+  end
+
+  def down do
+    alter table(:sources) do
+      add :on_import, :string
+      modify :import_policy, :string, null: true, default: nil
+    end
+
+    execute("UPDATE sources SET on_import = 'bring_in'")
+
+    execute("ALTER TABLE sources ALTER COLUMN on_import SET NOT NULL")
+
+    alter table(:media) do
+      add :custody, :string, null: false, default: "managed"
+    end
+  end
+end

--- a/priv/repo/migrations/20260814174318_root_relative_paths.exs
+++ b/priv/repo/migrations/20260814174318_root_relative_paths.exs
@@ -1,0 +1,217 @@
+defmodule Ambry.Repo.Migrations.RootRelativePaths do
+  @moduledoc """
+  Removes absolute paths from the database (PATHS_REFACTOR_PLAN §5.3–§5.4).
+
+  Every served file lives in a library root, so every stored path becomes
+  relative to one — a `library_root_id` FK plus a relative string. The one
+  exception is the legacy uploads tree, which keeps the convention four
+  columns already use: a `/uploads/...` path with a null FK, resolved
+  through `Ambry.Paths`.
+
+  The backfill maps each absolute path by longest-prefix match against the
+  registered roots. Fail-loud is per column:
+
+    * `media_tracks.path` — a serving path; must resolve. Tracks pointing
+      outside every root and outside the uploads tree are deleted first:
+      staging has two, written by the admin scan button from legacy
+      `source_files`, so they point into the downloads folder. Those
+      recordings keep their legacy outputs; Phase 4's relink gives them
+      real placements.
+    * `media.source_path` — must resolve; legacy ones are all under the
+      uploads tree and become `/uploads/...`.
+    * `media.source_files` — legacy recordings point into a *downloads*
+      folder, which is a source, not a root. They are provenance, not
+      serving paths, so anything unmatched is quarantined into
+      `legacy_source_files` (absolute, nullable) for Phase 4 to drain.
+  """
+
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  def up do
+    alter table(:media) do
+      add :library_root_id, references(:library_roots)
+      add :legacy_source_files, {:array, :text}
+    end
+
+    alter table(:media_tracks) do
+      add :library_root_id, references(:library_roots)
+    end
+
+    flush()
+
+    roots = repo().all(from(r in "library_roots", select: %{id: r.id, path: r.path}))
+    uploads = Application.fetch_env!(:ambry, :uploads_path)
+
+    backfill_tracks(roots, uploads)
+    backfill_media(roots, uploads)
+  end
+
+  def down do
+    # Best-effort: restore absolute paths from the FK (and the uploads
+    # config) before dropping it.
+    roots = repo().all(from(r in "library_roots", select: %{id: r.id, path: r.path}))
+    uploads = Application.fetch_env!(:ambry, :uploads_path)
+
+    repo().update_all(
+      from(t in "media_tracks",
+        where: like(t.path, "/uploads/%"),
+        update: [set: [path: fragment("? || substring(path from 9)", ^uploads)]]
+      ),
+      []
+    )
+
+    repo().update_all(
+      from(m in "media",
+        where: like(m.source_path, "/uploads/%"),
+        update: [set: [source_path: fragment("? || substring(source_path from 9)", ^uploads)]]
+      ),
+      []
+    )
+
+    for root <- roots do
+      repo().update_all(
+        from(t in "media_tracks",
+          where: t.library_root_id == ^root.id,
+          update: [set: [path: fragment("? || '/' || path", ^root.path)]]
+        ),
+        []
+      )
+
+      repo().update_all(
+        from(m in "media",
+          where: m.library_root_id == ^root.id,
+          update: [
+            set: [
+              source_path: fragment("? || '/' || source_path", ^root.path),
+              source_files:
+                fragment(
+                  "(SELECT coalesce(array_agg(? || '/' || f ORDER BY ord), '{}') FROM unnest(source_files) WITH ORDINALITY AS u(f, ord))",
+                  ^root.path
+                )
+            ]
+          ]
+        ),
+        []
+      )
+    end
+
+    repo().update_all(
+      from(m in "media",
+        where: not is_nil(m.legacy_source_files),
+        update: [set: [source_files: m.legacy_source_files]]
+      ),
+      []
+    )
+
+    alter table(:media) do
+      remove :library_root_id
+      remove :legacy_source_files
+    end
+
+    alter table(:media_tracks) do
+      remove :library_root_id
+    end
+  end
+
+  defp backfill_tracks(roots, uploads) do
+    tracks = repo().all(from(t in "media_tracks", select: %{id: t.id, path: t.path}))
+
+    for track <- tracks do
+      case classify(track.path, roots, uploads) do
+        {:root, root, relative} ->
+          repo().update_all(from(t in "media_tracks", where: t.id == ^track.id),
+            set: [path: relative, library_root_id: root.id]
+          )
+
+        {:uploads, web} ->
+          repo().update_all(from(t in "media_tracks", where: t.id == ^track.id),
+            set: [path: web]
+          )
+
+        :elsewhere ->
+          # A serving path outside every root has no place in the new model.
+          # The recording falls back to its legacy outputs; Phase 4 relinks.
+          repo().delete_all(from(t in "media_tracks", where: t.id == ^track.id))
+      end
+    end
+  end
+
+  defp backfill_media(roots, uploads) do
+    media =
+      repo().all(
+        from(m in "media",
+          select: %{id: m.id, source_path: m.source_path, source_files: m.source_files}
+        )
+      )
+
+    for row <- media do
+      {source_path, root_id} = media_source_path(row, roots, uploads)
+      {source_files, legacy_source_files} = split_source_files(row.source_files, roots, uploads)
+
+      repo().update_all(from(m in "media", where: m.id == ^row.id),
+        set: [
+          source_path: source_path,
+          library_root_id: root_id,
+          source_files: source_files,
+          legacy_source_files: legacy_source_files
+        ]
+      )
+    end
+  end
+
+  defp media_source_path(%{source_path: nil}, _roots, _uploads), do: {nil, nil}
+
+  defp media_source_path(%{source_path: path, id: id}, roots, uploads) do
+    case classify(path, roots, uploads) do
+      {:root, root, relative} -> {relative, root.id}
+      {:uploads, web} -> {web, nil}
+      :elsewhere -> raise "media #{id}: source_path resolves to no root or uploads: #{path}"
+    end
+  end
+
+  # Order is play order and is preserved; the split is stable because a
+  # recording's files share one folder, so they all land on one side.
+  defp split_source_files(nil, _roots, _uploads), do: {[], nil}
+
+  defp split_source_files(files, roots, uploads) do
+    {resolved, legacy} =
+      files
+      |> Enum.map(fn file ->
+        case classify(file, roots, uploads) do
+          {:root, _root, relative} -> {:resolved, relative}
+          {:uploads, web} -> {:resolved, web}
+          :elsewhere -> {:legacy, file}
+        end
+      end)
+      |> Enum.split_with(&match?({:resolved, _}, &1))
+
+    {Enum.map(resolved, &elem(&1, 1)),
+     case Enum.map(legacy, &elem(&1, 1)) do
+       [] -> nil
+       some -> some
+     end}
+  end
+
+  defp classify(path, roots, uploads) do
+    match =
+      roots
+      |> Enum.filter(&String.starts_with?(path, &1.path <> "/"))
+      |> Enum.max_by(&String.length(&1.path), fn -> nil end)
+
+    cond do
+      match ->
+        {:root, match, Path.relative_to(path, match.path)}
+
+      String.starts_with?(path, "/uploads/") ->
+        {:uploads, path}
+
+      String.starts_with?(path, uploads <> "/") ->
+        {:uploads, "/uploads/" <> Path.relative_to(path, uploads)}
+
+      true ->
+        :elsewhere
+    end
+  end
+end

--- a/priv/repo/migrations/20260814174318_root_relative_paths.exs
+++ b/priv/repo/migrations/20260814174318_root_relative_paths.exs
@@ -46,6 +46,7 @@ defmodule Ambry.Repo.Migrations.RootRelativePaths do
 
     backfill_tracks(roots, uploads)
     backfill_media(roots, uploads)
+    backfill_inbox_items()
   end
 
   def down do
@@ -105,6 +106,27 @@ defmodule Ambry.Repo.Migrations.RootRelativePaths do
       []
     )
 
+    sources = repo().all(from(s in "sources", select: %{id: s.id, path: s.path}))
+
+    for source <- sources do
+      repo().update_all(
+        from(i in "inbox_items",
+          where: i.source_id == ^source.id,
+          update: [
+            set: [
+              path: fragment("? || '/' || path", ^source.path),
+              files:
+                fragment(
+                  "(SELECT coalesce(array_agg(? || '/' || f ORDER BY ord), '{}') FROM unnest(files) WITH ORDINALITY AS u(f, ord))",
+                  ^source.path
+                )
+            ]
+          ]
+        ),
+        []
+      )
+    end
+
     alter table(:media) do
       remove :library_root_id
       remove :legacy_source_files
@@ -158,6 +180,50 @@ defmodule Ambry.Repo.Migrations.RootRelativePaths do
           legacy_source_files: legacy_source_files
         ]
       )
+    end
+  end
+
+  # The surviving (imported) inbox items become source-relative like every
+  # newly discovered one. All-or-nothing per item: if its path or any file
+  # doesn't sit under its source, the source is dropped and the item keeps
+  # the ad-hoc absolute form — a half-relative row would satisfy nobody.
+  defp backfill_inbox_items do
+    sources = repo().all(from(s in "sources", select: %{id: s.id, path: s.path}))
+
+    items =
+      repo().all(
+        from(i in "inbox_items",
+          where: not is_nil(i.source_id),
+          select: %{id: i.id, source_id: i.source_id, path: i.path, files: i.files}
+        )
+      )
+
+    for item <- items do
+      source = Enum.find(sources, &(&1.id == item.source_id))
+      relativized = relativize_item(item, source)
+
+      case relativized do
+        {:ok, path, files} ->
+          repo().update_all(from(i in "inbox_items", where: i.id == ^item.id),
+            set: [path: path, files: files]
+          )
+
+        :outside ->
+          repo().update_all(from(i in "inbox_items", where: i.id == ^item.id),
+            set: [source_id: nil]
+          )
+      end
+    end
+  end
+
+  defp relativize_item(item, source) do
+    paths = [item.path | item.files || []]
+
+    if source && Enum.all?(paths, &String.starts_with?(&1, source.path <> "/")) do
+      [path | files] = Enum.map(paths, &Path.relative_to(&1, source.path))
+      {:ok, path, files}
+    else
+      :outside
     end
   end
 

--- a/priv/repo/migrations/20260814181441_path_constraints.exs
+++ b/priv/repo/migrations/20260814181441_path_constraints.exs
@@ -1,0 +1,136 @@
+defmodule Ambry.Repo.Migrations.PathConstraints do
+  @moduledoc """
+  Makes the stored-path invariant structural (PATHS_REFACTOR_PLAN §2.4).
+
+  A stored path is root-relative when the row names a root, and a
+  `/uploads/...` path when it doesn't; inbox items are source-relative when
+  they have a source and absolute when they don't. These CHECKs are what
+  stop the convention regressing in a year — the resolver's refusals
+  protect the filesystem, these protect the database.
+
+  Deleting a referenced location is refused by the database, not by
+  convention: `library_root_id` and `inbox_items.source_id` become
+  `on_delete: :restrict`, paired with app-level deletes that return
+  reference counts so the admin UI explains instead of surfacing a
+  constraint violation. `sources.target_root_id` deliberately stays
+  `nilify_all` — that is a soft *preferred* root, not a dependency.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # Array columns need a per-element form; a tiny immutable SQL helper is
+    # cleaner than a trigger and usable in a CHECK.
+    execute("""
+    CREATE FUNCTION ambry_paths_all_relative(paths text[]) RETURNS boolean
+    IMMUTABLE LANGUAGE SQL AS
+    $$ SELECT coalesce(bool_and(p NOT LIKE '/%'), true) FROM unnest(paths) AS p $$
+    """)
+
+    execute("""
+    CREATE FUNCTION ambry_paths_all_uploads(paths text[]) RETURNS boolean
+    IMMUTABLE LANGUAGE SQL AS
+    $$ SELECT coalesce(bool_and(p LIKE '/uploads/%'), true) FROM unnest(paths) AS p $$
+    """)
+
+    execute("""
+    CREATE FUNCTION ambry_paths_all_absolute(paths text[]) RETURNS boolean
+    IMMUTABLE LANGUAGE SQL AS
+    $$ SELECT coalesce(bool_and(p LIKE '/%'), true) FROM unnest(paths) AS p $$
+    """)
+
+    create constraint(:media_tracks, :media_tracks_path_resolvable,
+             check: """
+             CASE WHEN library_root_id IS NOT NULL
+                  THEN path NOT LIKE '/%'
+                  ELSE path LIKE '/uploads/%' END
+             """
+           )
+
+    create constraint(:media, :media_source_path_resolvable,
+             check: """
+             source_path IS NULL OR
+             CASE WHEN library_root_id IS NOT NULL
+                  THEN source_path NOT LIKE '/%'
+                  ELSE source_path LIKE '/uploads/%' END
+             """
+           )
+
+    create constraint(:media, :media_source_files_resolvable,
+             check: """
+             CASE WHEN library_root_id IS NOT NULL
+                  THEN ambry_paths_all_relative(source_files)
+                  ELSE ambry_paths_all_uploads(source_files) END
+             """
+           )
+
+    # Legacy provenance is the pre-refactor exception, quarantined: a
+    # recording with a real placement has no business carrying it.
+    create constraint(:media, :media_legacy_source_files_quarantined,
+             check: "legacy_source_files IS NULL OR library_root_id IS NULL"
+           )
+
+    create constraint(:inbox_items, :inbox_items_path_locatable,
+             check: """
+             CASE WHEN source_id IS NOT NULL
+                  THEN path NOT LIKE '/%'
+                  ELSE path LIKE '/%' END
+             """
+           )
+
+    create constraint(:inbox_items, :inbox_items_files_locatable,
+             check: """
+             CASE WHEN source_id IS NOT NULL
+                  THEN ambry_paths_all_relative(files)
+                  ELSE ambry_paths_all_absolute(files) END
+             """
+           )
+
+    # Refused by the database, explained by the app (delete_root/1 and
+    # delete_source/1 return reference counts).
+    drop constraint(:media, "media_library_root_id_fkey")
+    drop constraint(:media_tracks, "media_tracks_library_root_id_fkey")
+    drop constraint(:inbox_items, "inbox_items_source_id_fkey")
+
+    alter table(:media) do
+      modify :library_root_id, references(:library_roots, on_delete: :restrict)
+    end
+
+    alter table(:media_tracks) do
+      modify :library_root_id, references(:library_roots, on_delete: :restrict)
+    end
+
+    alter table(:inbox_items) do
+      modify :source_id, references(:sources, on_delete: :restrict)
+    end
+  end
+
+  def down do
+    drop constraint(:media_tracks, :media_tracks_path_resolvable)
+    drop constraint(:media, :media_source_path_resolvable)
+    drop constraint(:media, :media_source_files_resolvable)
+    drop constraint(:media, :media_legacy_source_files_quarantined)
+    drop constraint(:inbox_items, :inbox_items_path_locatable)
+    drop constraint(:inbox_items, :inbox_items_files_locatable)
+
+    execute("DROP FUNCTION ambry_paths_all_relative(text[])")
+    execute("DROP FUNCTION ambry_paths_all_uploads(text[])")
+    execute("DROP FUNCTION ambry_paths_all_absolute(text[])")
+
+    drop constraint(:media, "media_library_root_id_fkey")
+    drop constraint(:media_tracks, "media_tracks_library_root_id_fkey")
+    drop constraint(:inbox_items, "inbox_items_source_id_fkey")
+
+    alter table(:media) do
+      modify :library_root_id, references(:library_roots)
+    end
+
+    alter table(:media_tracks) do
+      modify :library_root_id, references(:library_roots)
+    end
+
+    alter table(:inbox_items) do
+      modify :source_id, references(:sources, on_delete: :nilify_all)
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -23,7 +23,6 @@ alias Ambry.Thumbnails
 # dump media
 # Ambry.Media.Media |> Ambry.Repo.all() |> Ambry.Repo.preload(:media_narrators) |> IO.inspect(limit: :infinity); nil
 
-
 Repo.transact(fn ->
   ## People ##
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -23,7 +23,6 @@ alias Ambry.Thumbnails
 # dump media
 # Ambry.Media.Media |> Ambry.Repo.all() |> Ambry.Repo.preload(:media_narrators) |> IO.inspect(limit: :infinity); nil
 
-cwd = File.cwd!()
 
 Repo.transact(fn ->
   ## People ##
@@ -466,7 +465,7 @@ Repo.transact(fn ->
       blurhash: "L6P?aD8_-;_M_Mt7t7WW0ft6ofkB"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/8ab5c5d5-be2d-4b7d-8021-c4b170f8ad9a",
+    source_path: "/uploads/source_media/8ab5c5d5-be2d-4b7d-8021-c4b170f8ad9a",
     mpd_path: "/uploads/media/e01fadd2-49ed-413e-8839-00dd2cf7137c.mpd",
     hls_path: "/uploads/media/e01fadd2-49ed-413e-8839-00dd2cf7137c.m3u8",
     mp4_path: "/uploads/media/e01fadd2-49ed-413e-8839-00dd2cf7137c.mp4",
@@ -497,7 +496,7 @@ Repo.transact(fn ->
       blurhash: "LSIzPHuhaenO^+%foLn%OFxGWBR*"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/74a8b0f8-cf8c-4aa3-9949-7917655a77ce",
+    source_path: "/uploads/source_media/74a8b0f8-cf8c-4aa3-9949-7917655a77ce",
     mpd_path: "/uploads/media/480eb4cf-29b4-485f-8cad-6a88b32dd382.mpd",
     hls_path: "/uploads/media/480eb4cf-29b4-485f-8cad-6a88b32dd382.m3u8",
     mp4_path: "/uploads/media/480eb4cf-29b4-485f-8cad-6a88b32dd382.mp4",
@@ -528,7 +527,7 @@ Repo.transact(fn ->
       blurhash: "LPEyJfkC7QNbXAs:juNIK+f6wGoL"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/09bb82ef-7e65-4fa1-8202-96175df67915",
+    source_path: "/uploads/source_media/09bb82ef-7e65-4fa1-8202-96175df67915",
     mpd_path: "/uploads/media/d52151bb-d906-4e30-bbae-a7e7eaac2593.mpd",
     hls_path: "/uploads/media/d52151bb-d906-4e30-bbae-a7e7eaac2593.m3u8",
     mp4_path: "/uploads/media/d52151bb-d906-4e30-bbae-a7e7eaac2593.mp4",
@@ -559,7 +558,7 @@ Repo.transact(fn ->
       blurhash: "LHEyYxD%-;M{M{oeRjaz~qWBayj["
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/eca00c0f-5078-4f77-b3cc-dc1ab1113531",
+    source_path: "/uploads/source_media/eca00c0f-5078-4f77-b3cc-dc1ab1113531",
     mpd_path: "/uploads/media/1e63b924-dcb0-4f9d-869b-9924cc6c4185.mpd",
     hls_path: "/uploads/media/1e63b924-dcb0-4f9d-869b-9924cc6c4185.m3u8",
     mp4_path: "/uploads/media/1e63b924-dcb0-4f9d-869b-9924cc6c4185.mp4",
@@ -590,7 +589,7 @@ Repo.transact(fn ->
       blurhash: "LBD0S*_L01IUIUxt%MIV02Rj_2oz"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/ef4d8f9f-598e-4c7c-a4b8-81cae7fca005",
+    source_path: "/uploads/source_media/ef4d8f9f-598e-4c7c-a4b8-81cae7fca005",
     mpd_path: "/uploads/media/5b5db89a-674d-4044-b619-c01756062f6d.mpd",
     hls_path: "/uploads/media/5b5db89a-674d-4044-b619-c01756062f6d.m3u8",
     mp4_path: "/uploads/media/5b5db89a-674d-4044-b619-c01756062f6d.mp4",
@@ -621,7 +620,7 @@ Repo.transact(fn ->
       blurhash: "LAHV|R_K%e.6DloyRjV[MztQt6V["
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/bc68c3d5-936b-41be-8b15-13936d5c679c",
+    source_path: "/uploads/source_media/bc68c3d5-936b-41be-8b15-13936d5c679c",
     mpd_path: "/uploads/media/dac8816f-fb6a-4989-905a-0e6d9780a4c0.mpd",
     hls_path: "/uploads/media/dac8816f-fb6a-4989-905a-0e6d9780a4c0.m3u8",
     mp4_path: "/uploads/media/dac8816f-fb6a-4989-905a-0e6d9780a4c0.mp4",
@@ -652,7 +651,7 @@ Repo.transact(fn ->
       blurhash: "LLG7*hjt}qa|$Mj@S2azW-j@%1oL"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/6df0fd4d-6612-479f-a1f0-43b1bf77c934",
+    source_path: "/uploads/source_media/6df0fd4d-6612-479f-a1f0-43b1bf77c934",
     mpd_path: "/uploads/media/6cdce5ec-a4ad-4b12-a8b8-9c486070d080.mpd",
     hls_path: "/uploads/media/6cdce5ec-a4ad-4b12-a8b8-9c486070d080.m3u8",
     mp4_path: "/uploads/media/6cdce5ec-a4ad-4b12-a8b8-9c486070d080.mp4",
@@ -683,7 +682,7 @@ Repo.transact(fn ->
       blurhash: "L4JEhvM|00?Z8}W:-.RQ|]az70xZ"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/431f0e0d-e6b4-4fac-b65a-e9c46ca8f35a",
+    source_path: "/uploads/source_media/431f0e0d-e6b4-4fac-b65a-e9c46ca8f35a",
     mpd_path: "/uploads/media/e8f6e520-fec9-428c-a7b0-97780b6b7639.mpd",
     hls_path: "/uploads/media/e8f6e520-fec9-428c-a7b0-97780b6b7639.m3u8",
     mp4_path: "/uploads/media/e8f6e520-fec9-428c-a7b0-97780b6b7639.mp4",
@@ -714,7 +713,7 @@ Repo.transact(fn ->
       blurhash: "L8GbO{~W0K00cBM}^%xZ0z9a^7^+"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/9a414550-7669-4124-b7c8-0c80a5b1ade4",
+    source_path: "/uploads/source_media/9a414550-7669-4124-b7c8-0c80a5b1ade4",
     mpd_path: "/uploads/media/871fdad3-1e3e-444c-9615-7317f50e6d31.mpd",
     hls_path: "/uploads/media/871fdad3-1e3e-444c-9615-7317f50e6d31.m3u8",
     mp4_path: "/uploads/media/871fdad3-1e3e-444c-9615-7317f50e6d31.mp4",
@@ -745,7 +744,7 @@ Repo.transact(fn ->
       blurhash: "L18qEF}-00?]?wt8In0200-p_2E2"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/c2e1f1f2-983b-4e3c-8057-b1584cb44344",
+    source_path: "/uploads/source_media/c2e1f1f2-983b-4e3c-8057-b1584cb44344",
     mpd_path: "/uploads/media/690a5f6d-4592-4611-8f72-002aac108b0b.mpd",
     hls_path: "/uploads/media/690a5f6d-4592-4611-8f72-002aac108b0b.m3u8",
     mp4_path: "/uploads/media/690a5f6d-4592-4611-8f72-002aac108b0b.mp4",
@@ -776,7 +775,7 @@ Repo.transact(fn ->
       blurhash: "L1Am6o%100Ip^*x[9Zax00D*-UWB"
     },
     status: :ready,
-    source_path: "/app/uploads/source_media/92b8ff82-4904-450c-ac44-f7c6f3787db7",
+    source_path: "/uploads/source_media/92b8ff82-4904-450c-ac44-f7c6f3787db7",
     mpd_path: "/uploads/media/502f2012-70dc-4e61-b245-4cd0aa1db236.mpd",
     hls_path: "/uploads/media/502f2012-70dc-4e61-b245-4cd0aa1db236.m3u8",
     mp4_path: "/uploads/media/502f2012-70dc-4e61-b245-4cd0aa1db236.mp4",

--- a/test/ambry/credit_positions_test.exs
+++ b/test/ambry/credit_positions_test.exs
@@ -96,7 +96,7 @@ defmodule Ambry.CreditPositionsTest do
       {:ok, media} =
         Media.create_media(%{
           book_id: book.id,
-          source_path: "/tmp/#{Ecto.UUID.generate()}",
+          source_path: "/uploads/source_media/#{Ecto.UUID.generate()}",
           media_narrators: [%{narrator_id: second.id}, %{narrator_id: first.id}]
         })
 

--- a/test/ambry/factory_test.exs
+++ b/test/ambry/factory_test.exs
@@ -249,9 +249,15 @@ defmodule Ambry.FactoryTest do
 
       assert %Media{} = media
       assert is_binary(media.source_path)
+      assert String.starts_with?(media.source_path, "/uploads/")
 
+      # stored form is web-style; resolve to disk to check the files exist
       for path <- media.source_files do
         assert is_binary(path)
+        assert String.starts_with?(path, "/uploads/")
+      end
+
+      for path <- Media.source_file_paths(media) do
         assert File.exists?(path)
       end
     end

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -21,8 +21,8 @@ defmodule Ambry.Inbox.DraftTest do
     source = insert(:source)
 
     %InboxItem{
-      path: "/downloads/Some Release",
-      files: ["/downloads/Some Release/book.m4b"],
+      path: "Some Release",
+      files: ["Some Release/book.m4b"],
       source_id: source.id
     }
     |> Map.merge(attrs)
@@ -3099,7 +3099,7 @@ defmodule Ambry.Inbox.DraftTest do
       item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
 
-      moved = %{item | files: ["/downloads/Some Release/moved.m4b"]}
+      moved = %{item | files: ["Some Release/moved.m4b"]}
       stale = Seed.restale(item.draft, moved)
 
       assert stale.stale

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -15,7 +15,16 @@ defmodule Ambry.Inbox.DraftTest do
   alias Ambry.Repo
 
   defp item(attrs) do
-    %InboxItem{path: "/downloads/Some Release", files: ["/downloads/Some Release/book.m4b"]}
+    # A settled environment — one root, a sourced item — so the destination
+    # resolves silently and these tests stay about the decision tree.
+    if Ambry.Library.list_roots() == [], do: insert(:root)
+    source = insert(:source)
+
+    %InboxItem{
+      path: "/downloads/Some Release",
+      files: ["/downloads/Some Release/book.m4b"],
+      source_id: source.id
+    }
     |> Map.merge(attrs)
     |> then(&(%InboxItem{} |> InboxItem.changeset(Map.from_struct(&1)) |> Repo.insert!()))
   end

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -2711,7 +2711,7 @@ defmodule Ambry.Inbox.DraftTest do
       item =
         item(%{
           path:
-            "/downloads/[ACOTAR #1] A Court of Thorns and Roses [GraphicAudio]/[ACOTAR #1] A Court of Thorns and Roses - Part 1 of 2 [GraphicAudio] (chapterized).m4b",
+            "[ACOTAR #1] A Court of Thorns and Roses [GraphicAudio]/[ACOTAR #1] A Court of Thorns and Roses - Part 1 of 2 [GraphicAudio] (chapterized).m4b",
           matches: matches([provider_candidate(%{"title" => "A Court of Thorns and Roses"})]),
           # the publisher IS what distinguishes this set from the book's
           # other recordings, so it's the natural name
@@ -2735,7 +2735,7 @@ defmodule Ambry.Inbox.DraftTest do
     test "with no publisher anywhere, the proposal's name stays blank — never the book's" do
       item =
         item(%{
-          path: "/downloads/Some Book - Part 1 of 2/Some Book - Part 1 of 2.m4b",
+          path: "Some Book - Part 1 of 2/Some Book - Part 1 of 2.m4b",
           matches: matches([provider_candidate(%{})]),
           tags: %{}
         })
@@ -2797,7 +2797,7 @@ defmodule Ambry.Inbox.DraftTest do
     test "a reseed follows fresh detection for an uncurated proposal but never touches a curated or removed one" do
       item =
         item(%{
-          path: "/downloads/Some Book - Part 1 of 2/Some Book - Part 1 of 2.m4b",
+          path: "Some Book - Part 1 of 2/Some Book - Part 1 of 2.m4b",
           matches: matches([provider_candidate(%{})]),
           tags: %{}
         })
@@ -2831,7 +2831,7 @@ defmodule Ambry.Inbox.DraftTest do
 
       item =
         item(%{
-          path: "/downloads/Some Book - Part 2 of 2/Some Book - Part 2 of 2.m4b",
+          path: "Some Book - Part 2 of 2/Some Book - Part 2 of 2.m4b",
           matches: matches([provider_candidate(%{})]),
           tags: %{}
         })
@@ -2876,7 +2876,7 @@ defmodule Ambry.Inbox.DraftTest do
 
       item =
         item(%{
-          path: "/downloads/Some Book - Part 2 of 2/Some Book - Part 2 of 2.m4b",
+          path: "Some Book - Part 2 of 2/Some Book - Part 2 of 2.m4b",
           matches: matches([provider_candidate(%{})]),
           tags: %{}
         })
@@ -2908,7 +2908,7 @@ defmodule Ambry.Inbox.DraftTest do
 
       item =
         item(%{
-          path: "/downloads/ACOTAR - Part 2 of 2/ACOTAR - Part 2 of 2.m4b",
+          path: "ACOTAR - Part 2 of 2/ACOTAR - Part 2 of 2.m4b",
           matches:
             matches([
               provider_candidate(%{
@@ -2944,7 +2944,7 @@ defmodule Ambry.Inbox.DraftTest do
       # named anywhere — the number is the part's
       polluted =
         item(%{
-          path: "/downloads/Some Book - Part 2 of 2/Some Book - Part 2 of 2.m4b",
+          path: "Some Book - Part 2 of 2/Some Book - Part 2 of 2.m4b",
           tags: %{"series_number" => "2"}
         })
 
@@ -2955,7 +2955,7 @@ defmodule Ambry.Inbox.DraftTest do
       # a named series keeps its number even when it matches the part number
       named_series =
         item(%{
-          path: "/downloads/Another Book - Part 2 of 2/Another Book - Part 2 of 2.m4b",
+          path: "Another Book - Part 2 of 2/Another Book - Part 2 of 2.m4b",
           tags: %{"series" => "The Real Series", "series_number" => "2"}
         })
 
@@ -3072,7 +3072,7 @@ defmodule Ambry.Inbox.DraftTest do
       assert resolved.ready
 
       unresolved =
-        item(%{path: "/downloads/Another", matches: matches([]), tags: %{}})
+        item(%{path: "Another", matches: matches([]), tags: %{}})
 
       {:ok, unresolved} = Inbox.prepare_draft(unresolved)
       refute unresolved.ready

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -9,6 +9,7 @@ defmodule Ambry.Inbox.ImporterTest do
   alias Ambry.Inbox.Draft.GroupLink
   alias Ambry.Media
   alias Ambry.Media.Media.Chapter
+  alias Ambry.Media.MediaTrack
   alias Ambry.People.Author
   alias Ambry.People.Narrator
   alias Ambry.People.Person
@@ -38,8 +39,10 @@ defmodule Ambry.Inbox.ImporterTest do
       assert {:ok, media} = Inbox.import_item(item)
 
       media = Media.get_media!(media.id)
-      assert [%{path: placed}] = media.media_tracks
-      assert media.source_files == [placed]
+      assert [track] = media.media_tracks
+      assert media.source_files == [track.path]
+
+      assert {:ok, placed} = MediaTrack.disk_path(track)
       assert File.read_link!(placed) == file
 
       assert File.exists?(file)

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -7,6 +7,7 @@ defmodule Ambry.Inbox.ImporterTest do
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.GroupLink
+  alias Ambry.Inbox.InboxItem
   alias Ambry.Media
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaTrack
@@ -33,7 +34,7 @@ defmodule Ambry.Inbox.ImporterTest do
 
     test "a symlink import never touches the originals" do
       item = tagged_item()
-      [file] = item.files
+      [file] = item |> Repo.preload(:source) |> InboxItem.disk_files()
       before = File.stat!(file)
 
       assert {:ok, media} = Inbox.import_item(item)
@@ -628,7 +629,7 @@ defmodule Ambry.Inbox.ImporterTest do
     @tag :capture_log
     test "refuses a file that vanished between discovery and approval" do
       item = tagged_item()
-      item.files |> hd() |> File.rm!()
+      item |> Repo.preload(:source) |> InboxItem.disk_files() |> hd() |> File.rm!()
 
       assert {:error, {:unreadable, _reason}} = Inbox.import_item(item)
 

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -30,16 +30,17 @@ defmodule Ambry.Inbox.ImporterTest do
       assert Decimal.compare(media.duration, 0) == :gt
     end
 
-    test "references the files where they lie and never touches them" do
+    test "a symlink import never touches the originals" do
       item = tagged_item()
       [file] = item.files
       before = File.stat!(file)
 
       assert {:ok, media} = Inbox.import_item(item)
 
-      assert media.custody == :external
-      assert media.source_files == item.files
-      assert [%{path: ^file}] = Media.get_media!(media.id).media_tracks
+      media = Media.get_media!(media.id)
+      assert [%{path: placed}] = media.media_tracks
+      assert media.source_files == [placed]
+      assert File.read_link!(placed) == file
 
       assert File.exists?(file)
       assert File.stat!(file).size == before.size
@@ -634,7 +635,10 @@ defmodule Ambry.Inbox.ImporterTest do
     end
   end
 
-  # A real tagged file discovered the way discovery would find it.
+  # A real tagged file discovered the way discovery would find it. The
+  # source's policy is symlink, so the originals stay exactly where the test
+  # put them — these tests are about the entity graph, and the placement
+  # policies get their workout in `ManagedImportTest`.
   defp tagged_item(opts \\ []) do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     name = Keyword.get(opts, :name, "The Way of Kings [M4B]")
@@ -652,7 +656,22 @@ defmodule Ambry.Inbox.ImporterTest do
         Enum.each(names, &File.cp!(valid_audio(:mp3), Path.join(release, &1)))
     end
 
-    {:ok, _counts} = Inbox.discover(root)
+    # One root for the whole test — a second one would make every
+    # destination ambiguous, which is its own test elsewhere.
+    if Ambry.Library.list_roots() == [] do
+      library = Ambry.Paths.source_media_disk_path("library-#{Ecto.UUID.generate()}")
+      File.mkdir_p!(library)
+      insert(:root, path: library)
+    end
+
+    watched =
+      insert(:source,
+        path: root,
+        import_policy: :symlink,
+        name: "Watched #{Ecto.UUID.generate()}"
+      )
+
+    {:ok, _counts} = Inbox.discover(watched)
     {[item], false} = Inbox.list_items(filter: name)
     {:ok, item} = Inbox.probe_item(item)
 

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -31,7 +31,6 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert {:ok, media} = Inbox.import_item(item)
 
       media = Media.get_media!(media.id)
-      assert media.custody == :managed
 
       assert [placed] = media.source_files
 
@@ -233,7 +232,6 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       watched =
         insert(:source,
-          on_import: :bring_in,
           import_policy: :copy,
           path: downloads,
           name: "Downloads #{Ecto.UUID.generate()}"
@@ -350,7 +348,6 @@ defmodule Ambry.Inbox.ManagedImportTest do
       {:ok, item} =
         Inbox.update_draft(item, %{
           "destination" => %{
-            "custody" => "managed",
             "root_id" => chosen.id,
             "policy" => "hardlink",
             "approved" => true
@@ -442,21 +439,24 @@ defmodule Ambry.Inbox.ManagedImportTest do
   end
 
   describe "other sources" do
-    test "a leave-in-place source is still adopted exactly where it lies" do
-      %{item: item, source: source} =
-        downloads_item(on_import: :leave_in_place, policy: nil)
+    # The successor to leave-in-place: the files stay exactly where they are
+    # and the library holds pointers to them, but the pointers are Ambry's
+    # own names inside a root, organized by the template like everything
+    # else.
+    test "a symlink source's files stay where they lie, referenced by links" do
+      %{item: item, source: source, root: root} = downloads_item(policy: :symlink)
 
       assert {:ok, media} = Inbox.import_item(item)
 
       media = Media.get_media!(media.id)
-      assert media.custody == :external
-      assert media.source_files == [source]
+      assert [placed] = media.source_files
+      assert String.starts_with?(placed, root)
+      assert File.read_link(placed) == {:ok, source}
       assert File.exists?(source)
     end
   end
 
   defp downloads_item(opts \\ []) do
-    on_import = Keyword.get(opts, :on_import, :bring_in)
     policy = Keyword.get(opts, :policy, :hardlink)
 
     root =
@@ -487,7 +487,6 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
     watched =
       insert(:source,
-        on_import: on_import,
         import_policy: policy,
         path: downloads,
         name: "Downloads #{Ecto.UUID.generate()}"

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -32,23 +32,27 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       media = Media.get_media!(media.id)
 
+      # stored relative to the root the record itself names
+      assert media.library_root_id
       assert [placed] = media.source_files
 
       assert placed ==
                Path.join([
-                 root,
                  "Brandon Sanderson",
                  "The Way of Kings (2010)",
                  "The Way of Kings [#{Media.filename_token(media)}].m4b"
                ])
 
-      assert File.exists?(placed)
+      assert [placed_on_disk] = Media.Media.source_file_paths(media)
+      assert placed_on_disk == Path.join(root, placed)
+      assert File.exists?(placed_on_disk)
 
       # the whole point: one inode, two names, no extra bytes
-      assert {:ok, %{links: 2}} = File.stat(placed)
+      assert {:ok, %{links: 2}} = File.stat(placed_on_disk)
       assert File.exists?(source)
 
-      assert [%{path: ^placed}] = media.media_tracks
+      assert [%{path: ^placed, library_root_id: root_id}] = media.media_tracks
+      assert root_id == media.library_root_id
       assert media.source_path == Path.dirname(placed)
     end
 
@@ -59,7 +63,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert {:ok, media} = Inbox.import_item(item)
       media = Media.get_media!(media.id)
 
-      book_folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
+      book_folder = Path.join("Brandon Sanderson", "The Way of Kings (2010)")
 
       # A subfolder, because the book folder is shared with every other
       # recording of the same work — and indexed names, because play order
@@ -75,7 +79,9 @@ defmodule Ambry.Inbox.ManagedImportTest do
                Path.join(recording_folder, "The Way of Kings - 003.m4b")
              ]
 
-      assert Enum.all?(media.source_files, &File.exists?/1)
+      placed_on_disk = Media.Media.source_file_paths(media)
+      assert placed_on_disk == Enum.map(media.source_files, &Path.join(root, &1))
+      assert Enum.all?(placed_on_disk, &File.exists?/1)
       assert media.source_path == recording_folder
 
       # 01 before 02 before 10: the order the operator saw, not the order the
@@ -85,7 +91,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
              |> Enum.map(& &1.path) == media.source_files
 
       # Every one hardlinked, and every source still seeding.
-      assert Enum.all?(media.source_files, &match?({:ok, %{links: 2}}, File.stat(&1)))
+      assert Enum.all?(placed_on_disk, &match?({:ok, %{links: 2}}, File.stat(&1)))
       assert Enum.all?(sources, &File.exists?/1)
     end
 
@@ -131,15 +137,17 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert {:ok, media} = Inbox.import_item(item)
 
-      assert [placed] = Media.get_media!(media.id).source_files
+      media = Media.get_media!(media.id)
+      assert [placed] = media.source_files
 
       assert placed ==
                Path.join([
-                 root,
                  "Brandon Sanderson",
                  "2010 - The Way of Kings",
                  "The Way of Kings [#{Media.filename_token(media)}].m4b"
                ])
+
+      assert Media.Media.source_file_paths(media) == [Path.join(root, placed)]
     end
 
     test "moves instead, leaving the downloads folder clean" do
@@ -147,7 +155,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert {:ok, media} = Inbox.import_item(item)
 
-      assert [placed] = Media.get_media!(media.id).source_files
+      assert [placed] = Media.Media.source_file_paths(Media.get_media!(media.id))
       assert File.exists?(placed)
       # the source is removed only after the records committed
       refute File.exists?(source)
@@ -158,7 +166,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert {:ok, media} = Inbox.import_item(item)
 
-      assert [placed] = Media.get_media!(media.id).source_files
+      assert [placed] = Media.Media.source_file_paths(Media.get_media!(media.id))
       assert File.exists?(source)
       assert {:ok, %{links: 1}} = File.stat(placed)
     end
@@ -181,10 +189,13 @@ defmodule Ambry.Inbox.ManagedImportTest do
     test "two part imports share the folder with distinct filenames" do
       %{media1: media1, media2: media2, root: root} = two_part_imports()
 
-      folder = Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"])
+      folder = Path.join("Brandon Sanderson", "The Way of Kings (2010)")
 
-      assert [placed1] = Media.get_media!(media1.id).source_files
-      assert [placed2] = Media.get_media!(media2.id).source_files
+      media1 = Media.get_media!(media1.id)
+      media2 = Media.get_media!(media2.id)
+
+      assert [placed1] = media1.source_files
+      assert [placed2] = media2.source_files
 
       assert placed1 ==
                Path.join(
@@ -198,8 +209,12 @@ defmodule Ambry.Inbox.ManagedImportTest do
                  "The Way of Kings - Part 2 of 2 [#{Media.filename_token(media2)}].m4b"
                )
 
-      assert File.exists?(placed1)
-      assert File.exists?(placed2)
+      assert [disk1] = Media.Media.source_file_paths(media1)
+      assert [disk2] = Media.Media.source_file_paths(media2)
+      assert disk1 == Path.join(root, placed1)
+      assert disk2 == Path.join(root, placed2)
+      assert File.exists?(disk1)
+      assert File.exists?(disk2)
     end
 
     # The deletion worker rm_rfs a managed media's source folder. Parts share
@@ -207,8 +222,8 @@ defmodule Ambry.Inbox.ManagedImportTest do
     test "deleting one part leaves its sibling's file alone" do
       %{media1: media1, media2: media2} = two_part_imports()
 
-      [placed1] = Media.get_media!(media1.id).source_files
-      [placed2] = Media.get_media!(media2.id).source_files
+      [placed1] = Media.Media.source_file_paths(Media.get_media!(media1.id))
+      [placed2] = Media.Media.source_file_paths(Media.get_media!(media2.id))
 
       assert {:ok, _deleted} = Media.delete_media(Media.get_media!(media1.id))
       # file deletion happens in a background job on the default queue
@@ -356,7 +371,10 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert {:ok, media} = Inbox.import_item(item)
 
-      assert [placed] = Media.get_media!(media.id).source_files
+      media = Media.get_media!(media.id)
+      assert media.library_root_id == chosen.id
+
+      assert [placed] = Media.Media.source_file_paths(media)
       assert String.starts_with?(placed, chosen.path)
     end
 
@@ -390,8 +408,8 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert {:ok, media2} = Inbox.import_item(settle(second))
 
-      [placed1] = Media.get_media!(media1.id).source_files
-      [placed2] = Media.get_media!(media2.id).source_files
+      [placed1] = Media.Media.source_file_paths(Media.get_media!(media1.id))
+      [placed2] = Media.Media.source_file_paths(Media.get_media!(media2.id))
 
       # Same book folder, different files, both on disk.
       assert Path.dirname(placed1) == Path.dirname(placed2)
@@ -449,7 +467,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert {:ok, media} = Inbox.import_item(item)
 
       media = Media.get_media!(media.id)
-      assert [placed] = media.source_files
+      assert [placed] = Media.Media.source_file_paths(media)
       assert String.starts_with?(placed, root)
       assert File.read_link(placed) == {:ok, source}
       assert File.exists?(source)

--- a/test/ambry/inbox/undo_test.exs
+++ b/test/ambry/inbox/undo_test.exs
@@ -125,7 +125,6 @@ defmodule Ambry.Inbox.UndoTest do
 
     watched =
       insert(:source,
-        on_import: :bring_in,
         import_policy: Keyword.get(opts, :policy, :copy),
         path: downloads,
         name: "Downloads #{Ecto.UUID.generate()}"

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -350,22 +350,39 @@ defmodule Ambry.InboxTest do
   end
 
   describe "discover/1 and the existing library" do
+    # The scanned folder doubles as a registered root here — that's the one
+    # arrangement where a scan can meet the library's own files, and the
+    # comparison happens in {root, relative} coordinates.
     test "doesn't offer files the library already has as direct-play tracks" do
       root = watched_root()
-      release = release_folder(root, "Already Imported", ["book.m4b"])
+      _release = release_folder(root, "Already Imported", ["book.m4b"])
+      root_record = insert(:root, path: root)
 
-      media = insert(:media, book: build(:book))
-      insert(:media_track, media: media, path: Path.join(release, "book.m4b"))
+      media =
+        insert(:media,
+          book: build(:book),
+          library_root_id: root_record.id,
+          source_path: "Already Imported"
+        )
+
+      insert(:media_track,
+        media: media,
+        path: "Already Imported/book.m4b",
+        library_root_id: root_record.id
+      )
 
       assert {:ok, %{created: 0, skipped: 1}} = Inbox.discover(root)
       assert {[], false} = Inbox.list_items()
     end
 
+    # A legacy recording's downloads provenance is quarantined in
+    # `legacy_source_files`, and the ledger still honors it — otherwise every
+    # pre-refactor import would resurface as new on the next scan.
     test "doesn't offer files a legacy media was imported from" do
       root = watched_root()
       release = release_folder(root, "Already Imported", ["book.m4b"])
 
-      insert(:media, book: build(:book), source_files: [Path.join(release, "book.m4b")])
+      insert(:media, book: build(:book), legacy_source_files: [Path.join(release, "book.m4b")])
 
       assert {:ok, %{created: 0, skipped: 1}} = Inbox.discover(root)
       assert {[], false} = Inbox.list_items()
@@ -448,9 +465,11 @@ defmodule Ambry.InboxTest do
       assert item.draft.destination.policy == nil
       refute item.draft.destination.approved
 
-      source = insert(:source, path: dir, import_policy: :copy)
+      insert(:source, path: dir, import_policy: :copy)
       root = insert(:root)
-      item = item |> Ecto.Changeset.change(source_id: source.id) |> Repo.update!()
+      # the source's own scan is what adopts the item (and rewrites its
+      # stored paths into the source's coordinates)
+      assert {:ok, %{updated: 1}} = Inbox.discover()
 
       {:ok, healed} = Inbox.prepare_draft(Inbox.get_item!(item.id))
 

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -433,12 +433,11 @@ defmodule Ambry.InboxTest do
   end
 
   describe "prepare_draft/1 destination healing" do
-    # Custody is derived, never chosen — so re-deriving it un-answers
-    # nothing. It can change under a draft: an ad-hoc-scanned item adopts
-    # its source when that source's own scan next sees it, and a draft that
-    # sealed an external destination then leaves the operator staring at a
-    # root blocker with no root picker rendered.
-    test "re-derives the destination when the item adopts a source after drafting" do
+    # A destination's defaults are derived from the item's source, so healing
+    # fills gaps without un-answering anything. The gap: an ad-hoc-scanned
+    # item adopts its source when that source's own scan next sees it, and a
+    # draft sealed without a policy now has one on offer.
+    test "fills in the policy when the item adopts a source after drafting" do
       dir = watched_root()
       release_folder(dir, "Sourced Later", ["book.m4b"])
       {:ok, _counts} = Inbox.discover(dir)
@@ -446,27 +445,33 @@ defmodule Ambry.InboxTest do
       {:ok, item} = Inbox.probe_item(item)
 
       {:ok, item} = Inbox.prepare_draft(item)
-      assert item.draft.destination.custody == :external
+      assert item.draft.destination.policy == nil
+      refute item.draft.destination.approved
 
-      source = insert(:source, path: dir)
+      source = insert(:source, path: dir, import_policy: :copy)
       root = insert(:root)
       item = item |> Ecto.Changeset.change(source_id: source.id) |> Repo.update!()
 
       {:ok, healed} = Inbox.prepare_draft(Inbox.get_item!(item.id))
 
-      assert healed.draft.destination.custody == :managed
+      assert healed.draft.destination.policy == :copy
       # the single root auto-picks, exactly as a fresh seed would
       assert healed.draft.destination.root_id == root.id
+      assert healed.draft.destination.approved
     end
 
-    test "an unchanged custody leaves the stored destination alone" do
+    test "a settled destination is left alone" do
       dir = watched_root()
-      release_folder(dir, "Stays External", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(dir)
-      {[item], false} = Inbox.list_items(filter: "Stays External")
+      release_folder(dir, "Stays Settled", ["book.m4b"])
+      insert(:source, path: dir, import_policy: :copy)
+      insert(:root)
+      {:ok, _counts} = Inbox.discover()
+      {[item], false} = Inbox.list_items(filter: "Stays Settled")
       {:ok, item} = Inbox.probe_item(item)
 
       {:ok, item} = Inbox.prepare_draft(item)
+      assert item.draft.destination.approved
+
       {:ok, again} = Inbox.prepare_draft(Inbox.get_item!(item.id))
 
       assert again.draft.destination == item.draft.destination
@@ -575,7 +580,7 @@ defmodule Ambry.InboxTest do
       downloads = insert(:source, path: watched_root())
 
       collection =
-        insert(:source, path: watched_root(), on_import: :leave_in_place, import_policy: nil)
+        insert(:source, path: watched_root(), import_policy: :symlink)
 
       release_folder(downloads.path, "Leviathan Wakes", ["book.m4b"])
       release_folder(collection.path, "Project Hail Mary", ["book.m4b"])

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -621,6 +621,8 @@ defmodule Ambry.InboxTest do
 
     # An item found under a source adopts it: that's a fact the scan just
     # established, not a guess about an item whose origin was never known.
+    # Adoption also rewrites the stored path into the source's coordinates,
+    # so the columns agree with the FK.
     test "backfills the source of an item discovered before sources existed" do
       root = watched_root()
       release = release_folder(root, "Leviathan Wakes", ["book.m4b"])
@@ -628,13 +630,15 @@ defmodule Ambry.InboxTest do
       assert {:ok, %{created: 1}} = Inbox.discover(root)
       assert {[item], false} = Inbox.list_items()
       assert is_nil(item.source_id)
+      assert item.path == release
 
       source = insert(:source, path: root)
 
       assert {:ok, %{updated: 1}} = Inbox.discover()
       assert {[item], false} = Inbox.list_items()
-      assert item.path == release
+      assert item.path == "Leviathan Wakes"
       assert item.source_id == source.id
+      assert InboxItem.disk_path(item) == release
     end
   end
 

--- a/test/ambry/library/placement_test.exs
+++ b/test/ambry/library/placement_test.exs
@@ -88,6 +88,56 @@ defmodule Ambry.Library.PlacementTest do
     end
   end
 
+  describe "symlink" do
+    test "writes an absolute link that resolves", %{root: root, source: source} do
+      destination = Path.join([root, "Author", "Title", "Title.m4b"])
+
+      assert {:ok, placement} = Placement.place(source, destination, :symlink)
+      assert placement.policy == :symlink
+
+      assert File.read!(destination) == "audio bytes"
+      # Absolute deliberately: a relative link only survives when link and
+      # target move as one tree, which is the hardlink case anyway.
+      assert {:ok, target} = File.read_link(destination)
+      assert target == source
+      assert Path.type(target) == :absolute
+    end
+
+    if @other_filesystem do
+      test "crosses filesystems, which is its whole reason to exist", %{source: source} do
+        root = tmp_dir(Path.join(@other_filesystem, "ambry-placement"))
+        on_exit(fn -> File.rm_rf(root) end)
+
+        destination = Path.join([root, "Author", "Title.m4b"])
+
+        assert {:ok, _placement} = Placement.place(source, destination, :symlink)
+        assert File.read!(destination) == "audio bytes"
+      end
+    end
+
+    test "undo removes the link and leaves the target", %{root: root, source: source} do
+      destination = Path.join([root, "Author", "Title.m4b"])
+
+      assert {:ok, placement} = Placement.place(source, destination, :symlink)
+      assert :ok = Placement.undo(placement)
+
+      refute File.exists?(destination)
+      assert File.read!(source) == "audio bytes"
+    end
+
+    # `File.exists?` follows links, so a dangling one reads as absent — but
+    # the name is occupied, and clobbering it would be the collision the
+    # vacancy check exists to surface.
+    test "a dangling link still counts as an occupied destination", %{root: root, source: source} do
+      destination = Path.join(root, "Title.m4b")
+      File.mkdir_p!(root)
+      File.ln_s!("/nope/gone.m4b", destination)
+
+      assert {:error, {:destination_exists, ^destination}} =
+               Placement.place(source, destination, :symlink)
+    end
+  end
+
   describe "copy" do
     test "duplicates the file", %{root: root, source: source} do
       destination = Path.join(root, "Title.m4b")
@@ -234,6 +284,24 @@ defmodule Ambry.Library.PlacementTest do
       refute File.dir?(Path.join([root, "Author", "Series"]))
       assert File.exists?(keep)
       assert File.dir?(root)
+    end
+  end
+
+  # Recording deletion hands the recording's folder to `File.rm_rf`. These pin
+  # the Erlang behaviour that makes symlink placement safe to delete from:
+  # rm_rf unlinks a symlink — file or directory — without traversing into it.
+  describe "deleting a folder that contains symlinks" do
+    test "removes links, never their targets", %{root: root, source: source} do
+      book_folder = Path.join(root, "Book")
+      File.mkdir_p!(book_folder)
+      File.ln_s!(source, Path.join(book_folder, "Title.m4b"))
+      File.ln_s!(Path.dirname(source), Path.join(book_folder, "linked-dir"))
+
+      {:ok, _removed} = File.rm_rf(book_folder)
+
+      refute File.dir?(book_folder)
+      assert File.read!(source) == "audio bytes"
+      assert File.dir?(Path.dirname(source))
     end
   end
 

--- a/test/ambry/library_test.exs
+++ b/test/ambry/library_test.exs
@@ -6,23 +6,21 @@ defmodule Ambry.LibraryTest do
   alias Ambry.Library.Source
 
   describe "create_source/1" do
-    test "creates a bring-in source" do
+    test "creates a source" do
       assert {:ok, %Source{} = source} =
                Library.create_source(%{
                  name: "Downloads",
-                 path: "/data/downloads",
-                 on_import: :bring_in
+                 path: "/data/downloads"
                })
 
       assert source.path == "/data/downloads"
-      assert source.on_import == :bring_in
       assert source.enabled
       assert is_nil(source.last_scanned_at)
     end
 
-    test "defaults a bring-in source to hardlinking" do
+    test "defaults to hardlinking" do
       assert {:ok, source} =
-               Library.create_source(%{name: "D", path: "/data/d", on_import: :bring_in})
+               Library.create_source(%{name: "D", path: "/data/d"})
 
       assert source.import_policy == :hardlink
     end
@@ -32,35 +30,15 @@ defmodule Ambry.LibraryTest do
                Library.create_source(%{
                  name: "D",
                  path: "/data/d",
-                 on_import: :bring_in,
                  import_policy: :move
                })
 
       assert source.import_policy == :move
     end
 
-    # A leave-in-place source imports nothing into a root, so carrying a
-    # policy or a preferred root would only ever mislead whoever reads the
-    # row later.
-    test "clears the policy and preferred root for a leave-in-place source" do
-      {:ok, root} = Library.create_root(%{name: "R", path: "/data/library"})
-
-      assert {:ok, source} =
-               Library.create_source(%{
-                 name: "Collection",
-                 path: "/data/collection",
-                 on_import: :leave_in_place,
-                 import_policy: :hardlink,
-                 target_root_id: root.id
-               })
-
-      assert is_nil(source.import_policy)
-      assert is_nil(source.target_root_id)
-    end
-
     test "requires an absolute path" do
       assert {:error, changeset} =
-               Library.create_source(%{name: "D", path: "relative/path", on_import: :bring_in})
+               Library.create_source(%{name: "D", path: "relative/path"})
 
       assert "must be an absolute path" in errors_on(changeset).path
     end
@@ -69,8 +47,7 @@ defmodule Ambry.LibraryTest do
       assert {:ok, source} =
                Library.create_source(%{
                  name: "D",
-                 path: "  /data/downloads/  ",
-                 on_import: :bring_in
+                 path: "  /data/downloads/  "
                })
 
       assert source.path == "/data/downloads"
@@ -82,8 +59,7 @@ defmodule Ambry.LibraryTest do
       assert {:error, changeset} =
                Library.create_source(%{
                  name: "Other",
-                 path: "/data/downloads",
-                 on_import: :bring_in
+                 path: "/data/downloads"
                })
 
       assert "has already been taken" in errors_on(changeset).path
@@ -95,8 +71,7 @@ defmodule Ambry.LibraryTest do
       assert {:error, changeset} =
                Library.create_source(%{
                  name: "Downloads",
-                 path: "/data/other",
-                 on_import: :bring_in
+                 path: "/data/other"
                })
 
       assert "has already been taken" in errors_on(changeset).name
@@ -144,17 +119,6 @@ defmodule Ambry.LibraryTest do
       insert(:root)
 
       assert Library.watched_sources() |> Enum.map(& &1.id) == [watched.id]
-    end
-  end
-
-  describe "inside_root?/1" do
-    test "derived from the path, on segment boundaries" do
-      insert(:root, path: "/data/library")
-
-      assert Library.inside_root?("/data/library/Author/Book")
-      assert Library.inside_root?("/data/library")
-      refute Library.inside_root?("/data/library-other/Book")
-      refute Library.inside_root?("/data/downloads/Book")
     end
   end
 

--- a/test/ambry/library_test.exs
+++ b/test/ambry/library_test.exs
@@ -99,6 +99,96 @@ defmodule Ambry.LibraryTest do
     end
   end
 
+  describe "stored-path resolution" do
+    test "resolves a root-relative path" do
+      root = insert(:root, path: "/data/library")
+
+      assert Library.resolve(root, "Author/Book (2010)/Book.m4b") ==
+               {:ok, "/data/library/Author/Book (2010)/Book.m4b"}
+
+      assert Library.resolve(root.id, "Book.m4b") == {:ok, "/data/library/Book.m4b"}
+    end
+
+    test "resolves a legacy /uploads path with no root" do
+      assert {:ok, resolved} = Library.resolve(nil, "/uploads/source_media/abc")
+      assert resolved == Ambry.Paths.web_to_disk("/uploads/source_media/abc")
+    end
+
+    # These feed `File.rm_rf`, so the refusals are the first check, not an
+    # afterthought.
+    test "refuses traversal and absolute paths before anything else" do
+      root = insert(:root, path: "/data/library")
+
+      assert {:error, {:traversal, _path}} = Library.resolve(root, "../outside/Book.m4b")
+      assert {:error, {:traversal, _path}} = Library.resolve(root, "Author/../../etc/passwd")
+      assert {:error, {:not_relative, _path}} = Library.resolve(root, "/etc/passwd")
+      assert {:error, {:unresolvable, _path}} = Library.resolve(nil, "/anywhere/else")
+    end
+
+    # The real library has spaces, brackets and unicode in nearly every path.
+    test "relativize then resolve round-trips awkward real-world paths" do
+      root = insert(:root, path: "/data/library")
+
+      for path <- [
+            "/data/library/Sarah J. Maas/[ACOTAR #1] A Court of Thorns and Roses (chapterized)/01 – Chäpter Öne.m4b",
+            "/data/library/single.m4b"
+          ] do
+        assert {:ok, relative} = Library.relativize(root, path)
+        assert Library.resolve(root, relative) == {:ok, path}
+      end
+    end
+
+    test "relativize refuses a path outside its location" do
+      root = insert(:root, path: "/data/library")
+
+      assert Library.relativize(root, "/data/library-other/Book.m4b") ==
+               {:error, :outside_location}
+    end
+
+    test "locate picks the longest matching root on a segment boundary" do
+      insert(:root, path: "/data")
+      inner = insert(:root, path: "/data/library")
+      insert(:root, path: "/data/library-other")
+
+      assert {:ok, {root, "Book.m4b"}} = Library.locate("/data/library/Book.m4b")
+      assert root.id == inner.id
+
+      assert {:error, :no_location} = Library.locate("/somewhere/else.m4b")
+    end
+
+    # The motivating regression: the library moved mounts and every stored
+    # absolute path broke. Now the mount is one row, and every dependent
+    # resolution follows it with zero row updates.
+    test "a changed root path carries every resolution with it" do
+      root = insert(:root, path: "/mnt/old-nas/library")
+
+      media =
+        insert(:media,
+          book: build(:book),
+          library_root_id: root.id,
+          source_path: "Author/Book",
+          source_files: ["Author/Book/book.m4b"],
+          media_tracks: [
+            build(:media_track, path: "Author/Book/book.m4b", library_root_id: root.id)
+          ]
+        )
+
+      {:ok, _root} = Library.update_root(root, %{path: "/srv/media/library"})
+
+      media = Repo.reload(media) |> Repo.preload([:media_tracks, :library_root], force: true)
+
+      assert Ambry.Media.Media.source_path(media) == "/srv/media/library/Author/Book"
+
+      assert Ambry.Media.Media.source_file_paths(media) ==
+               ["/srv/media/library/Author/Book/book.m4b"]
+
+      assert [track] = media.media_tracks
+
+      assert Ambry.Media.MediaTrack.disk_path(track) ==
+               {:ok, "/srv/media/library/Author/Book/book.m4b"}
+    end
+  end
+
   describe "listing" do
     test "sources and roots are separate registries" do
       source = insert(:source)

--- a/test/ambry/library_test.exs
+++ b/test/ambry/library_test.exs
@@ -189,6 +189,110 @@ defmodule Ambry.LibraryTest do
     end
   end
 
+  describe "deleting a referenced location" do
+    test "a root holding recordings refuses with reference counts" do
+      root = insert(:root)
+
+      insert(:media,
+        book: build(:book),
+        library_root_id: root.id,
+        source_path: "Author/Book",
+        source_files: ["Author/Book/book.m4b"],
+        media_tracks: [
+          build(:media_track, path: "Author/Book/book.m4b", library_root_id: root.id)
+        ]
+      )
+
+      assert {:error, {:referenced, %{media: 1, media_tracks: 1}}} = Library.delete_root(root)
+      assert {:ok, _root} = Library.fetch_root(root.id)
+    end
+
+    test "a source with queued items refuses with reference counts" do
+      source = insert(:source)
+
+      Repo.insert!(%Ambry.Inbox.InboxItem{
+        source_id: source.id,
+        path: "Some Release",
+        files: ["Some Release/book.m4b"]
+      })
+
+      assert {:error, {:referenced, %{inbox_items: 1}}} = Library.delete_source(source)
+      assert {:ok, _source} = Library.fetch_source(source.id)
+    end
+
+    # The app-level refusal explains; the FK refuses even code that skips it.
+    test "the database refuses too" do
+      root = insert(:root)
+
+      insert(:media,
+        book: build(:book),
+        library_root_id: root.id,
+        source_path: "Author/Book"
+      )
+
+      assert_raise Ecto.ConstraintError, fn -> Repo.delete!(root) end
+    end
+  end
+
+  describe "the stored-path constraints" do
+    # The resolver's refusals protect the filesystem; these protect the
+    # database from code that never went through the resolver.
+    test "a rooted media may not store an absolute path" do
+      root = insert(:root)
+
+      assert_raise Postgrex.Error, ~r/media_source_path_resolvable/, fn ->
+        Repo.insert_all("media", [
+          %{
+            source_path: "/absolute/anywhere",
+            library_root_id: root.id,
+            full_cast: false,
+            status: "pending",
+            abridged: false,
+            book_id: insert(:book).id,
+            inserted_at: DateTime.utc_now(:second),
+            updated_at: DateTime.utc_now(:second)
+          }
+        ])
+      end
+    end
+
+    test "an unrooted track may only store an uploads path" do
+      media = insert(:media, book: build(:book))
+
+      assert_raise Postgrex.Error, ~r/media_tracks_path_resolvable/, fn ->
+        Repo.insert_all("media_tracks", [
+          %{
+            media_id: media.id,
+            index: 0,
+            path: "/mnt/downloads/book.m4b",
+            size: 1,
+            duration: Decimal.new(1),
+            start_offset: Decimal.new(0),
+            inserted_at: DateTime.utc_now(:second),
+            updated_at: DateTime.utc_now(:second)
+          }
+        ])
+      end
+    end
+
+    test "a sourced inbox item may not store an absolute path" do
+      source = insert(:source)
+
+      assert_raise Postgrex.Error, ~r/inbox_items_path_locatable/, fn ->
+        Repo.insert_all("inbox_items", [
+          %{
+            source_id: source.id,
+            path: "/mnt/downloads/Some Release",
+            files: ["Some Release/book.m4b"],
+            status: "pending",
+            inserted_at: DateTime.utc_now(:second),
+            updated_at: DateTime.utc_now(:second)
+          }
+        ])
+      end
+    end
+  end
+
   describe "listing" do
     test "sources and roots are separate registries" do
       source = insert(:source)

--- a/test/ambry/library_test.exs
+++ b/test/ambry/library_test.exs
@@ -380,11 +380,78 @@ defmodule Ambry.LibraryTest do
     end
   end
 
+  describe "the mount table" do
+    alias Ambry.Library.Mounts
+
+    # A realistic mountinfo excerpt: a root mount, a NAS export mounted
+    # twice (one superblock — same 0:70 — two mounts), a mount point with an
+    # escaped space, and an overmount shadowing /mnt/old.
+    @mountinfo """
+    40 1 0:34 /@ / rw,relatime shared:1 - btrfs /dev/nvme0n1p2 rw
+    91 40 0:70 / /mnt/nas-a rw,relatime shared:401 - nfs4 nas:/export rw
+    92 40 0:70 / /mnt/nas-b rw,relatime shared:402 - nfs4 nas:/export rw
+    93 40 0:71 / /mnt/my\\040nas rw,relatime shared:403 - nfs4 nas2:/export rw
+    94 40 0:72 / /mnt/old rw shared:404 - ext4 /dev/sdb1 rw
+    95 40 0:73 / /mnt/old rw shared:405 - ext4 /dev/sdc1 rw
+    """
+
+    test "parses ids and unescapes mount points" do
+      mounts = Mounts.parse(@mountinfo)
+
+      assert %{id: 40, mount_point: "/"} in mounts
+      assert %{id: 93, mount_point: "/mnt/my nas"} in mounts
+    end
+
+    test "matches the longest mount point on a segment boundary" do
+      mounts = Mounts.parse(@mountinfo)
+
+      assert {:ok, %{id: 91}} = Mounts.mount_of("/mnt/nas-a/downloads/book.m4b", mounts)
+      # /mnt/nas-a is not a prefix of /mnt/nas-abc
+      assert {:ok, %{id: 40}} = Mounts.mount_of("/mnt/nas-abc/file", mounts)
+      assert {:ok, %{id: 40}} = Mounts.mount_of("/home/x", mounts)
+    end
+
+    test "an overmount shadows the mount it covers" do
+      mounts = Mounts.parse(@mountinfo)
+
+      assert {:ok, %{id: 95}} = Mounts.mount_of("/mnt/old/file", mounts)
+    end
+
+    # The case this module exists for: one NFS export mounted twice is one
+    # superblock (one st_dev) and two mounts, and link(2) refuses across
+    # them — so the two sides of the export must never share a mount id.
+    test "two mounts of one export are two different mounts" do
+      mounts = Mounts.parse(@mountinfo)
+
+      assert {:ok, %{id: a}} = Mounts.mount_of("/mnt/nas-a/downloads", mounts)
+      assert {:ok, %{id: b}} = Mounts.mount_of("/mnt/nas-b/library", mounts)
+      refute a == b
+    end
+  end
+
+  # A real second filesystem, found at compile time — same trick as
+  # PlacementTest, so the refusal is exercised against the kernel.
+  @other_filesystem Enum.find(["/dev/shm", "/tmp"], fn candidate ->
+                      with true <- File.dir?(candidate),
+                           {:ok, %{major_device: theirs}} <- File.stat(candidate),
+                           {:ok, %{major_device: ours}} <- File.stat(File.cwd!()) do
+                        theirs != ours
+                      else
+                        _unusable -> false
+                      end
+                    end)
+
   describe "same_filesystem?/2" do
-    test "two paths on the same filesystem" do
+    test "two paths on the same filesystem and mount" do
       dir = tmp_dir()
       assert {:ok, true} = Library.same_filesystem?(dir, tmp_dir())
       assert {:ok, true} = Library.same_filesystem?(dir, dir)
+    end
+
+    if @other_filesystem do
+      test "two paths on different filesystems" do
+        assert {:ok, false} = Library.same_filesystem?(tmp_dir(), @other_filesystem)
+      end
     end
 
     # A missing mount must never read as "different filesystem", because the

--- a/test/ambry/media/audit_test.exs
+++ b/test/ambry/media/audit_test.exs
@@ -40,7 +40,11 @@ defmodule Ambry.Media.AuditTest do
     end
 
     test "when source folder is missing" do
-      media = insert(:media, source_path: "/some/path", book: build(:book))
+      media =
+        insert(:media,
+          source_path: "/uploads/source_media/missing-#{Ecto.UUID.generate()}",
+          book: build(:book)
+        )
 
       assert audit = Audit.get_media_file_details(media)
 
@@ -104,7 +108,7 @@ defmodule Ambry.Media.AuditTest do
         |> with_output_files()
 
       # an orphaned source folder with a file in it
-      orphaned_source_path = valid_source_path()
+      orphaned_source_path = Ambry.Paths.web_to_disk(valid_source_path())
       File.write!(Path.join(orphaned_source_path, "test.mp3"), "test")
 
       # an orphaned mp4 file
@@ -114,7 +118,7 @@ defmodule Ambry.Media.AuditTest do
       File.rm_rf!(Ambry.Paths.web_to_disk(media1.mp4_path))
 
       # a missing source folder
-      File.rm_rf!(media2.source_path)
+      File.rm_rf!(Ambry.Paths.web_to_disk(media2.source_path))
 
       assert %{
                orphaned_source_folders: _,

--- a/test/ambry/media/deletion_custody_test.exs
+++ b/test/ambry/media/deletion_custody_test.exs
@@ -2,68 +2,21 @@ defmodule Ambry.Media.DeletionCustodyTest do
   @moduledoc """
   What deleting a recording is allowed to do to the bytes.
 
-  Custody is the whole answer: `managed` means Ambry owns the files and may
-  remove them; `external` means the files belong to someone else's workflow
-  and removal deletes records only. Getting this wrong doesn't produce a
-  wrong page — it produces `rm -rf` on a folder the operator never gave
-  Ambry permission to touch.
+  Since the custody collapse the answer is structural rather than a flag:
+  deletion removes *Ambry's name* for the bytes — the file in the library
+  root — and the original a placement was made from is untouched by
+  construction. A hardlink's original is a separate name for the same
+  inode, a symlink is unlinked without being followed, a copy never knew
+  its original. Getting this wrong doesn't produce a wrong page — it
+  produces `rm -rf` on a folder the operator never gave Ambry.
   """
   use Ambry.DataCase
 
   alias Ambry.Media
 
-  describe "external custody" do
-    # The promise external custody makes is the entire reason it exists: the
-    # files are referenced where they lie and Ambry never writes to them.
-    # `delete_media` used to hand `source_path` to a worker that runs
-    # `File.rm_rf` on it — which for an inbox-approved recording is the
-    # operator's own downloads folder.
-    test "deleting a recording never touches the source folder" do
-      %{media: media, folder: folder, file: file} = external_media()
-
-      assert {:ok, _media} = Media.delete_media(media)
-      run_deletion_jobs()
-
-      assert File.exists?(file), "external source file was deleted"
-      assert File.dir?(folder), "external source folder was deleted"
-    end
-
-    test "the records are gone even though the files remain" do
-      %{media: media} = external_media()
-
-      assert {:ok, _media} = Media.delete_media(media)
-
-      assert_raise Ecto.NoResultsError, fn -> Media.get_media!(media.id) end
-    end
-  end
-
-  describe "replacing an external recording's files" do
-    # Replace deletes the *old* source folder once the new files are in
-    # place, which for an external recording is again the operator's own
-    # folder rather than Ambry's.
-    test "leaves the original source folder alone" do
-      %{media: media, folder: folder, file: file} = external_media()
-      new_folder = new_dir("replacement")
-      new_file = Path.join(new_folder, "better.m4b")
-      File.write!(new_file, "better audio")
-
-      assert {:ok, _media} =
-               Media.replace_media(media, %{
-                 source_path: new_folder,
-                 source_files: [new_file],
-                 processor: :mp4_concat
-               })
-
-      run_deletion_jobs()
-
-      assert File.exists?(file)
-      assert File.dir?(folder)
-    end
-  end
-
-  describe "managed custody" do
-    test "deleting a recording removes the library files it owns" do
-      %{media: media, folder: folder, file: file} = managed_media()
+  describe "deleting a recording" do
+    test "removes the library files it owns" do
+      %{media: media, folder: folder, file: file} = library_media()
 
       assert {:ok, _media} = Media.delete_media(media)
       run_deletion_jobs()
@@ -88,7 +41,6 @@ defmodule Ambry.Media.DeletionCustodyTest do
       media =
         insert(:media,
           book: build(:book),
-          custody: :managed,
           source_path: folder,
           source_files: [file],
           mpd_path: nil,
@@ -122,7 +74,6 @@ defmodule Ambry.Media.DeletionCustodyTest do
       media =
         insert(:media,
           book: build(:book),
-          custody: :managed,
           source_path: folder,
           source_files: [file],
           mpd_path: nil,
@@ -142,7 +93,7 @@ defmodule Ambry.Media.DeletionCustodyTest do
     # leaves the seeding copy untouched — that's inherent to hardlinks, and
     # it's precisely why hardlinking is safe to delete from.
     test "removing a hardlinked file leaves the other link alone" do
-      %{media: media, file: file} = managed_media()
+      %{media: media, file: file} = library_media()
 
       seeding = Path.join(System.tmp_dir!(), "seeding-#{Ecto.UUID.generate()}.m4b")
       File.ln!(file, seeding)
@@ -154,36 +105,68 @@ defmodule Ambry.Media.DeletionCustodyTest do
       refute File.exists?(file)
       assert File.read!(seeding) == "audio"
     end
+
+    # The symlink door's version of the same promise: `File.rm_rf` unlinks a
+    # symlink without following it, so deleting a symlinked recording removes
+    # the library's pointers and never the operator's originals.
+    test "removing a symlinked recording leaves the targets alone" do
+      original_folder = new_dir("originals")
+      original = Path.join(original_folder, "book.m4b")
+      File.write!(original, "audio")
+
+      folder = new_dir("library")
+      file = Path.join(folder, "book.m4b")
+      File.ln_s!(original, file)
+
+      media =
+        insert(:media,
+          book: build(:book),
+          source_path: folder,
+          source_files: [file],
+          mpd_path: nil,
+          hls_path: nil,
+          mp4_path: nil
+        )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.dir?(folder)
+      assert File.read!(original) == "audio"
+    end
   end
 
-  defp external_media do
-    folder = new_dir("external")
+  describe "replacing a recording's files" do
+    # The old folder is Ambry's name for the bytes and goes with the
+    # replacement, exactly like deletion.
+    test "removes the old source folder once the new files are in place" do
+      %{media: media, folder: folder, file: file} = library_media()
+      new_folder = new_dir("replacement")
+      new_file = Path.join(new_folder, "better.m4b")
+      File.write!(new_file, "better audio")
+
+      assert {:ok, _media} =
+               Media.replace_media(media, %{
+                 source_path: new_folder,
+                 source_files: [new_file],
+                 processor: :mp4_concat
+               })
+
+      run_deletion_jobs()
+
+      refute File.exists?(file)
+      refute File.dir?(folder)
+    end
+  end
+
+  defp library_media do
+    folder = new_dir("library")
     file = Path.join(folder, "book.m4b")
     File.write!(file, "audio")
 
     media =
       insert(:media,
         book: build(:book),
-        custody: :external,
-        source_path: folder,
-        source_files: [file],
-        mpd_path: nil,
-        hls_path: nil,
-        mp4_path: nil
-      )
-
-    %{media: media, folder: folder, file: file}
-  end
-
-  defp managed_media do
-    folder = new_dir("managed")
-    file = Path.join(folder, "book.m4b")
-    File.write!(file, "audio")
-
-    media =
-      insert(:media,
-        book: build(:book),
-        custody: :managed,
         source_path: folder,
         source_files: [file],
         mpd_path: nil,

--- a/test/ambry/media/deletion_custody_test.exs
+++ b/test/ambry/media/deletion_custody_test.exs
@@ -41,8 +41,8 @@ defmodule Ambry.Media.DeletionCustodyTest do
       media =
         insert(:media,
           book: build(:book),
-          source_path: folder,
-          source_files: [file],
+          source_path: Ambry.Paths.disk_to_web(folder),
+          source_files: [Ambry.Paths.disk_to_web(file)],
           mpd_path: nil,
           hls_path: nil,
           mp4_path: nil
@@ -74,8 +74,8 @@ defmodule Ambry.Media.DeletionCustodyTest do
       media =
         insert(:media,
           book: build(:book),
-          source_path: folder,
-          source_files: [file],
+          source_path: Ambry.Paths.disk_to_web(folder),
+          source_files: [Ambry.Paths.disk_to_web(file)],
           mpd_path: nil,
           hls_path: nil,
           mp4_path: nil
@@ -121,8 +121,8 @@ defmodule Ambry.Media.DeletionCustodyTest do
       media =
         insert(:media,
           book: build(:book),
-          source_path: folder,
-          source_files: [file],
+          source_path: Ambry.Paths.disk_to_web(folder),
+          source_files: [Ambry.Paths.disk_to_web(file)],
           mpd_path: nil,
           hls_path: nil,
           mp4_path: nil
@@ -147,8 +147,8 @@ defmodule Ambry.Media.DeletionCustodyTest do
 
       assert {:ok, _media} =
                Media.replace_media(media, %{
-                 source_path: new_folder,
-                 source_files: [new_file],
+                 source_path: Ambry.Paths.disk_to_web(new_folder),
+                 source_files: [Ambry.Paths.disk_to_web(new_file)],
                  processor: :mp4_concat
                })
 
@@ -167,8 +167,8 @@ defmodule Ambry.Media.DeletionCustodyTest do
     media =
       insert(:media,
         book: build(:book),
-        source_path: folder,
-        source_files: [file],
+        source_path: Ambry.Paths.disk_to_web(folder),
+        source_files: [Ambry.Paths.disk_to_web(file)],
         mpd_path: nil,
         hls_path: nil,
         mp4_path: nil

--- a/test/ambry/media/media_test.exs
+++ b/test/ambry/media/media_test.exs
@@ -100,7 +100,9 @@ defmodule Ambry.Media.MediaTest do
     end
 
     test "if the media's source path does not exist, returns an empty list" do
-      media = build(:media)
+      # the factory creates its workspace folder on disk, so point at one
+      # that was never made
+      media = build(:media, source_path: "/uploads/source_media/#{Ecto.UUID.generate()}")
 
       files = Media.files(media, [".mp3"])
 

--- a/test/ambry/media/organization_test.exs
+++ b/test/ambry/media/organization_test.exs
@@ -88,20 +88,9 @@ defmodule Ambry.Media.OrganizationTest do
       assert File.dir?(root)
     end
 
-    # External custody promises Ambry never writes to those files, and a
-    # rename is a write.
-    test "never moves an external recording" do
-      %{media: media, file: file} = organized_media(custody: :external)
-
-      {:ok, _book} = Books.update_book(Books.get_book!(media.book_id), %{title: "Oathbringer"})
-
-      assert {:ok, :noop} = Organization.organize(reload(media))
-      assert File.exists?(file)
-    end
-
-    # The legacy uploads library is `managed` but isn't template-organized —
+    # The legacy uploads library isn't template-organized —
     # it's Phase 4's to migrate, not this function's to rearrange.
-    test "never moves a managed recording that lives outside a library root" do
+    test "never moves a recording that lives outside a library root" do
       %{media: media, file: file} = organized_media(register_root: false)
 
       assert {:ok, :noop} = Organization.organize(reload(media))
@@ -317,7 +306,6 @@ defmodule Ambry.Media.OrganizationTest do
         # the recording's own date wins over the book's in the template, and
         # the factory would otherwise pick a random one
         published: ~D[2010-08-31],
-        custody: Keyword.get(opts, :custody, :managed),
         source_path: folder,
         source_files: [placeholder],
         mp4_path: nil,

--- a/test/ambry/media/organization_test.exs
+++ b/test/ambry/media/organization_test.exs
@@ -10,6 +10,7 @@ defmodule Ambry.Media.OrganizationTest do
 
   alias Ambry.Books
   alias Ambry.Media.Media
+  alias Ambry.Media.MediaTrack
   alias Ambry.Media.Organization
   alias Ambry.Repo
   alias Ambry.Settings
@@ -35,9 +36,10 @@ defmodule Ambry.Media.OrganizationTest do
       refute File.exists?(file)
 
       media = reload(media)
-      assert media.source_files == [moved]
-      assert media.source_path == Path.dirname(moved)
-      assert [%{path: ^moved}] = media.media_tracks
+      assert Media.source_file_paths(media) == [moved]
+      assert Media.source_path(media) == Path.dirname(moved)
+      assert [track] = media.media_tracks
+      assert MediaTrack.disk_path(track) == {:ok, moved}
     end
 
     test "does nothing when the file is already where it belongs" do
@@ -51,7 +53,7 @@ defmodule Ambry.Media.OrganizationTest do
     # suffix, so re-organizing one part of a set "corrected" it onto its
     # sibling's path.
     test "a part of a set keeps its part suffix" do
-      %{media: media, folder: folder, file: file} = organized_media()
+      %{media: media, folder: folder, file: file, root_record: root_record} = organized_media()
 
       part_file =
         Path.join(folder, "The Way of Kings - Part 2 of 3 [#{Media.filename_token(media)}].m4b")
@@ -60,13 +62,15 @@ defmodule Ambry.Media.OrganizationTest do
 
       group = insert(:recording_group, parts_total: 3)
       [track] = media.media_tracks
-      {:ok, _track} = track |> Ecto.Changeset.change(%{path: part_file}) |> Repo.update()
+
+      {:ok, _track} =
+        track |> Ecto.Changeset.change(%{path: stored(part_file, root_record)}) |> Repo.update()
 
       media
       |> Ecto.Changeset.change(%{
         part_number: 2,
         recording_group_id: group.id,
-        source_files: [part_file]
+        source_files: [stored(part_file, root_record)]
       })
       |> Repo.update!()
 
@@ -196,9 +200,18 @@ defmodule Ambry.Media.OrganizationTest do
       refute Enum.any?(files, &File.exists?/1)
 
       media = reload(media)
-      assert media.source_files == moved
-      assert media.source_path == subfolder
-      assert media.media_tracks |> Enum.sort_by(& &1.index) |> Enum.map(& &1.path) == moved
+      assert Media.source_file_paths(media) == moved
+      assert Media.source_path(media) == subfolder
+
+      track_paths =
+        media.media_tracks
+        |> Enum.sort_by(& &1.index)
+        |> Enum.map(fn track ->
+          {:ok, path} = MediaTrack.disk_path(track)
+          path
+        end)
+
+      assert track_paths == moved
     end
 
     test "does nothing when the files are already where they belong" do
@@ -211,7 +224,9 @@ defmodule Ambry.Media.OrganizationTest do
     # A file that maps to itself is skipped, not refused. Otherwise adding
     # one file to a forty-file recording would fail on the other thirty-nine.
     test "renames only the files whose names actually changed" do
-      %{media: media, root: root, files: files} = organized_multi_file_media()
+      %{media: media, root: root, root_record: root_record, files: files} =
+        organized_multi_file_media()
+
       subfolder = Path.dirname(hd(files))
 
       # A fourth file arrives under the release's own name and is scanned in.
@@ -220,11 +235,18 @@ defmodule Ambry.Media.OrganizationTest do
       arrived = Path.join(subfolder, "bonus-epilogue.mp3")
       File.write!(arrived, "audio 4")
 
-      insert(:media_track, media: media, path: arrived, index: 3)
+      insert(:media_track,
+        media: media,
+        path: stored(arrived, root_record),
+        index: 3,
+        library_root_id: root_record.id
+      )
 
       {:ok, _media} =
         media
-        |> Ecto.Changeset.change(%{source_files: files ++ [arrived]})
+        |> Ecto.Changeset.change(%{
+          source_files: Enum.map(files ++ [arrived], &stored(&1, root_record))
+        })
         |> Repo.update()
 
       assert {:ok, :moved} = Organization.organize(reload(media))
@@ -239,13 +261,14 @@ defmodule Ambry.Media.OrganizationTest do
       assert Enum.map(files, &File.read!/1) == ["audio 1", "audio 2", "audio 3"]
 
       media = reload(media)
-      assert media.source_files == files ++ [renamed]
+      assert Media.source_file_paths(media) == files ++ [renamed]
       assert File.dir?(Path.join([root, "Brandon Sanderson", "The Way of Kings (2010)"]))
     end
   end
 
   defp organized_multi_file_media do
-    %{media: media, root: root, folder: folder, file: file, book: book} = organized_media()
+    %{media: media, root: root, root_record: root_record, folder: folder, file: file, book: book} =
+      organized_media()
 
     File.rm!(file)
     subfolder = Path.join(folder, "The Way of Kings [#{Media.filename_token(media)}]")
@@ -263,23 +286,39 @@ defmodule Ambry.Media.OrganizationTest do
     files
     |> Enum.with_index()
     |> Enum.each(fn {path, index} ->
-      insert(:media_track, media: media, path: path, index: index)
+      insert(:media_track,
+        media: media,
+        path: stored(path, root_record),
+        index: index,
+        library_root_id: root_record.id
+      )
     end)
 
     {:ok, media} =
       media
-      |> Ecto.Changeset.change(%{source_path: subfolder, source_files: files})
+      |> Ecto.Changeset.change(%{
+        source_path: stored(subfolder, root_record),
+        source_files: Enum.map(files, &stored(&1, root_record))
+      })
       |> Repo.update()
 
-    %{media: reload(media), root: root, files: files, folder: folder, book: book}
+    %{
+      media: reload(media),
+      root: root,
+      root_record: root_record,
+      files: files,
+      folder: folder,
+      book: book
+    }
   end
 
   defp organized_media(opts \\ []) do
     root = new_dir("root")
 
-    if Keyword.get(opts, :register_root, true) do
-      insert(:root, path: root)
-    end
+    root_record =
+      if Keyword.get(opts, :register_root, true) do
+        insert(:root, path: root)
+      end
 
     author = insert(:author, name: "Brandon Sanderson")
 
@@ -306,36 +345,59 @@ defmodule Ambry.Media.OrganizationTest do
         # the recording's own date wins over the book's in the template, and
         # the factory would otherwise pick a random one
         published: ~D[2010-08-31],
-        source_path: folder,
-        source_files: [placeholder],
+        library_root_id: root_record && root_record.id,
+        source_path: stored(folder, root_record),
+        source_files: [stored(placeholder, root_record)],
         mp4_path: nil,
         hls_path: nil,
         mpd_path: nil,
-        media_tracks: [build(:media_track, path: placeholder)]
+        media_tracks: [
+          build(:media_track,
+            path: stored(placeholder, root_record),
+            library_root_id: root_record && root_record.id
+          )
+        ]
       )
 
     file = Path.join(folder, "The Way of Kings [#{Media.filename_token(media)}].m4b")
     File.rename!(placeholder, file)
-    {:ok, media} = repoint(media, [file])
+    {:ok, media} = repoint(media, [file], root_record)
 
-    %{media: reload(media), root: root, file: file, folder: folder, book: book}
+    %{
+      media: reload(media),
+      root: root,
+      root_record: root_record,
+      file: file,
+      folder: folder,
+      book: book
+    }
   end
 
   # Points a fixture's media and its tracks at the files it actually has.
-  defp repoint(media, files) do
+  defp repoint(media, files, root_record) do
     media = Repo.preload(media, :media_tracks, force: true)
 
     media.media_tracks
     |> Enum.sort_by(& &1.index)
     |> Enum.zip(files)
     |> Enum.each(fn {track, path} ->
-      {:ok, _track} = track |> Ecto.Changeset.change(%{path: path}) |> Repo.update()
+      {:ok, _track} =
+        track |> Ecto.Changeset.change(%{path: stored(path, root_record)}) |> Repo.update()
     end)
 
     media
-    |> Ecto.Changeset.change(%{source_path: files |> hd() |> Path.dirname(), source_files: files})
+    |> Ecto.Changeset.change(%{
+      source_path: files |> hd() |> Path.dirname() |> stored(root_record),
+      source_files: Enum.map(files, &stored(&1, root_record))
+    })
     |> Repo.update()
   end
+
+  # The stored form of an absolute path: root-relative when the fixture lives
+  # in a registered library root, `/uploads/...` when it doesn't (the fixture
+  # dirs all sit under the uploads tree).
+  defp stored(absolute, nil), do: Ambry.Paths.disk_to_web(absolute)
+  defp stored(absolute, root_record), do: Path.relative_to(absolute, root_record.path)
 
   defp reload(media) do
     media.id

--- a/test/ambry/media/reconciliation_test.exs
+++ b/test/ambry/media/reconciliation_test.exs
@@ -82,8 +82,8 @@ defmodule Ambry.Media.ReconciliationTest do
     # Calling it missing would cry wolf on exactly the recordings Phase 4 is
     # going to reclaim.
     test "ignores source files that only ever fed a transcode" do
-      %{media: media} = legacy_media()
-      File.rm_rf!(media.source_path)
+      %{media: media, dir: dir} = legacy_media()
+      File.rm_rf!(dir)
 
       assert Reconciliation.missing_files(Repo.preload(media, :media_tracks)) == []
     end
@@ -130,12 +130,12 @@ defmodule Ambry.Media.ReconciliationTest do
       insert(:media,
         book: build(:book),
         status: Keyword.get(opts, :status, :pending),
-        source_path: dir,
-        source_files: [file],
+        source_path: Ambry.Paths.disk_to_web(dir),
+        source_files: [Ambry.Paths.disk_to_web(file)],
         mp4_path: nil,
         hls_path: nil,
         mpd_path: nil,
-        media_tracks: [build(:media_track, path: file)]
+        media_tracks: [build(:media_track, path: Ambry.Paths.disk_to_web(file))]
       )
 
     %{media: Repo.preload(media, :media_tracks), file: file, dir: dir}
@@ -155,14 +155,14 @@ defmodule Ambry.Media.ReconciliationTest do
       insert(:media,
         book: build(:book),
         status: :ready,
-        source_path: dir,
-        source_files: [source],
+        source_path: Ambry.Paths.disk_to_web(dir),
+        source_files: [Ambry.Paths.disk_to_web(source)],
         mp4_path: "/uploads/media/#{filename}",
         hls_path: nil,
         mpd_path: nil
       )
 
-    %{media: media, mp4: mp4, source: source}
+    %{media: media, mp4: mp4, source: source, dir: dir}
   end
 
   defp new_dir(prefix) do

--- a/test/ambry/media/reconciliation_test.exs
+++ b/test/ambry/media/reconciliation_test.exs
@@ -130,7 +130,6 @@ defmodule Ambry.Media.ReconciliationTest do
       insert(:media,
         book: build(:book),
         status: Keyword.get(opts, :status, :pending),
-        custody: :managed,
         source_path: dir,
         source_files: [file],
         mp4_path: nil,

--- a/test/ambry/media/scanner_test.exs
+++ b/test/ambry/media/scanner_test.exs
@@ -9,7 +9,8 @@ defmodule Ambry.Media.ScannerTest do
     test "records what the file is, without touching it" do
       media = scannable_media(:m4a)
       [source_file] = media.source_files
-      before = File.stat!(source_file)
+      source_file_on_disk = Ambry.Paths.web_to_disk(source_file)
+      before = File.stat!(source_file_on_disk)
 
       assert {:ok, media} = Scanner.scan(media)
 
@@ -22,7 +23,7 @@ defmodule Ambry.Media.ScannerTest do
       assert track.format =~ "mp4"
       assert Decimal.equal?(track.start_offset, 0)
 
-      assert File.stat!(source_file).size == before.size
+      assert File.stat!(source_file_on_disk).size == before.size
     end
 
     test "gives the media the track's duration" do
@@ -143,7 +144,7 @@ defmodule Ambry.Media.ScannerTest do
 
     test "reports a file that has gone missing" do
       media = scannable_media(:m4a)
-      media.source_files |> hd() |> File.rm!()
+      media.source_files |> hd() |> Ambry.Paths.web_to_disk() |> File.rm!()
 
       assert {:error, :enoent} = Scanner.scan(media)
     end
@@ -248,6 +249,7 @@ defmodule Ambry.Media.ScannerTest do
   defp retag(flags, metadata) do
     media = scannable_media(:m4a)
     [source_file] = media.source_files
+    source_file = Ambry.Paths.web_to_disk(source_file)
     dir = Path.dirname(source_file)
     tagged_path = Path.join(dir, "tagged.m4b")
 
@@ -265,7 +267,9 @@ defmodule Ambry.Media.ScannerTest do
 
     File.rm!(source_file)
 
-    {:ok, media} = Media.update_media(media, %{source_files: [tagged_path]})
+    {:ok, media} =
+      Media.update_media(media, %{source_files: [Ambry.Paths.disk_to_web(tagged_path)]})
+
     Media.get_media!(media.id)
   end
 
@@ -294,6 +298,7 @@ defmodule Ambry.Media.ScannerTest do
   defp chaptered_media(attrs \\ []) do
     media = scannable_media(:m4a, 1, attrs)
     [source_file] = media.source_files
+    source_file = Ambry.Paths.web_to_disk(source_file)
 
     metadata_path = Path.join(Path.dirname(source_file), "chapters.txt")
 
@@ -330,7 +335,9 @@ defmodule Ambry.Media.ScannerTest do
 
     File.rm!(source_file)
 
-    {:ok, media} = Media.update_media(media, %{source_files: [chaptered_path]})
+    {:ok, media} =
+      Media.update_media(media, %{source_files: [Ambry.Paths.disk_to_web(chaptered_path)]})
+
     Media.get_media!(media.id)
   end
 end

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -876,7 +876,9 @@ defmodule Ambry.MediaTest do
         |> insert()
         |> with_output_files()
 
-      assert File.dir?(media.source_path)
+      source_disk_path = Media.Media.source_path(media)
+
+      assert File.dir?(source_disk_path)
       assert media.mp4_path |> Paths.web_to_disk() |> File.exists?()
       assert media.mpd_path |> Paths.web_to_disk() |> File.exists?()
       assert media.hls_path |> Paths.web_to_disk() |> File.exists?()
@@ -895,7 +897,7 @@ defmodule Ambry.MediaTest do
                           Paths.web_to_disk(Paths.hls_playlist_path(media.hls_path)),
                           Paths.web_to_disk(media.image_path)
                         ],
-                        "folder_paths" => [media.source_path]
+                        "folder_paths" => [source_disk_path]
                       }
     end
   end
@@ -931,15 +933,10 @@ defmodule Ambry.MediaTest do
     end
 
     test "updates source files, marks the media pending, and queues reprocessing", %{media: media} do
-      new_source_path = Paths.source_media_disk_path(Ecto.UUID.generate())
-      new_source_files = [valid_audio(:mp3)]
+      %{source_path: new_source_path, source_files: new_source_files} =
+        attrs = replace_attrs(:mp3)
 
-      {:ok, replaced} =
-        Media.replace_media(media, %{
-          source_path: new_source_path,
-          source_files: new_source_files,
-          processor: :auto
-        })
+      {:ok, replaced} = Media.replace_media(media, attrs)
 
       assert replaced.source_path == new_source_path
       assert replaced.source_files == new_source_files
@@ -950,12 +947,7 @@ defmodule Ambry.MediaTest do
     end
 
     test "keeps the same streaming output URLs (overwrites in place)", %{media: media} do
-      {:ok, replaced} =
-        Media.replace_media(media, %{
-          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
-          source_files: [valid_audio(:mp3)],
-          processor: :auto
-        })
+      {:ok, replaced} = Media.replace_media(media, replace_attrs(:mp3))
 
       assert replaced.mp4_path == media.mp4_path
       assert replaced.mpd_path == media.mpd_path
@@ -966,12 +958,7 @@ defmodule Ambry.MediaTest do
       media: media,
       playthrough: playthrough
     } do
-      {:ok, replaced} =
-        Media.replace_media(media, %{
-          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
-          source_files: [valid_audio(:mp3)],
-          processor: :auto
-        })
+      {:ok, replaced} = Media.replace_media(media, replace_attrs(:mp3))
 
       assert Enum.map(replaced.chapters, & &1.title) == ["Chapter 1", "Chapter 2"]
 
@@ -980,26 +967,16 @@ defmodule Ambry.MediaTest do
     end
 
     test "deletes the old source folder with a background job", %{media: media} do
-      old_source_path = media.source_path
+      old_source_disk_path = Media.Media.source_path(media)
 
-      {:ok, _replaced} =
-        Media.replace_media(media, %{
-          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
-          source_files: [valid_audio(:mp3)],
-          processor: :auto
-        })
+      {:ok, _replaced} = Media.replace_media(media, replace_attrs(:mp3))
 
       assert_enqueued worker: DeleteFiles,
-                      args: %{"disk_paths" => [], "folder_paths" => [old_source_path]}
+                      args: %{"disk_paths" => [], "folder_paths" => [old_source_disk_path]}
     end
 
     test "end-to-end: reprocessing regenerates the streaming files in place", %{media: media} do
-      {:ok, replaced} =
-        Media.replace_media(media, %{
-          source_path: Paths.source_media_disk_path(Ecto.UUID.generate()),
-          source_files: [valid_audio(:m4a)],
-          processor: :auto
-        })
+      {:ok, replaced} = Media.replace_media(media, replace_attrs(:m4a))
 
       # Simulate the enqueued RunProcessor Oban job running.
       {:ok, processed} = Ambry.Media.Processor.run!(Media.get_media!(replaced.id))
@@ -1099,5 +1076,22 @@ defmodule Ambry.MediaTest do
       assert description =~ "Sorcerer's Stone"
       refute description =~ "Philosopher's Stone"
     end
+  end
+
+  # `replace_media/2` takes stored-form (`/uploads/...`) paths, so build the
+  # new source workspace on disk the way an upload does and hand back the
+  # stored forms.
+  defp replace_attrs(type) do
+    disk_path = Paths.source_media_disk_path(Ecto.UUID.generate())
+    File.mkdir_p!(disk_path)
+
+    file_disk_path = Path.join(disk_path, "1-sample#{Path.extname(valid_audio(type))}")
+    File.cp!(valid_audio(type), file_disk_path)
+
+    %{
+      source_path: Paths.disk_to_web(disk_path),
+      source_files: [Paths.disk_to_web(file_disk_path)],
+      processor: :auto
+    }
   end
 end

--- a/test/ambry_web/controllers/track_controller_test.exs
+++ b/test/ambry_web/controllers/track_controller_test.exs
@@ -160,14 +160,15 @@ defmodule AmbryWeb.TrackControllerTest do
 
   defp served_track do
     media = :media |> build(book: build(:book)) |> with_copied_source_files(:m4a) |> insert()
-    [source_file] = media.source_files
+    [source_file] = Ambry.Media.Media.source_file_paths(media)
 
     # the real fixture, under the media's own source folder, named as a
     # client would see it
     path = Path.join(Path.dirname(source_file), "sample.m4a")
     File.rename!(source_file, path)
 
-    track = insert(:media_track, media: media, path: path, mime: "audio/mp4")
+    track =
+      insert(:media_track, media: media, path: Ambry.Paths.disk_to_web(path), mime: "audio/mp4")
 
     %{track: track, path: path, contents: File.read!(path)}
   end

--- a/test/ambry_web/live/admin/home_live/index_test.exs
+++ b/test/ambry_web/live/admin/home_live/index_test.exs
@@ -27,7 +27,7 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
         media_narrators: [%{narrator: narrator}]
       )
       |> with_thumbnails()
-      |> with_source_files()
+      |> with_copied_source_files()
       |> insert()
       |> with_output_files()
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1923,8 +1923,8 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "Referenced where it lies"
-      assert html =~ "never move, rename or delete"
+      assert html =~ "Symlinked into"
+      assert html =~ "dangles if the original ever moves"
     end
   end
 
@@ -2086,7 +2086,22 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       Path.join(release, "book.m4b")
     )
 
-    {:ok, _counts} = Inbox.discover(root)
+    # A settled destination needs a root to place into and a source to seed
+    # the policy; symlink keeps the fixtures where the test put them.
+    if Ambry.Library.list_roots() == [] do
+      library = Ambry.Paths.source_media_disk_path("library-#{Ecto.UUID.generate()}")
+      File.mkdir_p!(library)
+      insert(:root, path: library)
+    end
+
+    watched =
+      insert(:source,
+        path: root,
+        import_policy: :symlink,
+        name: "Watched #{Ecto.UUID.generate()}"
+      )
+
+    {:ok, _counts} = Inbox.discover(watched)
     {items, _more} = Inbox.list_items(filter: name)
     {:ok, item} = items |> hd() |> Inbox.probe_item()
 

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -389,7 +389,22 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
       end
     end)
 
-    {:ok, _counts} = Inbox.discover(root)
+    # A settled destination needs a root to place into and a source to seed
+    # the policy; symlink keeps the fixtures where the test put them.
+    if Ambry.Library.list_roots() == [] do
+      library = Ambry.Paths.source_media_disk_path("library-#{Ecto.UUID.generate()}")
+      File.mkdir_p!(library)
+      insert(:root, path: library)
+    end
+
+    watched =
+      insert(:source,
+        path: root,
+        import_policy: :symlink,
+        name: "Watched #{Ecto.UUID.generate()}"
+      )
+
+    {:ok, _counts} = Inbox.discover(watched)
 
     {items, _more} = Inbox.list_items(filter: name)
     item = hd(items)

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -218,7 +218,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
   test "ignores and restores without touching files", %{conn: conn} do
     item = probed_item()
-    file = hd(item.files)
+    file = item |> Inbox.disk_files() |> hd()
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
@@ -244,7 +244,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   # length of a NAS copy.
   test "imports a settled item into the library, leaving files alone", %{conn: conn} do
     item = probed_item() |> settle()
-    file = hd(item.files)
+    file = item |> Inbox.disk_files() |> hd()
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 

--- a/test/ambry_web/live/admin/location_live/form_test.exs
+++ b/test/ambry_web/live/admin/location_live/form_test.exs
@@ -8,12 +8,12 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
   setup :register_and_log_in_admin_user
 
   describe "new source" do
-    test "adds a bring-in source", %{conn: conn} do
+    test "adds a source", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/admin/locations/sources/new")
 
       view
       |> form("#location-form",
-        source: %{name: "Downloads NAS", path: "/data/downloads", on_import: "bring_in"}
+        source: %{name: "Downloads NAS", path: "/data/downloads"}
       )
       |> render_submit()
 
@@ -21,23 +21,14 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
 
       assert [source] = Library.list_sources()
       assert source.name == "Downloads NAS"
-      assert source.on_import == :bring_in
       assert source.import_policy == :hardlink
     end
 
-    test "shows the placement details only when files are brought in", %{conn: conn} do
-      {:ok, view, html} = live(conn, ~p"/admin/locations/sources/new")
+    test "always asks how the files come in", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/admin/locations/sources/new")
 
       assert html =~ "How the files come in"
-
-      html =
-        view
-        |> form("#location-form",
-          source: %{name: "C", path: "/data/c", on_import: "leave_in_place"}
-        )
-        |> render_change()
-
-      refute html =~ "How the files come in"
+      assert html =~ "Symlink"
     end
 
     # Finding out that a path is wrong at save time is late; finding out at
@@ -48,7 +39,7 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
       html =
         view
         |> form("#location-form",
-          source: %{name: "S", path: tmp_dir(), on_import: "bring_in"}
+          source: %{name: "S", path: tmp_dir()}
         )
         |> render_change()
 
@@ -57,7 +48,7 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
       html =
         view
         |> form("#location-form",
-          source: %{name: "S", path: "/mnt/nope", on_import: "bring_in"}
+          source: %{name: "S", path: "/mnt/nope"}
         )
         |> render_change()
 
@@ -69,7 +60,7 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
 
       html =
         view
-        |> form("#location-form", source: %{name: "S", path: "data/s", on_import: "bring_in"})
+        |> form("#location-form", source: %{name: "S", path: "data/s"})
         |> render_submit()
 
       assert html =~ "must be an absolute path"
@@ -81,7 +72,7 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
     test "adds a root, asking nothing but name and path", %{conn: conn} do
       {:ok, view, html} = live(conn, ~p"/admin/locations/roots/new")
 
-      refute html =~ "On import"
+      refute html =~ "How the files come in"
       refute html =~ "Watched"
 
       view

--- a/test/ambry_web/live/admin/location_live/index_test.exs
+++ b/test/ambry_web/live/admin/location_live/index_test.exs
@@ -13,11 +13,11 @@ defmodule AmbryWeb.Admin.LocationLive.IndexTest do
     assert html =~ "No sources yet"
   end
 
-  # Roots are optional by design: leave-in-place setups run without any.
-  test "an empty roots section says roots are optional", %{conn: conn} do
+  # Roots are mandatory now: every import places into one.
+  test "an empty roots section says imports need one", %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/admin/locations")
 
-    assert html =~ "Add one when a source needs to bring files in"
+    assert html =~ "Nothing can be imported until there is one"
   end
 
   test "lists sources and roots as two sections", %{conn: conn} do
@@ -28,7 +28,7 @@ defmodule AmbryWeb.Admin.LocationLive.IndexTest do
 
     assert html =~ "Downloads NAS"
     assert html =~ "/data/downloads"
-    assert html =~ "brings files in"
+    assert html =~ "hardlink"
     assert html =~ "Old Library"
     assert html =~ "/data/library"
   end
@@ -72,9 +72,7 @@ defmodule AmbryWeb.Admin.LocationLive.IndexTest do
     assert Library.get_source!(source.id).enabled
   end
 
-  # Removing a source or root is a registry edit, never a disk operation —
-  # for a leave-in-place source, touching the files would break the only
-  # promise external custody makes.
+  # Removing a source or root is a registry edit, never a disk operation.
   test "deleting a source leaves its files alone", %{conn: conn} do
     dir = tmp_dir()
     file = Path.join(dir, "book.m4b")

--- a/test/ambry_web/live/admin/media_live/chapters_import_test.exs
+++ b/test/ambry_web/live/admin/media_live/chapters_import_test.exs
@@ -33,7 +33,9 @@ defmodule AmbryWeb.Admin.MediaLive.ChaptersImportTest do
 
     :media
     |> build(book: book, chapters: chapters)
-    |> with_source_files()
+    # A real copy in the media's own folder, so the edit form's re-read can
+    # probe it — same reason as the sibling `ChaptersTest`.
+    |> with_copied_source_files()
     |> insert()
   end
 

--- a/test/ambry_web/live/audiobook_live_test.exs
+++ b/test/ambry_web/live/audiobook_live_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.AudiobookLiveTest do
       |> build(book: build(:book))
       |> with_image()
       |> with_thumbnails()
-      |> with_source_files()
+      |> with_copied_source_files()
       |> insert()
       |> with_output_files()
 

--- a/test/ambry_web/live/library_live_test.exs
+++ b/test/ambry_web/live/library_live_test.exs
@@ -11,7 +11,7 @@ defmodule AmbryWeb.LibraryLiveTest do
       |> build(book: build(:book))
       |> with_image()
       |> with_thumbnails()
-      |> with_source_files()
+      |> with_copied_source_files()
       |> insert()
       |> with_output_files()
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -412,7 +412,6 @@ defmodule Ambry.Factory do
     %Source{
       name: sequence(:source_name, &"Source #{&1}"),
       path: sequence(:source_path, &"/data/source-#{&1}"),
-      on_import: :bring_in,
       import_policy: :hardlink,
       enabled: true
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -203,7 +203,7 @@ defmodule Ambry.Factory do
   def media_track_factory do
     %MediaTrack{
       index: 0,
-      path: fn -> Ambry.Paths.source_media_disk_path("#{Ecto.UUID.generate()}.m4b") end,
+      path: fn -> "/uploads/source_media/#{Ecto.UUID.generate()}.m4b" end,
       size: trunc(Fake.uniform() * 500_000_000),
       mime: "audio/mp4",
       format: "mov,mp4,m4a,3gp,3g2,mj2",
@@ -234,10 +234,23 @@ defmodule Ambry.Factory do
     %{media | media_tracks: tracks}
   end
 
+  # The fixture is copied into the media's own workspace so the stored path
+  # has a resolvable `/uploads/...` form — absolute paths outside the
+  # uploads tree can no longer be stored. A copy, not a hardlink: the
+  # checkout and the uploads tree may sit on different filesystems.
   def with_source_files(%Media{} = media, type \\ :m4a, count \\ 1) do
-    audio_file_disk_path = valid_audio(type)
+    fixture = valid_audio(type)
+    folder = Media.source_path(media)
+    File.mkdir_p!(folder)
 
-    %{media | source_files: for(_ <- 1..count, do: audio_file_disk_path)}
+    files =
+      for index <- 1..count do
+        dest = Path.join(folder, "#{index}-source#{Path.extname(fixture)}")
+        if not File.exists?(dest), do: File.cp!(fixture, dest)
+        Ambry.Paths.disk_to_web(dest)
+      end
+
+    %{media | source_files: files}
   end
 
   @doc """
@@ -254,7 +267,7 @@ defmodule Ambry.Factory do
       for index <- 1..count do
         dest = Path.join(folder, "#{index}-sample#{Path.extname(fixture)}")
         File.cp!(fixture, dest)
-        dest
+        Ambry.Paths.disk_to_web(dest)
       end
 
     %{media | source_files: files}
@@ -400,10 +413,12 @@ defmodule Ambry.Factory do
 
   # Test files
 
+  # Stored form: paths in the database are `/uploads/...` (or
+  # root-relative), never absolute. The folder still exists on disk.
   def valid_source_path do
     path = Ambry.Paths.source_media_disk_path(Ecto.UUID.generate())
     File.mkdir_p!(path)
-    path
+    Ambry.Paths.disk_to_web(path)
   end
 
   # Library sources and roots


### PR DESCRIPTION
Executes `PATHS_REFACTOR_PLAN.md` in full, as six reviewable steps (one commit each):

1. **The fourth door: symlink placement** (§5.1) — `Placement` gains `:symlink` (absolute links, per §1.3), the vacancy check learns that a dangling link occupies a name, and a test pins that `File.rm_rf` unlinks symlinks without traversing them.
2. **One library, four doors: custody collapses** (§5.2) — `media.custody` and `sources.on_import` are dropped, the importer's `:adopt` branch is deleted, roots become mandatory, and the draft's destination becomes the pair of decisions it always was: which root, which policy. The import form gains a policy picker beside the root picker. `leave_in_place` sources migrate to `symlink`.
3. **Paths are relative to a root, and the root is one row** (§5.3–§5.4) — `media.source_path`, `source_files` and `media_tracks.path` become root-relative behind a `library_root_id` FK (legacy rows keep `/uploads/...` + null FK). One resolver in `Ambry.Library` rejects `..` and absolutes before anything that feeds `File.rm_rf`; the schema accessors resolve through it so every consumer stays correct. The backfill is longest-prefix, fail-loud per column, with pre-refactor downloads provenance quarantined into `legacy_source_files` for Phase 4 to drain. The motivating regression is now a test: change a root's path and every resolution follows with zero row updates.
4. **An inbox item's paths are relative to its source** (§2.2) — queued items survive a source mount move, decisions and all. The walk still speaks absolutes; conversion happens at the ledger and the write boundary.
5. **The path convention becomes a constraint** (§2.4) — CHECKs enforce the two-case rule on every path column (an immutable SQL helper handles the array columns), `on_delete: :restrict` on the location FKs, and `delete_root/1`/`delete_source/1` return reference counts the locations page turns into a sentence.
6. **Imported inbox items survive the wipe** — found by running the backfill against the dev library: the ledger cannot recognize a *placed* import from its originals, so the imported item row is the only thing preventing every imported release from resurfacing on rescan. Imported items are history, not derived state; they stay and get backfilled.
7. **Hardlinkable means same filesystem AND same mount** (§9, folded in) — `same_filesystem?/2` refines the `st_dev` comparison with mount ids read live from `/proc/self/mountinfo`: two mounts of one NFS export share a device and still refuse `EXDEV`, while btrfs subvolumes share a mount and refuse on device — each half catches what the other can't see. The locations page's filesystem tags group by `{device, mount}` for the same reason. Live read instead of the plan's sketched `mount_id` column: no staleness, no migration.

Three knowing deviations from the plan doc: §7's "symlinks are relative" test bullet contradicts §1.3 (stale draft leftover — absolute links are implemented and tested), and §2.2's separate `absolute_path` column is replaced by the CASE-form constraint on the same columns, keeping an item's identity in one place; and §9's mount check reads the mount table live rather than storing a `mount_id` column.

Verified beyond the suite (1615 tests, `mix check` clean): migrations run against the dev server's real data — all 10 recordings backfilled root-relative, every track resolves and exists, reconciliation clean, `organize_all` a pure no-op, 353-item rescan lands fully source-relative — and the locations page + destination card driven in real Chrome, including the delete-refused-with-counts flash and the policy picker's live summary swap.

Sequenced per §10: independent of the direct-play rollout gate (no client-visible change — `custody` was never in the GraphQL schema), and lands before Phase 4's relink, which consumes the stored paths this keeps precise.
