### PR TITLE
Placement is learned, not configured

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -71,6 +71,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.RunProbe
   alias Ambry.Inbox.Undo
   alias Ambry.Library
+  alias Ambry.Library.ImportPreference
   alias Ambry.Library.Root
   alias Ambry.Library.Source
   alias Ambry.Media.Media
@@ -753,6 +754,7 @@ defmodule Ambry.Inbox do
   def import_item(%InboxItem{} = item) do
     case Importer.import_item(item) do
       {:ok, media} ->
+        remember_placement(item)
         refresh_siblings(item)
         {:ok, media}
 
@@ -763,6 +765,47 @@ defmodule Ambry.Inbox do
         update_item(item, %{issue: describe_error(reason)})
         error
     end
+  end
+
+  # What the next import from this source should propose is what this one
+  # did. Remembered after the fact rather than when the operator picked: a
+  # choice made on a release that then failed to place is not what the
+  # source does.
+  defp remember_placement(%InboxItem{} = item) do
+    %InboxItem{source: source, draft: draft} = Repo.preload(item, :source)
+
+    with %Source{} = source <- source,
+         %Draft{destination: %Destination{root_id: id, policy: policy}} when not is_nil(policy) <-
+           draft,
+         %Root{} = root <- id && Repo.get(Root, id) do
+      previous = Library.recall_placement(source)
+      {:ok, _preference} = Library.remember_placement(source, root, policy)
+
+      if moved?(previous, root, policy), do: refresh_queued_destinations(source)
+    end
+
+    :ok
+  end
+
+  defp moved?(nil, _root, _policy), do: true
+  defp moved?(%ImportPreference{library_root_id: id, policy: p}, %Root{id: id}, p), do: false
+  defp moved?(%ImportPreference{}, _root, _policy), do: true
+
+  # The default just moved, and every queued item that was following the old
+  # one is now proposing the wrong thing. Opening each would fix it, but the
+  # queue's Ready badge reads a stored column — so nothing would look
+  # different until the operator opened all three hundred, which is the
+  # opposite of what remembering a choice is for.
+  #
+  # Only runs when the memory actually changed, which after the first import
+  # from a source is almost never.
+  defp refresh_queued_destinations(%Source{} = source) do
+    InboxItem
+    |> where([i], i.source_id == ^source.id and i.status == :pending)
+    |> Repo.all()
+    |> Enum.each(fn item ->
+      if item.draft, do: refresh_destination(item)
+    end)
   end
 
   @doc """

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -670,12 +670,12 @@ defmodule Ambry.Inbox do
     end
   end
 
-  # The draft's choice, which the seed filled from the source. Falling back
-  # to the source covers a preflight taken before any draft exists.
+  # The draft's choice, or the default the seed put there. There is no
+  # source-level fallback any more: how the files come in is a fact about
+  # the pairing, so with no root settled there is nothing to fall back to.
   defp chosen_policy(%InboxItem{draft: %{destination: %{policy: policy}}})
        when not is_nil(policy), do: policy
 
-  defp chosen_policy(%InboxItem{source: %Source{import_policy: policy}}), do: policy
   defp chosen_policy(%InboxItem{}), do: nil
 
   # The root the draft settled on, not one derived from the source: inputs

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -172,20 +172,20 @@ defmodule Ambry.Inbox do
   end
 
   @doc """
-  Scans one source, or one bare path.
+  Scans one source.
 
-  The bare-path form is for ad-hoc scans and for exercising the walk itself;
-  items it creates have no source, so they carry no default placement policy
-  and the operator chooses one at approval.
+  A source is the only way into the inbox. Scanning a bare path used to be
+  possible and produced items with no source, which meant absolute stored
+  paths, no placement default, and a whole second shape for every function
+  that touches an item's files to handle. It was never reachable from the
+  UI, so the exception bought nothing and cost that.
   """
   def discover(%Source{} = source) do
-    with {:ok, counts} <- scan(source.path, source) do
+    with {:ok, counts} <- scan(source) do
       {:ok, _source} = Library.mark_scanned(source)
       {:ok, counts}
     end
   end
-
-  def discover(root) when is_binary(root), do: scan(root, nil)
 
   defp discover_one(%Source{} = source) do
     case discover(source) do
@@ -203,12 +203,12 @@ defmodule Ambry.Inbox do
 
   defp merge_counts(acc, counts), do: Map.merge(acc, counts, fn _key, a, b -> a + b end)
 
-  defp scan(root, source) do
-    if File.dir?(root) do
+  defp scan(%Source{} = source) do
+    if File.dir?(source.path) do
       ledger = ledger()
 
       results =
-        root
+        source.path
         |> candidates()
         |> Enum.flat_map(&List.wrap(record_candidate(&1, ledger, source)))
 
@@ -1112,7 +1112,7 @@ defmodule Ambry.Inbox do
     |> Enum.flat_map(fn
       {nil, orphans} -> List.wrap(adopt(path, files, orphans, source))
       {:library, _theirs} -> [:skipped]
-      {%InboxItem{} = item, theirs} -> [refresh_owner(item, theirs, source)]
+      {%InboxItem{} = item, theirs} -> [refresh_owner(item, theirs)]
     end)
   end
 
@@ -1155,8 +1155,8 @@ defmodule Ambry.Inbox do
 
   # An imported item is the record of what was imported; its source files may
   # not even be where they were. Nothing about a scan may touch it.
-  defp refresh_owner(%InboxItem{status: :imported}, _files, _source), do: :skipped
-  defp refresh_owner(%InboxItem{} = item, files, source), do: refresh_known(item, files, source)
+  defp refresh_owner(%InboxItem{status: :imported}, _files), do: :skipped
+  defp refresh_owner(%InboxItem{} = item, files), do: refresh_known(item, files)
 
   # Nobody owns these. A candidate that is entirely unowned is a release, at
   # the grain the walk proposes; anything left over in a folder that is
@@ -1169,32 +1169,20 @@ defmodule Ambry.Inbox do
     do: Enum.map(orphans, &create_item(&1, [&1], source))
 
   # A known item's files can legitimately change (a torrent finished, a file
-  # was replaced). Its status is left alone: ignored stays ignored.
-  #
-  # An item found under a source adopts it if it had none — that's a fact
-  # the scan just established, not a guess — but a source is never swapped
-  # out from under an item that already has one. Adopting rewrites the
-  # stored path and files into the source's coordinates, so the columns
-  # always agree with the FK.
-  defp refresh_known(%InboxItem{} = item, files, source) do
+  # was replaced). Its status is left alone: ignored stays ignored, and its
+  # source is never swapped out from under it — the item's own source is
+  # what its stored paths are relative to, so re-keying them to whichever
+  # source happened to walk over them would silently rewrite coordinates.
+  defp refresh_known(%InboxItem{} = item, files) do
     item = Repo.preload(item, :source)
-    adopts_source? = is_nil(item.source_id) and not is_nil(source)
-    owner = if adopts_source?, do: source, else: item.source
+    stored_files = Enum.map(files, &stored_form(&1, item.source))
 
-    stored_files = Enum.map(files, &stored_form(&1, owner))
-
-    changes =
-      %{}
-      |> put_if(:files, stored_files, item.files != stored_files)
-      |> put_if(:source_id, adopts_source? && source.id, adopts_source?)
-      |> put_if(:path, stored_form(InboxItem.disk_path(item), owner), adopts_source?)
-
-    if changes == %{} do
+    if item.files == stored_files do
       :skipped
     else
-      {:ok, item} = update_item(item, changes)
+      {:ok, item} = update_item(item, %{files: stored_files})
 
-      if item.status == :pending and Map.has_key?(changes, :files) do
+      if item.status == :pending do
         # The draft describes files that just moved under it. Say so; don't
         # re-seed over whatever the operator already decided.
         mark_draft_stale(item)
@@ -1215,10 +1203,9 @@ defmodule Ambry.Inbox do
   defp put_if(map, _key, _value, false), do: map
   defp put_if(map, key, value, _truthy), do: Map.put(map, key, value)
 
-  # The stored form of an absolute path the walk produced: source-relative
-  # when the item has a source, absolute for the ad-hoc case.
-  defp stored_form(path, nil), do: path
-
+  # The stored form of an absolute path the walk produced. Always
+  # source-relative: a source whose mount point changes is then a one-row
+  # edit, and every queued item survives the move.
   defp stored_form(path, %Source{} = source) do
     {:ok, relative} = Library.relativize(source, path)
     relative
@@ -1229,7 +1216,7 @@ defmodule Ambry.Inbox do
     |> InboxItem.changeset(%{
       path: stored_form(path, source),
       files: Enum.map(files, &stored_form(&1, source)),
-      source_id: source && source.id
+      source_id: source.id
     })
     |> Repo.insert()
     |> case do

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -514,23 +514,21 @@ defmodule Ambry.Inbox do
     refresh_destination(item)
   end
 
-  # A destination the operator has not touched is a *default*, and a default
-  # that was frozen at match time is the wrong default the moment anything it
+  # A destination half the operator has not picked is a *default*, and a
+  # default frozen at match time is the wrong default the moment anything it
   # was derived from changes. A draft is written once and then only read, so
   # nothing would ever revise it: import the first of three hundred queued
   # releases, correct the policy while you're there, and the other two
   # hundred and ninety-nine would keep proposing the old one forever.
   #
-  # So an unchosen destination is re-derived here, on every prepare. A chosen
-  # one is never touched — that is the entire distinction `chosen` exists to
-  # draw.
-  defp refresh_destination(%InboxItem{draft: %{destination: %Destination{chosen: true}}} = item),
-    do: {:ok, item}
-
+  # So the unchosen halves are re-derived here, on every prepare. The chosen
+  # ones are never touched — that is the entire distinction the flags exist
+  # to draw.
   defp refresh_destination(%InboxItem{} = item) do
-    fresh = Seed.destination(item)
+    stored = item.draft.destination || %Destination{}
+    fresh = Seed.redefault(stored, item)
 
-    if item.draft.destination == fresh,
+    if stored == fresh,
       do: {:ok, item},
       else: put_destination(item, fresh)
   end

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -58,6 +58,7 @@ defmodule Ambry.Inbox do
 
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.Draft.Seed
   alias Ambry.Inbox.Importer
   alias Ambry.Inbox.InboxItem
@@ -510,30 +511,28 @@ defmodule Ambry.Inbox do
   def prepare_draft(%InboxItem{status: :imported} = item), do: {:ok, item}
 
   def prepare_draft(%InboxItem{} = item) do
-    heal_destination(item)
+    refresh_destination(item)
   end
 
-  # A destination's *defaults* are derived — from the item's source — while
-  # its root and policy are the operator's to choose, so healing fills gaps
-  # without un-answering anything. The gap it exists for: an ad-hoc-scanned
-  # item adopts its source when the source's own scan next sees it, at which
-  # point the draft's sealed destination has no policy and the source now
-  # knows one. That's a fact the scan established, not a choice to preserve.
-  defp heal_destination(%InboxItem{} = item) do
-    stored = item.draft.destination
+  # A destination the operator has not touched is a *default*, and a default
+  # that was frozen at match time is the wrong default the moment anything it
+  # was derived from changes. A draft is written once and then only read, so
+  # nothing would ever revise it: import the first of three hundred queued
+  # releases, correct the policy while you're there, and the other two
+  # hundred and ninety-nine would keep proposing the old one forever.
+  #
+  # So an unchosen destination is re-derived here, on every prepare. A chosen
+  # one is never touched — that is the entire distinction `chosen` exists to
+  # draw.
+  defp refresh_destination(%InboxItem{draft: %{destination: %Destination{chosen: true}}} = item),
+    do: {:ok, item}
+
+  defp refresh_destination(%InboxItem{} = item) do
     fresh = Seed.destination(item)
 
-    cond do
-      is_nil(stored) ->
-        put_destination(item, fresh)
-
-      is_nil(stored.policy) and not is_nil(fresh.policy) ->
-        healed = %{stored | policy: fresh.policy, root_id: stored.root_id || fresh.root_id}
-        put_destination(item, %{healed | approved: not is_nil(healed.root_id)})
-
-      true ->
-        {:ok, item}
-    end
+    if item.draft.destination == fresh,
+      do: {:ok, item},
+      else: put_destination(item, fresh)
   end
 
   defp put_destination(item, destination) do

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -664,7 +664,7 @@ defmodule Ambry.Inbox do
       {:ok, root} ->
         %{
           base
-          | summary: policy_summary(policy, root),
+          | summary: policy_summary(item, policy, root),
             blocker: hardlink_blocker(item, policy, root)
         }
     end
@@ -697,35 +697,56 @@ defmodule Ambry.Inbox do
     end
   end
 
-  defp policy_summary(:hardlink, root),
-    do: "Hardlinked into #{root.path} — one copy of the bytes, the download keeps seeding."
+  defp policy_summary(_item, :hardlink, root),
+    do: "Hardlinked into #{root.path}. One copy of the bytes, and the download keeps seeding."
 
-  defp policy_summary(:symlink, root),
-    do:
-      "Symlinked into #{root.path} — a pointer to the original, which dangles if the original ever moves or is deleted."
+  defp policy_summary(_item, :symlink, root),
+    do: "Symlinked into #{root.path}. The link dangles if the original ever moves or is deleted."
 
-  defp policy_summary(:copy, root), do: "Copied into #{root.path}, duplicating the bytes."
+  defp policy_summary(_item, :copy, root), do: "Copied into #{root.path}, duplicating the bytes."
 
-  defp policy_summary(:move, root),
-    do: "Moved into #{root.path}, leaving the downloads folder clean."
+  defp policy_summary(_item, :move, root),
+    do: "Moved into #{root.path}, leaving the source folder clean."
 
-  defp policy_summary(_unset, root), do: "Placed into #{root.path}."
+  # Nothing chosen and nothing proposed. Saying "Placed into <root>" here
+  # described a placement that had not been decided, on a card whose rail
+  # was amber for exactly that reason. The honest line says why it is
+  # asking: hardlinking is the one default worth assuming, so where it is
+  # unavailable there is no safe guess and the three remaining doors mean
+  # three different things.
+  defp policy_summary(item, _unset, root) do
+    case hardlinkable(item, root) do
+      {:ok, false} ->
+        "These can't be hardlinked into #{root.path} (different filesystems). Pick how they come in."
+
+      _yes_or_unknown ->
+        "Pick how these files come in."
+    end
+  end
 
   # The refusal this whole phase exists for: a hardlink cannot cross a
   # filesystem, and silently copying instead is the storage doubling the
   # roadmap set out to eliminate. Worth knowing before the click, not after.
   # Symlink deliberately gets no blocker: it has no precondition to fail.
-  defp hardlink_blocker(%InboxItem{files: [_ | _]} = item, :hardlink, root) do
-    [file | _rest] = InboxItem.disk_files(item)
-
-    case Library.same_filesystem?(Path.dirname(file), root.path) do
+  defp hardlink_blocker(item, :hardlink, root) do
+    case hardlinkable(item, root) do
       {:ok, true} -> nil
-      {:ok, false} -> describe_error({:cross_filesystem, file, root.path})
+      {:ok, false} -> describe_error({:cross_filesystem, first_file(item), root.path})
       {:error, _reason} -> "Couldn't tell whether these are on the same filesystem."
     end
   end
 
   defp hardlink_blocker(_item, _policy, _root), do: nil
+
+  # Asked of the item's real files rather than its source's path: the
+  # default is derived from the pairing, but the answer that gates a
+  # placement has to be about the bytes being placed.
+  defp hardlinkable(%InboxItem{files: [_ | _]} = item, root),
+    do: Library.same_filesystem?(Path.dirname(first_file(item)), root.path)
+
+  defp hardlinkable(%InboxItem{}, _root), do: {:error, :no_files}
+
+  defp first_file(%InboxItem{} = item), do: item |> InboxItem.disk_files() |> hd()
 
   @doc """
   A draft as params, for staging it back onto an item.

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -654,19 +654,10 @@ defmodule Ambry.Inbox do
   """
   def destination_preflight(%InboxItem{} = item) do
     item = Repo.preload(item, :source)
-    base = %{blocker: nil, summary: nil}
-    policy = chosen_policy(item)
 
     case chosen_root(item) do
-      {:error, reason} ->
-        %{base | blocker: describe_error(reason)}
-
-      {:ok, root} ->
-        %{
-          base
-          | summary: policy_summary(item, policy, root),
-            blocker: hardlink_blocker(item, policy, root)
-        }
+      {:error, reason} -> %{blocker: describe_error(reason)}
+      {:ok, root} -> %{blocker: hardlink_blocker(item, chosen_policy(item), root)}
     end
   end
 
@@ -694,33 +685,6 @@ defmodule Ambry.Inbox do
     case Library.list_roots() do
       [] -> {:error, :no_library_root}
       _some -> {:error, :ambiguous_library_root}
-    end
-  end
-
-  defp policy_summary(_item, :hardlink, root),
-    do: "Hardlinked into #{root.path}. One copy of the bytes, and the download keeps seeding."
-
-  defp policy_summary(_item, :symlink, root),
-    do: "Symlinked into #{root.path}. The link dangles if the original ever moves or is deleted."
-
-  defp policy_summary(_item, :copy, root), do: "Copied into #{root.path}, duplicating the bytes."
-
-  defp policy_summary(_item, :move, root),
-    do: "Moved into #{root.path}, leaving the source folder clean."
-
-  # Nothing chosen and nothing proposed. Saying "Placed into <root>" here
-  # described a placement that had not been decided, on a card whose rail
-  # was amber for exactly that reason. The honest line says why it is
-  # asking: hardlinking is the one default worth assuming, so where it is
-  # unavailable there is no safe guess and the three remaining doors mean
-  # three different things.
-  defp policy_summary(item, _unset, root) do
-    case hardlinkable(item, root) do
-      {:ok, false} ->
-        "These can't be hardlinked into #{root.path} (different filesystems). Pick how they come in."
-
-      _yes_or_unknown ->
-        "Pick how these files come in."
     end
   end
 
@@ -869,8 +833,8 @@ defmodule Ambry.Inbox do
   # rather than just what failed.
   def describe_error({:cross_filesystem, _source, _destination}),
     do:
-      "This folder and its library root are on different filesystems, so the file can't be " <>
-        "hardlinked. Point it at a root on the same disk, or set the source to copy or move."
+      "These files and the library root are on different filesystems, so they can't be " <>
+        "hardlinked. Choose copy or move, or a root on the same disk."
 
   # Occupied by a recording is now a *bug*, not a curation problem. Every
   # recording's name carries its own token, so two of them cannot render to

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -739,8 +739,14 @@ defmodule Ambry.Inbox do
   def import_item(%InboxItem{} = item) do
     case Importer.import_item(item) do
       {:ok, media} ->
-        remember_placement(item)
-        refresh_siblings(item)
+        # Bookkeeping, and it runs after the records are committed. Neither
+        # of these may fail the import — the library already holds the
+        # recording, so a job reported as failed would be a lie the operator
+        # acts on — and neither may skip the other, so they are guarded
+        # separately. `Placement.finalize/1` states the same rule one call
+        # further in, for the same reason.
+        after_commit(item, "remember the placement", fn -> remember_placement(item) end)
+        after_commit(item, "relink sibling drafts", fn -> refresh_siblings(item) end)
         {:ok, media}
 
       {:error, reason} = error ->
@@ -750,6 +756,23 @@ defmodule Ambry.Inbox do
         update_item(item, %{issue: describe_error(reason)})
         error
     end
+  end
+
+  # Work that happens once the import has committed is untidy when it
+  # fails, not broken. `RunImport` is `max_attempts: 1`, so a raise here
+  # would discard the job for a release the library actually has, and take
+  # the *other* piece of bookkeeping down with it.
+  defp after_commit(%InboxItem{} = item, what, work) do
+    work.()
+    :ok
+  rescue
+    error ->
+      Logger.error(fn ->
+        "Imported inbox item #{item.id}, but couldn't #{what}: " <>
+          Exception.message(error)
+      end)
+
+      :ok
   end
 
   # What the next import from this source should propose is what this one

--- a/lib/ambry/inbox/draft/destination.ex
+++ b/lib/ambry/inbox/draft/destination.ex
@@ -24,11 +24,29 @@ defmodule Ambry.Inbox.Draft.Destination do
 
   `hardlink | symlink | copy | move` describes what happens to the *source* —
   preserve it for seeding, reference it in place, or clear it out — so its
-  default comes from where the files came from (`Source.import_policy`). An
-  item with no source has no default and the policy is a real outstanding
-  decision. Whether a hardlink is actually possible depends on the input and
-  output being on one filesystem, which is a fact about the *pairing* and can
-  only be checked once both ends are known.
+  default comes from where the files came from (`Source.import_policy`).
+  Whether a hardlink is actually *possible* depends on the input and output
+  being on one filesystem, which is a fact about the **pairing** and can only
+  be checked once both ends are known.
+
+  ## `chosen` is the whole point of this struct
+
+  A destination holds two values and one fact about them: did a human pick
+  these, or did they fall out of a default? Without that fact a seeded
+  default is indistinguishable from a decision, and the consequence is not
+  theoretical — a draft is written once, at match time, and then only ever
+  read. Change what the default *should* be and every already-seeded draft
+  keeps the old one forever, because nothing can tell "the operator wanted
+  hardlink" from "hardlink is what the default was on Tuesday".
+
+  So `chosen` means the operator picked, and an unchosen destination is
+  re-derived from current defaults every time the item is prepared
+  (`Inbox.prepare_draft/1`). Defaults follow the latest thinking; decisions
+  don't move.
+
+  There is deliberately no separate `approved` flag. It only ever held
+  `root_id != nil and policy != nil`, which is `resolved?/1` — a stored copy
+  of a derivable fact, free to disagree with the fields it was derived from.
   """
 
   use Ecto.Schema
@@ -40,7 +58,10 @@ defmodule Ambry.Inbox.Draft.Destination do
   embedded_schema do
     field :root_id, :id
     field :policy, Ecto.Enum, values: [:hardlink, :symlink, :copy, :move]
-    field :approved, :boolean, default: false
+
+    # Whether a human picked the two above. False means they are a default
+    # and may be re-derived; see the moduledoc.
+    field :chosen, :boolean, default: false
 
     # Filled in at render time from the registry rather than stored: roots are
     # configuration and can change between seeding a draft and approving it.
@@ -49,37 +70,24 @@ defmodule Ambry.Inbox.Draft.Destination do
 
   @doc false
   def changeset(destination, attrs) do
-    destination
-    |> cast(attrs, [:root_id, :policy, :approved])
-    |> validate_approved_is_placeable()
-  end
-
-  # An approved import with no root or no policy is not a decision — it's one
-  # that would fail at the moment of placement, which is precisely what the
-  # invariant exists to prevent.
-  defp validate_approved_is_placeable(changeset) do
-    if get_field(changeset, :approved) do
-      changeset
-      |> validate_present(:root_id, "needs a library root to import into")
-      |> validate_present(:policy, "needs a placement policy")
-    else
-      changeset
-    end
-  end
-
-  defp validate_present(changeset, field, message) do
-    if is_nil(get_field(changeset, field)),
-      do: add_error(changeset, field, message),
-      else: changeset
+    cast(destination, attrs, [:root_id, :policy, :chosen])
   end
 
   @doc """
   Whether the destination still needs a human.
+
+  Both halves present is the whole test, however they got there. An import
+  that knows its root and its policy will place; one missing either would
+  fail at the moment of placement, which is exactly what asking is for.
   """
-  def resolved?(%__MODULE__{approved: true, root_id: root_id, policy: policy}),
+  def resolved?(%__MODULE__{root_id: root_id, policy: policy}),
     do: not is_nil(root_id) and not is_nil(policy)
 
-  def resolved?(%__MODULE__{}), do: false
+  @doc """
+  Marks the destination as the operator's own, so defaults stop moving it.
+  """
+  def choose(%__MODULE__{} = destination, changes),
+    do: struct!(%{destination | chosen: true}, changes)
 
   def state(%__MODULE__{} = destination) do
     cond do

--- a/lib/ambry/inbox/draft/destination.ex
+++ b/lib/ambry/inbox/draft/destination.ex
@@ -29,24 +29,31 @@ defmodule Ambry.Inbox.Draft.Destination do
   being on one filesystem, which is a fact about the **pairing** and can only
   be checked once both ends are known.
 
-  ## `chosen` is the whole point of this struct
+  ## The `chosen` flags are the whole point of this struct
 
-  A destination holds two values and one fact about them: did a human pick
-  these, or did they fall out of a default? Without that fact a seeded
-  default is indistinguishable from a decision, and the consequence is not
+  A destination holds two values and one fact about each: did a human pick
+  this, or did it fall out of a default? Without that fact a seeded default
+  is indistinguishable from a decision, and the consequence is not
   theoretical — a draft is written once, at match time, and then only ever
   read. Change what the default *should* be and every already-seeded draft
   keeps the old one forever, because nothing can tell "the operator wanted
   hardlink" from "hardlink is what the default was on Tuesday".
 
-  So `chosen` means the operator picked, and an unchosen destination is
-  re-derived from current defaults every time the item is prepared
-  (`Inbox.prepare_draft/1`). Defaults follow the latest thinking; decisions
-  don't move.
+  So an unchosen half is re-derived from current defaults every time the
+  item is prepared (`Inbox.prepare_draft/1`). Defaults follow the latest
+  thinking; decisions don't move. Clearing a picker back to its blank option
+  un-picks it and hands it back to the default, which is the only way to
+  change one's mind about having decided at all.
 
-  There is deliberately no separate `approved` flag. It only ever held
-  `root_id != nil and policy != nil`, which is `resolved?/1` — a stored copy
-  of a derivable fact, free to disagree with the fields it was derived from.
+  The two flags are separate because the two questions are. The policy is a
+  fact about the *pairing*, so picking a root re-derives an unchosen policy
+  rather than freezing whatever the previous root implied — with one flag,
+  answering "which root" would silently also answer "how", using the old
+  root's answer.
+
+  There is deliberately no `approved` flag. It only ever held `root_id !=
+  nil and policy != nil`, which is `resolved?/1` — a stored copy of a
+  derivable fact, free to disagree with the fields it was derived from.
   """
 
   use Ecto.Schema
@@ -59,9 +66,10 @@ defmodule Ambry.Inbox.Draft.Destination do
     field :root_id, :id
     field :policy, Ecto.Enum, values: [:hardlink, :symlink, :copy, :move]
 
-    # Whether a human picked the two above. False means they are a default
-    # and may be re-derived; see the moduledoc.
-    field :chosen, :boolean, default: false
+    # Whether a human picked each of the two above. False means it is a
+    # default and may be re-derived; see the moduledoc.
+    field :root_chosen, :boolean, default: false
+    field :policy_chosen, :boolean, default: false
 
     # Filled in at render time from the registry rather than stored: roots are
     # configuration and can change between seeding a draft and approving it.
@@ -70,7 +78,7 @@ defmodule Ambry.Inbox.Draft.Destination do
 
   @doc false
   def changeset(destination, attrs) do
-    cast(destination, attrs, [:root_id, :policy, :chosen])
+    cast(destination, attrs, [:root_id, :policy, :root_chosen, :policy_chosen])
   end
 
   @doc """
@@ -84,10 +92,20 @@ defmodule Ambry.Inbox.Draft.Destination do
     do: not is_nil(root_id) and not is_nil(policy)
 
   @doc """
-  Marks the destination as the operator's own, so defaults stop moving it.
+  Picks a root, or hands the choice back to the default when given `nil`.
+
+  Blank is how an operator un-decides. Recording it as "chose nothing" would
+  leave the import permanently unresolvable with no way back short of
+  rebuilding the draft.
   """
-  def choose(%__MODULE__{} = destination, changes),
-    do: struct!(%{destination | chosen: true}, changes)
+  def choose_root(%__MODULE__{} = destination, root_id),
+    do: %{destination | root_id: root_id, root_chosen: not is_nil(root_id)}
+
+  @doc """
+  Picks a policy, or hands the choice back to the default when given `nil`.
+  """
+  def choose_policy(%__MODULE__{} = destination, policy),
+    do: %{destination | policy: policy, policy_chosen: not is_nil(policy)}
 
   def state(%__MODULE__{} = destination) do
     cond do

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -322,11 +322,18 @@ defmodule Ambry.Inbox.Draft.Seed do
     %{destination | root_id: root && root.id, policy: policy}
   end
 
-  # What the source prefers, then the only root there is. The single-root
-  # case — which is nearly all of them — resolves silently: being asked to
-  # pick from a list of one is not a decision, it's an interruption.
+  # Where this source last imported, then what it prefers, then the only
+  # root there is. The single-root case — which is nearly all of them —
+  # resolves silently: being asked to pick from a list of one is not a
+  # decision, it's an interruption.
+  #
+  # The memory is filtered through the current registry rather than
+  # trusted, for the same reason a chosen root is.
   defp default_root(%Source{} = source, roots) do
-    find_root(roots, source.target_root_id) ||
+    remembered = Library.recall_placement(source)
+
+    find_root(roots, remembered && remembered.library_root_id) ||
+      find_root(roots, source.target_root_id) ||
       case roots do
         [only] -> only
         _none_or_several -> nil
@@ -336,7 +343,10 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp find_root(_roots, nil), do: nil
   defp find_root(roots, id), do: Enum.find(roots, &(&1.id == id))
 
-  defp default_policy(%Source{} = source, %Root{}), do: source.import_policy
+  # What this exact pairing last did, then the source's standing default.
+  defp default_policy(%Source{} = source, %Root{} = root) do
+    Library.recall_policy(source, root) || source.import_policy
+  end
 
   ## work
 

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -322,10 +322,10 @@ defmodule Ambry.Inbox.Draft.Seed do
     %{destination | root_id: root && root.id, policy: policy}
   end
 
-  # Where this source last imported, then what it prefers, then the only
-  # root there is. The single-root case — which is nearly all of them —
-  # resolves silently: being asked to pick from a list of one is not a
-  # decision, it's an interruption.
+  # Where this source last imported, then the only root there is. The
+  # single-root case — which is nearly all of them — resolves silently:
+  # being asked to pick from a list of one is not a decision, it's an
+  # interruption.
   #
   # The memory is filtered through the current registry rather than
   # trusted, for the same reason a chosen root is.
@@ -333,7 +333,6 @@ defmodule Ambry.Inbox.Draft.Seed do
     remembered = Library.recall_placement(source)
 
     find_root(roots, remembered && remembered.library_root_id) ||
-      find_root(roots, source.target_root_id) ||
       case roots do
         [only] -> only
         _none_or_several -> nil
@@ -343,9 +342,30 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp find_root(_roots, nil), do: nil
   defp find_root(roots, id), do: Enum.find(roots, &(&1.id == id))
 
-  # What this exact pairing last did, then the source's standing default.
+  # What this exact pairing last did, and failing that what the disk allows.
   defp default_policy(%Source{} = source, %Root{} = root) do
-    Library.recall_policy(source, root) || source.import_policy
+    Library.recall_policy(source, root) || feasible_policy(source, root)
+  end
+
+  # Nothing remembered yet, so there is one thing worth assuming and three
+  # worth asking about.
+  #
+  # Where the pair shares a filesystem, hardlink dominates: no extra bytes,
+  # the source untouched, nothing to dangle. The only reason to prefer
+  # something else there is wanting the folder emptied, which is a
+  # preference rather than a safe default — and one import corrects it for
+  # every item behind it.
+  #
+  # Across filesystems the three remaining doors mean three genuinely
+  # different things — reference it, duplicate it, relocate it — with no
+  # dominant answer, and guessing wrong silently doubles the operator's
+  # storage. So this proposes nothing and the destination stays an
+  # outstanding decision, once per pairing.
+  defp feasible_policy(%Source{} = source, %Root{} = root) do
+    case Library.same_filesystem?(source.path, root.path) do
+      {:ok, true} -> :hardlink
+      _different_or_unknown -> nil
+    end
   end
 
   ## work

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -285,8 +285,10 @@ defmodule Ambry.Inbox.Draft.Seed do
   # than fixed on the source. The single-root case — which is nearly all of
   # them — resolves silently: being asked to pick from a list of one is not a
   # decision, it's an interruption. The policy is seeded from the source the
-  # same way; an item with no source (ad-hoc scan) has no default and the
-  # policy stays an outstanding decision.
+  # same way.
+  #
+  # Everything here is a *default*. It is recomputed from scratch every time
+  # an item is prepared, and only an unchosen destination ever takes it.
   def destination(%InboxItem{} = item) do
     item = Repo.preload(item, :source)
 
@@ -308,11 +310,7 @@ defmodule Ambry.Inbox.Draft.Seed do
         {nil, _none_or_several} -> nil
       end
 
-    %Destination{
-      root_id: root && root.id,
-      policy: policy,
-      approved: not is_nil(root) and not is_nil(policy)
-    }
+    %Destination{root_id: root && root.id, policy: policy, chosen: false}
   end
 
   ## work

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -281,37 +281,62 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   ## destination
 
-  # Any input may feed any output, so the root is chosen per import rather
-  # than fixed on the source. The single-root case — which is nearly all of
-  # them — resolves silently: being asked to pick from a list of one is not a
-  # decision, it's an interruption. The policy is seeded from the source the
-  # same way.
-  #
-  # Everything here is a *default*. It is recomputed from scratch every time
-  # an item is prepared, and only an unchosen destination ever takes it.
-  def destination(%InboxItem{} = item) do
+  @doc """
+  A destination with nothing chosen: pure defaults.
+  """
+  def destination(%InboxItem{} = item), do: redefault(%Destination{}, item)
+
+  @doc """
+  Fills in whichever halves of a destination the operator hasn't picked.
+
+  Any input may feed any output, so the root is chosen per import rather than
+  fixed on the source, and the policy follows from the **pairing** rather
+  than from either end — which is why this runs again after a root is
+  picked. Choosing where the files go is not a statement about how they get
+  there, and freezing the policy at the moment the root changed would answer
+  a question nobody asked, using the previous root's answer.
+
+  Everything not chosen is recomputed from scratch on every prepare, so
+  correcting the first of three hundred queued releases corrects the other
+  two hundred and ninety-nine with it.
+  """
+  def redefault(%Destination{} = destination, %InboxItem{} = item) do
     item = Repo.preload(item, :source)
-
-    policy =
-      case item.source do
-        %Source{import_policy: policy} -> policy
-        nil -> nil
-      end
-
     roots = Library.list_roots()
 
-    # A source may still *prefer* a root; it just doesn't bind to one.
-    preferred = item.source && Enum.find(roots, &(&1.id == item.source.target_root_id))
-
     root =
-      case {preferred, roots} do
-        {%Root{} = root, _several} -> root
-        {nil, [only]} -> only
-        {nil, _none_or_several} -> nil
+      if destination.root_chosen,
+        # Filtered through the current registry rather than trusted: a root
+        # can be deleted between the choice and this, and a dangling id
+        # would seed a destination that only fails at placement.
+        do: find_root(roots, destination.root_id),
+        else: default_root(item.source, roots)
+
+    policy =
+      cond do
+        destination.policy_chosen -> destination.policy
+        is_nil(root) -> nil
+        true -> default_policy(item.source, root)
       end
 
-    %Destination{root_id: root && root.id, policy: policy, chosen: false}
+    %{destination | root_id: root && root.id, policy: policy}
   end
+
+  # What the source prefers, then the only root there is. The single-root
+  # case — which is nearly all of them — resolves silently: being asked to
+  # pick from a list of one is not a decision, it's an interruption.
+  defp default_root(%Source{} = source, roots) do
+    find_root(roots, source.target_root_id) ||
+      case roots do
+        [only] -> only
+        _none_or_several -> nil
+      end
+  end
+
+  defp find_root(_roots, nil), do: nil
+  defp find_root(roots, id), do: Enum.find(roots, &(&1.id == id))
+
+  defp default_policy(%Source{} = source, %Root{}), do: source.import_policy
 
   ## work
 

--- a/lib/ambry/inbox/draft/tier.ex
+++ b/lib/ambry/inbox/draft/tier.ex
@@ -80,10 +80,11 @@ defmodule Ambry.Inbox.Draft.Tier do
   def of(%Work{} = work), do: worst([of_evidence(work), of_identity(work)])
   def of(%Recording{} = recording), do: of_evidence(recording)
 
-  # The destination has no `curated` flag of its own — choosing a root is the
-  # only way it is ever approved, so approved *is* the operator's answer.
-  def of(%Destination{approved: true}), do: :reviewed
-  def of(%Destination{}), do: :waiting
+  # A destination that knows where it is going is settled whether the
+  # operator picked or a default did — the silent single-root resolution is
+  # meant to be indistinguishable from an answer, not flagged as a guess.
+  def of(%Destination{} = destination),
+    do: if(Destination.resolved?(destination), do: :reviewed, else: :waiting)
 
   @doc """
   Which provider records describe this thing — the records card's own tier.

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -9,10 +9,12 @@ defmodule Ambry.Inbox.InboxItem do
 
   `path` and `files` are stored relative to the item's source, so a source
   whose mount point changes is a one-row edit and every queued item — and
-  the operator decisions staged on it — survives the move. An ad-hoc item
-  with no source stores absolute paths; that exception stays inside the
-  inbox, whose rows are transient. Resolve through `disk_path/1` and
-  `disk_files/1`, never by joining the columns against anything directly.
+  the operator decisions staged on it — survives the move. Resolve through
+  `disk_path/1` and `disk_files/1`, never by joining the columns against
+  anything directly.
+
+  Every item has a source. There is no other way in, which is what makes
+  the relative form an invariant rather than a convention.
   """
 
   use Ecto.Schema
@@ -31,10 +33,8 @@ defmodule Ambry.Inbox.InboxItem do
   schema "inbox_items" do
     belongs_to :media, Media
 
-    # Where this was found, which seeds the placement policy import brings
-    # its files into a library root with. Nullable: items from an ad-hoc
-    # scan have no source to speak for them, so the operator picks the
-    # policy at approval.
+    # The watched folder this was found in, and the base its `path` and
+    # `files` are relative to.
     belongs_to :source, Source
 
     field :path, :string
@@ -70,7 +70,8 @@ defmodule Ambry.Inbox.InboxItem do
       :media_id,
       :source_id
     ])
-    |> validate_required([:path, :status])
+    |> validate_required([:path, :status, :source_id])
+    |> foreign_key_constraint(:source_id)
     |> unique_constraint(:path)
   end
 
@@ -116,12 +117,9 @@ defmodule Ambry.Inbox.InboxItem do
   """
   def disk_files(%__MODULE__{files: files} = item), do: Enum.map(files, &resolve!(item, &1))
 
-  # An ad-hoc item's paths are already absolute; a sourced item resolves
-  # against its source. Raising on anything else is deliberate: these paths
-  # get probed, placed and (on undo) checked before deletion, and a path
-  # that can't resolve must never quietly become a relative one.
-  defp resolve!(%__MODULE__{source_id: nil}, path), do: path
-
+  # Raising is deliberate: these paths get probed, placed and (on undo)
+  # checked before deletion, and a path that can't resolve must never
+  # quietly become a relative one.
   defp resolve!(%__MODULE__{} = item, path) do
     case Library.resolve(item_source(item), path) do
       {:ok, absolute} -> absolute

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -5,9 +5,10 @@ defmodule Ambry.Library do
   Two registries, deliberately separate because they are separate concepts:
 
     * **Sources** (`Ambry.Library.Source`) — watched folders audiobooks
-      arrive from. Read, never written. Each carries a default placement
-      policy (`import_policy`) naming how import brings its files into a
-      root.
+      arrive from. Read, never written. A path and nothing else: how import
+      brings files out of one is a fact about the *pairing* with a root, so
+      it is remembered per pairing (`Ambry.Library.ImportPreference`)
+      rather than configured on either end.
     * **Library roots** (`Ambry.Library.Root`) — the folders the library's
       audio is organized into, and the only place Ambry serves from.
       Written, never watched. At least one is required to import anything.

--- a/lib/ambry/library.ex
+++ b/lib/ambry/library.ex
@@ -37,10 +37,11 @@ defmodule Ambry.Library do
 
   use Boundary,
     deps: [Ambry.Paths, Ambry.Repo],
-    exports: [Source, Root, NamingTemplate, Placement]
+    exports: [Source, Root, ImportPreference, NamingTemplate, Placement]
 
   import Ecto.Query
 
+  alias Ambry.Library.ImportPreference
   alias Ambry.Library.Mounts
   alias Ambry.Library.Root
   alias Ambry.Library.Source
@@ -166,6 +167,61 @@ defmodule Ambry.Library do
   end
 
   def change_root(%Root{} = root, attrs \\ %{}), do: Root.changeset(root, attrs)
+
+  ## remembered placement
+
+  @doc """
+  Records what an import from `source` into `root` just did.
+
+  Called once the import has committed, not when the operator picks: what
+  the next import should propose is what the last one *actually did*, and a
+  choice made on a release that then failed to place is not that. See
+  `Ambry.Library.ImportPreference` for why this is remembered rather than
+  configured.
+  """
+  def remember_placement(%Source{} = source, %Root{} = root, policy) do
+    attrs = %{
+      source_id: source.id,
+      library_root_id: root.id,
+      policy: policy,
+      last_used_at: DateTime.utc_now(:second)
+    }
+
+    %ImportPreference{}
+    |> ImportPreference.changeset(attrs)
+    |> Repo.insert(
+      on_conflict: {:replace, [:policy, :last_used_at, :updated_at]},
+      conflict_target: [:source_id, :library_root_id]
+    )
+  end
+
+  @doc """
+  What this source last did, and where — `nil` until it has imported once.
+
+  The most recent pairing, which carries both halves of the proposal: the
+  root to offer, and the policy that went with it.
+  """
+  def recall_placement(%Source{id: id}) do
+    ImportPreference
+    |> where([p], p.source_id == ^id)
+    |> order_by([p], desc: p.last_used_at, desc: p.id)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  @doc """
+  The policy this pairing last used, or `nil`.
+
+  Asked per pairing rather than per source because the answer is a fact
+  about the pairing: the same downloads folder may hardlink into one root
+  and have to copy into another on a different disk.
+  """
+  def recall_policy(%Source{id: source_id}, %Root{id: root_id}) do
+    ImportPreference
+    |> where([p], p.source_id == ^source_id and p.library_root_id == ^root_id)
+    |> select([p], p.policy)
+    |> Repo.one()
+  end
 
   ## stored-path resolution
   #

--- a/lib/ambry/library/import_preference.ex
+++ b/lib/ambry/library/import_preference.ex
@@ -1,0 +1,58 @@
+defmodule Ambry.Library.ImportPreference do
+  @moduledoc """
+  What the last import from one source into one root did.
+
+  ## Why this is a memory and not a setting
+
+  Which of `hardlink | symlink | copy | move` an import uses is a property
+  of the **pairing**, not of either end. A hardlink is only possible when
+  the two paths share a filesystem, so the same downloads folder feeding two
+  roots on two NAS boxes genuinely wants two different answers — which a
+  policy stored on the source cannot express, and which the operator would
+  have to correct by hand on every import into the second root.
+
+  It is also not stable enough to be configuration. The choice is a real
+  per-import decision — normally hardlink from downloads, but this one
+  release isn't seeding and the folder should be left clean — and a settings
+  field that is overridden half the time is not a setting, it is a default
+  wearing configuration's costume.
+
+  So nothing is configured. The pairing remembers what it last did, and the
+  next import proposes that. `last_used_at` doubles as the *root* default:
+  the root a source most recently imported into is the one it proposes next.
+
+  ## What a memory is not allowed to do
+
+  Only propose. A remembered `:hardlink` for a pairing that has since moved
+  to another filesystem is still refused at the point of placement — see
+  `Ambry.Library.Placement` — because a memory is evidence about what the
+  operator wanted, never a claim about what the disk can do.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Library.Root
+  alias Ambry.Library.Source
+
+  schema "import_preferences" do
+    belongs_to :source, Source
+    belongs_to :library_root, Root
+
+    field :policy, Ecto.Enum, values: [:hardlink, :symlink, :copy, :move]
+    field :last_used_at, :utc_datetime
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(preference, attrs) do
+    preference
+    |> cast(attrs, [:source_id, :library_root_id, :policy, :last_used_at])
+    |> validate_required([:source_id, :library_root_id, :policy, :last_used_at])
+    |> foreign_key_constraint(:source_id)
+    |> foreign_key_constraint(:library_root_id)
+    |> unique_constraint([:source_id, :library_root_id])
+  end
+end

--- a/lib/ambry/library/placement.ex
+++ b/lib/ambry/library/placement.ex
@@ -2,9 +2,9 @@ defmodule Ambry.Library.Placement do
   @moduledoc """
   Bringing a file into a library root.
 
-  Four policies, set per source. They are exhaustive: a file either shares
-  its bytes with the original (hard or soft), duplicates them, or relocates
-  them — there is no fifth door.
+  Four policies, chosen per import. They are exhaustive: a file either
+  shares its bytes with the original (hard or soft), duplicates them, or
+  relocates them — there is no fifth door.
 
     * `:hardlink` — **same filesystem required**. One inode, two names, no
       extra bytes. This is the point of the whole exercise: the torrent keeps
@@ -55,8 +55,15 @@ defmodule Ambry.Library.Placement do
 
   alias Ambry.Library
 
+  @policies [:hardlink, :symlink, :copy, :move]
+
   @enforce_keys [:source, :destination, :policy]
   defstruct [:source, :destination, :policy]
+
+  @doc """
+  The four doors, in the order they're offered.
+  """
+  def policies, do: @policies
 
   @doc """
   Places `source` at `destination` according to `policy`.
@@ -65,7 +72,7 @@ defmodule Ambry.Library.Placement do
   `finalize/1` once the surrounding transaction commits, or to `undo/1` if it
   doesn't.
   """
-  def place(source, destination, policy) when policy in [:hardlink, :symlink, :copy, :move] do
+  def place(source, destination, policy) when policy in @policies do
     with :ok <- readable(source),
          :ok <- vacant(destination),
          :ok <- File.mkdir_p(Path.dirname(destination)),

--- a/lib/ambry/library/source.ex
+++ b/lib/ambry/library/source.ex
@@ -2,12 +2,25 @@ defmodule Ambry.Library.Source do
   @moduledoc """
   A watched folder audiobooks arrive from. Read, never written.
 
-  Import always places a source's files into a library root; the source
-  carries the default `import_policy` naming how — hardlink, symlink, copy
-  or move. The durability question the operator used to answer separately
-  ("can these files be trusted to stay?") is answered by the choice itself:
-  pick `:symlink` if they'll stay, `:hardlink`/`:copy`/`:move` if they
-  might not.
+  A source is a path and nothing else — where to look, and whether to keep
+  looking. What happens to what it finds is decided at import, because that
+  is where the question can be answered.
+
+  ## Why placement isn't configured here
+
+  Import places a source's files into a library root by hardlinking,
+  symlinking, copying or moving them, and this used to carry a default
+  naming which. Two things were wrong with that. Whether a hardlink is even
+  *possible* depends on the source and the root sharing a filesystem, which
+  one end cannot know — the same downloads folder may hardlink into one root
+  and have to copy into another on a different disk. And the field was never
+  binding: every import could change it, which makes it a default rather
+  than a setting, and a default that is overridden half the time is better
+  learned than typed.
+
+  So the pairing remembers instead (`Ambry.Library.ImportPreference`), and
+  the source's preferred root went the same way: the root it most recently
+  imported into is the one it proposes next.
 
   How organized the folder is doesn't matter and isn't asked: discovery
   measures release boundaries from the tree itself, and a messy downloads
@@ -18,43 +31,22 @@ defmodule Ambry.Library.Source do
 
   import Ecto.Changeset
 
-  alias Ambry.Library.Root
-
-  @import_policies [:hardlink, :symlink, :copy, :move]
-
   schema "sources" do
-    # A *preferred* root, not a binding one: any source may feed any root,
-    # and which one an import uses is a per-import decision this only seeds.
-    # Pairing each source with a same-filesystem root is what makes
-    # hardlinking possible, so complex setups pair them explicitly.
-    belongs_to :target_root, Root
-
     field :name, :string
     field :path, :string
-    field :import_policy, Ecto.Enum, values: @import_policies, default: :hardlink
     field :enabled, :boolean, default: true
     field :last_scanned_at, :utc_datetime
 
     timestamps(type: :utc_datetime)
   end
 
-  def import_policies, do: @import_policies
-
   @doc false
   def changeset(source, attrs) do
     source
-    |> cast(attrs, [
-      :name,
-      :path,
-      :import_policy,
-      :enabled,
-      :last_scanned_at,
-      :target_root_id
-    ])
+    |> cast(attrs, [:name, :path, :enabled, :last_scanned_at])
     |> update_change(:path, &normalize_path/1)
-    |> validate_required([:name, :path, :import_policy])
+    |> validate_required([:name, :path])
     |> validate_absolute_path()
-    |> foreign_key_constraint(:target_root_id)
     |> unique_constraint(:path)
     |> unique_constraint(:name)
   end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -50,7 +50,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
-  alias Ambry.Library.Source
+  alias Ambry.Library.Placement
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
   alias Ambry.People
@@ -1039,7 +1039,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
-  @placement_policies Source.import_policies()
+  @placement_policies Placement.policies()
 
   defp to_policy(value) do
     Enum.find(@placement_policies, &(to_string(&1) == value))

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -1045,15 +1045,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     Enum.find(@placement_policies, &(to_string(&1) == value))
   end
 
-  # The same four doors the location form offers, worded for one import
-  # rather than a standing default.
+  # Named, not explained. Each label used to carry a parenthetical about
+  # what the door costs, which is a definition an operator reads once and
+  # then re-reads on every import forever. The one consequence that still
+  # needs saying is the one that stops an import, and it says itself when
+  # the impossible door is picked.
   defp placement_policies do
-    [
-      {"Hardlink (same filesystem only, no extra storage)", :hardlink},
-      {"Symlink (crosses filesystems; dangles if the source ever moves)", :symlink},
-      {"Copy (duplicates the files)", :copy},
-      {"Move (empties the source folder)", :move}
-    ]
+    Enum.map(Placement.policies(), &{Phoenix.Naming.humanize(&1), &1})
   end
 
   ## rendering helpers

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -43,6 +43,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Chapters
+  alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.Recording
   alias Ambry.Inbox.Draft.Seed
@@ -771,7 +772,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      edit(socket, fn draft ->
-       update_in(draft.destination, &approve_destination(%{&1 | root_id: id}))
+       update_in(draft.destination, &Destination.choose(&1, %{root_id: id}))
      end)}
   end
 
@@ -780,7 +781,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      edit(socket, fn draft ->
-       update_in(draft.destination, &approve_destination(%{&1 | policy: policy}))
+       update_in(draft.destination, &Destination.choose(&1, %{policy: policy}))
      end)}
   end
 
@@ -1027,12 +1028,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       {int, ""} -> int
       _other -> nil
     end
-  end
-
-  # Approved is not a separate gesture: choosing the last missing half is
-  # the approval. Un-choosing either half un-approves.
-  defp approve_destination(destination) do
-    %{destination | approved: not is_nil(destination.root_id) and not is_nil(destination.policy)}
   end
 
   @placement_policies Source.import_policies()

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -767,21 +767,30 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.approve_work(&1, params["approved"] == "true"))}
   end
 
+  # Re-defaulted after each pick, because the policy is a fact about the
+  # pairing: changing the root changes what "how the files come in" should
+  # propose, and an unpicked policy has no business keeping the answer that
+  # belonged to the previous root.
   def handle_event("choose-root", %{"root_id" => root_id}, socket) do
+    item = socket.assigns.item
     id = to_int(root_id)
 
     {:noreply,
      edit(socket, fn draft ->
-       update_in(draft.destination, &Destination.choose(&1, %{root_id: id}))
+       update_in(draft.destination, &(&1 |> Destination.choose_root(id) |> Seed.redefault(item)))
      end)}
   end
 
   def handle_event("choose-policy", %{"policy" => policy}, socket) do
+    item = socket.assigns.item
     policy = to_policy(policy)
 
     {:noreply,
      edit(socket, fn draft ->
-       update_in(draft.destination, &Destination.choose(&1, %{policy: policy}))
+       update_in(
+         draft.destination,
+         &(&1 |> Destination.choose_policy(policy) |> Seed.redefault(item))
+       )
      end)}
   end
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -777,7 +777,7 @@
                 value={root.id}
                 selected={@item.draft.destination.root_id == root.id}
               >
-                {root.name} ({root.path})
+                {root.name}
               </option>
             </select>
           </form>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -802,7 +802,6 @@
             </select>
           </form>
         </div>
-        <p :if={@destination.summary} class="text-sm text-zinc-400">{@destination.summary}</p>
         <p
           :if={@destination.blocker}
           class="flex items-baseline gap-1.5 pl-3 text-sm text-red-400"

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -334,16 +334,12 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp source_label(%Source{name: name, import_policy: policy}),
     do: "#{name} · #{policy_word(policy)}"
 
-  defp source_label(nil), do: "ad-hoc scan"
-
   defp policy_word(:hardlink), do: "hardlinked in on import"
   defp policy_word(:symlink), do: "symlinked in on import"
   defp policy_word(:copy), do: "copied in on import"
   defp policy_word(:move), do: "moved in on import"
 
   defp source_color(%Source{}), do: "bg-blue-400/15 text-blue-300"
-
-  defp source_color(_other), do: "bg-white/10 text-zinc-300"
 
   @doc """
   The candidate's name — usually the release name, and the most recognizable

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -329,15 +329,11 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp rail_class(%{status: :imported}), do: "border-brand-dark/40 border-l-4"
   defp rail_class(_item), do: "border-l-4 border-zinc-700"
 
-  # Where an item came from seeds how its files reach the library, so it's
-  # worth reading off the row.
-  defp source_label(%Source{name: name, import_policy: policy}),
-    do: "#{name} · #{policy_word(policy)}"
-
-  defp policy_word(:hardlink), do: "hardlinked in on import"
-  defp policy_word(:symlink), do: "symlinked in on import"
-  defp policy_word(:copy), do: "copied in on import"
-  defp policy_word(:move), do: "moved in on import"
+  # Which watched folder this came from. What import will *do* with it is
+  # not here on purpose: that is a per-import decision now, it is stated in
+  # full on the item's own destination card, and there is no way to import
+  # without passing through it.
+  defp source_label(%Source{name: name}), do: name
 
   defp source_color(%Source{}), do: "bg-blue-400/15 text-blue-300"
 

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -113,9 +113,11 @@
             {progress_label(@progress[item.id])}
           </p>
 
-          <%!-- Where this came from decides what approving it does to the
-                bytes, so it belongs on the row rather than one click away —
-                and on the same rail as the match badges above it. --%>
+          <%!-- Which watched folder this came from, on the same rail as the
+                match badges above it. What import will do to the bytes is
+                deliberately not here: it is a per-import decision, stated
+                in full on the item's own destination card, and no item can
+                be imported without going through that card. --%>
           <div class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2">
             <span class="text-xs text-zinc-400">source</span>
             <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400">

--- a/lib/ambry_web/live/admin/location_live/form.ex
+++ b/lib/ambry_web/live/admin/location_live/form.ex
@@ -16,7 +16,7 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
   end
 
   defp apply_action(socket, :new_source, _params) do
-    source = %Source{import_policy: :hardlink}
+    source = %Source{}
 
     socket
     |> assign(page_title: "New Source", entity: source)
@@ -104,7 +104,6 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
     |> assign(:form, to_form(changeset))
     |> assign(:type, :source)
     |> assign(:status, path_status(Changeset.get_field(changeset, :path)))
-    |> assign(:root_options, root_options())
   end
 
   defp assign_root_form(socket, %Changeset{} = changeset) do
@@ -112,16 +111,7 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
     |> assign(:form, to_form(changeset))
     |> assign(:type, :root)
     |> assign(:status, path_status(Changeset.get_field(changeset, :path)))
-    |> assign(:root_options, [])
   end
-
-  defp root_options do
-    Enum.map(Library.list_roots(), &{&1.name, &1.id})
-  end
-
-  defp root_prompt([]), do: "No library roots yet"
-  defp root_prompt([{name, _id}]), do: "#{name} (the only root)"
-  defp root_prompt(_several), do: "Choose a library root"
 
   # Checking the path as it's typed is worth the stat call: "that folder isn't
   # there" is the single most common way one of these rows is wrong, and
@@ -131,17 +121,4 @@ defmodule AmbryWeb.Admin.LocationLive.Form do
   end
 
   defp path_status(_blank), do: nil
-
-  # The one question a source answers, asked in the operator's terms: what
-  # import does with these files. The old durability question ("can they be
-  # trusted to stay?") is answered by the choice — symlink if they'll stay,
-  # anything else if they might not.
-  defp policy_options do
-    [
-      {"Hardlink (same filesystem only, no extra storage)", :hardlink},
-      {"Symlink (crosses filesystems; dangles if the source ever moves)", :symlink},
-      {"Copy (duplicates the files)", :copy},
-      {"Move (empties the source folder)", :move}
-    ]
-  end
 end

--- a/lib/ambry_web/live/admin/location_live/form.html.heex
+++ b/lib/ambry_web/live/admin/location_live/form.html.heex
@@ -47,39 +47,6 @@
         <.input field={@form[:enabled]} type="checkbox" label="Watched" />
       </.field_group>
 
-      <.field_group :if={@type == :source} label="Bringing files in">
-        <div>
-          <.input
-            field={@form[:import_policy]}
-            type="select"
-            label="How the files come in"
-            options={policy_options()}
-          />
-          <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            Hardlinking only works within a single filesystem. Import refuses across
-            filesystems instead of silently copying. Symlinking crosses filesystems, but
-            the library entry breaks if these files ever move.
-          </p>
-        </div>
-
-        <div>
-          <.input
-            field={@form[:target_root_id]}
-            type="select"
-            label="Preferred library root"
-            options={@root_options}
-            prompt={root_prompt(@root_options)}
-          />
-          <p class="max-w-prose pl-3 text-sm text-zinc-400">
-            Optional. Any source can import into any root; this preselects one.
-          </p>
-          <p :if={@root_options == []} class="max-w-prose pl-3 text-sm text-amber-400">
-            No library roots yet, so nothing can be brought in. Add one under Locations
-            first.
-          </p>
-        </div>
-      </.field_group>
-
       <.form_footer>
         <.button>Save</.button>
       </.form_footer>

--- a/lib/ambry_web/live/admin/location_live/index.ex
+++ b/lib/ambry_web/live/admin/location_live/index.ex
@@ -124,22 +124,6 @@ defmodule AmbryWeb.Admin.LocationLive.Index do
   defp filesystem_tag(_filesystems, %{device: nil}), do: nil
   defp filesystem_tag(filesystems, status), do: filesystems[{status.device, status.mount}]
 
-  defp policy_label(:hardlink), do: "hardlink"
-  defp policy_label(:symlink), do: "symlink"
-  defp policy_label(:copy), do: "copy"
-  defp policy_label(:move), do: "move"
-
-  defp policy_blurb(:hardlink),
-    do: "Import hardlinks its files into a root — one copy of the bytes, seeding untouched."
-
-  defp policy_blurb(:symlink),
-    do:
-      "Import symlinks its files into a root. They're trusted to stay; the link dangles if they don't."
-
-  defp policy_blurb(:copy), do: "Import copies its files into a root, duplicating the bytes."
-
-  defp policy_blurb(:move), do: "Import moves its files into a root, leaving this folder clean."
-
   defp source_problem(status) do
     cond do
       !status.exists? -> "Not found. Is the volume mounted?"

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -30,13 +30,6 @@
               <h3 class="font-semibold" data-role="source-name">{source.name}</h3>
 
               <span
-                class="bg-blue-400/15 rounded-sm px-1.5 text-xs text-blue-300"
-                title="How import brings the files into a library root"
-              >
-                {policy_label(source.import_policy)}
-              </span>
-
-              <span
                 :if={fs = filesystem_tag(@filesystems, @statuses[{:source, source.id}])}
                 class="bg-white/10 rounded-sm px-1.5 text-xs text-zinc-300"
                 title="Paths sharing this tag can be hardlinked between"
@@ -53,8 +46,6 @@
             <p class="font-mono mt-1 truncate text-sm text-zinc-400" data-role="source-path">
               {source.path}
             </p>
-
-            <p class="mt-1 text-sm text-zinc-400">{policy_blurb(source.import_policy)}</p>
 
             <p
               :if={problem = source_problem(@statuses[{:source, source.id}])}

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -11,11 +11,6 @@
         </.button>
       </div>
 
-      <p class="max-w-prose text-sm text-zinc-400">
-        Watched folders that audiobooks arrive from. Everything they hold reaches the library
-        through the inbox.
-      </p>
-
       <div :if={@sources == []} class="rounded-lg bg-zinc-900 p-8 text-center">
         <p class="text-zinc-400">No sources yet, so there is nothing to scan.</p>
         <.add_button navigate={~p"/admin/locations/sources/new"} class="mx-auto mt-3">
@@ -99,11 +94,6 @@
 
     <section class="space-y-3">
       <h2 class="text-xl font-bold text-zinc-100">Library roots</h2>
-
-      <p class="max-w-prose text-sm text-zinc-400">
-        The folders managed audio is organized into, using the naming template. Ambry writes
-        only here. A source can only hardlink into a root sharing its <span class="font-semibold">filesystem</span> tag.
-      </p>
 
       <%!-- Roots are mandatory: every import places into one, so an empty
           section is a blocker, not a fine choice. --%>

--- a/priv/repo/migrations/20260814205459_inbox_items_require_a_source.exs
+++ b/priv/repo/migrations/20260814205459_inbox_items_require_a_source.exs
@@ -1,0 +1,87 @@
+defmodule Ambry.Repo.Migrations.InboxItemsRequireASource do
+  @moduledoc """
+  Makes `inbox_items.source_id` mandatory.
+
+  A source-less item came from an ad-hoc scan — `Inbox.discover/1`'s
+  bare-path form, which was never reachable from the UI. It stored absolute
+  paths where every other item stores source-relative ones, carried no
+  placement default, and made "resolve this item's files" a two-shape
+  question for every caller. That exception is gone, so the two locatable
+  CHECKs lose their `ELSE absolute` halves and state the invariant plainly:
+  an inbox path is relative, always.
+
+  Nothing should exist to convert: the only way to create one was from IEx.
+  Any that somehow do are deleted rather than assigned a source, because
+  guessing which watched folder an absolute path belongs to is exactly the
+  quiet re-keying the relative-path invariant exists to prevent. The delete
+  is limited to unsettled rows: an imported item is the record of what was
+  imported and the only thing keeping an already-imported release from
+  resurfacing as a new candidate, so one of those is a fact worth failing
+  over rather than discarding.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    DO $$
+    DECLARE stranded integer;
+    BEGIN
+      SELECT count(*) INTO stranded
+        FROM inbox_items WHERE source_id IS NULL AND status = 'imported';
+
+      IF stranded > 0 THEN
+        RAISE EXCEPTION
+          'inbox_items: % imported row(s) have no source. Point a source at their files and rescan before migrating.',
+          stranded;
+      END IF;
+    END $$;
+    """)
+
+    execute("DELETE FROM inbox_items WHERE source_id IS NULL")
+
+    drop constraint(:inbox_items, :inbox_items_path_locatable)
+    drop constraint(:inbox_items, :inbox_items_files_locatable)
+
+    # Refused by the database, explained by the app (`delete_source/1`
+    # returns reference counts), same as before — `modify` recreates the
+    # foreign key, so the `:restrict` has to be restated.
+    drop constraint(:inbox_items, "inbox_items_source_id_fkey")
+
+    alter table(:inbox_items) do
+      modify :source_id, references(:sources, on_delete: :restrict), null: false
+    end
+
+    create constraint(:inbox_items, :inbox_items_path_locatable, check: "path NOT LIKE '/%'")
+
+    create constraint(:inbox_items, :inbox_items_files_locatable,
+             check: "ambry_paths_all_relative(files)"
+           )
+  end
+
+  def down do
+    drop constraint(:inbox_items, :inbox_items_path_locatable)
+    drop constraint(:inbox_items, :inbox_items_files_locatable)
+    drop constraint(:inbox_items, "inbox_items_source_id_fkey")
+
+    alter table(:inbox_items) do
+      modify :source_id, references(:sources, on_delete: :restrict), null: true
+    end
+
+    create constraint(:inbox_items, :inbox_items_path_locatable,
+             check: """
+             CASE WHEN source_id IS NOT NULL
+                  THEN path NOT LIKE '/%'
+                  ELSE path LIKE '/%' END
+             """
+           )
+
+    create constraint(:inbox_items, :inbox_items_files_locatable,
+             check: """
+             CASE WHEN source_id IS NOT NULL
+                  THEN ambry_paths_all_relative(files)
+                  ELSE ambry_paths_all_absolute(files) END
+             """
+           )
+  end
+end

--- a/priv/repo/migrations/20260814210822_remember_placement_per_pairing.exs
+++ b/priv/repo/migrations/20260814210822_remember_placement_per_pairing.exs
@@ -1,0 +1,42 @@
+defmodule Ambry.Repo.Migrations.RememberPlacementPerPairing do
+  @moduledoc """
+  Records what the last import from a source into a root actually did.
+
+  Which of hardlink / symlink / copy / move an import uses is a fact about
+  the **pairing**, not about either end: whether a hardlink is even possible
+  depends on the two paths sharing a filesystem, and "leave the source
+  alone" versus "clear the folder out" depends on what the root is for. A
+  default stored on the source alone can only ever be right for one root.
+
+  So the default is learned instead of configured. One row per pairing,
+  written after a successful import; the next import from that source
+  proposes what the last one did. `last_used_at` also orders the rows, which
+  is how a source proposes a *root*: the one it most recently imported into.
+
+  Deleting either end takes its preferences with it — a remembered choice
+  about a location that no longer exists is not a fact about anything. That
+  is why this is `delete_all` where `inbox_items.source_id` is `restrict`:
+  an inbox item's stored paths are meaningless without its source, so losing
+  one is data loss; losing a preference just means the next import proposes
+  a default instead of a memory.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create table(:import_preferences) do
+      add :source_id, references(:sources, on_delete: :delete_all), null: false
+      add :library_root_id, references(:library_roots, on_delete: :delete_all), null: false
+      add :policy, :string, null: false
+      add :last_used_at, :utc_datetime, null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:import_preferences, [:source_id, :library_root_id])
+
+    # "Which root did this source last go to" is the root default, read on
+    # every seed.
+    create index(:import_preferences, [:source_id, :last_used_at])
+  end
+end

--- a/priv/repo/migrations/20260814211731_placement_is_not_a_source_setting.exs
+++ b/priv/repo/migrations/20260814211731_placement_is_not_a_source_setting.exs
@@ -1,0 +1,76 @@
+defmodule Ambry.Repo.Migrations.PlacementIsNotASourceSetting do
+  @moduledoc """
+  Drops the two placement fields from `sources`.
+
+    * `import_policy` — hardlink / symlink / copy / move is a property of the
+      **pairing**, not of the input. Whether a hardlink is even possible
+      depends on the source and the root sharing a filesystem, which one end
+      cannot know. It was never binding either: every import could change it,
+      which makes it a default, and a default belongs where it can be
+      learned. `import_preferences` learns it.
+
+    * `target_root_id` — a preferred root, which the same table now supplies
+      from the root the source last imported into. Keeping both would mean
+      two mechanisms for one job with a precedence question, and the loser is
+      always the configured one: it is consulted before the first import and
+      shadowed forever after. A field that silently stops mattering is worse
+      than either mechanism alone.
+
+  What is lost, deliberately: a fresh install can no longer declare "this
+  source goes to that root" before importing anything. With one root nothing
+  changes — it resolves silently either way. With several, the first import
+  asks, which is the honest answer to a genuinely ambiguous question, and
+  the memory answers it from then on.
+
+  Existing choices are carried over rather than dropped: each source's
+  policy, paired with its preferred root (or the only root, if there is
+  one), becomes its first remembered placement. Anything already remembered
+  from a real import wins — that is a fact, and this is a translation of a
+  setting.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    # The root a setting implied: the one it named, or the only one there is.
+    only_root =
+      "(SELECT r.id FROM library_roots r WHERE (SELECT count(*) FROM library_roots) = 1)"
+
+    execute("""
+    INSERT INTO import_preferences
+      (source_id, library_root_id, policy, last_used_at, inserted_at, updated_at)
+    SELECT s.id, coalesce(s.target_root_id, #{only_root}), s.import_policy, now(), now(), now()
+      FROM sources s
+     WHERE s.import_policy IS NOT NULL
+       AND coalesce(s.target_root_id, #{only_root}) IS NOT NULL
+    ON CONFLICT (source_id, library_root_id) DO NOTHING
+    """)
+
+    alter table(:sources) do
+      remove :import_policy
+      remove :target_root_id
+    end
+  end
+
+  def down do
+    alter table(:sources) do
+      add :import_policy, :string
+      add :target_root_id, references(:library_roots, on_delete: :nilify_all)
+    end
+
+    execute("""
+    UPDATE sources s
+       SET import_policy = p.policy,
+           target_root_id = p.library_root_id
+      FROM (SELECT DISTINCT ON (source_id) source_id, library_root_id, policy
+              FROM import_preferences
+             ORDER BY source_id, last_used_at DESC, id DESC) p
+     WHERE p.source_id = s.id
+    """)
+
+    execute("UPDATE sources SET import_policy = 'hardlink' WHERE import_policy IS NULL")
+
+    execute("ALTER TABLE sources ALTER COLUMN import_policy SET NOT NULL")
+    execute("ALTER TABLE sources ALTER COLUMN import_policy SET DEFAULT 'hardlink'")
+  end
+end

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -277,12 +277,11 @@ defmodule Ambry.Inbox.DraftTest do
       candidates = [provider_candidate(%{"title" => "The Long Way to a Small, Angry Planet"})]
 
       item =
-        %InboxItem{path: "/downloads/The Long Way to a Small, Angry Planet"}
-        |> Map.merge(%{
+        item(%{
+          path: "The Long Way to a Small, Angry Planet",
           matches: matches(candidates, confidence: 0.5),
           tags: %{"book_title" => "Wayfarers, Book 1", "published" => "2014-01-01"}
         })
-        |> then(&(%InboxItem{} |> InboxItem.changeset(Map.from_struct(&1)) |> Repo.insert!()))
 
       {:ok, item} = Inbox.prepare_draft(item)
 
@@ -1843,12 +1842,11 @@ defmodule Ambry.Inbox.DraftTest do
   describe "the file's own name is a proposal, not a rival" do
     test "it is offered as a chip without making the field a question" do
       item =
-        %InboxItem{path: "/downloads/The Long Way to a Small, Angry Planet"}
-        |> Map.merge(%{
+        item(%{
+          path: "The Long Way to a Small, Angry Planet",
           matches: matches([]),
           tags: %{"book_title" => "Wayfarers, Book 1", "published" => "2014-01-01"}
         })
-        |> then(&(%InboxItem{} |> InboxItem.changeset(Map.from_struct(&1)) |> Repo.insert!()))
 
       draft = Seed.build(item)
 
@@ -1865,9 +1863,11 @@ defmodule Ambry.Inbox.DraftTest do
     # stops being advisory and answers the question.
     test "it settles the field when nothing else proposed anything" do
       item =
-        %InboxItem{path: "/downloads/Leviathan Wakes"}
-        |> Map.merge(%{matches: matches([]), tags: %{"published" => "2011-06-15"}})
-        |> then(&(%InboxItem{} |> InboxItem.changeset(Map.from_struct(&1)) |> Repo.insert!()))
+        item(%{
+          path: "Leviathan Wakes",
+          matches: matches([]),
+          tags: %{"published" => "2011-06-15"}
+        })
 
       draft = Seed.build(item)
 
@@ -1877,12 +1877,11 @@ defmodule Ambry.Inbox.DraftTest do
 
     test "it is not repeated as a second chip when it agrees" do
       item =
-        %InboxItem{path: "/downloads/Leviathan Wakes"}
-        |> Map.merge(%{
+        item(%{
+          path: "Leviathan Wakes",
           matches: matches([provider_candidate(%{})]),
           tags: %{"book_title" => "Leviathan Wakes"}
         })
-        |> then(&(%InboxItem{} |> InboxItem.changeset(Map.from_struct(&1)) |> Repo.insert!()))
 
       draft = Seed.build(item)
 

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -15,10 +15,13 @@ defmodule Ambry.Inbox.DraftTest do
   alias Ambry.Repo
 
   defp item(attrs) do
-    # A settled environment — one root, a sourced item — so the destination
-    # resolves silently and these tests stay about the decision tree.
-    if Ambry.Library.list_roots() == [], do: insert(:root)
+    # A settled environment — one root, a sourced item, a pairing that has
+    # imported before — so the destination resolves silently and these tests
+    # stay about the decision tree. The memory is what settles it: these
+    # paths don't exist on disk, so nothing can be derived from them.
+    root = List.first(Ambry.Library.list_roots()) || insert(:root)
     source = insert(:source)
+    {:ok, _memory} = Ambry.Library.remember_placement(source, root, :hardlink)
 
     %InboxItem{
       path: "Some Release",

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -16,6 +16,28 @@ defmodule Ambry.Inbox.ImporterTest do
   alias Ambry.People.Person
 
   describe "approve/1" do
+    # The recording is in the library by the time this runs, so a raise here
+    # would discard a `max_attempts: 1` job for an import that succeeded and
+    # report a failure the operator would act on. `Placement.finalize/1`
+    # already states the rule for post-commit work; this holds the two
+    # pieces of bookkeeping beside it to the same one.
+    @tag :capture_log
+    test "bookkeeping that fails after the commit doesn't fail the import" do
+      item = tagged_item()
+
+      patch(Ambry.Library, :remember_placement, fn _source, _root, _policy ->
+        raise "the database went away"
+      end)
+
+      assert {:ok, media} = Inbox.import_item(item)
+      assert Media.get_media!(media.id)
+      assert Inbox.get_item!(item.id).status == :imported
+
+      # and the other piece still ran, rather than being skipped by the first
+      # one's failure
+      refute Inbox.get_item!(item.id).issue
+    end
+
     test "creates the whole graph from a tagged file" do
       item = tagged_item()
 

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -33,7 +33,7 @@ defmodule Ambry.Inbox.ImporterTest do
     end
 
     test "a symlink import never touches the originals" do
-      item = tagged_item()
+      item = tagged_item(policy: :symlink)
       [file] = item |> Repo.preload(:source) |> InboxItem.disk_files()
       before = File.stat!(file)
 
@@ -639,10 +639,11 @@ defmodule Ambry.Inbox.ImporterTest do
     end
   end
 
-  # A real tagged file discovered the way discovery would find it. The
-  # source's policy is symlink, so the originals stay exactly where the test
-  # put them — these tests are about the entity graph, and the placement
-  # policies get their workout in `ManagedImportTest`.
+  # A real tagged file discovered the way discovery would find it. Root and
+  # fixtures share a filesystem, so it hardlinks and the originals stay
+  # exactly where the test put them — these tests are about the entity
+  # graph, and the placement policies get their workout in
+  # `ManagedImportTest`. Pass `policy:` to exercise a different door.
   defp tagged_item(opts \\ []) do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     name = Keyword.get(opts, :name, "The Way of Kings [M4B]")
@@ -668,12 +669,15 @@ defmodule Ambry.Inbox.ImporterTest do
       insert(:root, path: library)
     end
 
-    watched =
-      insert(:source,
-        path: root,
-        import_policy: :symlink,
-        name: "Watched #{Ecto.UUID.generate()}"
-      )
+    watched = insert(:source, path: root, name: "Watched #{Ecto.UUID.generate()}")
+
+    # The policy lives on the pairing now. Root and fixtures share a
+    # filesystem here, so it would default to hardlinking; a test that wants
+    # a different door seeds it the way an earlier import would have.
+    if policy = Keyword.get(opts, :policy) do
+      {:ok, _memory} =
+        Ambry.Library.remember_placement(watched, hd(Ambry.Library.list_roots()), policy)
+    end
 
     {:ok, _counts} = Inbox.discover(watched)
     {[item], false} = Inbox.list_items(filter: name)

--- a/test/ambry/inbox/lookup_test.exs
+++ b/test/ambry/inbox/lookup_test.exs
@@ -218,8 +218,9 @@ defmodule Ambry.Inbox.LookupTest do
 
     %InboxItem{}
     |> InboxItem.changeset(%{
-      path: "/downloads/Leviathan Wakes",
-      files: ["/downloads/Leviathan Wakes/book.m4b"],
+      path: "Leviathan Wakes",
+      files: ["Leviathan Wakes/book.m4b"],
+      source_id: insert(:source).id,
       matches: %{
         "work" => %{
           "candidates" => [record],

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -6,6 +6,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
   use Ambry.DataCase
 
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft.Destination
   alias Ambry.Library
   alias Ambry.Media
   alias Ambry.Settings
@@ -388,7 +389,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
       {:ok, item} = Inbox.rebuild_draft(Repo.reload(item))
 
       assert item.draft.destination.root_id == chosen.id
-      assert item.draft.destination.approved
+      assert Destination.resolved?(item.draft.destination)
     end
 
     # Two recordings of one book used to render to one path and refuse; each

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -8,6 +8,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft.Destination
   alias Ambry.Library
+  alias Ambry.Library.ImportPreference
   alias Ambry.Media
   alias Ambry.Settings
 
@@ -379,6 +380,59 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert String.starts_with?(placed, chosen.path)
     end
 
+    # Which of the four doors an import uses is a fact about the *pairing*,
+    # so it is learned rather than configured: the next import from a source
+    # proposes what the last one into that root actually did.
+    test "the next import proposes what the last one from this source did" do
+      %{item: item, watched: watched, root: root} = downloads_item(policy: :hardlink)
+
+      item = pick(item, &Destination.choose_policy(&1, :move))
+      assert {:ok, _media} = Inbox.import_item(item)
+
+      assert %ImportPreference{} = memory = Library.recall_placement(watched)
+      assert Library.get_root!(memory.library_root_id).path == root
+      assert memory.policy == :move
+
+      # a fresh candidate from the same source starts where the last one
+      # ended up, not at the source's standing default
+      next = second_release(watched)
+      {:ok, next} = Inbox.prepare_draft(next)
+
+      assert next.draft.destination.policy == :move
+      refute next.draft.destination.policy_chosen
+    end
+
+    # The reason the memory is written after the import rather than when the
+    # operator picks: the queue's Ready badge reads a stored column, so an
+    # item nobody has opened since would go on proposing the old default and
+    # look settled while proposing it.
+    test "items already queued follow the memory when it moves" do
+      %{item: item, watched: watched} = downloads_item(policy: :hardlink)
+
+      queued = second_release(watched)
+      {:ok, queued} = Inbox.prepare_draft(queued)
+      assert queued.draft.destination.policy == :hardlink
+
+      item = pick(item, &Destination.choose_policy(&1, :copy))
+      assert {:ok, _media} = Inbox.import_item(item)
+
+      # not reopened, not prepared — read straight back off the row
+      assert Repo.reload(queued).draft.destination.policy == :copy
+    end
+
+    test "a policy the operator picked for one release is not moved by the memory" do
+      %{item: item, watched: watched} = downloads_item(policy: :hardlink)
+
+      queued = second_release(watched)
+      {:ok, queued} = Inbox.prepare_draft(queued)
+      queued = pick(queued, &Destination.choose_policy(&1, :symlink))
+
+      item = pick(item, &Destination.choose_policy(&1, :copy))
+      assert {:ok, _media} = Inbox.import_item(item)
+
+      assert Repo.reload(queued).draft.destination.policy == :symlink
+    end
+
     test "a source's preferred root preselects without binding" do
       %{item: item, watched: watched} = downloads_item()
 
@@ -528,6 +582,27 @@ defmodule Ambry.Inbox.ManagedImportTest do
       watched: watched,
       downloads: downloads
     }
+  end
+
+  # Another candidate under the same watched folder, probed and queued.
+  defp second_release(watched) do
+    release = Path.join(watched.path, "Words of Radiance [M4B]")
+    File.mkdir_p!(release)
+    File.cp!(tagged_audio(), Path.join(release, "book.m4b"))
+
+    {:ok, _counts} = Inbox.discover(watched)
+    {[item], false} = Inbox.list_items(filter: "Words of Radiance")
+    {:ok, item} = Inbox.probe_item(item)
+
+    item
+  end
+
+  # What the form's destination pickers do: transform the stored destination
+  # and save it back.
+  defp pick(item, fun) do
+    draft = %{item.draft | destination: fun.(item.draft.destination)}
+    {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+    item
   end
 
   defp new_dir(prefix) do

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -237,7 +237,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
     defp two_part_imports do
       root = new_dir("root")
-      insert(:root, path: root, name: "Library")
+      root_record = insert(:root, path: root, name: "Library")
 
       downloads = new_dir("downloads")
 
@@ -247,12 +247,8 @@ defmodule Ambry.Inbox.ManagedImportTest do
         File.cp!(tagged_audio(), Path.join(release, "book.m4b"))
       end
 
-      watched =
-        insert(:source,
-          import_policy: :copy,
-          path: downloads,
-          name: "Downloads #{Ecto.UUID.generate()}"
-        )
+      watched = insert(:source, path: downloads, name: "Downloads #{Ecto.UUID.generate()}")
+      {:ok, _memory} = Library.remember_placement(watched, root_record, :copy)
 
       {:ok, _counts} = Inbox.discover(watched)
       {items, false} = Inbox.list_items()
@@ -347,8 +343,11 @@ defmodule Ambry.Inbox.ManagedImportTest do
     # With several roots the choice is about which NAS, and therefore about
     # whether hardlinking is possible at all. Guessing is not acceptable.
     test "refuses when several roots exist and none was chosen" do
+      # No memory to inherit and no preference to fall back on, so the root
+      # is a genuine question — asked once, and answered from then on.
+      %{item: item} = downloads_item(policy: :unremembered)
       insert(:root, path: new_dir("second-root"))
-      %{item: item} = downloads_item()
+      {:ok, item} = Inbox.prepare_draft(Repo.reload(item))
 
       assert {:error, {:unresolved, outstanding}} = Inbox.import_item(item)
       assert Enum.any?(outstanding, &(&1.section == :destination))
@@ -431,19 +430,6 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert {:ok, _media} = Inbox.import_item(item)
 
       assert Repo.reload(queued).draft.destination.policy == :symlink
-    end
-
-    test "a source's preferred root preselects without binding" do
-      %{item: item, watched: watched} = downloads_item()
-
-      chosen = insert(:root, path: new_dir("preferred-root"))
-
-      {:ok, _watched} = Library.update_source(watched, %{target_root_id: chosen.id})
-
-      {:ok, item} = Inbox.rebuild_draft(Repo.reload(item))
-
-      assert item.draft.destination.root_id == chosen.id
-      assert Destination.resolved?(item.draft.destination)
     end
 
     # Two recordings of one book used to render to one path and refuse; each
@@ -539,9 +525,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
         path -> path
       end
 
-    if root do
-      insert(:root, path: root, name: "Library")
-    end
+    root_record = if root, do: insert(:root, path: root, name: "Library")
 
     downloads = new_dir("downloads")
     release = Path.join(downloads, "The Way of Kings [M4B]")
@@ -558,12 +542,15 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
     source = hd(sources)
 
-    watched =
-      insert(:source,
-        import_policy: policy,
-        path: downloads,
-        name: "Downloads #{Ecto.UUID.generate()}"
-      )
+    watched = insert(:source, path: downloads, name: "Downloads #{Ecto.UUID.generate()}")
+
+    # The policy is a memory of the pairing now, not a field on either end,
+    # so a test that wants a particular one seeds it the way an earlier
+    # import would have. `:unremembered` leaves the pairing blank, which is
+    # what a source that has never imported looks like.
+    if root_record && policy != :unremembered do
+      {:ok, _memory} = Library.remember_placement(watched, root_record, policy)
+    end
 
     {:ok, _counts} = Inbox.discover(watched)
     {[item], false} = Inbox.list_items()

--- a/test/ambry/inbox/progress_test.exs
+++ b/test/ambry/inbox/progress_test.exs
@@ -131,9 +131,10 @@ defmodule Ambry.Inbox.ProgressTest do
       %Ambry.Inbox.InboxItem{}
       |> Ambry.Inbox.InboxItem.changeset(
         Enum.into(attrs, %{
-          path: "/downloads/release-#{Ecto.UUID.generate()}",
-          files: ["/downloads/x/book.m4b"],
-          status: :pending
+          path: "release-#{Ecto.UUID.generate()}",
+          files: ["x/book.m4b"],
+          status: :pending,
+          source_id: insert(:source).id
         })
       )
       |> Repo.insert()

--- a/test/ambry/inbox/run_import_test.exs
+++ b/test/ambry/inbox/run_import_test.exs
@@ -76,8 +76,9 @@ defmodule Ambry.Inbox.RunImportTest do
   defp unsettled_item do
     %InboxItem{}
     |> InboxItem.changeset(%{
-      path: "/downloads/Nothing Settled Here",
-      files: ["/downloads/Nothing Settled Here/book.m4b"]
+      path: "Nothing Settled Here",
+      files: ["Nothing Settled Here/book.m4b"],
+      source_id: insert(:source).id
     })
     |> Repo.insert!()
   end

--- a/test/ambry/inbox/run_match_test.exs
+++ b/test/ambry/inbox/run_match_test.exs
@@ -27,8 +27,9 @@ defmodule Ambry.Inbox.RunMatchTest do
 
   defp item do
     %InboxItem{
-      path: "/downloads/The Way of Kings",
-      files: ["/downloads/The Way of Kings/book.m4b"],
+      path: "The Way of Kings",
+      files: ["The Way of Kings/book.m4b"],
+      source_id: insert(:source).id,
       tags: %{"book_title" => "The Way of Kings", "authors" => ["Brandon Sanderson"]}
     }
     |> Map.from_struct()

--- a/test/ambry/inbox/undo_test.exs
+++ b/test/ambry/inbox/undo_test.exs
@@ -114,7 +114,7 @@ defmodule Ambry.Inbox.UndoTest do
   # it.
   defp downloads_item(opts \\ []) do
     root = new_dir("root")
-    insert(:root, path: root, name: "Library")
+    root_record = insert(:root, path: root, name: "Library")
 
     downloads = new_dir("downloads")
     release = Path.join(downloads, "The Way of Kings [M4B]")
@@ -123,12 +123,12 @@ defmodule Ambry.Inbox.UndoTest do
     source = Path.join(release, "book.m4b")
     File.cp!(tagged_audio(), source)
 
-    watched =
-      insert(:source,
-        import_policy: Keyword.get(opts, :policy, :copy),
-        path: downloads,
-        name: "Downloads #{Ecto.UUID.generate()}"
-      )
+    watched = insert(:source, path: downloads, name: "Downloads #{Ecto.UUID.generate()}")
+
+    # The policy lives on the pairing now, so a test that wants a particular
+    # one seeds it the way an earlier import would have.
+    {:ok, _memory} =
+      Ambry.Library.remember_placement(watched, root_record, Keyword.get(opts, :policy, :copy))
 
     {:ok, _counts} = Inbox.discover(watched)
     {[item], false} = Inbox.list_items()

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -3,6 +3,7 @@ defmodule Ambry.InboxTest do
 
   alias Ambry.Inbox
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library.Source
   alias Ambry.Media.Scanner
 
   describe "discover/1" do
@@ -10,11 +11,11 @@ defmodule Ambry.InboxTest do
       root = watched_root()
       release = release_folder(root, "The Way of Kings [M4B]", ["book.m4b"])
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       assert {[%InboxItem{} = item], false} = Inbox.list_items()
-      assert item.path == release
-      assert item.files == [Path.join(release, "book.m4b")]
+      assert InboxItem.disk_path(item) == release
+      assert InboxItem.disk_files(item) == [Path.join(release, "book.m4b")]
       assert item.status == :pending
     end
 
@@ -22,11 +23,11 @@ defmodule Ambry.InboxTest do
       root = watched_root()
       loose = copy_audio(root, "Project Hail Mary.m4b")
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       assert {[item], false} = Inbox.list_items()
-      assert item.path == loose
-      assert item.files == [loose]
+      assert InboxItem.disk_path(item) == loose
+      assert InboxItem.disk_files(item) == [loose]
     end
 
     test "finds audio nested inside a release folder" do
@@ -36,10 +37,10 @@ defmodule Ambry.InboxTest do
       File.mkdir_p!(nested)
       copy_audio(nested, "01.mp3")
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       assert {[item], false} = Inbox.list_items()
-      assert item.path == release
+      assert InboxItem.disk_path(item) == release
       assert [file] = item.files
       assert file =~ "Disc 1/01.mp3"
     end
@@ -48,10 +49,10 @@ defmodule Ambry.InboxTest do
       root = watched_root()
       release = release_folder(root, "Chaptered Book", ["01.mp3", "02.mp3", "03.mp3"])
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       assert {[item], false} = Inbox.list_items()
-      assert item.path == release
+      assert InboxItem.disk_path(item) == release
       assert length(item.files) == 3
     end
 
@@ -64,7 +65,7 @@ defmodule Ambry.InboxTest do
         release_folder(root, name, ["book.m4b"])
       end
 
-      assert {:ok, %{created: 3}} = Inbox.discover(root)
+      assert {:ok, %{created: 3}} = discover(root)
     end
 
     # Every shape below is copied from the operator's real downloads folder,
@@ -78,7 +79,7 @@ defmodule Ambry.InboxTest do
         release_folder(series, title, ["book.m4b"])
       end
 
-      assert {:ok, %{created: 3}} = Inbox.discover(root)
+      assert {:ok, %{created: 3}} = discover(root)
 
       {items, false} = Inbox.list_items()
 
@@ -97,7 +98,7 @@ defmodule Ambry.InboxTest do
         release_folder(book, part, ["01.mp3", "02.mp3"])
       end
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       {[item], false} = Inbox.list_items()
       assert InboxItem.name(item) == "1 The Way of Kings"
@@ -112,7 +113,7 @@ defmodule Ambry.InboxTest do
         release_folder(book, disc, ["01.mp3"])
       end
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       {[item], false} = Inbox.list_items()
       assert InboxItem.name(item) == "The Colorado Kid by Stephen King"
@@ -129,7 +130,7 @@ defmodule Ambry.InboxTest do
         release_folder(trilogy, book, ["book.m4b"])
       end
 
-      assert {:ok, %{created: 3}} = Inbox.discover(root)
+      assert {:ok, %{created: 3}} = discover(root)
     end
 
     test "looks inside an author folder holding a single book" do
@@ -137,7 +138,7 @@ defmodule Ambry.InboxTest do
       author = Path.join(root, "Dennis E. Taylor")
       release_folder(author, "Book 5 - Not Till We Are Lost", ["book.m4b"])
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       {[item], false} = Inbox.list_items()
       assert InboxItem.name(item) == "Book 5 - Not Till We Are Lost"
@@ -150,7 +151,7 @@ defmodule Ambry.InboxTest do
       File.mkdir_p!(extras)
       copy_audio(extras, "interview.mp3")
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       {[item], false} = Inbox.list_items()
       assert InboxItem.name(item) == "Dan Brown - Origin"
@@ -164,12 +165,12 @@ defmodule Ambry.InboxTest do
       File.write!(Path.join(junk, "cover.jpg"), "not audio")
       File.write!(Path.join(root, "readme.txt"), "not audio")
 
-      assert {:ok, %{created: 0}} = Inbox.discover(root)
+      assert {:ok, %{created: 0}} = discover(root)
       assert {[], false} = Inbox.list_items()
     end
 
     test "reports a watched location that isn't there" do
-      assert {:error, :watched_source_missing} = Inbox.discover("/nope/not/here")
+      assert {:error, :watched_source_missing} = discover("/nope/not/here")
     end
   end
 
@@ -195,9 +196,9 @@ defmodule Ambry.InboxTest do
 
       pair = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
 
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {items, false} = Inbox.list_items()
-      grains = Map.new(items, &{&1.path, Inbox.split_grains(&1)})
+      grains = Map.new(items, &{InboxItem.disk_path(&1), Inbox.split_grains(&1)})
 
       # parts of several files each: both grains say something different
       assert grains[set] == %{folder: 2, file: 4}
@@ -215,19 +216,19 @@ defmodule Ambry.InboxTest do
     test "a file already owned is never re-grouped, however the walk sees it" do
       root = watched_root()
       release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       # the operator says these are two books, at the finest grain
       {[item], false} = Inbox.list_items()
       {:ok, _children} = Inbox.split_item(item, :file)
 
       # the walk still sees one folder holding two files, and is not asked
-      assert {:ok, %{created: 0, updated: 0}} = Inbox.discover(root)
+      assert {:ok, %{created: 0, updated: 0}} = discover(root)
 
       {items, false} = Inbox.list_items()
       assert length(items) == 2
 
-      assert items |> Enum.flat_map(& &1.files) |> Enum.sort() ==
+      assert items |> Enum.flat_map(&InboxItem.disk_files/1) |> Enum.sort() ==
                [Path.join(release, "one.m4b"), Path.join(release, "two.m4b")]
     end
 
@@ -237,21 +238,21 @@ defmodule Ambry.InboxTest do
       for part <- ["1 of 2", "2 of 2"], do: release_folder(book, part, ["01.mp3", "02.mp3"])
       copy_audio(book, "stray.mp3")
 
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
       assert length(item.files) == 5
 
       {:ok, _children} = Inbox.split_item(item, :folder)
       before = ownership()
 
-      assert {:ok, %{created: 0, updated: 0}} = Inbox.discover(root)
+      assert {:ok, %{created: 0, updated: 0}} = discover(root)
       assert ownership() == before
     end
 
     test "an imported item is never touched, even when its files have moved" do
       root = watched_root()
       release = release_folder(root, "Already Mine", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       {[item], false} = Inbox.list_items()
       {:ok, item} = Inbox.update_item(item, %{status: :imported})
@@ -260,7 +261,7 @@ defmodule Ambry.InboxTest do
       File.rm_rf!(release)
       File.mkdir_p!(release)
 
-      assert {:ok, %{updated: 0}} = Inbox.discover(root)
+      assert {:ok, %{updated: 0}} = discover(root)
 
       assert %{status: :imported, files: files} = Inbox.get_item!(item.id)
       assert files == item.files
@@ -269,11 +270,11 @@ defmodule Ambry.InboxTest do
     test "a new file joins the item that owns its folder, rather than starting one" do
       root = watched_root()
       release = release_folder(root, "Growing Release", ["01.mp3"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       copy_audio(release, "02.mp3")
 
-      assert {:ok, %{created: 0, updated: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 0, updated: 1}} = discover(root)
       assert {[item], false} = Inbox.list_items()
       assert length(item.files) == 2
     end
@@ -281,13 +282,13 @@ defmodule Ambry.InboxTest do
     test "a new file in a folder the operator took apart becomes its own item" do
       root = watched_root()
       release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
       {:ok, _children} = Inbox.split_item(item, :file)
 
       copy_audio(release, "three.m4b")
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       {items, false} = Inbox.list_items()
       assert length(items) == 3
@@ -300,8 +301,8 @@ defmodule Ambry.InboxTest do
       root = watched_root()
       release_folder(root, "A Book", ["book.m4b"])
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
-      assert {:ok, %{created: 0, skipped: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
+      assert {:ok, %{created: 0, skipped: 1}} = discover(root)
 
       assert {[_one], false} = Inbox.list_items()
     end
@@ -309,12 +310,12 @@ defmodule Ambry.InboxTest do
     test "never resurrects something ignored" do
       root = watched_root()
       release_folder(root, "Not Wanted", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       {[item], false} = Inbox.list_items()
       {:ok, _item} = Inbox.ignore_item(item)
 
-      assert {:ok, %{created: 0}} = Inbox.discover(root)
+      assert {:ok, %{created: 0}} = discover(root)
 
       assert {[item], false} = Inbox.list_items()
       assert item.status == :ignored
@@ -323,11 +324,11 @@ defmodule Ambry.InboxTest do
     test "picks up files that appeared after the first look" do
       root = watched_root()
       release = release_folder(root, "Growing Set", ["01.mp3"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       copy_audio(release, "02.mp3")
 
-      assert {:ok, %{updated: 1}} = Inbox.discover(root)
+      assert {:ok, %{updated: 1}} = discover(root)
 
       assert {[item], false} = Inbox.list_items()
       assert length(item.files) == 2
@@ -336,12 +337,12 @@ defmodule Ambry.InboxTest do
     test "leaves an ignored item ignored even when its files change" do
       root = watched_root()
       release = release_folder(root, "Growing Set", ["01.mp3"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
       {:ok, _item} = Inbox.ignore_item(item)
 
       copy_audio(release, "02.mp3")
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       assert {[item], false} = Inbox.list_items()
       assert item.status == :ignored
@@ -371,7 +372,7 @@ defmodule Ambry.InboxTest do
         library_root_id: root_record.id
       )
 
-      assert {:ok, %{created: 0, skipped: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 0, skipped: 1}} = discover(root)
       assert {[], false} = Inbox.list_items()
     end
 
@@ -384,7 +385,7 @@ defmodule Ambry.InboxTest do
 
       insert(:media, book: build(:book), legacy_source_files: [Path.join(release, "book.m4b")])
 
-      assert {:ok, %{created: 0, skipped: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 0, skipped: 1}} = discover(root)
       assert {[], false} = Inbox.list_items()
     end
   end
@@ -393,7 +394,7 @@ defmodule Ambry.InboxTest do
     test "records what the file is and what it claims about itself" do
       root = watched_root()
       release = release_folder(root, "Tagged Book", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
 
       assert {:ok, item} = Inbox.probe_item(item)
@@ -409,7 +410,7 @@ defmodule Ambry.InboxTest do
     test "measures a multi-file release as the one recording it will become" do
       root = watched_root()
       release_folder(root, "Chaptered Book", ["01.mp3", "02.mp3"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
 
       assert {:ok, item} = Inbox.probe_item(item)
@@ -428,7 +429,7 @@ defmodule Ambry.InboxTest do
 
       # The whole book, not the first file: the durations add up into one
       # timeline, and so do the bytes.
-      {:ok, one} = Scanner.probe_file(Path.join(item.path, "01.mp3"))
+      {:ok, one} = Scanner.probe_file(Path.join(InboxItem.disk_path(item), "01.mp3"))
       assert Decimal.equal?(Decimal.new(item.probe["duration"]), Decimal.mult(one.duration, 2))
       assert item.probe["size"] == one.size * 2
     end
@@ -439,7 +440,7 @@ defmodule Ambry.InboxTest do
       release = Path.join(root, "Broken")
       File.mkdir_p!(release)
       File.write!(Path.join(release, "book.m4b"), "this is not audio")
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
 
       assert {:ok, item} = Inbox.probe_item(item)
@@ -450,35 +451,6 @@ defmodule Ambry.InboxTest do
   end
 
   describe "prepare_draft/1 destination healing" do
-    # A destination's defaults are derived from the item's source, so healing
-    # fills gaps without un-answering anything. The gap: an ad-hoc-scanned
-    # item adopts its source when that source's own scan next sees it, and a
-    # draft sealed without a policy now has one on offer.
-    test "fills in the policy when the item adopts a source after drafting" do
-      dir = watched_root()
-      release_folder(dir, "Sourced Later", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(dir)
-      {[item], false} = Inbox.list_items(filter: "Sourced Later")
-      {:ok, item} = Inbox.probe_item(item)
-
-      {:ok, item} = Inbox.prepare_draft(item)
-      assert item.draft.destination.policy == nil
-      refute item.draft.destination.approved
-
-      insert(:source, path: dir, import_policy: :copy)
-      root = insert(:root)
-      # the source's own scan is what adopts the item (and rewrites its
-      # stored paths into the source's coordinates)
-      assert {:ok, %{updated: 1}} = Inbox.discover()
-
-      {:ok, healed} = Inbox.prepare_draft(Inbox.get_item!(item.id))
-
-      assert healed.draft.destination.policy == :copy
-      # the single root auto-picks, exactly as a fresh seed would
-      assert healed.draft.destination.root_id == root.id
-      assert healed.draft.destination.approved
-    end
-
     test "a settled destination is left alone" do
       dir = watched_root()
       release_folder(dir, "Stays Settled", ["book.m4b"])
@@ -521,7 +493,7 @@ defmodule Ambry.InboxTest do
     test "take an item out of the queue and back, without touching files" do
       root = watched_root()
       release = release_folder(root, "A Book", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
 
       {:ok, item} = Inbox.ignore_item(item)
@@ -538,7 +510,7 @@ defmodule Ambry.InboxTest do
       root = watched_root()
       release_folder(root, "Keeper", ["book.m4b"])
       release_folder(root, "Reject", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       {items, false} = Inbox.list_items()
       reject = Enum.find(items, &(InboxItem.name(&1) == "Reject"))
@@ -556,9 +528,9 @@ defmodule Ambry.InboxTest do
     test "the queue is newest-found first" do
       root = watched_root()
       release_folder(root, "Found first", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       release_folder(root, "Found second", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       assert {items, false} = Inbox.list_items(status: :pending)
       assert Enum.map(items, &InboxItem.name/1) == ["Found second", "Found first"]
@@ -571,7 +543,7 @@ defmodule Ambry.InboxTest do
       root = watched_root()
       release_folder(root, "Found first", ["book.m4b"])
       release_folder(root, "Found second", ["book.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
 
       {items, false} = Inbox.list_items()
       first = Enum.find(items, &(InboxItem.name(&1) == "Found first"))
@@ -638,25 +610,19 @@ defmodule Ambry.InboxTest do
       assert %DateTime{} = Ambry.Library.get_source!(source.id).last_scanned_at
     end
 
-    # An item found under a source adopts it: that's a fact the scan just
-    # established, not a guess about an item whose origin was never known.
-    # Adoption also rewrites the stored path into the source's coordinates,
-    # so the columns agree with the FK.
-    test "backfills the source of an item discovered before sources existed" do
-      root = watched_root()
-      release = release_folder(root, "Leviathan Wakes", ["book.m4b"])
+    # The stored columns are the source's coordinates, never the disk's:
+    # that is what lets a source's mount point move without stranding
+    # everything queued under it.
+    test "stores every path relative to the source it was found in" do
+      source = insert(:source, path: watched_root())
+      release = release_folder(source.path, "Leviathan Wakes", ["book.m4b"])
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = Inbox.discover()
+
       assert {[item], false} = Inbox.list_items()
-      assert is_nil(item.source_id)
-      assert item.path == release
-
-      source = insert(:source, path: root)
-
-      assert {:ok, %{updated: 1}} = Inbox.discover()
-      assert {[item], false} = Inbox.list_items()
-      assert item.path == "Leviathan Wakes"
       assert item.source_id == source.id
+      assert item.path == "Leviathan Wakes"
+      assert item.files == ["Leviathan Wakes/book.m4b"]
       assert InboxItem.disk_path(item) == release
     end
   end
@@ -669,12 +635,12 @@ defmodule Ambry.InboxTest do
     test "splits a folder of separate books into one item per file" do
       root = watched_root()
       release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
       {[item], false} = Inbox.list_items()
 
       assert {:ok, children} = Inbox.split_item(item)
 
-      assert Enum.sort(Enum.map(children, & &1.path)) ==
+      assert Enum.sort(Enum.map(children, &InboxItem.disk_path/1)) ==
                Enum.sort([Path.join(release, "one.m4b"), Path.join(release, "two.m4b")])
 
       assert Enum.all?(children, &(&1.files == [&1.path]))
@@ -690,11 +656,11 @@ defmodule Ambry.InboxTest do
     test "a rescan respects the split instead of re-merging the folder" do
       root = watched_root()
       release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
       {:ok, _children} = Inbox.split_item(item)
 
-      assert {:ok, %{created: 0}} = Inbox.discover(root)
+      assert {:ok, %{created: 0}} = discover(root)
 
       {items, false} = Inbox.list_items()
       assert length(items) == 2
@@ -704,30 +670,39 @@ defmodule Ambry.InboxTest do
     test "a file that appears in a split folder becomes its own item" do
       root = watched_root()
       release = release_folder(root, "Two Novellas", ["one.m4b", "two.m4b"])
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], false} = Inbox.list_items()
       {:ok, _children} = Inbox.split_item(item)
 
       copy_audio(release, "three.m4b")
 
-      assert {:ok, %{created: 1}} = Inbox.discover(root)
+      assert {:ok, %{created: 1}} = discover(root)
 
       {items, false} = Inbox.list_items()
       assert length(items) == 3
-      assert Enum.any?(items, &(&1.path == Path.join(release, "three.m4b")))
+      assert Enum.any?(items, &(InboxItem.disk_path(&1) == Path.join(release, "three.m4b")))
     end
 
     test "refuses an imported item and a single-file item" do
-      imported = raw_item(%{path: "/two", files: ["/a.m4b", "/b.m4b"], status: :imported})
+      imported = raw_item(%{path: "two", files: ["a.m4b", "b.m4b"], status: :imported})
       assert {:error, :already_imported} = Inbox.split_item(imported)
 
-      single = raw_item(%{path: "/only.m4b", files: ["/only.m4b"]})
+      single = raw_item(%{path: "only.m4b", files: ["only.m4b"]})
       assert {:error, :not_multi_file} = Inbox.split_item(single)
     end
   end
 
   defp raw_item(attrs) do
+    attrs = Map.put_new_lazy(attrs, :source_id, fn -> insert(:source).id end)
     %InboxItem{} |> InboxItem.changeset(attrs) |> Repo.insert!()
+  end
+
+  # Every item comes from a source, so the walk is only ever exercised
+  # through one. Get-or-create because rescanning the same tree is the point
+  # of half these tests.
+  defp discover(root) do
+    source = Repo.get_by(Source, path: root) || insert(:source, path: root)
+    Inbox.discover(source)
   end
 
   # Nothing in the inbox may modify what it finds, so every test works

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -460,8 +460,9 @@ defmodule Ambry.InboxTest do
     setup do
       dir = watched_root()
       release_folder(dir, "Waiting Release", ["book.m4b"])
-      source = insert(:source, path: dir, import_policy: :hardlink)
-      root = insert(:root)
+      source = insert(:source, path: dir)
+      root = insert(:root, path: watched_root())
+      {:ok, _memory} = Library.remember_placement(source, root, :hardlink)
 
       {:ok, _counts} = Inbox.discover()
       {[item], false} = Inbox.list_items(filter: "Waiting Release")
@@ -480,7 +481,7 @@ defmodule Ambry.InboxTest do
     end
 
     test "an untouched destination follows the default when it moves", ctx do
-      {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
+      {:ok, _memory} = Library.remember_placement(ctx.source, ctx.root, :move)
 
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
@@ -491,7 +492,7 @@ defmodule Ambry.InboxTest do
     test "a policy the operator chose is never moved by a default", ctx do
       pick(ctx.item, &Destination.choose_policy(&1, :copy))
 
-      {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
+      {:ok, _memory} = Library.remember_placement(ctx.source, ctx.root, :move)
 
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
@@ -501,32 +502,35 @@ defmodule Ambry.InboxTest do
 
     # The two halves are separate decisions: "where" is not an answer to
     # "how", and one flag would have made picking a root freeze whatever
-    # policy the previous root happened to imply.
+    # policy the previous root happened to imply — here, the first root's
+    # remembered hardlink following the operator to a root that has its own
+    # answer.
     test "picking a root leaves an unpicked policy free to follow the default", ctx do
-      other = insert(:root)
-      pick(ctx.item, &Destination.choose_root(&1, other.id))
+      other = insert(:root, path: watched_root())
+      {:ok, _memory} = Library.remember_placement(ctx.source, other, :move)
 
-      {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
+      pick(ctx.item, &Destination.choose_root(&1, other.id))
 
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
       assert item.draft.destination.root_id == other.id
       assert item.draft.destination.root_chosen
       assert item.draft.destination.policy == :move
+      refute item.draft.destination.policy_chosen
     end
 
     # Blank is how an operator un-decides; recording it as a choice would
     # leave the import unresolvable with no way back.
     test "clearing a picker hands the choice back to the default", ctx do
-      other = insert(:root)
+      other = insert(:root, path: watched_root())
       pick(ctx.item, &Destination.choose_root(&1, other.id))
       pick(Inbox.get_item!(ctx.item.id), &Destination.choose_root(&1, nil))
 
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
       refute item.draft.destination.root_chosen
-      # two roots now, and no preference between them
-      assert is_nil(item.draft.destination.root_id)
+      # back to the remembered root, not stuck on the one just cleared
+      assert item.draft.destination.root_id == ctx.root.id
     end
 
     # A root can be deleted between the choice and the next look, and a
@@ -658,7 +662,7 @@ defmodule Ambry.InboxTest do
       downloads = insert(:source, path: watched_root())
 
       collection =
-        insert(:source, path: watched_root(), import_policy: :symlink)
+        insert(:source, path: watched_root())
 
       release_folder(downloads.path, "Leviathan Wakes", ["book.m4b"])
       release_folder(collection.path, "Project Hail Mary", ["book.m4b"])

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -2,7 +2,9 @@ defmodule Ambry.InboxTest do
   use Ambry.DataCase
 
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Library
   alias Ambry.Library.Source
   alias Ambry.Media.Scanner
 
@@ -450,22 +452,58 @@ defmodule Ambry.InboxTest do
     end
   end
 
-  describe "prepare_draft/1 destination healing" do
-    test "a settled destination is left alone" do
+  # A draft is written once, at match time, and then only read. So a
+  # destination nobody touched has to be re-derived rather than remembered,
+  # or the first three hundred items queued behind a change keep proposing
+  # what the default used to be.
+  describe "prepare_draft/1 destination defaults" do
+    setup do
       dir = watched_root()
-      release_folder(dir, "Stays Settled", ["book.m4b"])
-      insert(:source, path: dir, import_policy: :copy)
-      insert(:root)
+      release_folder(dir, "Waiting Release", ["book.m4b"])
+      source = insert(:source, path: dir, import_policy: :hardlink)
+      root = insert(:root)
+
       {:ok, _counts} = Inbox.discover()
-      {[item], false} = Inbox.list_items(filter: "Stays Settled")
+      {[item], false} = Inbox.list_items(filter: "Waiting Release")
       {:ok, item} = Inbox.probe_item(item)
-
       {:ok, item} = Inbox.prepare_draft(item)
-      assert item.draft.destination.approved
 
-      {:ok, again} = Inbox.prepare_draft(Inbox.get_item!(item.id))
+      %{item: item, source: source, root: root}
+    end
 
-      assert again.draft.destination == item.draft.destination
+    test "a seeded destination is resolved, but not the operator's", %{item: item, root: root} do
+      assert item.draft.destination.root_id == root.id
+      assert item.draft.destination.policy == :hardlink
+      assert Destination.resolved?(item.draft.destination)
+      refute item.draft.destination.chosen
+    end
+
+    test "an untouched destination follows the default when it moves", ctx do
+      {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
+
+      {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
+
+      assert item.draft.destination.policy == :move
+      refute item.draft.destination.chosen
+    end
+
+    test "a destination the operator chose is never moved by a default", ctx do
+      chosen = Destination.choose(ctx.item.draft.destination, %{policy: :copy})
+      draft = %{ctx.item.draft | destination: chosen}
+      {:ok, _item} = Inbox.update_draft(ctx.item, Inbox.dump_draft(draft))
+
+      {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
+
+      {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
+
+      assert item.draft.destination.policy == :copy
+      assert item.draft.destination.chosen
+    end
+
+    test "re-preparing an unchanged item changes nothing", ctx do
+      {:ok, again} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
+
+      assert again.draft.destination == ctx.item.draft.destination
     end
   end
 

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -2,6 +2,7 @@ defmodule Ambry.InboxTest do
   use Ambry.DataCase
 
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.InboxItem
   alias Ambry.Library
@@ -577,6 +578,35 @@ defmodule Ambry.InboxTest do
 
       preflight = Inbox.destination_preflight(item)
       assert preflight.blocker =~ "more than one library root"
+    end
+
+    # An unanswered question must not read as a settled outcome. The old copy
+    # said "Placed into <root>." on a card whose rail was amber precisely
+    # because nothing had been decided.
+    test "an unpicked policy asks, rather than describing a placement" do
+      dir = watched_root()
+      release_folder(dir, "No Policy Yet", ["book.m4b"])
+      source = insert(:source, path: dir)
+      # An unmounted root: nothing can be derived from a path that isn't
+      # there, and guessing is what the whole refusal exists to prevent.
+      root = insert(:root, path: "/data/not-mounted")
+
+      {:ok, _counts} = Inbox.discover()
+      {[item], false} = Inbox.list_items(filter: "No Policy Yet")
+      {:ok, item} = Inbox.probe_item(item)
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      assert is_nil(item.draft.destination.policy)
+      assert Enum.any?(Draft.unresolved(item.draft), &(&1.section == :destination))
+
+      preflight = Inbox.destination_preflight(item)
+      assert preflight.summary =~ "Pick how these files come in"
+      refute preflight.summary =~ "Placed into"
+
+      # The remembered pairing is what settles it from then on.
+      {:ok, _memory} = Library.remember_placement(source, root, :move)
+      {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(item.id))
+      assert Inbox.destination_preflight(item).summary =~ "Moved into"
     end
   end
 

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -475,7 +475,8 @@ defmodule Ambry.InboxTest do
       assert item.draft.destination.root_id == root.id
       assert item.draft.destination.policy == :hardlink
       assert Destination.resolved?(item.draft.destination)
-      refute item.draft.destination.chosen
+      refute item.draft.destination.root_chosen
+      refute item.draft.destination.policy_chosen
     end
 
     test "an untouched destination follows the default when it moves", ctx do
@@ -484,26 +485,74 @@ defmodule Ambry.InboxTest do
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
       assert item.draft.destination.policy == :move
-      refute item.draft.destination.chosen
+      refute item.draft.destination.policy_chosen
     end
 
-    test "a destination the operator chose is never moved by a default", ctx do
-      chosen = Destination.choose(ctx.item.draft.destination, %{policy: :copy})
-      draft = %{ctx.item.draft | destination: chosen}
-      {:ok, _item} = Inbox.update_draft(ctx.item, Inbox.dump_draft(draft))
+    test "a policy the operator chose is never moved by a default", ctx do
+      pick(ctx.item, &Destination.choose_policy(&1, :copy))
 
       {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
 
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
       assert item.draft.destination.policy == :copy
-      assert item.draft.destination.chosen
+      assert item.draft.destination.policy_chosen
+    end
+
+    # The two halves are separate decisions: "where" is not an answer to
+    # "how", and one flag would have made picking a root freeze whatever
+    # policy the previous root happened to imply.
+    test "picking a root leaves an unpicked policy free to follow the default", ctx do
+      other = insert(:root)
+      pick(ctx.item, &Destination.choose_root(&1, other.id))
+
+      {:ok, _source} = Library.update_source(ctx.source, %{import_policy: :move})
+
+      {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
+
+      assert item.draft.destination.root_id == other.id
+      assert item.draft.destination.root_chosen
+      assert item.draft.destination.policy == :move
+    end
+
+    # Blank is how an operator un-decides; recording it as a choice would
+    # leave the import unresolvable with no way back.
+    test "clearing a picker hands the choice back to the default", ctx do
+      other = insert(:root)
+      pick(ctx.item, &Destination.choose_root(&1, other.id))
+      pick(Inbox.get_item!(ctx.item.id), &Destination.choose_root(&1, nil))
+
+      {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
+
+      refute item.draft.destination.root_chosen
+      # two roots now, and no preference between them
+      assert is_nil(item.draft.destination.root_id)
+    end
+
+    # A root can be deleted between the choice and the next look, and a
+    # dangling id would seed a destination that only fails at placement.
+    test "a chosen root that has since been deleted is asked about again", ctx do
+      doomed = insert(:root)
+      pick(ctx.item, &Destination.choose_root(&1, doomed.id))
+      {:ok, _root} = Library.delete_root(doomed)
+
+      {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
+
+      assert is_nil(item.draft.destination.root_id)
+      refute Destination.resolved?(item.draft.destination)
     end
 
     test "re-preparing an unchanged item changes nothing", ctx do
       {:ok, again} = Inbox.prepare_draft(Inbox.get_item!(ctx.item.id))
 
       assert again.draft.destination == ctx.item.draft.destination
+    end
+
+    # What the form's pickers do: transform the stored destination and save.
+    defp pick(item, fun) do
+      draft = %{item.draft | destination: fun.(item.draft.destination)}
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
+      item
     end
   end
 

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -580,10 +580,11 @@ defmodule Ambry.InboxTest do
       assert preflight.blocker =~ "more than one library root"
     end
 
-    # An unanswered question must not read as a settled outcome. The old copy
-    # said "Placed into <root>." on a card whose rail was amber precisely
-    # because nothing had been decided.
-    test "an unpicked policy asks, rather than describing a placement" do
+    # The card does not narrate. What import will do is the two pickers'
+    # own values, read off the controls; prose appears only when something
+    # can't happen. A sentence restating a choice back at the operator is
+    # noise on every visit after the first.
+    test "an unpicked policy is outstanding, and nothing is narrated" do
       dir = watched_root()
       release_folder(dir, "No Policy Yet", ["book.m4b"])
       source = insert(:source, path: dir)
@@ -599,14 +600,15 @@ defmodule Ambry.InboxTest do
       assert is_nil(item.draft.destination.policy)
       assert Enum.any?(Draft.unresolved(item.draft), &(&1.section == :destination))
 
-      preflight = Inbox.destination_preflight(item)
-      assert preflight.summary =~ "Pick how these files come in"
-      refute preflight.summary =~ "Placed into"
+      refute Map.has_key?(Inbox.destination_preflight(item), :summary)
 
-      # The remembered pairing is what settles it from then on.
+      # The remembered pairing is what settles it from then on, still
+      # without a sentence about it.
       {:ok, _memory} = Library.remember_placement(source, root, :move)
       {:ok, item} = Inbox.prepare_draft(Inbox.get_item!(item.id))
-      assert Inbox.destination_preflight(item).summary =~ "Moved into"
+
+      assert item.draft.destination.policy == :move
+      assert Inbox.destination_preflight(item) == %{blocker: nil}
     end
   end
 

--- a/test/ambry/library_test.exs
+++ b/test/ambry/library_test.exs
@@ -18,24 +18,6 @@ defmodule Ambry.LibraryTest do
       assert is_nil(source.last_scanned_at)
     end
 
-    test "defaults to hardlinking" do
-      assert {:ok, source} =
-               Library.create_source(%{name: "D", path: "/data/d"})
-
-      assert source.import_policy == :hardlink
-    end
-
-    test "keeps an explicit import policy" do
-      assert {:ok, source} =
-               Library.create_source(%{
-                 name: "D",
-                 path: "/data/d",
-                 import_policy: :move
-               })
-
-      assert source.import_policy == :move
-    end
-
     test "requires an absolute path" do
       assert {:error, changeset} =
                Library.create_source(%{name: "D", path: "relative/path"})

--- a/test/ambry_web/live/admin/inbox_live/chapters_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/chapters_test.exs
@@ -24,13 +24,23 @@ defmodule AmbryWeb.Admin.InboxLive.ChaptersTest do
   setup :register_and_log_in_admin_user
 
   # A two-file release, so the probe stages two file-boundary markers.
+
+  # Every item comes from a source; get-or-create so a rescan of the same
+  # tree is still one source.
+  defp discover(root) do
+    source =
+      Repo.get_by(Ambry.Library.Source, path: root) || insert(:source, path: root)
+
+    Inbox.discover(source)
+  end
+
   defp chaptered_item do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     release = Path.join(root, "Chaptered Book")
     File.mkdir_p!(release)
     Enum.each(["01.mp3", "02.mp3"], &File.cp!(valid_audio(:mp3), Path.join(release, &1)))
 
-    {:ok, _counts} = Inbox.discover(root)
+    {:ok, _counts} = discover(root)
     {[item], false} = Inbox.list_items(filter: "Chaptered Book")
     {:ok, item} = Inbox.probe_item(item)
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1811,7 +1811,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       File.cp!(tagged_fixture(true, false, nil), Path.join(release, "one.m4b"))
       File.cp!(tagged_fixture(true, false, nil), Path.join(release, "two.m4b"))
 
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], _more} = Inbox.list_items(filter: "Two Novellas")
       {:ok, item} = Inbox.probe_item(item)
       Repo.delete_all(Oban.Job)
@@ -1848,7 +1848,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
         File.cp!(tagged_fixture(true, false, nil), Path.join(dir, "part#{file}.m4b"))
       end
 
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], _more} = Inbox.list_items(filter: "The Way of Kings")
       {:ok, item} = Inbox.probe_item(item)
       Repo.delete_all(Oban.Job)
@@ -1872,7 +1872,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
                ["The Way of Kings/1 of 3", "The Way of Kings/2 of 3", "The Way of Kings/3 of 3"]
 
       # a rescan must not re-merge what the operator just took apart
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {items, _more} = Inbox.list_items(filter: "The Way of Kings")
       assert length(items) == 3
     end
@@ -1895,7 +1895,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
         File.cp!(tagged_fixture(true, false, nil), Path.join(dir, "book.m4b"))
       end
 
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {[item], _more} = Inbox.list_items(filter: "Discworld")
       {:ok, item} = Inbox.probe_item(item)
       Repo.delete_all(Oban.Job)
@@ -1908,7 +1908,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {items, _more} = Inbox.list_items(filter: "Discworld")
       assert length(items) == 3
 
-      {:ok, _counts} = Inbox.discover(root)
+      {:ok, _counts} = discover(root)
       {items, _more} = Inbox.list_items(filter: "Discworld")
 
       assert length(items) == 3
@@ -2047,6 +2047,15 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   defp add_second_person(view, key) do
     view |> element("#person-#{key} button[phx-click='separate-name']") |> render_click()
     view |> element("#person-#{key} button[phx-click='add-person']") |> render_click()
+  end
+
+  # Every item comes from a source; get-or-create so a rescan of the same
+  # tree is still one source.
+  defp discover(root) do
+    source =
+      Repo.get_by(Ambry.Library.Source, path: root) || insert(:source, path: root)
+
+    Inbox.discover(source)
   end
 
   defp watched_root do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1919,7 +1919,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
   describe "destination" do
     test "says where the file is going before anything is committed", %{conn: conn} do
-      item = probed_item() |> settle()
+      item = probed_item(policy: :symlink) |> settle()
 
       {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
@@ -2095,20 +2095,24 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       Path.join(release, "book.m4b")
     )
 
-    # A settled destination needs a root to place into and a source to seed
-    # the policy; symlink keeps the fixtures where the test put them.
+    # A settled destination needs a root to place into. Root and fixtures
+    # share a filesystem here, so the policy defaults to hardlinking, which
+    # leaves the fixtures where the test put them.
     if Ambry.Library.list_roots() == [] do
       library = Ambry.Paths.source_media_disk_path("library-#{Ecto.UUID.generate()}")
       File.mkdir_p!(library)
       insert(:root, path: library)
     end
 
-    watched =
-      insert(:source,
-        path: root,
-        import_policy: :symlink,
-        name: "Watched #{Ecto.UUID.generate()}"
-      )
+    watched = insert(:source, path: root, name: "Watched #{Ecto.UUID.generate()}")
+
+    # The policy lives on the pairing now. Root and fixtures share a
+    # filesystem here, so it would default to hardlinking; a test that wants
+    # a different door seeds it the way an earlier import would have.
+    if policy = Keyword.get(opts, :policy) do
+      {:ok, _memory} =
+        Ambry.Library.remember_placement(watched, hd(Ambry.Library.list_roots()), policy)
+    end
 
     {:ok, _counts} = Inbox.discover(watched)
     {items, _more} = Inbox.list_items(filter: name)

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1932,6 +1932,24 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       refute html =~ "dangles if the original"
       refute html =~ "duplicating the bytes"
     end
+
+    # The options name the four doors. They used to define them too, which
+    # is a thing you read once and then re-read on every import forever.
+    test "the pickers name things rather than define them", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      for door <- ~w(Hardlink Symlink Copy Move), do: assert(html =~ door)
+      refute html =~ "same filesystem only"
+      refute html =~ "empties the source folder"
+
+      # A root name is unique, so the path underneath it identified nothing
+      # the name didn't.
+      [root] = Ambry.Library.list_roots()
+      assert html =~ root.name
+      refute html =~ "#{root.name} (#{root.path})"
+    end
   end
 
   # Two plausible works from one provider, so the record list is a real

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1918,13 +1918,19 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
   end
 
   describe "destination" do
-    test "says where the file is going before anything is committed", %{conn: conn} do
+    test "is two pickers and no prose", %{conn: conn} do
       item = probed_item(policy: :symlink) |> settle()
 
       {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "Symlinked into"
-      assert html =~ "dangles if the original ever moves"
+      assert html =~ "Library root"
+      assert html =~ "How the files come in"
+
+      # What import will do is the pickers' own values. Restating it in a
+      # sentence underneath is noise on every visit after the first.
+      refute html =~ "Symlinked into"
+      refute html =~ "dangles if the original"
+      refute html =~ "duplicating the bytes"
     end
   end
 

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -389,8 +389,9 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
       end
     end)
 
-    # A settled destination needs a root to place into and a source to seed
-    # the policy; symlink keeps the fixtures where the test put them.
+    # A settled destination needs a root to place into. Root and fixtures
+    # share a filesystem here, so the policy defaults to hardlinking, which
+    # leaves the fixtures where the test put them.
     if Ambry.Library.list_roots() == [] do
       library = Ambry.Paths.source_media_disk_path("library-#{Ecto.UUID.generate()}")
       File.mkdir_p!(library)
@@ -398,11 +399,7 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     end
 
     watched =
-      insert(:source,
-        path: root,
-        import_policy: :symlink,
-        name: "Watched #{Ecto.UUID.generate()}"
-      )
+      insert(:source, path: root, name: "Watched #{Ecto.UUID.generate()}")
 
     {:ok, _counts} = Inbox.discover(watched)
 

--- a/test/ambry_web/live/admin/inbox_live/progress_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/progress_test.exs
@@ -68,9 +68,10 @@ defmodule AmbryWeb.Admin.InboxLive.ProgressTest do
       %InboxItem{}
       |> InboxItem.changeset(
         Enum.into(attrs, %{
-          path: "/downloads/release-#{Ecto.UUID.generate()}",
-          files: ["/downloads/x/book.m4b"],
-          status: :pending
+          path: "release-#{Ecto.UUID.generate()}",
+          files: ["x/book.m4b"],
+          status: :pending,
+          source_id: insert(:source).id
         })
       )
       |> Repo.insert()

--- a/test/ambry_web/live/admin/inbox_live/reorder_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/reorder_test.exs
@@ -17,6 +17,16 @@ defmodule AmbryWeb.Admin.InboxLive.ReorderTest do
 
   # The fixture credits two narrators via its composer tag, which is exactly
   # a list whose order the operator might want to change.
+
+  # Every item comes from a source; get-or-create so a rescan of the same
+  # tree is still one source.
+  defp discover(root) do
+    source =
+      Repo.get_by(Ambry.Library.Source, path: root) || insert(:source, path: root)
+
+    Inbox.discover(source)
+  end
+
   defp probed_item do
     dir = Ambry.Paths.source_media_disk_path("tagged-#{Ecto.UUID.generate()}")
     root = Path.join(dir, "The Way of Kings [M4B]")
@@ -42,7 +52,7 @@ defmodule AmbryWeb.Admin.InboxLive.ReorderTest do
         path
       ])
 
-    {:ok, _counts} = Inbox.discover(dir)
+    {:ok, _counts} = discover(dir)
     {[item], false} = Inbox.list_items(filter: "The Way of Kings")
     {:ok, item} = Inbox.probe_item(item)
     Repo.delete_all(Oban.Job)

--- a/test/ambry_web/live/admin/location_live/form_test.exs
+++ b/test/ambry_web/live/admin/location_live/form_test.exs
@@ -21,14 +21,17 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
 
       assert [source] = Library.list_sources()
       assert source.name == "Downloads NAS"
-      assert source.import_policy == :hardlink
     end
 
-    test "always asks how the files come in", %{conn: conn} do
+    # A source is a path and nothing else. How its files reach the library
+    # is a fact about the pairing with a root, decided per import and
+    # remembered there — asking it here could only ever be right for one
+    # destination.
+    test "asks nothing about placement", %{conn: conn} do
       {:ok, _view, html} = live(conn, ~p"/admin/locations/sources/new")
 
-      assert html =~ "How the files come in"
-      assert html =~ "Symlink"
+      refute html =~ "How the files come in"
+      refute html =~ "Preferred library root"
     end
 
     # Finding out that a path is wrong at save time is late; finding out at
@@ -94,14 +97,13 @@ defmodule AmbryWeb.Admin.LocationLive.FormTest do
       {:ok, view, _html} = live(conn, ~p"/admin/locations/sources/#{source}/edit")
 
       view
-      |> form("#location-form", source: %{name: "New Name", import_policy: "move"})
+      |> form("#location-form", source: %{name: "New Name"})
       |> render_submit()
 
       assert_redirect(view, ~p"/admin/locations")
 
       source = Library.get_source!(source.id)
       assert source.name == "New Name"
-      assert source.import_policy == :move
     end
 
     test "updates a root", %{conn: conn} do

--- a/test/ambry_web/live/admin/location_live/index_test.exs
+++ b/test/ambry_web/live/admin/location_live/index_test.exs
@@ -28,9 +28,13 @@ defmodule AmbryWeb.Admin.LocationLive.IndexTest do
 
     assert html =~ "Downloads NAS"
     assert html =~ "/data/downloads"
-    assert html =~ "hardlink"
     assert html =~ "Old Library"
     assert html =~ "/data/library"
+
+    # A row is a name, a path and its facts. What a source or a root *is*
+    # is not restated in prose above the list on every visit.
+    refute html =~ "Watched folders that audiobooks arrive from"
+    refute html =~ "Ambry writes"
   end
 
   # The whole reason this page exists: hardlinks can't cross a filesystem, and

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -427,7 +427,6 @@ defmodule Ambry.Factory do
     %Source{
       name: sequence(:source_name, &"Source #{&1}"),
       path: sequence(:source_path, &"/data/source-#{&1}"),
-      import_policy: :hardlink,
       enabled: true
     }
   end


### PR DESCRIPTION
Whether an import hardlinks, symlinks, copies or moves is a fact about the **pairing** of a source and a root, not about either end. A hardlink is only possible when the two paths share a filesystem, which one end cannot know, and in production the downloads folder and the library live on two different NAS boxes. A policy stored on the source could only ever be right for one destination.

It was never a setting either: every import could change it, which makes it a default, and a default that is overridden half the time is better learned than typed.

So `sources.import_policy` and `sources.target_root_id` are gone, and an `import_preferences` row per `(source, root)` records what the last import actually did and seeds the next. `last_used_at` doubles as the root default: a source proposes the root it most recently imported into.

## The bug this exposed

A draft is written once, at match time, and afterwards only read. A seeded default was therefore indistinguishable from a decision — change what the default *should* be and every already-seeded draft keeps the old one forever. This was already true: editing a source's policy today reaches none of the queued items. `heal_destination/1` was the half-measure, filling a nil policy but unable to revise a wrong one, because nothing could tell the two cases apart.

The destination now stores only what the operator **picked** and re-derives the rest on every `prepare_draft/1`. Two flags, not one: the policy is a fact about the pairing, so picking a root re-derives an unpicked policy under it rather than freezing whatever the previous root implied. Clearing a picker un-picks it and hands the choice back to the default.

A bounded pass brings the queue along when a remembered value moves — the Ready badge reads a stored column, so without it three hundred items would look settled while proposing the old thing. It only runs when the memory actually changed.

## Cold start

Nothing remembered yet: hardlink where the pair shares a filesystem, because it strictly dominates there (no extra bytes, source untouched, nothing to dangle). Across filesystems the three remaining doors mean three genuinely different things with no dominant answer, and guessing wrong silently doubles storage — so nothing is proposed and the operator is asked, once per pairing.

Existing settings are carried into the memory by the migration rather than dropped.

## Also here

**Ad-hoc scans are gone.** `Inbox.discover/1`'s bare-path form created items with no source. It was never reachable from the UI, and it bought a second shape for everything downstream: absolute stored paths where every other item is source-relative, no placement default, a nullable FK, an adoption pass on every rescan, and an `ELSE absolute` half on both locatable CHECKs. `inbox_items.source_id` is now `NOT NULL` and the CHECKs state the invariant plainly.

**An unanswered question is not a placement.** Found by opening a real release: with nothing to propose, the destination card read "Placed into /path." on a card whose rail was amber precisely because nothing had been decided. It now says why it is asking. The other four summaries lose their em dashes, which §8 of the design language forbids in rendered text.

## Verification

`mix check` green, 1626 tests passing. Driven in real Chrome against the dev server and its real data: the carried-over memory proposes `copy`; picking `move` persists across a reload; clearing the picker returns it to the remembered default; and with the memory cleared, the cross-filesystem pairing proposes nothing and the card explains why.

## Migrations

Three, in order: `inbox_items_require_a_source`, `remember_placement_per_pairing`, `placement_is_not_a_source_setting`. The last carries each source's policy (against its preferred root, or the only root) into a preference row. All three are reversible.


---

## Then: three commits of copy removal (operator-requested)

Same surfaces, opposite direction. The standing rule being applied: *if the UI needs explaining, the UI is wrong.* Explanatory prose an operator reads once and then re-reads on every visit forever is noise.

**The locations page stops introducing itself.** Both standing paragraphs, one above each list, restating what a source and a root are. The first-run reader is looking at an empty state, and both of those already orient; the one non-obvious fact in either paragraph (a source can only hardlink into a root sharing its filesystem tag) was already the tag's own tooltip.

**The destination card stops narrating.** "Copied into /path, duplicating the bytes." restated the operator's own choice back at them, under the picker they had just used. What import will do is the two pickers' own values. Prose here is now reserved for something that *can't* happen: the cross-filesystem hardlink refusal, which is a blocker rather than an explanation and only appears once the impossible thing has been picked. Choosing badly is one click and self-correcting; it costs nothing when nobody chooses badly.

This reverses the summary added earlier in this branch. That fix was right about the problem ("Placed into <root>." asserted an outcome for an undecided question) and wrong about the remedy, which was more prose rather than less. The refusal also loses its last reference to a setting that no longer exists ("set the source to copy or move").

**The pickers name things rather than define them.** "Hardlink (same filesystem only, no extra storage)" is a definition living inside an option label. The four doors are now just named. The library root picker drops the path beside the name for the same reason: a root's name is uniquely indexed, so the path identified nothing the name didn't.

Verified in Chrome after these: picking Hardlink on the cross-filesystem pairing raises the refusal and disables the Add button; clearing the picker returns it to the remembered default.
