### PR TITLE
The inbox queue is one axis, and a level that found nothing says so

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -94,7 +94,6 @@ defmodule Ambry.Inbox do
     items =
       InboxItem
       |> filter_by_status(opts[:status])
-      |> filter_by_ready(opts[:ready])
       |> filter_by_path(opts[:filter])
       |> order_by(^newest_first(opts[:status]))
       |> offset(^Keyword.get(opts, :offset, 0))
@@ -133,18 +132,6 @@ defmodule Ambry.Inbox do
     |> select([i], {i.status, count(i.id)})
     |> Repo.all()
     |> Map.new()
-  end
-
-  @doc """
-  How many pending items are fully settled and waiting on a click.
-
-  Reads the denormalized flag rather than loading every draft — the whole
-  reason it's stored.
-  """
-  def count_ready do
-    InboxItem
-    |> where([i], i.status == :pending and i.ready == true)
-    |> Repo.aggregate(:count)
   end
 
   def get_item!(id), do: Repo.get!(InboxItem, id)
@@ -1054,9 +1041,6 @@ defmodule Ambry.Inbox do
 
   defp filter_by_status(query, nil), do: query
   defp filter_by_status(query, status), do: where(query, [i], i.status == ^status)
-
-  defp filter_by_ready(query, nil), do: query
-  defp filter_by_ready(query, ready?), do: where(query, [i], i.ready == ^ready?)
 
   defp filter_by_path(query, blank) when blank in [nil, ""], do: query
 

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -818,14 +818,20 @@ defmodule Ambry.Inbox.AutoMatch do
   # about a book. Ranking them together made the form ask one question that
   # was really two.
   defp match_work(hints, opts) do
-    query = work_query(hints)
-
-    {candidates, outcomes} = provider_books(:work, query, hints, opts)
+    {query, candidates, outcomes} = search_ladder(:work, work_queries(hints), hints, opts)
 
     query
     |> level_result(candidates, outcomes, hints.author)
     |> Map.put("local", local_books(hints))
     |> hydrate_top(opts)
+  end
+
+  # The work level asks the same two questions the recording level does,
+  # minus the ASIN — that is a recording key and names an edition, not a work.
+  defp work_queries(hints) do
+    tagged = work_query(hints)
+
+    [tagged, release_title_query(hints, tagged)] |> Enum.reject(&is_nil/1)
   end
 
   # A search hit is a summary, not the record. Measured against
@@ -963,11 +969,10 @@ defmodule Ambry.Inbox.AutoMatch do
     end
   end
 
-  # An ASIN is a recording-level key, so when there is one it *is* the query:
-  # a hit on it is definitive in a way no title match ever is.
-  defp match_recording(%{asin: asin} = hints, work, opts) when is_binary(asin) do
-    query = %Provider.Query{keywords: asin}
-    {candidates, outcomes} = provider_books(:recording, query, hints, opts)
+  defp match_recording(hints, work, opts) do
+    {query, candidates, outcomes} =
+      search_ladder(:recording, recording_queries(hints), hints, opts)
+
     {editions, edition_outcomes} = editions_for(top_group(work["candidates"]), hints, opts)
 
     level_result(
@@ -978,27 +983,96 @@ defmodule Ambry.Inbox.AutoMatch do
     )
   end
 
-  # Structured, not concatenated. Audible's catalog matches `title` against
-  # the title alone, so the old `"#{title} #{author}"` string searched for a
-  # book literally called that and returned nothing — the recording level came
-  # up empty on every single item. The narrator goes in too: it is the field
-  # that tells two recordings of one work apart.
-  defp match_recording(hints, work, opts) do
-    query = %Provider.Query{
-      title: hints.title,
-      author: hints.author,
-      narrator: hints.narrator
-    }
+  # An ASIN is a recording-level key, so when there is one it leads: a hit on
+  # it is definitive in a way no title match ever is.
+  #
+  # It no longer *replaces* the title search, though. An ASIN that doesn't
+  # resolve — regional, delisted, or simply wrong — used to end the level at
+  # zero candidates with the title question never asked, which made having an
+  # ASIN strictly worse than not having one. Measured on the operator's queue:
+  # two items whose work level matched at confidence 1.0 had recording levels
+  # that found nothing, both because a tagged ASIN returned no rows.
+  defp recording_queries(hints) do
+    # Structured, not concatenated. Audible's catalog matches `title` against
+    # the title alone, so the old `"#{title} #{author}"` string searched for a
+    # book literally called that and returned nothing — the recording level
+    # came up empty on every single item. The narrator goes in too: it is the
+    # field that tells two recordings of one work apart.
+    tagged = %Provider.Query{title: hints.title, author: hints.author, narrator: hints.narrator}
 
-    {candidates, outcomes} = provider_books(:recording, query, hints, opts)
-    {editions, edition_outcomes} = editions_for(top_group(work["candidates"]), hints, opts)
+    [
+      hints.asin && %Provider.Query{keywords: hints.asin},
+      tagged,
+      release_title_query(hints, tagged)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
 
-    level_result(
-      query,
-      candidates |> Kernel.++(editions) |> dedupe_records() |> apply_narrator_evidence(hints),
-      outcomes ++ edition_outcomes,
-      hints.author
-    )
+  # The release name as a second question, asked only when the tag title's
+  # question came back empty.
+  #
+  # Not a *better* source — the two disagree on 105 of 198 releases and
+  # neither wins reliably, which is why the tags still lead and this is a
+  # fallback rather than a merge. It is a genuinely *different* question,
+  # which is the point: "DW35-Wintersmith" in the tags is "Discworld 35
+  # Wintersmith" on disk, and no amount of cleaning turns the first into the
+  # second. Asking costs nothing on the items that already matched, and
+  # whatever comes back is ranked against the file's own raw text, so a bad
+  # question returning bad answers is ranked out rather than adopted.
+  defp release_title_query(%{release_title: release} = hints, template) when is_binary(release) do
+    cond do
+      same_question?(release, hints.title) -> nil
+      # A name that parsed to nothing but the author is not a second opinion
+      # about the title. "Wild - Cheryl Strayed" splits with the author on
+      # both sides, and searching an author's name for a title finds their
+      # other books — the one shape of junk worth refusing up front rather
+      # than leaving to the ranker.
+      same_question?(release, hints.author) -> nil
+      true -> %{template | title: release, keywords: nil}
+    end
+  end
+
+  defp release_title_query(_hints, _template), do: nil
+
+  # Same question, allowing for punctuation and case — the two sources
+  # writing one title differently is not a second opinion worth a round trip.
+  defp same_question?(one, two) when is_binary(one) and is_binary(two),
+    do: comparable(one) == comparable(two)
+
+  defp same_question?(_one, _two), do: false
+
+  defp comparable(text), do: text |> String.downcase() |> String.replace(~r/[^\p{L}\p{N}]+/u, "")
+
+  # Asks each query in turn, stopping at the first that finds anything.
+  #
+  # A level that finds nothing is nearly always the *question* being wrong
+  # rather than the book being absent: of the seven levels on the operator's
+  # 343-item queue that came up empty, five had a perfectly findable book
+  # behind a polluted title and two were genuinely uncatalogued. So the
+  # ladder widens the question rather than giving up, which is what a
+  # provider does internally when its own search misses.
+  #
+  # Every attempt's outcomes are kept and tallied, not just the winner's: a
+  # provider that was rate-limited on the first question and never asked the
+  # second must still say so, or the level looks like it was answered when
+  # it was only partly asked.
+  #
+  # The query reported back is the one that found something, or the last one
+  # tried — "we went this far and still found nothing" is the useful thing to
+  # say on a level that failed, and it is what the form prints.
+  defp search_ladder(level, queries, hints, opts, outcomes \\ [])
+
+  defp search_ladder(_level, [], _hints, _opts, outcomes), do: {nil, [], tally(outcomes)}
+
+  defp search_ladder(level, [query | rest], hints, opts, outcomes) do
+    {candidates, fresh} = provider_books(level, query, hints, opts)
+    outcomes = outcomes ++ fresh
+
+    if candidates == [] and rest != [] do
+      search_ladder(level, rest, hints, opts, outcomes)
+    else
+      {query, candidates, tally(outcomes)}
+    end
   end
 
   @doc """

--- a/lib/ambry/inbox/draft/tier.ex
+++ b/lib/ambry/inbox/draft/tier.ex
@@ -49,10 +49,15 @@ defmodule Ambry.Inbox.Draft.Tier do
   alias Ambry.Inbox.Draft.Work
 
   @typedoc "Worst to best, which is also the order `worst/1` ranks them in."
-  @type t :: :blocked | :waiting | :unreviewed | :reviewed
+  @type t :: :blocked | :waiting | :uncatalogued | :unreviewed | :reviewed
 
   # Best first. `worst/1` takes the last one it finds.
-  @order [:reviewed, :unreviewed, :waiting, :blocked]
+  #
+  # `:uncatalogued` sits below `:unreviewed` and above `:waiting`: it is
+  # worth a look and shouldn't be mistaken for a match, but it is not a
+  # question the operator can answer by choosing something — there is
+  # nothing to choose between.
+  @order [:reviewed, :unreviewed, :uncatalogued, :waiting, :blocked]
 
   @doc """
   The tier of one decision.
@@ -106,8 +111,17 @@ defmodule Ambry.Inbox.Draft.Tier do
   def of_identity(%Work{} = work),
     do: from(if(work.approved, do: :approved, else: :unconfirmed), work.curated)
 
-  # A level that found nothing is settled: there is nothing to choose
-  # between, and the seeder approves it. A doubted one is not.
+  # A level that found nothing is settled — there is nothing to choose
+  # between, and the seeder approves it so a release no catalogue lists can
+  # still be imported from its own tags. Settled is not the same as
+  # *matched*, though, and saying "matched" over an empty candidate list is
+  # how the queue came to print "matched · no match" on one line. It gets
+  # its own word: the fields below it came from the file, not a provider.
+  #
+  # Worth surfacing rather than hiding because with this many providers a
+  # level that finds nothing is usually a polluted query, not an absent
+  # book — five of the seven measured on the operator's queue.
+  defp level_state(_approved, :nothing_found), do: :uncatalogued
   defp level_state(_approved, :low_confidence), do: :unconfirmed
   defp level_state(true, _doubt), do: :approved
   defp level_state(_unapproved, _doubt), do: :unconfirmed
@@ -116,6 +130,12 @@ defmodule Ambry.Inbox.Draft.Tier do
 
   defp from(:approved, true), do: :reviewed
   defp from(:approved, _untouched), do: :unreviewed
+
+  # A human who has been through a level nothing was found for has answered
+  # the only question it poses — "is this really not listed anywhere" — so
+  # it stops flagging itself, the same way any other reviewed decision does.
+  defp from(:uncatalogued, true), do: :reviewed
+  defp from(:uncatalogued, _untouched), do: :uncatalogued
   defp from(:missing, _curated), do: :blocked
 
   # A membership the operator has to number is as blocked as a field nobody
@@ -149,6 +169,8 @@ defmodule Ambry.Inbox.Draft.Tier do
   Whether this tier still wants the operator.
 
   What the footer counts and what "no amber, no red" means in code.
+  `:uncatalogued` is in: it renders amber, and a tier that draws the eye
+  while claiming not to want it is the aggregate lying.
   """
-  def outstanding?(tier), do: tier in [:blocked, :waiting]
+  def outstanding?(tier), do: tier in [:blocked, :waiting, :uncatalogued]
 end

--- a/lib/ambry/inbox/release_name.ex
+++ b/lib/ambry/inbox/release_name.ex
@@ -38,10 +38,15 @@ defmodule Ambry.Inbox.ReleaseName do
   ]
 
   # Quality/format noise that shows up in brackets and parens.
+  #
+  # `disc` and the bare small number are a pair: `noise?/1` splits a bracket
+  # on whitespace and requires *every* word to be noise, so "[Disc 1]" needs
+  # both halves listed. The bare number also finishes the job `cd\d*` only
+  # half did — it matched "CD1" but never "CD 1".
   @noise ~r/^(m4b|mp3|m4a|flac|ogg|opus|aax|aaxc|unabridged|abridged|audiobook|
               retail|complete|chapterized|chaptered|dramatized|dramatised|graphicaudio|
-              \d{4}|\d+\s*k(bps)?|\d+kb|v\d+|cd\d*|web|h?\d{2,3}\.\d+|
-              \d+(\.\d+)?\s*(mb|gb)|\d{1,2}[.:]\d{2}[.:]\d{2})$/xi
+              \d{4}|\d+\s*k(bps)?|\d+kb|v\d+|cd\d*|discs?\d*|web|h?\d{2,3}\.\d+|
+              \d{1,3}|\d+(\.\d+)?\s*(mb|gb)|\d{1,2}[.:]\d{2}[.:]\d{2})$/xi
 
   @asin ~r/\b(B0[A-Z0-9]{8})\b/
 
@@ -91,6 +96,7 @@ defmodule Ambry.Inbox.ReleaseName do
     |> remove_noise_brackets()
     |> remove_noise_parens()
     |> remove_noise_subtitle()
+    |> remove_series_tail()
     |> remove_part_phrase()
     |> remove_sequence_numbers()
     |> collapse_spaces()
@@ -190,6 +196,28 @@ defmodule Ambry.Inbox.ReleaseName do
   @noise_subtitle ~r/\s*[:—-]\s+an?\s+(novel|memoir|thriller|mystery|novella)\s*$/i
 
   defp remove_noise_subtitle(title), do: Regex.replace(@noise_subtitle, title, "")
+
+  # "Kill Joy - A Good Girl's Guide to Murder Series, Book 0" — the series
+  # statement a tag title carries in its tail. Real information, which is why
+  # only the *query* loses it: the series parser reads its own fields off the
+  # unstripped title, and the verbatim tag stays on offer as a chip. As a
+  # title search it is poison — the catalogue title is "Kill Joy", and the
+  # whole string returns nothing from any provider.
+  #
+  # A separator has to introduce it, and the run before "Series" may not
+  # cross another one, so a book actually called "The Series" keeps its name.
+  @series_tail ~r/\s*[-–—:,]\s*[^-–—:]*\bseries,?\s+book\s+[\d.]+\s*$/i
+
+  # The same tail without the word, which only a comma is trusted to
+  # introduce: "Wayfarers, Book 4" is a statement about a series, while
+  # "Book 4" attached by a dash could be the title.
+  @book_tail ~r/,\s*book\s+[\d.]+\s*$/i
+
+  defp remove_series_tail(title) do
+    title
+    |> then(&Regex.replace(@series_tail, &1, ""))
+    |> then(&Regex.replace(@book_tail, &1, ""))
+  end
 
   @doc """
   The best search string for a provider: title and author when both are

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -2076,14 +2076,19 @@ defmodule AmbryWeb.Admin.Decisions do
   @doc """
   The block's left rail — the one thing that encodes settledness (§2).
 
-  Four tiers, because settled-versus-waiting threw away the question the
+  The tiers exist because settled-versus-waiting threw away the question the
   operator actually asks of a machine-matched import: has anyone looked at
   this yet. A 4px rail renders crisp at any DPI where a tinted hairline goes
   mushy.
+
+  `:uncatalogued` shares amber with `:waiting`: both want a look, and the
+  rail says *how settled*, not *what to do about it* — the badge beside it
+  is where the two part company.
   """
   def state_rail(%{__struct__: _} = decision), do: state_rail(Tier.of(decision))
   def state_rail(:blocked), do: "border-red-400/70"
   def state_rail(:waiting), do: "border-amber-400/70"
+  def state_rail(:uncatalogued), do: "border-amber-400/70"
   def state_rail(:unreviewed), do: "border-blue-400/70"
   def state_rail(:reviewed), do: "border-brand-dark/60"
 
@@ -2117,11 +2122,18 @@ defmodule AmbryWeb.Admin.Decisions do
   A tier as words and a colour, for surfaces with no room for a rail.
 
   A queue row is one line: it has nowhere to put a 4px edge per level, so it
-  says the same four states in words. Same vocabulary as the form's rail, or
-  the two drift — which is exactly what happened when the queue had its own.
+  says the same states in words. Same vocabulary as the form's rail, or the
+  two drift — which is exactly what happened when the queue had its own.
+
+  `:uncatalogued` is the one tier the words say more than the rail does: it
+  shares amber with `:waiting` because both want a look, but "nothing found"
+  and "needs you" ask for completely different things, and the queue printing
+  "matched" over an empty candidate list is what made the distinction worth
+  having.
   """
   def tier_words(:blocked), do: {"blocked", :red}
   def tier_words(:waiting), do: {"needs you", :yellow}
+  def tier_words(:uncatalogued), do: {"nothing found", :yellow}
   def tier_words(:unreviewed), do: {"matched", :blue}
   def tier_words(:reviewed), do: {"reviewed", :brand}
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -102,7 +102,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # The list state the operator arrived with, echoed back as a path. Only the
   # keys the index actually reads, so a hand-typed URL can't turn this into an
   # open redirect or a 500 on a junk param.
-  @list_params ~w(filter page status ready)
+  @list_params ~w(filter page status)
 
   defp return_to(params) do
     case Map.take(params, @list_params) do

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -123,29 +123,16 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   def handle_event("filter-status", %{"status" => status}, socket) do
     {:noreply,
-     push_patch(socket,
-       to: ~p"/admin/inbox?#{patch(socket, status: status, ready: nil, page: "1")}"
-     )}
-  end
-
-  def handle_event("filter-ready", _params, socket) do
-    ready = if !socket.assigns.ready, do: "true"
-
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/admin/inbox?#{patch(socket, ready: ready, status: "pending", page: "1")}"
-     )}
+     push_patch(socket, to: ~p"/admin/inbox?#{patch(socket, status: status, page: "1")}")}
   end
 
   defp load_items(socket, params) do
     list_opts = get_list_opts(params)
     status = parse_status(params["status"])
-    ready = parse_ready(params["ready"])
 
     {items, has_more?} =
       Inbox.list_items(
         status: status,
-        ready: ready,
         filter: list_opts.filter,
         offset: page_to_offset(list_opts.page),
         limit: limit()
@@ -157,19 +144,16 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       # one query for the page, not one per row
       progress: Inbox.progress(items),
       counts: Inbox.count_by_status(),
-      ready_count: Inbox.count_ready(),
-      ready: ready,
       status: status,
       list_opts: list_opts,
       has_next: has_more?,
       has_prev: list_opts.page > 1,
       # Built from the full query, not the shared filter+page helpers —
-      # those drop status and ready, so paging out of "Imported" silently
-      # landed back on the default view.
-      next_page_path:
-        ~p"/admin/inbox?#{page_query(list_opts, status, ready, list_opts.page + 1)}",
+      # those drop the status, so paging out of "Imported" silently landed
+      # back on the default view.
+      next_page_path: ~p"/admin/inbox?#{page_query(list_opts, status, list_opts.page + 1)}",
       prev_page_path:
-        ~p"/admin/inbox?#{page_query(list_opts, status, ready, max(list_opts.page - 1, 1))}"
+        ~p"/admin/inbox?#{page_query(list_opts, status, max(list_opts.page - 1, 1))}"
     )
     |> assign(:statuses, @statuses)
     |> schedule_tick()
@@ -227,9 +211,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     %{
       "filter" => Keyword.get(overrides, :filter, socket.assigns.list_opts.filter),
       "page" => Keyword.get(overrides, :page, to_string(socket.assigns.list_opts.page)),
-      "status" => Keyword.get(overrides, :status, to_string(socket.assigns.status || "all")),
-      "ready" =>
-        Keyword.get(overrides, :ready, socket.assigns.ready && to_string(socket.assigns.ready))
+      "status" => Keyword.get(overrides, :status, to_string(socket.assigns.status || "all"))
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Map.new()
@@ -246,14 +228,13 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   queue go" happens.
   """
   def return_query(assigns),
-    do: page_query(assigns.list_opts, assigns.status, assigns.ready, assigns.list_opts.page)
+    do: page_query(assigns.list_opts, assigns.status, assigns.list_opts.page)
 
-  defp page_query(list_opts, status, ready, page) do
+  defp page_query(list_opts, status, page) do
     %{
       "filter" => list_opts.filter,
       "page" => to_string(page),
-      "status" => to_string(status || "all"),
-      "ready" => ready && to_string(ready)
+      "status" => to_string(status || "all")
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Map.new()
@@ -266,9 +247,6 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   # work queue, and opening it means "what needs me", not "everything ever".
   defp parse_status("all"), do: nil
   defp parse_status(_anything), do: :pending
-
-  defp parse_ready("true"), do: true
-  defp parse_ready(_anything), do: nil
 
   # The segmented filter: the active segment reads as a raised tab, the rest
   # recede. Spans rather than buttons so the existing test selectors (and the
@@ -287,15 +265,14 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp segment_label(:ignored), do: "Ignored"
   defp segment_label(:imported), do: "Imported"
 
-  # Pending work glows amber and settled-but-unimported glows lime — but only
-  # while there IS any; a zero is just a zero.
+  # Pending work glows amber — but only while there IS any; a zero is just a
+  # zero.
   defp segment_count_class(status, count) do
     [
       "rounded-full px-1.5 text-xs font-bold tabular-nums",
       case {status, count} do
         {_status, 0} -> "bg-white/5 text-zinc-500"
         {:pending, _n} -> "bg-amber-400/15 text-amber-300"
-        {:ready, _n} -> "bg-brand-dark/15 text-lime-300"
         _other -> "bg-white/10 text-zinc-400"
       end
     ]
@@ -317,7 +294,33 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp button_color(:brand), do: :brand
   defp button_color(_quiet), do: :zinc
 
-  defp status_color(:pending), do: :yellow
+  @doc """
+  The row's one badge: what this item is, in the words that vary from row to
+  row.
+
+  One badge, not two. A pending row used to wear its status *and* its
+  readiness, but inside the Pending tab "pending" is the tab's own word
+  repeated on every row — it never told two rows apart. What does is how much
+  the row still owes, which is what a settled row's "ready" already said and
+  what an outstanding one now says with a number.
+
+  A draft that doesn't exist yet is not a pile of decisions to work through;
+  it is one nobody has asked. Counting it as one decision would send the
+  operator to a form with nothing on it, so it says what is actually true and
+  the card's progress line says what to do about it.
+  """
+  def state_words(%InboxItem{status: :pending, ready: true}), do: {"ready", :brand}
+  def state_words(%InboxItem{status: :pending, draft: nil}), do: {"not prepared", :yellow}
+
+  def state_words(%InboxItem{status: :pending, draft: draft}) do
+    case length(Draft.unresolved(draft)) do
+      1 -> {"1 decision needed", :yellow}
+      n -> {"#{n} decisions needed", :yellow}
+    end
+  end
+
+  def state_words(%InboxItem{status: status}), do: {to_string(status), status_color(status)}
+
   defp status_color(:imported), do: :brand
   defp status_color(:ignored), do: :gray
 

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -14,27 +14,32 @@
 
       <%!-- The filters are the queue's primary navigation — a segmented
             control, not a row of text links. Counts ride along so the state
-            of the queue is readable without clicking anything. --%>
+            of the queue is readable without clicking anything.
+
+            One axis only: where an item is in its life, which is the one
+            thing about it that changes because a human decided something.
+            A "Ready" bucket lived here too and was removed — every draft
+            gets opened either way, so it only ever split work that was
+            going to be done in full, while making every row wear two
+            badges to explain which bucket it was in. Background job state
+            is deliberately not an axis either: a row that changed tabs
+            because a job started would vanish out from under the click
+            that started it. That belongs to the row's own overlay, and to
+            the ambient job widget. --%>
       <div class="inline-flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg bg-zinc-900 p-1 text-sm">
-        <span phx-click="filter-status" phx-value-status="all" class={segment_class(!@status && !@ready)}>
+        <span phx-click="filter-status" phx-value-status="all" class={segment_class(!@status)}>
           All
         </span>
         <span
           :for={status <- @statuses}
           phx-click="filter-status"
           phx-value-status={status}
-          class={segment_class(!@ready && @status == status)}
+          class={segment_class(@status == status)}
         >
           {segment_label(status)}
           <span class={segment_count_class(status, Map.get(@counts, status, 0))}>
             {Map.get(@counts, status, 0)}
           </span>
-        </span>
-
-        <%!-- Everything settled, waiting on a click. The point of the whole
-              form is that this bucket is where items end up. --%>
-        <span phx-click="filter-ready" class={segment_class(@ready)} data-role="ready-filter">
-          Ready <span class={segment_count_class(:ready, @ready_count)}>{@ready_count}</span>
         </span>
       </div>
     </div>
@@ -154,11 +159,12 @@
         inert={busy?(@progress[item.id])}
       >
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 sm:flex-col sm:items-end">
+          <%!-- One badge. Inside a tab named for the status, printing the
+                status on every row says nothing; what the row owes does. --%>
           <div class="flex items-center gap-2">
-            <.badge :if={item.ready and item.status == :pending} color={:brand} class="text-xs">
-              ready
+            <.badge color={elem(state_words(item), 1)} class="text-xs" data-role="item-state">
+              {elem(state_words(item), 0)}
             </.badge>
-            <.badge color={status_color(item.status)} class="text-xs">{item.status}</.badge>
           </div>
 
           <div class="flex items-center gap-2 text-xs text-zinc-400">
@@ -178,9 +184,13 @@
           </div>
 
           <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
-            <%!-- Only a settled item can be imported from here. Anything else
-                opens the form, because the queue has no way to say what's
-                outstanding and the form's whole job is to. --%>
+            <%!-- Only a settled item can be imported from here — the queue
+                has no way to say what's outstanding, and the form's whole job
+                is to. Import is the *extra* a settled row earns, though, not
+                a replacement for Open: these two were once mutually
+                exclusive, which left a ready item's action rail with no way
+                into its own form. Reviewing a draft before importing it is
+                the normal path, not the exception. --%>
             <span
               :if={item.status == :pending and item.ready}
               role="button"
@@ -194,9 +204,9 @@
             </span>
 
             <.link
-              :if={item.status == :pending and not item.ready}
+              :if={item.status == :pending}
               navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
-              title="Settle what's outstanding"
+              title="Look the draft over"
               class={action_class(:neutral)}
             >
               <%!-- fa-pencil, the app's edit glyph — pen-to-square isn't in

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -97,8 +97,15 @@
               </.badge>
               <%!-- basis-48 + grow keeps the title from being shrunk out of
                     existence (meta wraps down instead); max-w-fit stops the grow
-                    at the title's own width so the provenance stays beside it. --%>
-              <span class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap">
+                    at the title's own width so the provenance stays beside it.
+
+                    Nothing here when nothing was found: the badge beside it
+                    already says so, and printing "no match" next to it was
+                    half of the line that read "matched · no match". --%>
+              <span
+                :if={match.best}
+                class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap"
+              >
                 {candidate_label(match.best)}
               </span>
               <span :if={candidate_origin(match.best)} class="flex-none text-xs text-zinc-400">

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -1325,6 +1325,164 @@ defmodule Ambry.Inbox.AutoMatchTest do
   # rate-limited one left the record thin (no description, no cover, no
   # editions) and said nothing anywhere, so the item settled, went `ready`,
   # and imported a book the provider actually knew more about.
+  # A level that finds nothing is nearly always the *question* being wrong
+  # rather than the book being absent — measured on the operator's queue,
+  # five of the seven empty levels had a perfectly findable book behind a
+  # polluted title. So a query that comes back empty is widened rather than
+  # given up on.
+  describe "match/1 widens a query that found nothing" do
+    setup do
+      patch(Providers, :editions, fn _id, _work_id, _opts -> {:ok, []} end)
+      patch(Providers, :search_authors, fn _id, _query, _opts -> {:ok, []} end)
+
+      patch(Providers, :book_details, fn _id, id, _opts ->
+        {:ok, %Provider.Book{provider: "test", id: id}}
+      end)
+
+      :ok
+    end
+
+    # Answers only the queries a test names and records every one it is
+    # asked, because "which question was asked" is what these assertions are
+    # actually about. Everything else finds nothing, which is the condition
+    # the ladder exists for. `search_books` runs in the calling process, so
+    # the test's own mailbox is the log.
+    defp patch_by_query(answers) do
+      test = self()
+
+      patch(Providers, :search_books, fn _id, query, _opts ->
+        send(test, {:searched, query})
+
+        {:ok,
+         Enum.find_value(answers, [], fn {match, books} -> query_says?(query, match) && books end)}
+      end)
+    end
+
+    defp query_says?(query, match), do: to_string(query) =~ match
+
+    defp queries_asked, do: drain_queries([])
+
+    defp drain_queries(acc) do
+      receive do
+        {:searched, query} -> drain_queries([query | acc])
+      after
+        0 -> acc |> Enum.reverse() |> Enum.uniq()
+      end
+    end
+
+    # An ASIN that doesn't resolve — regional, delisted, or simply wrong —
+    # used to end the recording level at zero with the title question never
+    # asked, which made carrying an ASIN strictly worse than carrying none.
+    test "an ASIN that resolves to nothing falls back to the title" do
+      patch_by_query([{"Wintersmith", [book("Wintersmith", ["Terry Pratchett"])]}])
+
+      %{matches: matches} =
+        AutoMatch.match(item(title: "Wintersmith", author: "Terry Pratchett", asin: "B000000000"))
+
+      assert [best | _rest] = matches["recording"]["candidates"]
+      assert best["title"] == "Wintersmith"
+      # the query reported is the one that answered, not the one that failed
+      refute matches["recording"]["query"] == "B000000000"
+    end
+
+    # The ladder stops at the first answer, so the definitive key still wins
+    # and still costs exactly one round of calls.
+    test "an ASIN that resolves is the only recording question asked" do
+      patch_by_query([
+        {"B003ZWFO7E", [book("Kings, The Way Of", ["Brandon Sanderson"], asin: "B003ZWFO7E")]},
+        {"The Way of Kings", [book("A Different Edition", ["Brandon Sanderson"])]}
+      ])
+
+      %{matches: matches} =
+        AutoMatch.match(
+          item(title: "The Way of Kings", narrator: "Michael Kramer", asin: "B003ZWFO7E")
+        )
+
+      assert matches["recording"]["query"] == "B003ZWFO7E"
+      assert [best] = matches["recording"]["candidates"]
+      assert best["asin"] == "B003ZWFO7E"
+
+      # the narrator rides only on the recording level's title query, so its
+      # absence is proof the ladder stopped at the key
+      refute Enum.any?(queries_asked(), & &1.narrator)
+    end
+
+    # The release name is a genuinely different question, not a better one:
+    # no amount of cleaning turns "DW35-Wintersmith" into the title on disk.
+    test "the release name is asked when the tag title finds nothing" do
+      patch_by_query([{"Discworld 35 Wintersmith", [book("Wintersmith", ["Terry Pratchett"])]}])
+
+      %{matches: matches} =
+        AutoMatch.match(
+          item(
+            title: "DW35-Wintersmith",
+            author: "Terry Pratchett",
+            path: "/downloads/Discworld 35 Wintersmith"
+          )
+        )
+
+      assert [best | _rest] = matches["work"]["candidates"]
+      assert best["title"] == "Wintersmith"
+    end
+
+    # "Wild - Cheryl Strayed" parses with the author on both sides, so the
+    # release "title" is the author's name. Searching an author's name for a
+    # title finds their other books — the one shape of junk worth refusing up
+    # front rather than leaving to the ranker.
+    test "a release name that is only the author's name is not asked" do
+      patch_by_query([])
+
+      AutoMatch.match(
+        item(
+          title: "Wild [Disc 1]",
+          author: "Cheryl Strayed",
+          path: "/downloads/Wild - Cheryl Strayed"
+        )
+      )
+
+      titles = queries_asked() |> Enum.map(& &1.title) |> Enum.reject(&is_nil/1)
+
+      # the disc marker is stripped, so the question worth asking is asked;
+      # the author's own name is never asked *as a title*
+      assert "Wild" in titles
+      refute "Cheryl Strayed" in titles
+    end
+
+    # Outcomes are per call, and a provider that was rate-limited on the
+    # first question and never asked the second must still say so — or a
+    # level looks answered when it was only partly asked.
+    @tag :capture_log
+    test "a failure on the first question survives the second" do
+      patch(Providers, :search_books, fn id, query, _opts ->
+        cond do
+          work_provider?(id) -> {:ok, []}
+          query_says?(query, "B000000000") -> {:error, :rate_limited}
+          true -> {:ok, [book("Wintersmith", ["Terry Pratchett"])]}
+        end
+      end)
+
+      %{matches: matches} =
+        AutoMatch.match(item(title: "Wintersmith", author: "Terry Pratchett", asin: "B000000000"))
+
+      # the second question answered, and the first one's failure is still on
+      # the record — a level that was only partly asked must not look answered
+      assert matches["recording"]["candidates"] != []
+      assert Enum.any?(matches["recording"]["providers"], &(&1["status"] == "failed"))
+    end
+
+    # One entry per provider however many questions it was asked, or the
+    # form's chip row grows a duplicate for every rung of the ladder.
+    test "asking twice does not report the provider twice" do
+      patch_by_query([{"Wintersmith", [book("Wintersmith", ["Terry Pratchett"])]}])
+
+      %{matches: matches} =
+        AutoMatch.match(item(title: "Wintersmith", author: "Terry Pratchett", asin: "B000000000"))
+
+      ids = Enum.map(matches["recording"]["providers"], & &1["id"])
+      assert ids == Enum.uniq(ids)
+    end
+  end
+
   describe "match/1 reports the calls made after the search" do
     setup do
       patch_work_results([book("The Way of Kings", ["Brandon Sanderson"])])
@@ -1662,7 +1820,7 @@ defmodule Ambry.Inbox.AutoMatchTest do
 
   defp item(opts) do
     %InboxItem{
-      path: "/downloads/#{Keyword.get(opts, :title, "Unknown")}",
+      path: Keyword.get(opts, :path, "/downloads/#{Keyword.get(opts, :title, "Unknown")}"),
       tags:
         %{
           "book_title" => opts[:title],

--- a/test/ambry/inbox/draft/tier_test.exs
+++ b/test/ambry/inbox/draft/tier_test.exs
@@ -82,9 +82,19 @@ defmodule Ambry.Inbox.Draft.TierTest do
     end
 
     # "Found nothing" is an answer, not a failure — there is nothing to choose
-    # between, and plenty of narrators are in no database at all.
-    test "a level that found nothing is settled" do
-      assert Tier.of(%Recording{approved: true, doubt: :nothing_found}) == :unreviewed
+    # between, and plenty of narrators are in no database at all. It is its
+    # own tier rather than `:unreviewed` because it is not a match, and it
+    # ranks below one: worth a look, above the tiers that block.
+    test "a level that found nothing says so" do
+      assert Tier.of(%Recording{approved: true, doubt: :nothing_found}) == :uncatalogued
+      assert Tier.worst([:unreviewed, :uncatalogued]) == :uncatalogued
+      assert Tier.worst([:uncatalogued, :waiting]) == :waiting
+    end
+
+    test "a human who has looked settles a level that found nothing" do
+      recording = %Recording{approved: true, doubt: :nothing_found, evidence_curated: true}
+
+      assert Tier.of(recording) == :reviewed
     end
 
     test "a recording is never linked, so it has no identity question" do

--- a/test/ambry/inbox/draft_test.exs
+++ b/test/ambry/inbox/draft_test.exs
@@ -1345,13 +1345,32 @@ defmodule Ambry.Inbox.DraftTest do
     end
 
     # A level found nothing, which is an answer rather than a failure: there
-    # is nothing to choose between, so it does not wait on the operator.
-    test "a level that found nothing is settled, not waiting" do
+    # is nothing to choose between, so it does not block the import. It is
+    # not a *match* either — saying "matched" over an empty candidate list is
+    # how the queue came to print "matched · no match" on one line — so it
+    # gets its own tier rather than borrowing either neighbour's.
+    test "a level that found nothing says so, and still imports" do
       item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
       {:ok, item} = Inbox.prepare_draft(item)
 
       assert item.draft.recording.doubt == :nothing_found
-      assert Tier.of(item.draft.recording) == :unreviewed
+      assert Tier.of(item.draft.recording) == :uncatalogued
+      # the tier is display; the invariant reads `approved` directly, and a
+      # release no catalogue lists has to stay importable from its own tags
+      assert item.draft.recording.approved
+      refute Enum.any?(Draft.unresolved(item.draft), &(&1.label == "Audiobook records"))
+    end
+
+    # Looking is the only answer the level can take, so it stops flagging
+    # itself once a human has been there — same as any other reviewed
+    # decision, and the reason this isn't just permanently amber.
+    test "a reviewed uncatalogued level stops asking" do
+      item = item(%{matches: matches([provider_candidate(%{})]), tags: %{}})
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      reviewed = %{item.draft.recording | evidence_curated: true}
+
+      assert Tier.of(reviewed) == :reviewed
     end
 
     test "the tick survives the reseed it triggers" do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -59,16 +59,18 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
 
     # Returning them to an unfiltered page one is how "where did my queue go"
-    # happens — they were on the ready tab, and that is where they go back.
+    # happens — they were on page three of Pending, and that is where they go
+    # back. An unknown param is dropped rather than echoed, so a hand-typed
+    # URL can't turn this into an open redirect.
     test "importing returns to the list the operator came from", %{conn: conn} do
       item = probed_item() |> settle()
 
-      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}?status=pending&ready=true")
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}?status=pending&page=3&junk=1")
 
       view |> element("button[data-role='import']") |> render_click()
 
       # params come back in map order, which is fine — it is the same list
-      assert_redirect(view, ~p"/admin/inbox?ready=true&status=pending")
+      assert_redirect(view, ~p"/admin/inbox?page=3&status=pending")
     end
 
     # A stale tab can still send the event twice, and the second one must not

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -26,7 +26,10 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert html =~ "Sanderson"
     # the facts
     assert html =~ "aac"
-    assert html =~ "pending"
+    # and what it still owes, which is the row's one badge. Nothing has
+    # matched this yet, so there are no decisions to count — the badge says
+    # that rather than inventing one.
+    assert item_states(html) == ["not prepared"]
   end
 
   @tag :capture_log
@@ -160,8 +163,8 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   end
 
   # The page links used to be built from the shared filter+page helpers,
-  # which drop status and ready — so paging through "Imported" silently
-  # landed back on the default pending view.
+  # which drop the status — so paging through "Imported" silently landed
+  # back on the default pending view.
   test "the page links keep the status filter", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=ignored&page=2")
 
@@ -300,20 +303,38 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert Inbox.get_item!(item.id).status == :pending
   end
 
-  test "the ready bucket counts what is waiting on a click", %{conn: conn} do
+  # Readiness was a tab and is now a badge. Every draft gets opened either
+  # way, so the bucket only ever split work that was going to be done in
+  # full — and it cost every row a second badge to say which bucket it was
+  # in. What varies from row to row is how much the row still owes.
+  test "a row says what it still owes rather than which tab it is in", %{conn: conn} do
     ready = probed_item(name: "Settled") |> settle()
-    _outstanding = probed_item(name: "Outstanding")
+    {:ok, _outstanding} = probed_item(name: "Outstanding") |> Inbox.prepare_draft()
+
+    {:ok, view, html} = live(conn, ~p"/admin/inbox")
+
+    refute has_element?(view, "span[data-role='ready-filter']")
+
+    states = item_states(html)
+    assert "ready" in states
+    assert Enum.any?(states, &(&1 =~ ~r/\d+ decisions? needed/))
+    # the tab's own word, which never told two rows apart
+    refute "pending" in states
+
+    # the flag is still stored rather than recomputed per render — the
+    # import button reads it, and `put_draft/2` is what keeps it honest
+    assert Inbox.get_item!(ready.id).ready
+  end
+
+  # These were once mutually exclusive, so a settled item's action rail had
+  # no way into its own form and the title link was the only road in.
+  test "a settled row offers both Import and Open", %{conn: conn} do
+    item = probed_item() |> settle()
 
     {:ok, view, _html} = live(conn, ~p"/admin/inbox")
 
-    html = view |> element("span[data-role='ready-filter']") |> render_click()
-
-    assert html =~ "Settled"
-    refute html =~ "Outstanding"
-    assert Inbox.count_ready() == 1
-    # the flag is stored, not recomputed per render — that's what lets the
-    # bucket be a plain SQL filter
-    assert Inbox.get_item!(ready.id).ready
+    assert has_element?(view, "span[phx-click='import'][phx-value-id='#{item.id}']")
+    assert has_element?(view, "a[href^='/admin/inbox/#{item.id}']")
   end
 
   test "filters by status", %{conn: conn} do
@@ -366,6 +387,16 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
 
       refute has_element?(view, "[data-role='busy-overlay']")
     end
+  end
+
+  # The rows' badges, as text. Read out of the markup rather than asserted
+  # against the raw HTML: the formatter puts the badge's content on its own
+  # line, so an exact-string match on the rendered page is a whitespace bet.
+  defp item_states(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("[data-role='item-state']")
+    |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
   end
 
   defp probed_item(opts \\ []) do


### PR DESCRIPTION
Two changes to the inbox, from a pass over the real queue.

## 1. The queue's tabs are one axis

The tab strip mixed two questions and the row badges printed both answers. Where an item is in its life (pending/ignored/imported) and whether its draft is settled are different axes, so every settled row wore `ready` beside `pending`, and "pending" came to mean four different things because it was the only word three other situations had.

Readiness was never navigation. Every draft gets opened and looked over either way, so the bucket only ever split work that was going to be done in full — and a future auto-import would empty it without a human ever visiting it. **The Ready tab is gone; the badge stays.**

| | before | after |
|---|---|---|
| Tabs | All · Pending · Ignored · Imported · **Ready** | All · Pending · Ignored · Imported |
| Pending row badges | `ready` + `pending`, or just `pending` | one: `ready`, or `3 decisions needed` |
| Ready row actions | Import only | Import **and** Open |

What varies from row to row is how much the row still owes, so that is what the one badge says, off `Draft.unresolved/1`. A draft that does not exist yet says `not prepared` rather than counting itself as one decision and sending the operator to an empty form.

Background job state is deliberately still not an axis. A row that changed tabs because a job started would vanish out from under the click that started it — re-match especially, whose whole point is that you keep watching the row. That stays in the row's own overlay and belongs to the ambient job widget at the page level.

Also fixes a real gap this uncovered: **Import and Open were mutually exclusive**, so a settled item's action rail had no way into its own form and the title link was the only road in.

## 2. A level that found nothing says so, and is asked twice before it gives up

A real item read `audiobook: matched · no match` — two axes on one line again. `Tier.level_state/2` demoted `:low_confidence` but let `:nothing_found` fall through to `:approved`, which the queue prints as "matched", while the label came from the empty candidate list. The form has said the right thing all along; only the queue lied.

`:nothing_found` now has its own tier. **Approval is untouched** — the seeder approves it on purpose so a release no catalogue lists still imports from its own tags — because settled and *matched* are different claims and only the second was false.

Worth surfacing because with five providers a level that finds nothing is usually a bad question rather than an absent book. Of the seven empty levels on the 343-item dev queue, five had a findable book behind a polluted title:

- **two searched an ASIN Audible would not resolve.** An ASIN *was* the recording query, so a delisted or regional one ended the level at zero with the title question never asked — carrying an ASIN was strictly worse than carrying none. One had already matched its work at confidence 1.0.
- `Wild [Disc 1]`, `…Series, Book 0` — noise `strip_noise/1` did not know about.
- `DW35-Wintersmith`, which no cleaning fixes: the folder beside it says `Discworld 35 Wintersmith`.

So a query that finds nothing is widened rather than given up on: the ladder asks the ASIN, then the tag title, then the release name, stopping at the first that answers. The common case is still one round of calls. The release name is a *different* question, not a better one (the two disagree on 105 of 198 releases and neither wins reliably), so it stays a fallback, and whatever it returns is ranked against the file's raw text. A release name that parsed to nothing but the author's own name is refused up front.

Every rung's outcomes are tallied, not just the winner's, or a provider rate-limited on the first question would leave a level looking answered when it was only partly asked.

### Measured, re-matched against the real providers

| item | before | after |
|---|---|---|
| 423, 424 | recording: nothing found | **1.0** (ASIN fallback) |
| 555 | both levels: nothing found | **1.0** both (series tail) |
| 702 | recording: nothing found | **1.0** (disc marker) |
| 518 | nothing found, unasked | asks the release name too; catalogue genuinely has no answer |

## Deliberately out of scope

- The ladder fires on **zero** results, not low confidence, so a query returning junk candidates never widens. 518's work level stays wrong for that reason. Re-match and the operator are what that has.
- Two items (a BBC R4 drama, a bonus release) are genuinely uncatalogued and now say so plainly instead of claiming a match.

## Verification

`mix check` clean (format, credo, dialyzer); 1637 passed, 1 skipped. Both surfaces driven in real Chrome against the dev server's 343-item queue — queue tabs, badges, the `nothing found` row, and the form's amber records card with the fallback query pre-filled in "Search again".