### PR TITLE
The overview's issue count opens the items it counted, and the next tag is 2.0.0

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,7 +5,9 @@ config :ambry, Ambry.Repo,
   username: "postgres",
   password: "postgres",
   hostname: "localhost",
-  database: "ambry_dev",
+  # Overridable so a second server can run against a restored dump (a
+  # production copy, a migration rehearsal) without disturbing this one.
+  database: System.get_env("AMBRY_DEV_DATABASE", "ambry_dev"),
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
@@ -19,7 +21,7 @@ config :ambry, Ambry.Repo,
 config :ambry, AmbryWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {0, 0, 0, 0}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT", "4000"))],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -95,6 +95,7 @@ defmodule Ambry.Inbox do
       InboxItem
       |> filter_by_status(opts[:status])
       |> filter_by_path(opts[:filter])
+      |> filter_by_issue(opts[:issue])
       |> order_by(^newest_first(opts[:status]))
       |> offset(^Keyword.get(opts, :offset, 0))
       |> limit(^over_limit)
@@ -1130,6 +1131,12 @@ defmodule Ambry.Inbox do
   defp filter_by_path(query, blank) when blank in [nil, ""], do: query
 
   defp filter_by_path(query, filter), do: where(query, [i], ilike(i.path, ^"%#{filter}%"))
+
+  # An issue cuts across the three buckets rather than replacing them (see
+  # `queue_summary/0`), so it narrows whatever list is already showing
+  # instead of being a status of its own.
+  defp filter_by_issue(query, true), do: where(query, [i], not is_nil(i.issue))
+  defp filter_by_issue(query, _no), do: query
 
   defp candidates(root) do
     root |> entries() |> Enum.flat_map(&candidate/1)

--- a/lib/ambry_web/live/admin/home_live/index.ex
+++ b/lib/ambry_web/live/admin/home_live/index.ex
@@ -192,7 +192,10 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
         words: "Queue items with an issue",
         count: queue.issues,
         tone: :amber,
-        navigate: ~p"/admin/inbox"
+        # `status=pending` because that is what the count counts — landing on
+        # a list that disagrees with the number that was clicked is its own
+        # small betrayal.
+        navigate: ~p"/admin/inbox?problem=issue&status=pending"
       },
       %{
         words: "Ready to publish, held by the switch",

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -127,13 +127,14 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   end
 
   defp load_items(socket, params) do
-    list_opts = get_list_opts(params)
+    list_opts = params |> get_list_opts() |> Map.put(:problem, parse_problem(params))
     status = parse_status(params["status"])
 
     {items, has_more?} =
       Inbox.list_items(
         status: status,
         filter: list_opts.filter,
+        issue: list_opts.problem == "issue",
         offset: page_to_offset(list_opts.page),
         limit: limit()
       )
@@ -211,7 +212,8 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     %{
       "filter" => Keyword.get(overrides, :filter, socket.assigns.list_opts.filter),
       "page" => Keyword.get(overrides, :page, to_string(socket.assigns.list_opts.page)),
-      "status" => Keyword.get(overrides, :status, to_string(socket.assigns.status || "all"))
+      "status" => Keyword.get(overrides, :status, to_string(socket.assigns.status || "all")),
+      "problem" => Keyword.get(overrides, :problem, to_string(socket.assigns.list_opts[:problem]))
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Map.new()
@@ -234,11 +236,40 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     %{
       "filter" => list_opts.filter,
       "page" => to_string(page),
-      "status" => to_string(status || "all")
+      "status" => to_string(status || "all"),
+      "problem" => to_string(list_opts[:problem])
     }
     |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
     |> Map.new()
   end
+
+  # The overview counts queue items carrying an issue, and a count the
+  # operator can't open is half an answer — so it links here naming the
+  # trouble, exactly as the audiobooks list does. An issue is not a status:
+  # it cuts across the three buckets (see `Inbox.queue_summary/0`), so it
+  # narrows the tab the operator is on rather than replacing it.
+  @problems %{
+    "issue" => %{
+      words: "Queue items with an issue",
+      empty: "Nothing here is carrying an issue."
+    }
+  }
+
+  defp parse_problem(params) do
+    problem = params |> Map.get("problem", "") |> String.trim()
+
+    if Map.has_key?(@problems, problem), do: problem
+  end
+
+  @doc "What the overview sent the operator here to look at, if anything."
+  def problem_words(problem) when is_map_key(@problems, problem), do: @problems[problem].words
+  def problem_words(_none), do: nil
+
+  @doc "What an empty list means when it is a problem list that came up dry."
+  def problem_empty_words(problem) when is_map_key(@problems, problem),
+    do: @problems[problem].empty
+
+  def problem_empty_words(_none), do: nil
 
   defp parse_status(status) when status in ["pending", "ignored", "imported"],
     do: String.to_existing_atom(status)

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -7,6 +7,21 @@
       next_page_path={@next_page_path}
       prev_page_path={@prev_page_path}
     />
+    <%!-- The list is narrowed by something the operator chose on the
+          overview, so it says which list this is and offers the way out.
+          Leaving it keeps the tab and the search — an issue narrows the
+          queue, it doesn't replace it. --%>
+    <div :if={problem_words(@list_opts[:problem])} class="flex items-baseline gap-2 pt-2">
+      <.microlabel>Showing</.microlabel>
+      <.link
+        navigate={~p"/admin/inbox?#{Map.delete(return_query(assigns), "problem")}"}
+        class="bg-amber-400/15 flex items-center gap-1.5 rounded-md px-3 py-1 text-sm text-amber-300 hover:bg-amber-400/25"
+        data-role="problem-filter"
+      >
+        {problem_words(@list_opts[:problem])}
+        <.icon name="fa-xmark" class="h-3 w-3 text-current" />
+      </.link>
+    </div>
     <div class="flex flex-wrap items-center gap-3 pt-2">
       <.button phx-click="scan">
         <.icon name="fa-magnifying-glass" class="mr-2 h-4 w-4" /> Scan for new
@@ -47,7 +62,11 @@
 
   <.flex_table rows={@items} filter={@list_opts.filter} row_class={&rail_class/1}>
     <:empty>
-      Nothing waiting. Use <span class="font-bold">Scan for new</span> to look in the watched folder.
+      <%= if words = problem_empty_words(@list_opts[:problem]) do %>
+        {words}
+      <% else %>
+        Nothing waiting. Use <span class="font-bold">Scan for new</span> to look in the watched folder.
+      <% end %>
     </:empty>
 
     <:row :let={item}>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ambry.MixProject do
   def project do
     [
       app: :ambry,
-      version: "1.10.0",
+      version: "2.0.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary, :phoenix_live_view] ++ Mix.compilers(),

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -42,6 +42,35 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert html =~ item.path
   end
 
+  # The overview's issue count used to link at the bare queue, which showed
+  # every pending item and named none of them — the number was clickable and
+  # still unanswerable.
+  test "shows only the items the overview counted, and says so", %{conn: conn} do
+    trouble = probed_item(name: "Trouble [M4B]", files: ["book.m4b"], unreadable: true)
+    fine = probed_item(name: "Fine [M4B]")
+
+    {:ok, view, html} = live(conn, ~p"/admin/inbox?problem=issue&status=pending")
+
+    assert html =~ "Queue items with an issue"
+    assert html =~ trouble.path
+    refute html =~ fine.path
+
+    # An issue narrows the tab rather than replacing it, so leaving the
+    # filter keeps the operator where they were.
+    way_out = view |> element("a[data-role='problem-filter']") |> render()
+    assert way_out =~ "status=pending"
+    refute way_out =~ "problem=issue"
+  end
+
+  test "a problem list that comes up dry says which list is empty", %{conn: conn} do
+    _fine = probed_item(name: "Fine [M4B]")
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox?problem=issue&status=pending")
+
+    assert html =~ "Nothing here is carrying an issue."
+    refute html =~ "Nothing waiting"
+  end
+
   test "counts a multi-file release's files on the row", %{conn: conn} do
     _item = probed_item(files: ["01.mp3", "02.mp3"])
 


### PR DESCRIPTION
Three things, all in front of the 2.0.0 tag.

## The overview's issue count was half an answer

"Queue items with an issue — 1" linked at the bare inbox, which showed every pending item and named none of them. Every other problem row on the overview already links with the trouble named (`?problem=missing`, `?problem=error`) and says on arrival which list it is showing and how to leave it; the queue's issue count never got that treatment.

So this is the existing pattern, not a new one:

- `?problem=issue` narrows the queue, carried through search, paging, and the return-from-form query
- a banner naming the list with the way out, which keeps the tab and the search
- an empty state that says *which* list came up dry
- the tile pins `status=pending`, because that is what the count counts

An issue is not a status — it cuts across the three buckets (`Inbox.queue_summary/0`), so it narrows the tab rather than replacing it, and the queue keeps its one axis. No fourth segment.

Two tests: the filtered list shows only the counted items and offers a way out that keeps the tab; and a problem list that comes up dry says so.

## The next tag is 2.0.0

The roadmap spent 2.0.0 on "the switch flips", but that is an app-settings toggle plus a background job — it deploys nothing, so it cannot be a release. The breaking changes are all here: the GraphQL contract moved (`partsTotal` off `Media`), the import path was replaced, the admin was rebuilt, every device must update. The Flux ImagePolicy range (`>=1.6.0`) already accepts a major.

## A second dev server can point at a restored dump

Database name and port now read from env with unchanged defaults. This is what let the migration batch be rehearsed against the nightly production dump without disturbing the running dev server.

## Rehearsal result, for the record

Against the 2026-08-14 production dump: **30 migrations, zero errors**; 437/437 media resolve, with all 1748 mp4/hls/mpd/image paths still pointing at real files; the `root_relative_paths` raise never fires on production data. Real Chrome over nine surfaces on a database with no library roots: all 200, no console errors. Both manual-form doors complete an import and transcode to `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)