### PR TITLE
Fix the LiveView crash when adding an audiobook to a set (v2.0.1)

### DIFF
--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -159,7 +159,7 @@ defmodule AmbryWeb.Components.EntityResolver do
           Create “{@equery}”
         </li>
         <li
-          :if={@matches == [] and not (@text_name && present?(@equery))}
+          :if={@matches == [] and !(@text_name && present?(@equery))}
           class="px-3 py-2 text-zinc-500"
         >
           No matches

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -170,10 +170,15 @@
                   type="autocomplete"
                   options={@recording_groups}
                 />
+                <%!-- `flex` is load-bearing, not decoration: it collapses the
+                    button to the icon's own box, which is what puts `top-3` on
+                    the input's centre line. `.delete_button` carries it for the
+                    list rows; this one is hand-rolled because removing the
+                    group is an event, not a drop input, so it has to say it. --%>
                 <button
                   type="button"
                   phx-click="remove-group-row"
-                  class="absolute top-3 right-2"
+                  class="absolute top-3 right-2 flex"
                   title="Not part of a set"
                 >
                   <.icon

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ambry.MixProject do
   def project do
     [
       app: :ambry,
-      version: "2.0.0",
+      version: "2.0.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary, :phoenix_live_view] ++ Mix.compilers(),

--- a/test/ambry_web/live/admin/media_live/set_picker_test.exs
+++ b/test/ambry_web/live/admin/media_live/set_picker_test.exs
@@ -1,0 +1,46 @@
+defmodule AmbryWeb.Admin.MediaLive.SetPickerTest do
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_admin_user
+
+  describe "the \"Part of a set\" picker" do
+    # The first audiobook of a book is the common case, and it is the one
+    # where the picker has nothing to offer: the book has no sets yet, so
+    # the option list is empty and the list's empty state is what renders.
+    # That branch read `not (@text_name && ...)`, and `text_name` is nil in
+    # a pure picker — `:erlang.not(nil)` took the LiveView down before the
+    # operator could type anything.
+    test "opens with an empty option list instead of crashing", %{conn: conn} do
+      media = insert(:media, book: insert(:book))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+      view |> element("button[phx-click='add-group-row']") |> render_click()
+
+      html = view |> element("#media_recording_group_id-input") |> render_focus()
+
+      assert html =~ "No matches"
+      # a pure picker never offers to invent a record
+      refute html =~ "Create “"
+    end
+
+    test "opens with an empty option list after filtering everything out", %{conn: conn} do
+      book = insert(:book)
+      insert(:recording_group, book: book, name: "Unabridged")
+      media = insert(:media, book: book)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+      view |> element("button[phx-click='add-group-row']") |> render_click()
+
+      html =
+        view
+        |> element("#media_recording_group_id-input")
+        |> render_change(%{"resolver" => %{"media_recording_group_id" => "zzzz"}})
+
+      assert html =~ "No matches"
+    end
+  end
+end


### PR DESCRIPTION
Hotfix for a crash reported in prod: adding an audiobook to a set is impossible right now.

## The crash

```
** (ArgumentError) argument error
    (erts 17.0.4) :erlang.not(nil)
    (ambry 2.0.0) lib/ambry_web/components/entity_resolver.ex:162
```

The resolver's "No matches" row guarded itself with

```elixir
:if={@matches == [] and not (@text_name && present?(@equery))}
```

`text_name` is nil in a pure picker — `<.input type="autocomplete">` never passes one, since inventing records makes no sense on an edit form — so `@text_name && present?(@equery)` is `nil`, and Erlang's `not` is strict. Every other truthiness test in the component already used `!`; this line was the one outlier, and it is the only strict `not` on a possibly-nil assign in `ambry_web`.

**"Part of a set" hits it on the common path, not an edge.** The first audiobook of a book has no sets to offer, so `@matches` is `[]` the moment the picker opens — it crashes before you can type anything. The other eleven autocompletes (book, series, universe, person, recording group, narrators) were one empty filter result away from the same fall.

## Also: the ✕ was 5.7px low

`<.delete_button>` carries `class={["flex", @class]}`, and that `flex` is load-bearing: it collapses the button to the icon's own 16px box, which is what makes the shared `top-3 right-2` land on the input's centre line. The set row hand-rolls its button — it has to, since removing the group is a `phx-click` event rather than a drop input — and dropped the `flex`, leaving it `display: block` inside a taller inline line box. It is the only hand-rolled one of the twelve.

Measured in Chrome against the dev server:

| | before | after |
|---|---|---|
| Read by (`.delete_button`) | 0px | 0px |
| Part of a set | **5.7px low** | 0px |

Fixed by adding the missing `flex`, not by nudging the offset.

## Verification

- New `test/ambry_web/live/admin/media_live/set_picker_test.exs` covers both routes to an empty list: no sets exist, and filtered down to nothing. **Confirmed it fails with the reported `:erlang.not(nil)` when the guard is reverted** — it does not merely pass with the fix in place.
- Full suite green: 1702 passed, 1 skipped, with `--warnings-as-errors`.
- `mix format --check-formatted` and `credo --strict` clean.
- Driven in real Chrome against the running dev server, per the standing rule that LiveView tests are not a browser.

Branched off `main`, which is exactly `v2.0.0`, so this release carries only this fix.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ