### PR TITLE
Expose a set's label to clients

### DIFF
--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -90,8 +90,11 @@ defmodule AmbrySchema.Media do
   end
 
   node object(:recording_group) do
-    @desc "Admin-only organizational label; clients should not display it"
+    @desc "This set's name, shown to readers only when `show_label` says so"
     field :name, non_null(:string)
+
+    @desc "Whether to show `name` on this set's tile; an operator choice, never inferred"
+    field :show_label, non_null(:boolean)
 
     @desc "How many releases the set has, when known (\"Part 2 of 3\")"
     field :parts_total, :integer

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ambry.MixProject do
   def project do
     [
       app: :ambry,
-      version: "2.0.1",
+      version: "2.1.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary, :phoenix_live_view] ++ Mix.compilers(),

--- a/test/ambry_schema/sync_test.exs
+++ b/test/ambry_schema/sync_test.exs
@@ -146,6 +146,7 @@ defmodule AmbrySchema.SyncTest do
       recordingGroupsChangedSince(since: $since) {
         id
         name
+        showLabel
         partsTotal
       }
       mediaChangedSince(since: $since) {
@@ -167,6 +168,7 @@ defmodule AmbrySchema.SyncTest do
       {:ok, group} =
         Ambry.Media.create_recording_group(%{
           name: "Season One",
+          show_label: true,
           parts_total: 3,
           book_id: book.id
         })
@@ -188,7 +190,9 @@ defmodule AmbrySchema.SyncTest do
 
       assert %{
                "data" => %{
-                 "recordingGroupsChangedSince" => [%{"name" => "Season One", "partsTotal" => 3}],
+                 "recordingGroupsChangedSince" => [
+                   %{"name" => "Season One", "showLabel" => true, "partsTotal" => 3}
+                 ],
                  "mediaChangedSince" => [
                    %{
                      "partNumber" => 1,


### PR DESCRIPTION
The mobile app can't honor the show-the-set's-name option because the server never sends it.

`recording_group.show_label` has existed since #1164 and the admin UI has been setting it ever since, but the GraphQL object exposes neither the flag nor a `name` clients are allowed to render. `name` still carries its pre-#1164 annotation:

```elixir
@desc "Admin-only organizational label; clients should not display it"
```

That annotation *is* the decision #1164 reversed. On web a set's name renders on its tile (`core_components.ex:1317`) and as the parts-rail heading (`audiobook_live.ex:82`) whenever the operator opts in. Mobile has no way to reach the same rule.

## The change

Add `show_label`, and re-word `name` to say what actually governs it. Three lines plus the test.

`show_label` is `non_null` — it has a schema default of `false` and every row has a value, so there's nothing for a nullable field to mean.

## No `updated_at` touch migration

The obvious way to backfill already-flagged groups is a server-side `UPDATE recording_groups SET updated_at = NOW() WHERE show_label`, so incremental sync re-sends them. That races the app rollout and loses: a client that syncs after this deploys but *before* it has the new app version consumes those rows, advances its cursor, and never learns the fields exist.

The client already solves this correctly. `synced_servers.needs_full_refetch` (mobile migration 0025) exists for exactly this case — set by the migration that adds the columns, so the backfill fires when the *client* gains the fields, whatever order the two deploys land in. The mobile PR will use it.

## Deploy ordering

**Deploy this before the app version that queries it.** There's no schema negotiation, and the library sync is one large query — a client asking for an unknown field fails its entire sync, not just the one field.

## Testing

Extended the `recordingGroupsChangedSince` sync test to select `showLabel` and assert it against a group created with the flag *on*, so a hardcoded `false` can't pass it.