### PR TITLE
Work out what relinking a legacy recording would do, without doing it

### DIFF
--- a/lib/ambry/library/naming_template.ex
+++ b/lib/ambry/library/naming_template.ex
@@ -66,7 +66,8 @@ defmodule Ambry.Library.NamingTemplate do
   end
 
   @doc """
-  The filename for a recording's file, keeping the source's extension.
+  The filename for a recording's file, keeping the source's extension (except
+  that audio MPEG-4 is named `.m4b` whatever it arrived as — see `extname/1`).
 
   See `filenames/3` — `recording` describes which recording this is.
   """
@@ -178,7 +179,29 @@ defmodule Ambry.Library.NamingTemplate do
   # re-organize.
   defp index_width(count), do: max(3, count |> to_string() |> String.length())
 
-  defp extname(source_path), do: source_path |> Path.extname() |> String.downcase()
+  # `.mp4`, `.m4a` and `.m4b` are the *same container* — ISO base media, MPEG-4
+  # part 14 — and the extension only says what a player should expect to find
+  # inside: generic, audio, or audio that is a book. Ambry places nothing but
+  # audiobook audio into a root, so the honest name for all three here is
+  # `.m4b`, and it is the one that makes the tree readable by everything else:
+  # audiobook players key their whole behaviour off it, remembering position
+  # and shelving the file as a book rather than a song.
+  #
+  # Nothing about the bytes changes, and nothing in Ambry depends on the
+  # difference — `Probe` maps all three to `audio/mp4` already. This is purely
+  # so a library that outlives Ambry is a library, not a pile of `.mp4`s.
+  #
+  # Every other format keeps its extension, because renaming those *would* be
+  # a lie: an mp3 is not an m4b, whatever a library would prefer.
+  defp extname(source_path) do
+    source_path
+    |> Path.extname()
+    |> String.downcase()
+    |> case do
+      ext when ext in [".mp4", ".m4a"] -> ".m4b"
+      ext -> ext
+    end
+  end
 
   defp part_suffix(nil), do: ""
 

--- a/lib/ambry/media/relink.ex
+++ b/lib/ambry/media/relink.ex
@@ -1,0 +1,426 @@
+defmodule Ambry.Media.Relink do
+  @moduledoc """
+  Working out what upgrading a legacy recording to direct play would do.
+
+  A recording imported before direct play existed was transcoded: its audio
+  lives twice on disk, once as the files it came from and once as the packaged
+  artifact Ambry serves. Relinking points the recording at the originals —
+  placed into a library root and scanned into tracks — so the artifact can go.
+
+  **This module only plans. It writes nothing**, which is what makes it safe to
+  run against production before anything else exists, one recording at a time,
+  and read the answer.
+
+  ## Why a plan is a separate thing from doing it
+
+  Every input here is a guess about the world that can be wrong in a way no
+  database constraint can catch. A recorded path can still resolve while
+  holding a *different file* than the one that was transcoded — the downloads
+  folder is live, and files get replaced, upgraded and re-downloaded in place.
+  Relinking that would silently move a recording's audio under saved positions
+  and curated chapter markers.
+
+  So the plan carries its evidence and every reason it might be wrong, and
+  refuses rather than guessing. An operator reads it; a batch run gates on it.
+
+  ## The two eras, and how the files are found
+
+  Which files a recording came from is recorded differently depending on when
+  it was imported, and neither way is a list you can simply trust:
+
+    * **Web-upload era** — `source_files` is empty, because that column
+      postdates these rows. The files are whatever audio sits in the
+      recording's `source_media/<uuid>/` folder, found by listing it. The
+      recorded truth is a *folder*, so anything else in it comes along.
+    * **Server-import era** — `legacy_source_files` holds absolute container
+      paths, the one column the paths refactor left holding absolutes because
+      it is provenance for recordings that predate roots. **Absolute means
+      environment-dependent**: they were `/app/local/...` until prod moved to
+      a single `/data` mount, and they will be wrong again after any future
+      remount.
+
+  A recording with tracks already is not a candidate, and neither is one whose
+  files cannot be found at all.
+
+  ## The duration gate
+
+  The one check that catches a path pointing at the wrong file. Sum the probed
+  durations of the sources and compare against the recording's stored duration
+  — which came from the transcode, so agreement means the files on disk are
+  the files that were transcoded.
+
+  The tolerance is **file-count-aware, not flat**. ffmpeg's concat accumulates
+  mp3 frame padding per file boundary, so a 63-file recording legitimately
+  drifts a few seconds while a single-file one should agree to the microsecond.
+  A flat window wide enough for the first is far too wide for the second.
+
+  Surveyed across the whole production back catalogue (435 recordings,
+  2026-08-16): **every single one agrees.** Multi-file mp3 sets drift by a
+  strikingly consistent ~65ms per boundary — 63 files → 4.10s, 56 → 3.62s,
+  28 → 1.72s — and every one lands comfortably inside its tolerance. Nothing
+  in the library has a source that is not the file it was transcoded from.
+
+  That makes the gate cheap insurance rather than a filter, which is the right
+  thing for it to be: it is what *established* the above, and it is what will
+  catch the case whenever the downloads folder does move under a recording.
+
+  Note the drift is the *transcode* being imprecise, not the sources — so the
+  relinked timeline is the more accurate one, which is also why stored chapter
+  markers on a long multi-file mp3 set can sit a second or two off afterwards.
+
+  **Measure with `Scanner.Probe`, never with `ffprobe -show_format` alone.**
+  A VBR mp3 without an index reports a *claimed* duration that can be tens of
+  seconds out; `Probe` decode-counts those, which is what the transcode did.
+  A first survey using the claimed figure invented two mismatches that do not
+  exist.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Books
+  alias Ambry.Library
+  alias Ambry.Library.NamingTemplate
+  alias Ambry.Library.Placement
+  alias Ambry.Library.Root
+  alias Ambry.Media.Media
+  alias Ambry.Media.MediaTrack
+  alias Ambry.Media.Scanner
+  alias Ambry.Repo
+  alias Ambry.Settings
+
+  @extensions ~w(.mp3 .mp4 .m4a .m4b .flac .ogg .opus .wav)
+
+  # Per file *boundary*, with headroom: the measured figure is ~65ms and the
+  # padding is systematic rather than noisy, so 1.5x covers it without
+  # widening far enough to admit a genuinely different file. The floor is what
+  # a single-file recording gets.
+  @drift_per_boundary_ms 65
+  @drift_headroom 1.5
+  @minimum_tolerance_seconds 2.0
+
+  defmodule Plan do
+    @moduledoc """
+    What relinking one recording would do, and every reason it might not.
+
+    `:verdict` is `:ok` only when nothing was found wrong. Everything else is
+    reported rather than raised, so a batch can list its refusals instead of
+    stopping at the first.
+    """
+
+    @enforce_keys [:media_id, :title, :era, :verdict, :problems, :sources]
+    defstruct [
+      :media_id,
+      :title,
+      :era,
+      :verdict,
+      :problems,
+      :sources,
+      :stored_duration,
+      :probed_duration,
+      :drift,
+      :tolerance,
+      :root,
+      :policy,
+      :destinations
+    ]
+  end
+
+  @doc """
+  Plans the relink of one recording. Reads only.
+
+  Pass a media id or a loaded `Media`. Probing reads each source file's
+  header, so this costs an ffprobe per file and no decoding.
+  """
+  def plan(media_id) when is_integer(media_id) do
+    case Repo.get(Media, media_id) do
+      nil -> {:error, :not_found}
+      media -> plan(media)
+    end
+  end
+
+  def plan(%Media{} = media) do
+    media = preload_for_plan(media)
+    era = era(media)
+    sources = sources(media, era)
+
+    %Plan{
+      media_id: media.id,
+      title: title(media),
+      era: era,
+      sources: sources,
+      verdict: :ok,
+      problems: []
+    }
+    |> refuse_if_already_direct_play(media)
+    |> refuse_if_sources_missing()
+    |> check_duration(media)
+    |> propose_destination(media)
+    |> settle_verdict()
+  end
+
+  @doc """
+  Every legacy recording, oldest first — the candidates for relinking.
+
+  A recording is legacy here if it has no tracks. Whether it still has its
+  packaged artifacts is a separate question and deliberately not asked: the
+  artifacts are what relinking retires, not what qualifies it.
+  """
+  def candidates do
+    tracked = from(t in MediaTrack, select: t.media_id, distinct: true)
+
+    Media
+    |> where([m], m.id not in subquery(tracked))
+    |> order_by([m], asc: m.id)
+    |> Repo.all()
+  end
+
+  @doc """
+  Plans every candidate, and groups the results by verdict.
+
+  The whole-library read to do before letting anything run.
+
+  **Budget an hour.** Probing an indexed container is instant, but a VBR mp3
+  has to be decode-counted, and most of a back catalogue is mp3. Measured over
+  the 437-recording production library: 53 minutes, ~14s per recording. That
+  is a console command to start and walk away from, and the reason a version
+  of this that runs in a request or a LiveView needs to be an Oban job.
+  """
+  def survey(media_list \\ nil) do
+    (media_list || candidates())
+    |> Enum.map(&plan/1)
+    |> Enum.group_by(& &1.verdict)
+  end
+
+  # ==========================================================================
+  # Which files, and where they are
+  # ==========================================================================
+
+  # `source_files` is authoritative when a recording has it. The upload era
+  # has neither that nor `legacy_source_files`, and its files are found by
+  # listing the folder `source_path` names — the same fallback `Media.files/2`
+  # has always used for these rows.
+  defp era(%Media{legacy_source_files: [_ | _]}), do: :server_import
+  defp era(%Media{source_files: [_ | _]}), do: :recorded_list
+  defp era(%Media{}), do: :web_upload
+
+  defp sources(%Media{} = media, :server_import) do
+    Enum.map(media.legacy_source_files, &source/1)
+  end
+
+  defp sources(%Media{} = media, _era) do
+    media
+    |> Media.files(@extensions)
+    |> Enum.map(&source/1)
+  end
+
+  defp source(path) do
+    %{path: path, exists?: File.regular?(path)}
+  end
+
+  # ==========================================================================
+  # The checks
+  # ==========================================================================
+
+  defp refuse_if_already_direct_play(plan, media) do
+    case Repo.aggregate(from(t in MediaTrack, where: t.media_id == ^media.id), :count) do
+      0 -> plan
+      n -> problem(plan, "already has #{n} track(s); it is not a legacy recording")
+    end
+  end
+
+  defp refuse_if_sources_missing(%Plan{sources: []} = plan) do
+    problem(plan, "no source files found — nothing recorded and nothing on disk")
+  end
+
+  defp refuse_if_sources_missing(%Plan{sources: sources} = plan) do
+    case Enum.reject(sources, & &1.exists?) do
+      [] ->
+        plan
+
+      missing ->
+        problem(
+          plan,
+          "#{length(missing)} of #{length(sources)} source file(s) are not on disk: " <>
+            (missing |> Enum.take(3) |> Enum.map_join(", ", & &1.path))
+        )
+    end
+  end
+
+  # Skipped when the files aren't all there — probing what is present would
+  # produce a total that is short for a known reason and read like a mismatch.
+  defp check_duration(%Plan{problems: [_ | _]} = plan, _media), do: plan
+
+  defp check_duration(plan, media) do
+    stored = media.duration && seconds(media.duration)
+    tolerance = tolerance(length(plan.sources))
+
+    case probe_total(plan.sources) do
+      {:ok, probed} ->
+        drift = stored && probed - stored
+
+        plan = %{
+          plan
+          | stored_duration: stored,
+            probed_duration: probed,
+            drift: drift,
+            tolerance: tolerance
+        }
+
+        cond do
+          is_nil(stored) ->
+            problem(plan, "no stored duration to check the sources against")
+
+          abs(drift) > tolerance ->
+            problem(
+              plan,
+              "sources total #{fmt(probed)} against a stored #{fmt(stored)} " <>
+                "(#{fmt(drift, :signed)}, tolerance #{fmt(tolerance)}) — " <>
+                "the file at the recorded path may not be the file that was transcoded"
+            )
+
+          true ->
+            plan
+        end
+
+      {:error, reason} ->
+        problem(%{plan | tolerance: tolerance}, "couldn't probe the sources: #{inspect(reason)}")
+    end
+  end
+
+  # Probed durations are `Decimal`, as is the stored one; both become floats
+  # here because the comparison is a tolerance in seconds, not an exactness
+  # question, and a float round-trips a real duration exactly.
+  defp probe_total(sources) do
+    sources
+    |> Enum.map(& &1.path)
+    |> Scanner.probe_all()
+    |> case do
+      {:ok, probes} -> {:ok, Enum.reduce(probes, 0.0, &(seconds(&1.duration) + &2))}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp seconds(%Decimal{} = d), do: Decimal.to_float(d)
+  defp seconds(n) when is_number(n), do: n / 1
+
+  @doc """
+  The duration tolerance for a recording of `count` files, in seconds.
+
+  Exposed because it is the number an operator will want to argue with.
+  """
+  def tolerance(count) when count <= 1, do: @minimum_tolerance_seconds
+
+  def tolerance(count) do
+    max(
+      @minimum_tolerance_seconds,
+      (count - 1) * @drift_per_boundary_ms * @drift_headroom / 1000
+    )
+  end
+
+  # ==========================================================================
+  # Where it would go
+  # ==========================================================================
+
+  # Only computed for a plan that is otherwise sound: rendering a destination
+  # for a recording that cannot be relinked invites reading it as an intention.
+  defp propose_destination(%Plan{problems: [_ | _]} = plan, _media), do: plan
+
+  defp propose_destination(plan, media) do
+    case Library.list_roots() do
+      [] ->
+        problem(plan, "no library root exists to place into")
+
+      roots ->
+        root = Enum.min_by(roots, & &1.id)
+        place_into(plan, media, root)
+    end
+  end
+
+  defp place_into(plan, media, %Root{} = root) do
+    values = Books.naming_values(media.book, media)
+
+    with {:ok, folder} <- NamingTemplate.render(Settings.library_naming_template(), values),
+         {:ok, filenames} <-
+           NamingTemplate.filenames(values, Enum.map(plan.sources, & &1.path), recording(media)),
+         {:ok, policy} <- policy(plan.sources, root) do
+      destinations = Enum.map(filenames, &Path.join([root.path, folder, &1]))
+
+      %{plan | root: root, policy: policy, destinations: destinations}
+    else
+      {:error, {:undecidable_policy, reason}} ->
+        problem(
+          %{plan | root: root},
+          "couldn't tell whether the sources and the root share a filesystem: " <>
+            "#{inspect(reason)} — the root's volume is probably not mounted"
+        )
+
+      {:error, reason} ->
+        problem(plan, "couldn't render a destination name: #{inspect(reason)}")
+    end
+  end
+
+  # Hardlink where the sources and the root share a filesystem, which is the
+  # whole point — no bytes move and the recording keeps its second name only
+  # until the artifact goes. Otherwise this is a move, and a move deletes: the
+  # plan says so rather than quietly proposing it, because the two have very
+  # different consequences if the relink turns out to be wrong.
+  #
+  # **`hardlinkable?/2` answers `{:ok, boolean}` or `{:error, reason}` despite
+  # the name**, and the error is what an unmounted root looks like —
+  # `Library.device/1` is deliberately strict about the path existing, because
+  # walking up to an existing ancestor would report the OS disk's device for a
+  # path on an unmounted volume. Treating that tuple as a truthy boolean
+  # proposes a hardlink for a destination nothing can even stat, which is the
+  # oldest rule here: a call that failed and a call that found nothing must
+  # never look the same. So it refuses instead.
+  defp policy([%{path: path} | _], %Root{path: root_path}) do
+    case Placement.hardlinkable?(path, root_path) do
+      {:ok, true} -> {:ok, :hardlink}
+      {:ok, false} -> {:ok, :move}
+      {:error, reason} -> {:error, {:undecidable_policy, reason}}
+    end
+  end
+
+  defp policy([], _root), do: {:ok, nil}
+
+  defp recording(media) do
+    %{part: part(media), token: Media.filename_token(media)}
+  end
+
+  defp part(%Media{part_number: nil}), do: nil
+
+  defp part(%Media{part_number: number, recording_group: group}) do
+    %{number: number, total: group && group.parts_total, word: group && group.part_word}
+  end
+
+  # ==========================================================================
+  # Plumbing
+  # ==========================================================================
+
+  defp preload_for_plan(media) do
+    Repo.preload(
+      media,
+      [
+        :library_root,
+        :recording_group,
+        {:media_narrators, :narrator},
+        {:book, [{:book_authors, :author}, {:series_books, :series}]}
+      ],
+      force: true
+    )
+  end
+
+  defp title(%Media{book: book} = media) when not is_nil(book), do: Media.display_title(media)
+  defp title(%Media{}), do: "(no book)"
+
+  defp problem(plan, message), do: %{plan | problems: plan.problems ++ [message]}
+
+  defp settle_verdict(%Plan{problems: []} = plan), do: %{plan | verdict: :ok}
+  defp settle_verdict(plan), do: %{plan | verdict: :refused}
+
+  defp fmt(seconds, :signed) when is_number(seconds),
+    do: "#{if seconds >= 0, do: "+"}#{Float.round(seconds / 1, 2)}s"
+
+  defp fmt(nil), do: "unknown"
+  defp fmt(seconds), do: "#{Float.round(seconds / 1, 2)}s"
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ambry.MixProject do
   def project do
     [
       app: :ambry,
-      version: "2.1.0",
+      version: "2.2.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary, :phoenix_live_view] ++ Mix.compilers(),

--- a/test/ambry/library/naming_template_test.exs
+++ b/test/ambry/library/naming_template_test.exs
@@ -128,6 +128,22 @@ defmodule Ambry.Library.NamingTemplateTest do
                NamingTemplate.filename(@book, "/downloads/x/BOOK.MP3")
     end
 
+    # One container, three extensions saying what a player should expect
+    # inside. A root holds nothing but audiobook audio, so `.m4b` is the true
+    # one — and the one other audiobook software keys its behaviour off.
+    test "names audio MPEG-4 as the audiobook it is" do
+      assert {:ok, "The Way of Kings.m4b"} = NamingTemplate.filename(@book, "x/book.mp4")
+      assert {:ok, "The Way of Kings.m4b"} = NamingTemplate.filename(@book, "x/book.m4a")
+      assert {:ok, "The Way of Kings.m4b"} = NamingTemplate.filename(@book, "x/BOOK.MP4")
+    end
+
+    # Renaming these would be a lie rather than a tidy-up.
+    test "leaves every other format's extension alone" do
+      assert {:ok, "The Way of Kings.mp3"} = NamingTemplate.filename(@book, "x/book.mp3")
+      assert {:ok, "The Way of Kings.flac"} = NamingTemplate.filename(@book, "x/book.flac")
+      assert {:ok, "The Way of Kings.opus"} = NamingTemplate.filename(@book, "x/book.opus")
+    end
+
     test "sanitizes the title" do
       assert {:ok, "ACDC Live.m4b"} =
                NamingTemplate.filename(%{@book | title: "AC/DC Live"}, "a.m4b")
@@ -209,10 +225,18 @@ defmodule Ambry.Library.NamingTemplateTest do
 
     test "keeps each file's own extension" do
       assert {:ok, [first, second]} =
-               NamingTemplate.filenames(@book, ["/x/a.MP3", "/x/b.m4a"])
+               NamingTemplate.filenames(@book, ["/x/a.MP3", "/x/b.flac"])
 
       assert first =~ ".mp3"
-      assert second =~ ".m4a"
+      assert second =~ ".flac"
+    end
+
+    test "names audio MPEG-4 as the audiobook it is, file by file" do
+      assert {:ok, [first, second]} =
+               NamingTemplate.filenames(@book, ["/x/a.mp4", "/x/b.m4a"])
+
+      assert first =~ ".m4b"
+      assert second =~ ".m4b"
     end
 
     test "a part of a set takes its suffix into the subfolder name too" do

--- a/test/ambry/media/relink_test.exs
+++ b/test/ambry/media/relink_test.exs
@@ -1,0 +1,198 @@
+defmodule Ambry.Media.RelinkTest do
+  use Ambry.DataCase
+
+  alias Ambry.Media
+  alias Ambry.Media.Relink
+  alias Ambry.Media.Scanner
+
+  # Every plan that gets as far as proposing a destination needs a root that
+  # actually exists on disk — the filesystem question is asked of the real
+  # path, deliberately, so a fabricated one cannot answer it.
+  setup do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "ambry_test_files/relink-root-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(path)
+    on_exit(fn -> File.rm_rf!(path) end)
+
+    %{root: insert(:root, path: path)}
+  end
+
+  describe "plan/1 — finding the sources" do
+    test "uses the recorded list when a recording has one" do
+      media = legacy_media(:m4a, 2)
+
+      plan = Relink.plan(media)
+
+      assert plan.era == :recorded_list
+      assert length(plan.sources) == 2
+      assert Enum.all?(plan.sources, & &1.exists?)
+    end
+
+    # The 233 web-upload-era recordings have neither column, and their file
+    # list only exists as whatever is sitting in the folder.
+    test "falls back to listing the folder when nothing was recorded" do
+      media = legacy_media(:m4a, 2)
+      {:ok, media} = media |> Ecto.Changeset.change(%{source_files: []}) |> Repo.update()
+
+      plan = Relink.plan(Media.get_media!(media.id))
+
+      assert plan.era == :web_upload
+      assert length(plan.sources) == 2
+      assert plan.verdict == :ok
+    end
+
+    test "refuses a recording whose files are gone" do
+      media = legacy_media(:m4a, 1)
+      media.source_files |> Enum.map(&Ambry.Paths.web_to_disk/1) |> Enum.each(&File.rm!/1)
+
+      plan = Relink.plan(Media.get_media!(media.id))
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "not on disk"))
+    end
+
+    test "refuses a recording that already has tracks" do
+      media = legacy_media(:m4a, 1)
+      {:ok, _scanned} = Scanner.scan(media)
+
+      plan = Relink.plan(Media.get_media!(media.id))
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "already has 1 track"))
+    end
+  end
+
+  describe "plan/1 — the duration gate" do
+    test "accepts sources that agree with the stored duration" do
+      media = legacy_media(:m4a, 1)
+
+      plan = Relink.plan(media)
+
+      assert plan.verdict == :ok
+      assert_in_delta plan.drift, 0.0, 0.1
+    end
+
+    # The case this whole gate exists for: the recorded path still resolves,
+    # but the file at it is not the one that was transcoded. Measured in
+    # production as a source replaced in place by a corrected re-download.
+    test "refuses when the file at the path is not the file that was transcoded" do
+      media = legacy_media(:m4a, 1)
+
+      {:ok, media} =
+        media |> Ecto.Changeset.change(%{duration: Decimal.new("9999.0")}) |> Repo.update()
+
+      plan = Relink.plan(Media.get_media!(media.id))
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "may not be the file that was transcoded"))
+    end
+
+    test "refuses a recording with no stored duration to check against" do
+      media = legacy_media(:m4a, 1)
+      {:ok, media} = media |> Ecto.Changeset.change(%{duration: nil}) |> Repo.update()
+
+      plan = Relink.plan(Media.get_media!(media.id))
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "no stored duration"))
+    end
+  end
+
+  describe "tolerance/1" do
+    # ffmpeg's concat accumulates ~65ms of mp3 frame padding per boundary, so
+    # the window has to grow with the file count. A flat number wide enough
+    # for a 63-file recording would wave through a wrong single file.
+    test "is a floor for a single file" do
+      assert Relink.tolerance(1) == 2.0
+    end
+
+    test "grows with the number of file boundaries" do
+      assert Relink.tolerance(63) > 6.0
+      assert Relink.tolerance(63) > Relink.tolerance(42)
+      assert Relink.tolerance(42) > Relink.tolerance(10)
+    end
+
+    test "never drops below the floor for small counts" do
+      assert Relink.tolerance(2) == 2.0
+    end
+  end
+
+  describe "plan/1 — the destination" do
+    test "refuses when there is no library root to place into" do
+      Repo.delete_all(Ambry.Library.Root)
+      media = legacy_media(:m4a, 1)
+
+      plan = Relink.plan(media)
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "no library root"))
+    end
+
+    test "proposes a destination under the root, named by the template", %{root: root} do
+      media = legacy_media(:m4a, 1)
+
+      plan = Relink.plan(media)
+
+      assert plan.verdict == :ok
+      assert plan.root.id == root.id
+      assert [destination] = plan.destinations
+      assert String.starts_with?(destination, root.path)
+      # the per-recording token is what keeps two readings of one book apart
+      assert destination =~ Media.Media.filename_token(media)
+    end
+
+    # `hardlinkable?/2` answers `{:ok, boolean} | {:error, reason}` despite its
+    # name, and an unmounted root is the error. Treated as a plain boolean the
+    # tuple is truthy, so a destination nothing can even stat proposes a
+    # hardlink — a failure and an answer looking alike, which is the oldest
+    # rule here. Caught by spot-checking against a restored production copy.
+    test "refuses rather than guessing when the root cannot be stat'd" do
+      Repo.delete_all(Ambry.Library.Root)
+      insert(:root, path: "/nonexistent/unmounted/root")
+      media = legacy_media(:m4a, 1)
+
+      plan = Relink.plan(media)
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "share a filesystem"))
+      refute plan.policy
+    end
+  end
+
+  describe "candidates/0" do
+    test "lists recordings without tracks and skips those with them" do
+      legacy = legacy_media(:m4a, 1)
+      direct_play = legacy_media(:m4a, 1)
+      {:ok, _} = Scanner.scan(direct_play)
+
+      ids = Enum.map(Relink.candidates(), & &1.id)
+
+      assert legacy.id in ids
+      refute direct_play.id in ids
+    end
+  end
+
+  defp legacy_media(type, count) do
+    :media
+    |> build(book: build(:book))
+    |> with_copied_source_files(type, count)
+    |> insert()
+    |> then(&Media.get_media!(&1.id))
+    |> give_it_the_transcode_duration()
+  end
+
+  # A legacy recording's stored duration came from its transcode, which is
+  # what the gate compares against. Scanning to learn it and then throwing the
+  # tracks away is the only way to get a fixture whose stored duration is
+  # honestly derived from its files.
+  defp give_it_the_transcode_duration(media) do
+    {:ok, scanned} = Scanner.scan(media)
+    Repo.delete_all(from(t in Media.MediaTrack, where: t.media_id == ^media.id))
+
+    Media.get_media!(scanned.id)
+  end
+end


### PR DESCRIPTION
First slice of the back-catalogue reclaim: the read-only half.

`Ambry.Media.Relink.plan/1` works out what relinking a legacy recording would
do — which files it came from, whether they are still on disk, whether they
are still *the same* files, and where they would be placed — and **writes
nothing**, so it is safe to point at production and read the answer.

```
[243] Wild: From Lost to Found on the Pacific Crest Trail
   era=web_upload files=11 verdict=ok
   stored=46952.39s probed=46952.39s drift=-0.001s tol=2.0s
   -> Cheryl Strayed/Wild … (2012)/Wild … [087]/Wild … - 001.mp3
```

## Surveyed against a restored copy of production

**435 of 435 recoverable recordings agree with their stored duration.** The
only refusals are the two whose source files are genuinely gone. 53 minutes,
~14s per recording, nearly all of it decode-counting VBR mp3s — which is why
`survey/0`'s doc says to start it and walk away, and why a version of this
that runs in a LiveView has to be an Oban job.

Multi-file mp3 sets drift by a consistent ~65ms per file boundary (63 files →
−4.10s, 28 → −1.72s), every one at roughly two-thirds of its tolerance. That
drift is the *transcode* being imprecise, not the sources.

## Two things the spot-check caught

**A truthy error tuple.** `Placement.hardlinkable?/2` returns
`{:ok, boolean} | {:error, reason}` despite the name, and an unmounted root is
the error. Treated as a boolean, the tuple is truthy — so a destination
nothing could stat proposed a *hardlink*. Only visible because the restored
copy's library root pointed at a directory that no longer existed; a fixture
would have had a real one.

**Two "anomalies" that were measurement error.** An earlier census using
`ffprobe -show_entries format=duration` reported two mismatched recordings.
Both agree exactly under `Scanner.Probe`, which decode-counts VBR mp3s the way
the transcode did — one of them to six decimal places. The claimed duration of
a VBR mp3 is not a measurement.

## Also: audio MPEG-4 is named `.m4b`

`.mp4`, `.m4a` and `.m4b` are one container — verified on two files in this
library that are byte-identical with the same `ftyp=isom`, differing only in
extension. A library root holds nothing but audiobook audio, so `.m4b` is the
honest name and the one other audiobook software keys its behaviour off. Every
other format keeps its extension.

Landing it now costs nothing: the library root holds only `.mp3` and `.m4b`
today, so it renames zero files. After the reclaim it would have been 32.

## Not in this PR, deliberately

Deletion still reads `source_path` rather than `media_tracks`. That change has
to come before anything actually relinks — a relinked recording will not set
`library_root_id` at all (the `media_legacy_source_files_quarantined` CHECK
forbids carrying both provenance and a placement), so its library files would
otherwise have nothing that knows to clean them up. It touches deletion
semantics and deserves its own PR.

`mix check` clean, 1719 tests passing with `--warnings-as-errors`.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ
