### PR TITLE
Delete the files a recording's tracks name, and never a folder

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -402,11 +402,17 @@ defmodule Ambry.Media do
 
   """
   def delete_media(%Media{} = media) do
+    # Worked out *before* the delete: `media_tracks` cascades on
+    # `on_delete: :delete_all`, so by the time the row is gone the record of
+    # what this recording owned on disk is gone with it — and deletion would
+    # silently fall through to whatever `source_path` happens to say.
+    deletions = source_deletions(media)
+
     Repo.transact(fn ->
       with {:ok, deleted_media} <- Repo.delete(media),
            :ok <- delete_orphaned_recording_group(media.recording_group_id),
            :ok <- Search.delete(deleted_media),
-           {:ok, _job} <- delete_all_files_async(deleted_media),
+           {:ok, _job} <- delete_all_files_async(deleted_media, deletions),
            {:ok, _job} <- broadcast_media_deleted(deleted_media) do
         {:ok, deleted_media}
       end
@@ -419,11 +425,12 @@ defmodule Ambry.Media do
     |> PubSub.broadcast_async()
   end
 
-  defp delete_all_files_async(%Media{} = media) do
-    {folders, own_files} = source_deletions(media)
+  defp delete_all_files_async(%Media{} = media, deletions) do
+    %{folders: folders, files: files, prune_from: prune_from} = deletions
 
-    try_delete_files_async(all_file_paths(media) ++ own_files, folders,
-      prune_until: if(folders != [], do: library_root_paths())
+    try_delete_files_async(all_file_paths(media) ++ files, folders,
+      prune_until: if(folders != [] or prune_from != [], do: library_root_paths()),
+      prune_from: prune_from
     )
   end
 
@@ -442,24 +449,76 @@ defmodule Ambry.Media do
   # for the same inode, a symlink is unlinked without being followed, a
   # copy never knew its original, and a move's original is already gone.
   #
-  # This is still worth care: the deletion worker runs `File.rm_rf` on
-  # every folder it's given, so `source_path` must always be a folder that
-  # is Ambry's to remove.
-  #
   # Transcoded outputs, images and thumbnails are always Ambry's own, under
   # the uploads path, so they're removed too.
-  # A folder shared with a sibling is not this media's to remove: a
-  # multi-part recording places every part in one book folder, so deleting
-  # part 1 with an rm_rf of `source_path` would take part 2's file with it.
-  # A shared folder yields only the media's own files; the folder itself
-  # goes with its last part.
-  defp source_deletions(%Media{source_path: path} = media) when is_binary(path) do
-    if shared_source_path?(media),
-      do: {[], Media.source_file_paths(media)},
-      else: {[Media.source_path(media)], []}
+  #
+  # ## A recording with tracks deletes files, never folders
+  #
+  # `media_tracks` names every file the recording is served from, so those
+  # are exactly what deletion removes — one `File.rm/1` each, and nothing
+  # else. No folder is handed to `rm_rf` at all.
+  #
+  # The point is not that a folder might hold something foreign — a root is
+  # Ambry's, and nothing else writes there. It is that a folder deletion has
+  # to be *right*, and a file deletion cannot be wrong. A book folder really
+  # is shared: every recording of that book sits in it, and a single-file
+  # recording sits in it directly. Removing only the files you own makes "is
+  # this folder shared", "does another part of the set live here" and "is
+  # this somehow the library root itself" stop being questions. An earlier
+  # draft of this answered all three, and getting them right was harder than
+  # not asking.
+  #
+  # What it leaves behind is empty folders, which is a tidiness problem
+  # rather than a correctness one, and pruning already solves it: after the
+  # files go, walk up from where they were removing folders that are now
+  # empty, stopping at a registered root.
+  #
+  # `source_path` is the fallback, and only for a recording with no tracks.
+  # There it still means what it first meant — the upload workspace Ambry
+  # created, which holds more than the audio (progress files, the `_out`
+  # folder) and genuinely is Ambry's to remove wholesale. That clause, and
+  # the last `rm_rf` with it, retires when the reclaim leaves nothing
+  # without tracks.
+  defp source_deletions(%Media{} = media) do
+    case owned_tracks(media) do
+      [] -> legacy_source_deletions(media)
+      tracks -> track_deletions(tracks)
+    end
   end
 
-  defp source_deletions(%Media{}), do: {[], []}
+  # Asked of the database rather than a preload, and *before* the row is
+  # deleted: `media_tracks` cascades on `on_delete: :delete_all`, so asking
+  # afterwards returns an empty list and falls silently through to the legacy
+  # clause. An unloaded assoc reads the same way. One cheap query is the
+  # right price for an operation that removes files.
+  defp owned_tracks(%Media{id: id}) do
+    Repo.all(from t in MediaTrack, where: t.media_id == ^id)
+  end
+
+  defp track_deletions(tracks) do
+    files = Enum.flat_map(tracks, &resolved_disk_path/1)
+    %{folders: [], files: files, prune_from: files}
+  end
+
+  defp resolved_disk_path(track) do
+    case MediaTrack.disk_path(track) do
+      {:ok, path} -> [path]
+      {:error, _reason} -> []
+    end
+  end
+
+  # A folder shared with a sibling is not this media's to remove: a
+  # multi-part recording places every part in one book folder, so deleting
+  # part 1 with an rm_rf of the folder would take part 2's file with it.
+  # A shared folder yields only the media's own files; the folder itself
+  # goes with its last part.
+  defp legacy_source_deletions(%Media{source_path: path} = media) when is_binary(path) do
+    if shared_source_path?(media),
+      do: %{folders: [], files: Media.source_file_paths(media), prune_from: []},
+      else: %{folders: [Media.source_path(media)], files: [], prune_from: []}
+  end
+
+  defp legacy_source_deletions(%Media{}), do: %{folders: [], files: [], prune_from: []}
 
   # Compared as {root, relative} rather than as strings: two roots may
   # legitimately hold the same relative path, and they are different folders.

--- a/lib/ambry/utils.ex
+++ b/lib/ambry/utils.ex
@@ -105,6 +105,7 @@ defmodule Ambry.Utils do
   def try_delete_files_async(disk_paths, folder_paths \\ [], opts \\ []) do
     %{"disk_paths" => disk_paths, "folder_paths" => folder_paths}
     |> maybe_put("prune_until", opts[:prune_until])
+    |> maybe_put("prune_from", opts[:prune_from])
     |> DeleteFiles.new()
     |> Oban.insert()
   end

--- a/lib/ambry/utils/delete_files.ex
+++ b/lib/ambry/utils/delete_files.ex
@@ -14,16 +14,20 @@ defmodule Ambry.Utils.DeleteFiles do
   def perform(%Oban.Job{args: %{"disk_paths" => disk_paths} = args}) do
     try_delete_files(disk_paths)
 
-    if Map.has_key?(args, "folder_paths") do
-      folder_paths = args["folder_paths"]
-      try_delete_folders(folder_paths)
+    folder_paths = args["folder_paths"] || []
+    try_delete_folders(folder_paths)
 
-      # Only when the caller says where to stop. Without a boundary this
-      # would happily walk up and remove a library root, whose existence is
-      # configuration rather than a consequence of holding a book.
-      if stop_paths = args["prune_until"] do
-        try_prune_empty_parents(folder_paths, stop_paths)
-      end
+    # Only when the caller says where to stop. Without a boundary this would
+    # happily walk up and remove a library root, whose existence is
+    # configuration rather than a consequence of holding a book.
+    if stop_paths = args["prune_until"] do
+      # `folder_paths` were just removed, so pruning starts above them.
+      # `prune_from` are *files* that were removed, so pruning starts at the
+      # folder each one was in — which is the whole point: a recording that
+      # deletes only its own files leaves the folder standing, and this is
+      # what clears it when nothing else is left. Both cases are the same
+      # walk, since it begins at `Path.dirname/1` of whatever it is given.
+      try_prune_empty_parents(folder_paths ++ (args["prune_from"] || []), stop_paths)
     end
 
     :ok

--- a/test/ambry/media/deletion_custody_test.exs
+++ b/test/ambry/media/deletion_custody_test.exs
@@ -136,6 +136,139 @@ defmodule Ambry.Media.DeletionCustodyTest do
     end
   end
 
+  # `media_tracks` names every file a recording is served from, so those are
+  # exactly what deletion removes — and nothing else. No folder is handed to
+  # `rm_rf` at all, which is what makes "did I just delete someone else's
+  # audio" un-askable rather than answered correctly.
+  describe "a recording with tracks" do
+    test "deletes the files its tracks name, not whatever source_path says" do
+      library = new_dir("library")
+      folder = Path.join(library, "Some Author/Some Book")
+      File.mkdir_p!(folder)
+      file = Path.join(folder, "book.m4b")
+      File.write!(file, "audio")
+
+      # The vestigial upload-era folder: still named by the column, nothing
+      # of this recording in it, and emphatically not Ambry's to remove.
+      stale = new_dir("stale-source")
+      bystander = Path.join(stale, "someone-elses.m4b")
+      File.write!(bystander, "not ours")
+
+      root = insert(:root, path: library)
+
+      media =
+        insert(:media,
+          book: build(:book),
+          source_path: Ambry.Paths.disk_to_web(stale),
+          source_files: [],
+          mpd_path: nil,
+          hls_path: nil,
+          mp4_path: nil
+        )
+
+      insert(:media_track,
+        media: media,
+        library_root_id: root.id,
+        path: "Some Author/Some Book/book.m4b"
+      )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.exists?(file)
+      assert File.read!(bystander) == "not ours"
+      assert File.dir?(stale)
+    end
+
+    # The real shared case: a book folder holds every recording of that book,
+    # and a single-file recording sits directly in it.
+    test "leaves a sibling recording's file in the folder they share" do
+      library = new_dir("library")
+      root = insert(:root, path: library)
+
+      folder = Path.join(library, "Some Book")
+      File.mkdir_p!(folder)
+      mine = Path.join(folder, "mine.m4b")
+      theirs = Path.join(folder, "theirs.m4b")
+      File.write!(mine, "audio")
+      File.write!(theirs, "sibling")
+
+      media = insert(:media, book: build(:book), mpd_path: nil, hls_path: nil, mp4_path: nil)
+      sibling = insert(:media, book: build(:book), mpd_path: nil, hls_path: nil, mp4_path: nil)
+      insert(:media_track, media: media, library_root_id: root.id, path: "Some Book/mine.m4b")
+
+      insert(:media_track,
+        media: sibling,
+        library_root_id: root.id,
+        path: "Some Book/theirs.m4b"
+      )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.exists?(mine)
+      assert File.read!(theirs) == "sibling"
+      assert File.dir?(folder)
+    end
+
+    # Tidiness, not correctness: once the files are gone the folder they were
+    # in is empty and worth clearing, walking up until something is left.
+    test "prunes the folders its files leave empty, stopping at the root" do
+      library = new_dir("library")
+      root = insert(:root, path: library)
+
+      folder = Path.join(library, "Some Author/Some Book")
+      File.mkdir_p!(folder)
+      file = Path.join(folder, "book.m4b")
+      File.write!(file, "audio")
+
+      media = insert(:media, book: build(:book), mpd_path: nil, hls_path: nil, mp4_path: nil)
+
+      insert(:media_track,
+        media: media,
+        library_root_id: root.id,
+        path: "Some Author/Some Book/book.m4b"
+      )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.dir?(folder)
+      refute File.dir?(Path.join(library, "Some Author"))
+      assert File.dir?(library)
+    end
+
+    test "stops pruning where the author still has another book" do
+      library = new_dir("library")
+      root = insert(:root, path: library)
+
+      author = Path.join(library, "Some Author")
+      keeper = Path.join([author, "Another Book", "keep.m4b"])
+      File.mkdir_p!(Path.dirname(keeper))
+      File.write!(keeper, "another book")
+
+      folder = Path.join(author, "Some Book")
+      File.mkdir_p!(folder)
+      file = Path.join(folder, "book.m4b")
+      File.write!(file, "audio")
+
+      media = insert(:media, book: build(:book), mpd_path: nil, hls_path: nil, mp4_path: nil)
+
+      insert(:media_track,
+        media: media,
+        library_root_id: root.id,
+        path: "Some Author/Some Book/book.m4b"
+      )
+
+      assert {:ok, _media} = Media.delete_media(media)
+      run_deletion_jobs()
+
+      refute File.dir?(folder)
+      assert File.exists?(keeper)
+      assert File.dir?(author)
+    end
+  end
+
   describe "replacing a recording's files" do
     # The old folder is Ambry's name for the bytes and goes with the
     # replacement, exactly like deletion.


### PR DESCRIPTION
Deletion was the last place still asking `source_path` what a recording owned.
`media_tracks` names every file it is served from, so those are exactly what
gets removed — one `File.rm/1` each, and nothing else.

## Files, not folders

A library root is Ambry's and nothing else writes there, so this isn't about
stray files. It's that a folder deletion has to be **right** and a file
deletion **cannot be wrong**. A book folder really is shared — every recording
of a book sits in it, and a single-file recording sits in it directly.

An earlier revision of this PR removed folders, and to do that safely it
needed: a `starts_with` query against sibling tracks, a same-root comparison, a
special case for tracks that disagree about their folder, and a guard against
`Path.dirname/1` returning `"."` and resolving to the library root itself —
that last one protecting against `rm -rf` on the entire library.

All four are gone. Not asking turned out to be much easier than answering
correctly.

Empty folders are left behind, which is tidiness rather than correctness, and
pruning already handles it: `try_prune_empty_parents/2` walks up from where
each file was, clearing folders that are now empty and stopping at a
registered root. The worker gains `prune_from` to point it at removed files
rather than removed folders.

## Worked out before the row is deleted

`media_tracks` cascades on `on_delete: :delete_all`, so asking after
`Repo.delete` returns an empty list and falls silently through to the legacy
clause. Read from the database rather than a preloaded assoc, since an
unloaded assoc reads as "no tracks" the same way.

## Why it has to land before anything relinks

A relinked recording **cannot** repoint `source_path` — carrying
`legacy_source_files` and a `library_root_id` together violates
`media_legacy_source_files_quarantined` (*"a recording with a real placement
has no business carrying it"*). So it will have tracks and nothing else, and
435 of them would otherwise leave library files nothing knows how to clean up.

`source_path` remains the fallback for a recording with no tracks, where it
still means what it first meant: the upload workspace Ambry created, which
holds more than the audio and genuinely is Ambry's to remove wholesale. That
clause, and the last `rm_rf`, retire with the reclaim.

`mix check` clean, 1723 tests passing with `--warnings-as-errors`.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ