### PR TITLE
Relink copies across a filesystem boundary rather than moving

### DIFF
--- a/lib/ambry/media/relink.ex
+++ b/lib/ambry/media/relink.ex
@@ -360,10 +360,25 @@ defmodule Ambry.Media.Relink do
   end
 
   # Hardlink where the sources and the root share a filesystem, which is the
-  # whole point — no bytes move and the recording keeps its second name only
-  # until the artifact goes. Otherwise this is a move, and a move deletes: the
-  # plan says so rather than quietly proposing it, because the two have very
-  # different consequences if the relink turns out to be wrong.
+  # whole point — no bytes move, and the recording simply gains a second name
+  # for them.
+  #
+  # Otherwise **copy, deliberately, and not move**. A move is place-then-delete
+  # and the delete is what makes a relink one-way: the upload-era originals in
+  # `source_media` are the only copy those recordings have.
+  #
+  # Note what the two policies actually differ on. The destination gains the
+  # same bytes either way — the copy has to land there regardless — so its free
+  # space says nothing about which to pick. The *only* difference is whether
+  # the originals on the other NAS are deleted now or later, and deleting them
+  # now buys back space on a volume that is not short of it while spending the
+  # last copy before anything has been heard.
+  #
+  # So the reclaim happens in two deliberate acts. This one adds a copy and is
+  # reversible by deleting it. Emptying `source_media` is a later pass over
+  # recordings that have already been verified playing, and it is the one that
+  # cannot be undone — which is exactly why it should not be a side effect of
+  # this one.
   #
   # **`hardlinkable?/2` answers `{:ok, boolean}` or `{:error, reason}` despite
   # the name**, and the error is what an unmounted root looks like —
@@ -376,7 +391,7 @@ defmodule Ambry.Media.Relink do
   defp policy([%{path: path} | _], %Root{path: root_path}) do
     case Placement.hardlinkable?(path, root_path) do
       {:ok, true} -> {:ok, :hardlink}
-      {:ok, false} -> {:ok, :move}
+      {:ok, false} -> {:ok, :copy}
       {:error, reason} -> {:error, {:undecidable_policy, reason}}
     end
   end

--- a/test/ambry/media/relink_test.exs
+++ b/test/ambry/media/relink_test.exs
@@ -141,6 +141,11 @@ defmodule Ambry.Media.RelinkTest do
       assert plan.root.id == root.id
       assert [destination] = plan.destinations
       assert String.starts_with?(destination, root.path)
+      # Fixtures and the test root share a filesystem, so this is the
+      # hardlink branch. The other one is a copy, never a move: the delete
+      # half of a move is what would make a relink one-way, and the
+      # upload-era originals are the only copy there is.
+      assert plan.policy == :hardlink
       # the per-recording token is what keeps two readings of one book apart
       assert destination =~ Media.Media.filename_token(media)
     end


### PR DESCRIPTION
A move is place-then-delete, and that delete makes a relink one-way. The
upload-era recordings whose sources sit in `source_media` have **no other
copy**, so proposing a move spends the only safety net there is at the moment
the relink runs — before anyone has listened to a single relinked recording.

## What the two policies actually differ on

Worth being precise, because it's easy to cite the wrong number.

**nasoftheseus** (`/data`, receiving the placement) gains the same ~102G under
either policy — the copy has to land there regardless. Its free space answers
"can the destination hold the library", not "which policy".

The only real difference is on **lochnasmonster** (`/app/uploads`), where the
originals live: a move frees ~102G there now, a copy defers it. With 1.1T free
there, that deferred gain is worth nothing urgent — while the deletion spends
the last copy of 233 recordings before any of them has been heard.

## Two deliberate acts

- **this one** adds a copy, and is undone by deleting it
- **emptying `source_media`** is a later pass over recordings already verified
  playing — the one that cannot be undone, which is exactly why it shouldn't
  be a side effect of the one that can

Recordings already sharing a filesystem with the root are unaffected: they
hardlink, no bytes move, and there was never a delete to defer.

Dry run against production — the server-import era is untouched, the upload
era changes verb:

```
[372] Tiamat's Wrath   server_import  hardlink  (no bytes copied)
[231] Summer Frost     web_upload     copy      (was: copy then delete source)
```

`mix check` clean, 1723 tests passing.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ