### PR TITLE
Withhold a recording's tracks while it still serves its artifacts

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -122,6 +122,68 @@ defmodule Ambry.Media do
   end
 
   @doc """
+  The tracks a client may be told about, changed since `since`.
+
+  Sync's answer for `media_tracks`, and deliberately not a plain
+  `Sync.changes_since/2`: a recording is only *served* through its tracks once
+  it has no legacy artifacts left, and until then handing them out offers
+  clients a second, contradictory way to play it.
+
+  ## Why the legacy trio, and not the publishing predicate
+
+  "Is this recording served as tracks yet" is exactly "are `mp4_path`,
+  `mpd_path` and `hls_path` all null" — the trio is the packaged artifact, and
+  its absence is what makes the tracks the only way in.
+
+  The publishing gate looks similar and answers a different question. It keys
+  on `status == :pending`, which is true of a recording waiting to be
+  published for the first time and false of a back-catalogue recording that
+  has been `:ready` for years and stays that way through a relink. Using it
+  here would withhold nothing from exactly the recordings this exists for.
+
+  ## What it buys
+
+  Relinking the back catalogue (`Ambry.Media.Relink`) writes tracks for a
+  recording that is still serving its artifacts, and every client syncs every
+  track row that exists on its next sync. A 2c-era app branches on
+  `mediaTracks.length > 0` before it looks at anything else, so tracks
+  arriving early make it abandon a download it already holds and stream
+  instead — silently, while still calling the recording downloaded.
+
+  With this filter the relink is invisible: tracks accumulate server-side and
+  reach clients at the moment the artifacts are cleared, which is the moment
+  they became the truth.
+
+  ## "Changed" includes "became visible"
+
+  A withheld track's `updated_at` is the day it was scanned, which may be
+  months before the recording stopped serving artifacts. Filtering on it alone
+  would reveal the tracks to nobody: the reveal is a change to the *media*
+  row, not to the tracks.
+
+  So a track is returned when either row changed since — which makes the
+  reveal true by construction rather than by remembering to touch every track
+  when the artifacts are cleared. It costs re-sending a recording's tracks
+  whenever the recording itself is edited, and a track upsert is idempotent.
+  """
+  def tracks_changed_since(since) do
+    query =
+      from t in MediaTrack,
+        join: m in Media,
+        on: m.id == t.media_id,
+        where: is_nil(m.mp4_path) and is_nil(m.hls_path) and is_nil(m.mpd_path)
+
+    query =
+      if since do
+        from [t, m] in query, where: t.updated_at >= ^since or m.updated_at >= ^since
+      else
+        query
+      end
+
+    {:ok, Repo.all(query)}
+  end
+
+  @doc """
   Returns a limited list of media and whether or not there are more.
 
   By default, it will limit to the first 10 results. Supply `offset` and `limit`

--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -14,6 +14,7 @@ defmodule AmbrySchema.Resolvers do
   alias Ambry.Books.Universe
   alias Ambry.Deletions.Deletion
   alias Ambry.Hashids
+  alias Ambry.Media, as: MediaContext
   alias Ambry.Media.Media
   alias Ambry.Media.MediaNarrator
   alias Ambry.Media.MediaTrack
@@ -108,8 +109,11 @@ defmodule AmbrySchema.Resolvers do
   def media_narrators_changed_since(args, _resolution),
     do: Sync.changes_since(MediaNarrator, args[:since])
 
+  # Not a plain projection like its neighbours: a recording still serving its
+  # packaged artifacts has no business handing clients tracks. See
+  # `Ambry.Media.tracks_changed_since/1`.
   def media_tracks_changed_since(args, _resolution),
-    do: Sync.changes_since(MediaTrack, args[:since])
+    do: MediaContext.tracks_changed_since(args[:since])
 
   def recording_groups_changed_since(args, _resolution),
     do: Sync.changes_since(RecordingGroup, args[:since])

--- a/test/ambry_schema/sync_test.exs
+++ b/test/ambry_schema/sync_test.exs
@@ -225,6 +225,80 @@ defmodule AmbrySchema.SyncTest do
     end
   end
 
+  describe "mediaTracksChangedSince" do
+    @query ~G"""
+    query Sync($since: DateTime) {
+      mediaTracksChangedSince(since: $since) {
+        index
+        path
+      }
+    }
+    """
+    test "returns the tracks of a recording that is served by them", %{conn: conn} do
+      media = insert(:media, book: build(:book))
+      insert(:media_track, media: media, index: 0)
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{"data" => %{"mediaTracksChangedSince" => [%{"index" => 0}]}} =
+               json_response(conn, 200)
+    end
+
+    test "withholds them while the recording still serves its artifacts", %{conn: conn} do
+      media =
+        insert(:media,
+          book: build(:book),
+          mp4_path: "/uploads/media/#{Ecto.UUID.generate()}.mp4",
+          mpd_path: "/uploads/media/#{Ecto.UUID.generate()}.mpd",
+          hls_path: "/uploads/media/#{Ecto.UUID.generate()}.m3u8"
+        )
+
+      insert(:media_track, media: media, index: 0)
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => %{}})
+
+      assert %{"data" => %{"mediaTracksChangedSince" => []}} = json_response(conn, 200)
+    end
+
+    # The reveal is a change to the media row; the tracks were written months
+    # earlier and their own timestamps say so. A client that has synced since
+    # then still has to be told about them.
+    test "hands them over when the artifacts are cleared, however old they are", %{conn: conn} do
+      media =
+        insert(:media,
+          book: build(:book),
+          status: :ready,
+          mp4_path: "/uploads/media/#{Ecto.UUID.generate()}.mp4",
+          mpd_path: "/uploads/media/#{Ecto.UUID.generate()}.mpd",
+          hls_path: "/uploads/media/#{Ecto.UUID.generate()}.m3u8"
+        )
+
+      insert(:media_track,
+        media: media,
+        index: 0,
+        inserted_at: ~U[2020-01-01 00:00:00Z],
+        updated_at: ~U[2020-01-01 00:00:00Z]
+      )
+
+      since = %{"since" => "2024-01-01T00:00:00Z"}
+
+      conn = post(conn, "/gql", %{"query" => @query, "variables" => since})
+
+      assert %{"data" => %{"mediaTracksChangedSince" => []}} = json_response(conn, 200)
+
+      {:ok, _media} =
+        media
+        |> Ambry.Repo.preload(:media_tracks)
+        |> Ambry.Media.update_media(%{mp4_path: nil, mpd_path: nil, hls_path: nil})
+
+      conn =
+        post(build_conn_with_same_auth(conn), "/gql", %{"query" => @query, "variables" => since})
+
+      assert %{"data" => %{"mediaTracksChangedSince" => [%{"index" => 0}]}} =
+               json_response(conn, 200)
+    end
+  end
+
   defp build_conn_with_same_auth(conn) do
     auth_header = Plug.Conn.get_req_header(conn, "authorization")
 


### PR DESCRIPTION
`mediaTracksChangedSince` was `Sync.changes_since(MediaTrack, since)` with no
filter at all -- not on status, not on the direct-play switch. Every track row
that exists reaches every client on its next sync.

That is dormant today only because no legacy recording has tracks yet. It fires
on the *first* back-catalogue relink, and the client it fires at is the one
already in people's hands: a 2c app branches on `mediaTracks.length > 0` before
it looks at the download, and a legacy download row has `files = null` because
it predates the column. So every track misses its local copy, the recording
streams, the download row stays, and the downloads screen still lists it as
downloaded. Nothing breaks and nothing is deleted -- it just quietly burns
bandwidth, which for family and friends on metered connections is the failure
you find out about last.

## The predicate

"Is this recording served as tracks yet" is exactly "are `mp4_path`, `mpd_path`
and `hls_path` all null". The trio is the packaged artifact; its absence is
what makes the tracks the only way in.

Not `publish_pending_direct_play/0`'s predicate, which looks similar and
answers a different question: it keys on `status == :pending`, and a relinked
back-catalogue recording is `:ready` already and stays that way. It would
withhold nothing from exactly the recordings this exists for.

## "Changed" has to include "became visible"

A withheld track's `updated_at` is the day it was scanned, which can be months
before the recording stopped serving artifacts. Filtering on it alone would
reveal the tracks to nobody -- the reveal is a change to the *media* row.

So a track is returned when either row changed since. That makes the reveal
true by construction rather than by remembering to touch 400-odd tracks at
whatever point the artifacts are cleared. It costs re-sending a recording's
tracks whenever the recording is edited, and a track upsert is idempotent.

## What it buys the reclaim

Relinking becomes invisible to the fleet: tracks accumulate server-side, every
download keeps working, and nothing about playback changes. Clearing the legacy
paths is the reveal, and it is a separate, later, per-batch act. The mobile
stale-download fix (mobile #86) gates *that* step, not this one -- so the whole
relink phase can proceed while the app release makes its way through TestFlight
and the Play track.

Scoped to the sync feed rather than the `Media.tracks` field: sync is a
projection that writes into every client's local database, while the node field
is a direct question asked and answered on the spot, and no client selects it.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ