### PR TITLE
Relink a legacy recording, for real this time

### DIFF
--- a/lib/ambry/media/relink.ex
+++ b/lib/ambry/media/relink.ex
@@ -1,15 +1,26 @@
 defmodule Ambry.Media.Relink do
   @moduledoc """
-  Working out what upgrading a legacy recording to direct play would do.
+  Upgrading a legacy recording to direct play.
 
   A recording imported before direct play existed was transcoded: its audio
   lives twice on disk, once as the files it came from and once as the packaged
   artifact Ambry serves. Relinking points the recording at the originals —
   placed into a library root and scanned into tracks — so the artifact can go.
 
-  **This module only plans. It writes nothing**, which is what makes it safe to
-  run against production before anything else exists, one recording at a time,
-  and read the answer.
+  Two halves, and the split is the safety property:
+
+    * **`plan/1` writes nothing.** Safe to point at production before anything
+      else exists, one recording at a time, and read the answer.
+    * **`relink/1` does it**, and only ever for a plan that came back `:ok`,
+      re-measured immediately beforehand.
+
+  Even the doing half adds rather than replaces. Nothing is deleted, nothing
+  is published, the artifacts stay, and the recording goes on being served
+  exactly as it was — so a relink is undone by deleting what it placed. The
+  irreversible half of the reclaim (emptying the old sources, clearing the
+  legacy paths, deleting 246G of artifacts) is a separate later pass over
+  recordings that have been verified playing, and it should never be a side
+  effect of the reversible one.
 
   ## Why a plan is a separate thing from doing it
 
@@ -84,6 +95,7 @@ defmodule Ambry.Media.Relink do
   alias Ambry.Library.Root
   alias Ambry.Media.Media
   alias Ambry.Media.MediaTrack
+  alias Ambry.Media.Processor.Shared
   alias Ambry.Media.Scanner
   alias Ambry.Repo
   alias Ambry.Settings
@@ -192,6 +204,158 @@ defmodule Ambry.Media.Relink do
   end
 
   # ==========================================================================
+  # Doing it
+  # ==========================================================================
+
+  @doc """
+  Relinks one recording. **This writes**, unlike everything above it.
+
+  Places the recording's sources into the library root, points the recording
+  at the placed copies, and scans them into tracks. Returns
+  `{:ok, media, plan}` with the scanned recording and the plan it acted on,
+  `{:error, %Plan{}}` when the plan refuses, or `{:error, reason}` when a step
+  failed.
+
+  The plan comes back because it is the record of what was done and why — which
+  files, which policy, what the durations said — and a batch that relinks four
+  hundred recordings has nothing else to write down.
+
+  ## What it deliberately does not do
+
+  **Nothing is deleted and nothing is published.** The recording keeps its
+  `mp4_path`/`mpd_path`/`hls_path` and its status, so it goes on being served
+  exactly as before — the artifacts are retired in a separate, later pass over
+  recordings that have been verified playing, and clients are not told about
+  the new tracks until that pass clears the trio (`tracks_changed_since/1`).
+
+  The source files are left alone too. The policy the plan chose is `:hardlink`
+  or `:copy` and neither has anything to finalize, which is the point: this
+  half of the reclaim adds a name or a copy, and is undone by deleting it.
+  `Placement.finalize/1` is not called, because the only thing it would ever do
+  is the `:move` delete, and a delete that destroys the last copy of a
+  recording on the old NAS needs more confidence than "the transaction
+  committed".
+
+  ## Why it re-plans instead of taking a plan
+
+  A plan is a measurement of the world at a moment, and the world here is a
+  live downloads folder. Executing a plan made an hour ago — or made by a
+  survey that took an hour to reach this recording — is exactly how a relink
+  points a recording at a file that was replaced in the meantime. The probe is
+  the gate, so the gate runs immediately before the write or it isn't one.
+
+  ## What it costs
+
+  Two probe passes: the plan's, over the sources, and the scan's, over the
+  placed files. That is not waste. For a copy it is the only thing that checks
+  the bytes arrived intact, and for a hardlink it costs nothing — the second
+  probe reads the same inode.
+  """
+  def relink(media_id) when is_integer(media_id) do
+    case Repo.get(Media, media_id) do
+      nil -> {:error, :not_found}
+      media -> relink(media)
+    end
+  end
+
+  def relink(%Media{} = media) do
+    case plan(media) do
+      %Plan{verdict: :ok} = plan -> execute(plan, media)
+      %Plan{} = refused -> {:error, refused}
+    end
+  end
+
+  # Files first, database second. A file placed before a failed commit is a
+  # stray in the library that `undo/1` removes; a commit before a failed
+  # placement is a recording pointing at nothing.
+  defp execute(%Plan{} = plan, media) do
+    pairs = Enum.zip(Enum.map(plan.sources, & &1.path), plan.destinations)
+
+    case Placement.place_all(pairs, plan.policy) do
+      {:ok, placements} ->
+        case record_and_scan(plan, media) do
+          {:ok, media} ->
+            {:ok, media, plan}
+
+          {:error, reason} ->
+            Placement.undo(placements)
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, {:placement_failed, reason}}
+    end
+  end
+
+  # Repoint, then scan — the opposite order from an import, which repoints the
+  # tracks it already has. There are none here, so the scan is what creates
+  # them, and it derives each one's root and relative path from where the
+  # recording now says its files are.
+  defp record_and_scan(plan, media) do
+    Repo.transact(fn ->
+      with {:ok, media} <- repoint(media, plan),
+           {:ok, media} <- Scanner.scan(Repo.preload(media, :media_tracks)),
+           :ok <- verify(media, plan) do
+        {:ok, media}
+      end
+    end)
+  end
+
+  # `legacy_source_files` goes with the repoint, and not by choice: a recording
+  # with a real placement may not carry it (`media_legacy_source_files_
+  # quarantined`, added by the paths refactor). What it recorded — the
+  # downloads-side paths this recording was transcoded from — is what the
+  # inbox ledger used to know those files were already imported, so relinking
+  # would resurface them as new releases if the ledger still compared paths
+  # alone. It compares content now, and a hardlinked placement is the same
+  # bytes by the strictest possible test.
+  #
+  # Written through `Ecto.Changeset.change/2` rather than the media changeset,
+  # which deliberately doesn't cast any of these.
+  defp repoint(media, plan) do
+    media
+    |> Ecto.Changeset.change(%{
+      library_root_id: plan.root.id,
+      source_path: relativize!(plan.root, plan.destinations |> hd() |> Path.dirname()),
+      source_files: Enum.map(plan.destinations, &relativize!(plan.root, &1)),
+      legacy_source_files: nil
+    })
+    |> Repo.update()
+  end
+
+  # The plan's duration check, asked again of the files that were actually
+  # placed. For a copy this is the only thing that would catch a short write;
+  # for a hardlink it re-confirms the same inode and costs nothing. A failure
+  # here rolls the transaction back and the placement with it.
+  #
+  # `media.duration` is the scan's own total now — it replaced the transcode's
+  # figure, which is the more accurate of the two, so the comparison is
+  # against the duration the plan read before any of this started.
+  defp verify(media, plan) do
+    placed = length(plan.destinations)
+    tracks = length(media.media_tracks)
+    drift = seconds(media.duration) - plan.stored_duration
+
+    cond do
+      tracks != placed ->
+        {:error, {:track_count_mismatch, tracks, placed}}
+
+      abs(drift) > plan.tolerance ->
+        {:error, {:placed_duration_mismatch, fmt(drift, :signed), fmt(plan.tolerance)}}
+
+      true ->
+        :ok
+    end
+  end
+
+  # Placement just wrote these under the root, so being outside it is a bug
+  # worth crashing on rather than recording.
+  defp relativize!(root, absolute) do
+    {:ok, relative} = Library.relativize(root, absolute)
+    relative
+  end
+
+  # ==========================================================================
   # Which files, and where they are
   # ==========================================================================
 
@@ -203,8 +367,16 @@ defmodule Ambry.Media.Relink do
   defp era(%Media{source_files: [_ | _]}), do: :recorded_list
   defp era(%Media{}), do: :web_upload
 
+  # Filtered and natural-sorted the way `Media.files/2` does it for every
+  # other era, because the order here is the order the recording plays in:
+  # the destination filenames are numbered by position, so a list in
+  # filesystem order would place `Chapter 10` first and renumber the book
+  # into nonsense. `Media.files/2` sorts on the way through, which is what
+  # the transcode read, so matching it is matching what was heard.
   defp sources(%Media{} = media, :server_import) do
-    Enum.map(media.legacy_source_files, &source/1)
+    media.legacy_source_files
+    |> Shared.filter_filenames(@extensions)
+    |> Enum.map(&source/1)
   end
 
   defp sources(%Media{} = media, _era) do

--- a/test/ambry/media/relink_test.exs
+++ b/test/ambry/media/relink_test.exs
@@ -45,6 +45,24 @@ defmodule Ambry.Media.RelinkTest do
       assert plan.verdict == :ok
     end
 
+    # The destination filenames are numbered by position, so the order the
+    # sources come out in *is* the order the relinked book plays in. A
+    # recorded list is not sorted — `Media.files/2` sorts on the way through,
+    # which is the order the transcode read and therefore the order the
+    # stored duration and every saved position belong to.
+    test "reads a recorded list in play order, not the order it was stored in" do
+      media = server_import_media(:m4a, 10)
+      scrambled = Enum.reverse(media.legacy_source_files)
+
+      {:ok, media} =
+        media |> Ecto.Changeset.change(%{legacy_source_files: scrambled}) |> Repo.update()
+
+      plan = Relink.plan(Media.get_media!(media.id))
+
+      assert Enum.map(plan.sources, & &1.path) == Enum.sort(scrambled, NaturalOrder)
+      assert plan.sources |> List.last() |> Map.fetch!(:path) =~ "10-sample"
+    end
+
     test "refuses a recording whose files are gone" do
       media = legacy_media(:m4a, 1)
       media.source_files |> Enum.map(&Ambry.Paths.web_to_disk/1) |> Enum.each(&File.rm!/1)
@@ -181,6 +199,93 @@ defmodule Ambry.Media.RelinkTest do
     end
   end
 
+  describe "relink/1" do
+    test "places the sources into the root and scans them into tracks", %{root: root} do
+      media = legacy_media(:m4a, 2)
+
+      assert {:ok, relinked, _plan} = Relink.relink(media)
+
+      assert relinked.library_root_id == root.id
+      assert length(relinked.media_tracks) == 2
+
+      assert Enum.all?(relinked.source_files, &(not String.starts_with?(&1, "/")))
+      assert Enum.all?(relinked.media_tracks, &(&1.library_root_id == root.id))
+
+      for file <- relinked.source_files do
+        assert File.regular?(Path.join(root.path, file))
+      end
+    end
+
+    # The whole point of placing before deleting anything: the reclaim's first
+    # half only ever adds, so it is undone by removing what it added.
+    test "leaves the originals, the artifacts and the status alone" do
+      media = legacy_media(:m4a, 1)
+      originals = Enum.map(media.source_files, &Ambry.Paths.web_to_disk/1)
+
+      assert {:ok, relinked, _plan} = Relink.relink(media)
+
+      assert Enum.all?(originals, &File.regular?/1)
+      assert relinked.status == media.status
+      assert relinked.mp4_path == media.mp4_path
+      assert relinked.mpd_path == media.mpd_path
+      assert relinked.hls_path == media.hls_path
+    end
+
+    # Provenance that a placed recording is forbidden to carry
+    # (`media_legacy_source_files_quarantined`). What it recorded is why the
+    # inbox ledger has to compare content and not only paths.
+    test "clears the legacy provenance a placed recording may not keep" do
+      media = server_import_media(:m4a, 1)
+
+      assert {:ok, relinked, _plan} = Relink.relink(media)
+
+      assert relinked.legacy_source_files == nil
+      assert length(relinked.media_tracks) == 1
+    end
+
+    test "refuses whatever the plan refuses, and writes nothing", %{root: root} do
+      media = legacy_media(:m4a, 1)
+
+      {:ok, media} =
+        media |> Ecto.Changeset.change(%{duration: Decimal.new("9999.0")}) |> Repo.update()
+
+      assert {:error, plan} = Relink.relink(Media.get_media!(media.id))
+
+      assert plan.verdict == :refused
+      assert File.ls!(root.path) == []
+      assert Media.get_media!(media.id).library_root_id == nil
+    end
+
+    # Placement is all-or-nothing per recording, and a half-placed recording
+    # is a book that plays up to chapter one and stops.
+    test "leaves nothing behind when a file can't be placed", %{root: root} do
+      media = legacy_media(:m4a, 2)
+      plan = Relink.plan(media)
+      [_first, second] = plan.destinations
+
+      File.mkdir_p!(Path.dirname(second))
+      File.write!(second, "in the way")
+
+      assert {:error, {:placement_failed, {:destination_exists, ^second}}} = Relink.relink(media)
+
+      assert Media.get_media!(media.id).library_root_id == nil
+      placed = root.path |> Path.join("**/*") |> Path.wildcard() |> Enum.filter(&File.regular?/1)
+      assert placed == [second]
+    end
+
+    # Not a guard anyone wrote: a relinked recording has tracks, and a
+    # recording with tracks is not a candidate.
+    test "refuses a recording it already relinked" do
+      media = legacy_media(:m4a, 1)
+
+      assert {:ok, _relinked, _plan} = Relink.relink(media)
+      assert {:error, plan} = Relink.relink(Media.get_media!(media.id))
+
+      assert plan.verdict == :refused
+      assert Enum.any?(plan.problems, &(&1 =~ "already has 1 track"))
+    end
+  end
+
   defp legacy_media(type, count) do
     :media
     |> build(book: build(:book))
@@ -188,6 +293,22 @@ defmodule Ambry.Media.RelinkTest do
     |> insert()
     |> then(&Media.get_media!(&1.id))
     |> give_it_the_transcode_duration()
+  end
+
+  # The 204 server-import-era recordings: no recorded `source_files` at all,
+  # and absolute paths into a downloads folder that is a source, not a root.
+  defp server_import_media(type, count) do
+    media = legacy_media(type, count)
+
+    {:ok, media} =
+      media
+      |> Ecto.Changeset.change(%{
+        source_files: [],
+        legacy_source_files: Enum.map(media.source_files, &Ambry.Paths.web_to_disk/1)
+      })
+      |> Repo.update()
+
+    Media.get_media!(media.id)
   end
 
   # A legacy recording's stored duration came from its transcode, which is


### PR DESCRIPTION
The write half. `Relink.plan/1` worked out what upgrading a legacy recording to
direct play would do; `Relink.relink/1` does it -- places the sources into the
library root, points the recording at the placed copies, and scans them into
tracks.

## It only ever adds

Nothing is deleted, nothing is published, the artifacts stay and the status is
untouched, so the recording goes on being served exactly as it was and the
relink is undone by deleting what it placed. The policy is `:hardlink` or
`:copy` and neither has anything to finalize -- `Placement.finalize/1` is
deliberately not called, because the only thing it would ever do is the `:move`
delete, and a delete that destroys the last copy of a recording on the old NAS
needs more confidence than "the transaction committed".

Files are placed before the database is touched. A file placed before a failed
commit is a stray in the library that `undo/1` removes; a commit before a
failed placement is a recording pointing at nothing.

## It re-plans rather than taking a plan

A plan is a measurement of a live downloads folder at a moment. Executing one
made an hour ago -- or made by a survey that took an hour to reach this
recording -- is exactly how a relink points a recording at a file that was
replaced in the meantime. The probe is the gate, so it runs immediately before
the write or it isn't one.

That costs a second probe pass over the placed files, which is not waste: for a
copy it is the only thing that would catch a short write, and for a hardlink it
reads the same inode and costs nothing. The scan's total is compared against
the duration the plan read, with the plan's own file-count-aware tolerance, and
a mismatch rolls back the transaction and the placement with it.

Repoint then scan, the opposite order from an import -- `record_placement/3`
repoints tracks that already exist, and at relink time there are none.

## Two things that fell out of writing it

**`legacy_source_files` cannot survive the repoint.** A recording with a real
placement may not carry it (`media_legacy_source_files_quarantined`). That
column is what told the inbox ledger those downloads-side files were already
imported, so relinking resurfaces them as new releases for as long as the
ledger compares paths alone. Content comparison is the companion change; a
hardlinked placement is the same bytes by the strictest test there is.

**A recorded list is not in play order.** `sources/2` read
`legacy_source_files` verbatim while every other era goes through
`Media.files/2`, which filters and natural-sorts. Harmless while the module
only planned. Not harmless now: the destination filenames are numbered by
position, so a list in filesystem order places `Chapter 10` first and renumbers
a 63-file book into nonsense -- against a stored duration and saved positions
that belong to the order the transcode read.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ