### PR TITLE
Skip a release whose bytes the library already holds

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -57,6 +57,7 @@ defmodule Ambry.Inbox do
   import Ecto.Query
 
   alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.Content
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.Draft.Seed
@@ -1241,13 +1242,20 @@ defmodule Ambry.Inbox do
   end
 
   # A file's owner, in the order that decides it: the item that already lists
-  # it, the library, then the nearest item *above* it — which is how a file
-  # that appears in a known release folder joins that release rather than
-  # becoming an item of its own.
+  # it, the library — by path, then by content — then the nearest item *above*
+  # it, which is how a file that appears in a known release folder joins that
+  # release rather than becoming an item of its own.
+  #
+  # The two library questions are different questions, not a fallback. A path
+  # answers "have I imported this file"; content answers "do I already hold
+  # these bytes", which is what a copy, a hardlink under another name, or a
+  # relinked recording's original looks like. Neither subsumes the other, and
+  # the cheap one goes first.
   defp owner_of(file, ledger) do
     cond do
       item = ledger.by_file[file] -> item
       MapSet.member?(ledger.library, library_coordinates(file, ledger.roots)) -> :library
+      Content.holds?(ledger.contents, file) -> :library
       item = nearest_owner(file, ledger.by_path) -> item
       true -> nil
     end
@@ -1364,13 +1372,15 @@ defmodule Ambry.Inbox do
   # directly.
   defp ledger do
     items = InboxItem |> Repo.all() |> Repo.preload(:source)
+    roots = Library.list_roots()
 
     %{
       by_file:
         for(item <- items, file <- InboxItem.disk_files(item), into: %{}, do: {file, item}),
       by_path: Map.new(items, &{InboxItem.disk_path(&1), &1}),
       library: imported_files(),
-      roots: Library.list_roots()
+      contents: Content.index(roots),
+      roots: roots
     }
   end
 

--- a/lib/ambry/inbox/content.ex
+++ b/lib/ambry/inbox/content.ex
@@ -1,0 +1,176 @@
+defmodule Ambry.Inbox.Content do
+  @moduledoc """
+  Whether the library already holds a file's *bytes*, wherever they sit.
+
+  The inbox ledger's other half asks where a file is: a scanned path, compared
+  against the paths the library records. That is the only question a path can
+  answer, and it is blind by construction to the same bytes under a different
+  name.
+
+  Which the library is full of. Measured against production, 2026-08-16: of
+  304 releases in the downloads folder, 40 are **byte-identical copies of
+  files the library already holds** — verified by size on all 40 and by
+  head+tail digest on a sample. They were imported through the web upload
+  form, which *copies* into `source_media/<uuid>/`, so the library's recorded
+  source is the copy, the downloads original was never recorded anywhere, and
+  sometimes it doesn't even share an extension (`Romancing the Duke` is `.mp4`
+  in uploads and `.m4b` in downloads, same 258,479,113 bytes).
+
+  Relinking makes this load-bearing rather than merely tidy. A relinked
+  recording may not keep `legacy_source_files` — a placement and that column
+  are mutually exclusive by CHECK — so the downloads-side paths it recorded
+  stop existing the moment it relinks, and every one of the 204 server-import
+  releases would resurface in the queue as brand new.
+
+  ## The test, in the order it is asked
+
+  1. **Size**, from `media_tracks.size`, which is already in the database.
+     Free, and fully discriminating on this library: 40 of 40 matched
+     completely, zero partial matches, no collisions across 3,707
+     downloads-side files. It is a weak promise in principle, so it indexes
+     rather than decides.
+  2. **Identity** — same device and inode. A hardlinked placement *is* the
+     file, and this says so for nothing: no reads, no arguing about digests.
+     This is what the server-import era becomes after a relink.
+  3. **A head and tail digest**, for genuine copies, which is the only case
+     left. It is what turns the size match from a strong hint into an answer.
+
+  Every step after the first runs only for a file whose size already matches
+  something, so a release that is genuinely new costs one `stat` and a map
+  lookup.
+
+  ## Why the digest window is small
+
+  Discovery runs hourly, and these files never stop being twins — the 40 will
+  size-match on every scan for as long as both copies exist. A full digest of
+  a 14-hour book, or even the 8MB-a-side one an earlier draft of the reclaim
+  plan proposed, is a lot of NFS traffic to pay every hour to re-confirm
+  something that has not changed.
+
+  1MB at each end is confirmation, not evidence: the discriminator is the
+  exact byte size, and two audiobook files of identical length whose container
+  headers, first audio frames and last audio frames all agree are the same
+  file. What the digest rules out is the pathological case where size alone
+  would have been believed.
+
+  ## What it does not answer
+
+  Legacy recordings that have not been relinked yet — their sources sit in
+  `source_media` with no `media_tracks` row and therefore no recorded size, so
+  the twins of *those* recordings stay in the queue until the recording is
+  relinked, at which point they match here. That is the honest place for the
+  queue to heal: as the reclaim proceeds, not by walking the whole uploads NAS
+  once an hour to find out something the reclaim is about to make true anyway.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Library
+  alias Ambry.Library.Root
+  alias Ambry.Media.MediaTrack
+  alias Ambry.Repo
+
+  # Enough to cover a container header, its metadata and real audio frames at
+  # both ends — see the moduledoc on why it is not larger.
+  @window 1024 * 1024
+
+  @doc """
+  Indexes the library's files by size, for `holds?/2` to ask about.
+
+  Takes the roots the caller already loaded, so this costs exactly one query
+  and no per-track root lookups.
+  """
+  def index(roots) do
+    by_id = Map.new(roots, &{&1.id, &1})
+
+    MediaTrack
+    |> select([t], {t.library_root_id, t.path, t.size})
+    |> Repo.all()
+    |> Enum.reduce(%{}, fn {root_id, path, size}, acc ->
+      case absolute(by_id, root_id, path) do
+        {:ok, absolute} -> Map.update(acc, size, [absolute], &[absolute | &1])
+        :error -> acc
+      end
+    end)
+  end
+
+  @doc """
+  Whether the library already holds this file's bytes under some other name.
+
+  False for anything it cannot answer about — an unreadable file, a track
+  whose own file has gone. "I couldn't tell" must never be actioned as "yes,
+  already imported", because the cost of that answer is a release silently
+  never being offered.
+  """
+  def holds?(index, path) do
+    case File.stat(path) do
+      {:ok, stat} -> index |> Map.get(stat.size, []) |> Enum.any?(&same_file?(&1, path, stat))
+      {:error, _reason} -> false
+    end
+  end
+
+  defp same_file?(library_path, path, stat) do
+    case File.stat(library_path) do
+      {:ok, %File.Stat{inode: inode, major_device: device}}
+      when inode == stat.inode and device == stat.major_device ->
+        true
+
+      {:ok, _different_file} ->
+        digest(library_path) == digest(path)
+
+      {:error, _gone} ->
+        false
+    end
+  end
+
+  # `nil` on failure, and `nil != nil` is not how this compares: two
+  # unreadable files must not read as the same file, so a failed digest is a
+  # unique value rather than a shared one.
+  defp digest(path) do
+    case File.open(path, [:read, :binary, :raw]) do
+      {:ok, io} ->
+        try do
+          :crypto.hash(:sha256, [read_at(io, 0), tail(io, path)])
+        after
+          File.close(io)
+        end
+
+      {:error, reason} ->
+        {:unreadable, path, reason}
+    end
+  end
+
+  defp tail(io, path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} when size > @window -> read_at(io, size - @window)
+      _small_or_gone -> ""
+    end
+  end
+
+  defp read_at(io, offset) do
+    case :file.pread(io, offset, @window) do
+      {:ok, bytes} -> bytes
+      _eof_or_error -> ""
+    end
+  end
+
+  defp absolute(_roots, nil, "/uploads/" <> _rest = web_path) do
+    case Library.resolve(nil, web_path) do
+      {:ok, absolute} -> {:ok, absolute}
+      {:error, _reason} -> :error
+    end
+  end
+
+  defp absolute(roots, root_id, path) do
+    case roots do
+      %{^root_id => %Root{} = root} ->
+        case Library.resolve(root, path) do
+          {:ok, absolute} -> {:ok, absolute}
+          {:error, _reason} -> :error
+        end
+
+      _unknown_root ->
+        :error
+    end
+  end
+end

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -439,10 +439,13 @@ defmodule Ambry.Inbox.ManagedImportTest do
 
       assert {:ok, media1} = Inbox.import_item(first)
 
-      # A second reading of the same work, in its own release folder.
+      # A second reading of the same work, in its own release folder — a
+      # different narrator, and so genuinely different bytes. A copy of the
+      # first file would be skipped by the scan as something the library
+      # already holds, which is what a second *copy* is.
       second_release = Path.join(downloads, "The Way of Kings [Re-read]")
       File.mkdir_p!(second_release)
-      File.cp!(tagged_audio(), Path.join(second_release, "book.m4b"))
+      File.cp!(tagged_audio(composer: "Kate Reading"), Path.join(second_release, "book.m4b"))
       {:ok, _counts} = Inbox.discover(watched)
       {[second], false} = Inbox.list_items(filter: "Re-read")
       {:ok, second} = Inbox.probe_item(second)
@@ -572,10 +575,14 @@ defmodule Ambry.Inbox.ManagedImportTest do
   end
 
   # Another candidate under the same watched folder, probed and queued.
+  #
+  # Its own file, not a copy of the imported one: a scan skips a release whose
+  # bytes the library already holds, however it is named, so a second release
+  # made by copying the first is not a second release at all.
   defp second_release(watched) do
     release = Path.join(watched.path, "Words of Radiance [M4B]")
     File.mkdir_p!(release)
-    File.cp!(tagged_audio(), Path.join(release, "book.m4b"))
+    File.cp!(tagged_audio(album: "Words of Radiance"), Path.join(release, "book.m4b"))
 
     {:ok, _counts} = Inbox.discover(watched)
     {[item], false} = Inbox.list_items(filter: "Words of Radiance")

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -393,6 +393,46 @@ defmodule Ambry.InboxTest do
     end
   end
 
+  # A path answers "have I imported this file", which is the only question a
+  # path can answer. These are the cases where the answer is yes and the path
+  # cannot see it: the library holds the same bytes under a different name.
+  describe "discover/1 and the library's bytes" do
+    # What a relinked server-import recording looks like from the downloads
+    # side: the library's copy is a second name for the same inode.
+    test "doesn't offer a hardlink of a file the library serves" do
+      %{root: root, library: library, track: track} = library_with_a_track()
+      hardlink = Path.join(root, "Seeding Still.m4b")
+      File.ln!(Path.join(library.path, track.path), hardlink)
+
+      assert {:ok, %{created: 0, skipped: 1}} = discover(root)
+      assert {[], false} = Inbox.list_items()
+    end
+
+    # The 40 measured in production: downloaded, then imported through the
+    # upload form, which copies. Different folder, sometimes a different
+    # extension, same bytes.
+    test "doesn't offer a byte-identical copy under another name" do
+      %{root: root, library: library, track: track} = library_with_a_track()
+      File.cp!(Path.join(library.path, track.path), Path.join(root, "Romancing the Duke.mp4"))
+
+      assert {:ok, %{created: 0, skipped: 1}} = discover(root)
+      assert {[], false} = Inbox.list_items()
+    end
+
+    # Size indexes; it does not decide. A different recording of the same
+    # length is a different book and has to be offered.
+    test "offers a file of the same size that isn't the same file" do
+      %{root: root, library: library, track: track} = library_with_a_track()
+      impostor = Path.join(root, "A Different Reading.m4b")
+      File.cp!(Path.join(library.path, track.path), impostor)
+      corrupt_a_byte(impostor)
+
+      assert {:ok, %{created: 1}} = discover(root)
+      assert {[item], false} = Inbox.list_items()
+      assert InboxItem.disk_files(item) == [impostor]
+    end
+  end
+
   describe "probe_item/1" do
     test "records what the file is and what it claims about itself" do
       root = watched_root()
@@ -963,6 +1003,45 @@ defmodule Ambry.InboxTest do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     File.mkdir_p!(root)
     root
+  end
+
+  # A watched folder, and a separate library root holding one real file that
+  # a real track points at — the arrangement every content question is asked
+  # in, and deliberately not the same folder.
+  defp library_with_a_track do
+    root = watched_root()
+    path = Ambry.Paths.source_media_disk_path("library-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(Path.join(path, "The Library's Copy"))
+
+    library = insert(:root, path: path)
+    copy_audio(Path.join(path, "The Library's Copy"), "book.m4b")
+
+    media =
+      insert(:media,
+        book: build(:book),
+        library_root_id: library.id,
+        source_path: "The Library's Copy"
+      )
+
+    track =
+      insert(:media_track,
+        media: media,
+        path: "The Library's Copy/book.m4b",
+        library_root_id: library.id,
+        size: File.stat!(Path.join(path, "The Library's Copy/book.m4b")).size
+      )
+
+    %{root: root, library: library, track: track}
+  end
+
+  # Same length, different bytes — the only thing that separates a twin from
+  # a coincidence.
+  defp corrupt_a_byte(path) do
+    contents = File.read!(path)
+    at = div(byte_size(contents), 2)
+    <<head::binary-size(^at), byte, tail::binary>> = contents
+
+    File.write!(path, <<head::binary, Bitwise.bxor(byte, 0xFF), tail::binary>>)
   end
 
   defp release_folder(root, name, filenames) do


### PR DESCRIPTION
`imported_files/0` compares paths, which is the only question a path can
answer, and it is blind by construction to the same bytes under a different
name. The library is full of those.

Measured against production 2026-08-16: of 304 releases in the downloads
folder, **40 are byte-identical copies of files the library already holds** --
verified by size on all 40 and by head+tail digest on a sample. They were
downloaded and then imported through the web upload form, which *copies* into
`source_media/<uuid>/`, so the library's recorded source is the copy, the
downloads original was never recorded anywhere, and sometimes it does not even
share an extension: `Romancing the Duke` is `.mp4` in uploads and `.m4b` in
downloads, same 258,479,113 bytes.

Relinking turns this from tidiness into a requirement. A relinked recording may
not keep `legacy_source_files` -- a placement and that column are mutually
exclusive by CHECK -- so the downloads-side paths it recorded stop existing the
moment it relinks, and all 204 server-import releases would resurface in the
queue as brand new.

## Size indexes, identity and a digest decide

1. **Size**, from `media_tracks.size`, already in the database. Free, and fully
   discriminating on this library -- 40 of 40, no partial matches, no
   collisions across 3,707 downloads-side files. It is a weak promise in
   principle, so it indexes rather than decides.
2. **Same device and inode.** A hardlinked placement *is* the file and this
   says so for nothing. That is what the server-import era looks like from the
   downloads side after a relink, which is the case that would otherwise cost
   the most.
3. **A head and tail digest** for genuine copies, the only case left.

Everything after step 1 runs only for a file whose size already matches, so a
genuinely new release costs one `stat` and a map lookup.

The digest window is 1MB at each end rather than the 8MB the reclaim plan
sketched. Discovery runs hourly and these twins never stop being twins, so the
confirmation is paid every hour forever; 2MB of container headers and real
audio frames from a file that already matches to the byte is confirmation, and
re-reading 16MB an hour to re-learn the same fact is not.

Anything it cannot answer is a no. An unreadable file, a track whose own file
has gone: "I couldn't tell" must never be actioned as "already imported",
because that answer is a release silently never being offered.

## What it deliberately does not cover

Legacy recordings that have not been relinked yet have no tracks and so no
recorded size, so the twins of *those* stay in the queue -- ignorable, exactly
as they are today -- until the recording relinks and they match here. That is
the honest place for the queue to heal: as the reclaim proceeds, rather than by
walking the whole uploads NAS once an hour to learn something the reclaim is
about to make true anyway.

## Two tests changed with it

Both built their "second release" by copying the file they had just imported,
which is now skipped, correctly: a copy of an imported file is a copy of an
imported file whatever folder it is in. They make their own file now -- a
different album, a different narrator -- which is what a second release
actually is.

Pairs with #1252 -- independent of it, but that PR's relink is what makes this load-bearing.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ