### PR TITLE
Hardlink the twin already on the destination instead of copying

### DIFF
--- a/lib/ambry/media/relink.ex
+++ b/lib/ambry/media/relink.ex
@@ -9,9 +9,9 @@ defmodule Ambry.Media.Relink do
 
   Two halves, and the split is the safety property:
 
-    * **`plan/1` writes nothing.** Safe to point at production before anything
+    * **`plan/2` writes nothing.** Safe to point at production before anything
       else exists, one recording at a time, and read the answer.
-    * **`relink/1` does it**, and only ever for a plan that came back `:ok`,
+    * **`relink/2` does it**, and only ever for a plan that came back `:ok`,
       re-measured immediately beforehand.
 
   Even the doing half adds rather than replaces. Nothing is deleted, nothing
@@ -53,6 +53,26 @@ defmodule Ambry.Media.Relink do
   A recording with tracks already is not a candidate, and neither is one whose
   files cannot be found at all.
 
+  ## Which copy of the bytes it relinks
+
+  A recording's *recorded* source is not always the nearest copy of its audio.
+  40 of the upload era's recordings were downloaded first and then imported
+  through the web upload form, which copies into `source_media/<uuid>/` — so
+  the recording points at a copy on the uploads volume while the original is
+  still sitting on the destination NAS, still seeding, unrecorded anywhere.
+
+  Placing the recorded source would copy ~18G across the wire to write bytes
+  that are already on the other end, and leave the library holding a third
+  copy of them. So when every one of a recording's sources has a byte-identical
+  twin on the destination filesystem, the plan relinks *the twins* instead:
+  one hardlink each, no bytes, and the uploads-side originals left untouched
+  for the later pass that empties that volume.
+
+  Size indexes the search and a head-and-tail digest decides it, all of them
+  or none — see `twin_index/1`. And because the substitution happens before
+  the duration gate below, what gets verified against the recording's stored
+  duration is the file that will actually be placed.
+
   ## The duration gate
 
   The one check that catches a path pointing at the wrong file. Sum the probed
@@ -93,6 +113,7 @@ defmodule Ambry.Media.Relink do
   alias Ambry.Library.NamingTemplate
   alias Ambry.Library.Placement
   alias Ambry.Library.Root
+  alias Ambry.Library.Source
   alias Ambry.Media.Media
   alias Ambry.Media.MediaTrack
   alias Ambry.Media.Processor.Shared
@@ -109,6 +130,11 @@ defmodule Ambry.Media.Relink do
   @drift_per_boundary_ms 65
   @drift_headroom 1.5
   @minimum_tolerance_seconds 2.0
+
+  # Read from each end of a candidate twin — the figure the reclaim's census
+  # used to confirm all 40 of them. Paid once per recording, against a
+  # decision that otherwise copies a gigabyte across the wire.
+  @digest_window 8 * 1024 * 1024
 
   defmodule Plan do
     @moduledoc """
@@ -133,7 +159,8 @@ defmodule Ambry.Media.Relink do
       :tolerance,
       :root,
       :policy,
-      :destinations
+      :destinations,
+      :twins
     ]
   end
 
@@ -142,15 +169,24 @@ defmodule Ambry.Media.Relink do
 
   Pass a media id or a loaded `Media`. Probing reads each source file's
   header, so this costs an ffprobe per file and no decoding.
+
+  ## Options
+
+    * `:twins` — a prebuilt index from `twin_index/1`. Only consulted for a
+      recording whose sources are on the wrong filesystem, and worth passing
+      for a batch: the index is a walk of every source folder, which is one
+      walk per batch rather than one per recording.
   """
-  def plan(media_id) when is_integer(media_id) do
+  def plan(media, opts \\ [])
+
+  def plan(media_id, opts) when is_integer(media_id) do
     case Repo.get(Media, media_id) do
       nil -> {:error, :not_found}
-      media -> plan(media)
+      media -> plan(media, opts)
     end
   end
 
-  def plan(%Media{} = media) do
+  def plan(%Media{} = media, opts) do
     media = preload_for_plan(media)
     era = era(media)
     sources = sources(media, era)
@@ -165,6 +201,8 @@ defmodule Ambry.Media.Relink do
     }
     |> refuse_if_already_direct_play(media)
     |> refuse_if_sources_missing()
+    |> choose_root()
+    |> prefer_twins_on_the_destination(opts)
     |> check_duration(media)
     |> propose_destination(media)
     |> settle_verdict()
@@ -210,6 +248,8 @@ defmodule Ambry.Media.Relink do
   @doc """
   Relinks one recording. **This writes**, unlike everything above it.
 
+  Takes the same options as `plan/2`, which it re-runs.
+
   Places the recording's sources into the library root, points the recording
   at the placed copies, and scans them into tracks. Returns
   `{:ok, media, plan}` with the scanned recording and the plan it acted on,
@@ -251,15 +291,17 @@ defmodule Ambry.Media.Relink do
   the bytes arrived intact, and for a hardlink it costs nothing — the second
   probe reads the same inode.
   """
-  def relink(media_id) when is_integer(media_id) do
+  def relink(media, opts \\ [])
+
+  def relink(media_id, opts) when is_integer(media_id) do
     case Repo.get(Media, media_id) do
       nil -> {:error, :not_found}
-      media -> relink(media)
+      media -> relink(media, opts)
     end
   end
 
-  def relink(%Media{} = media) do
-    case plan(media) do
+  def relink(%Media{} = media, opts) do
+    case plan(media, opts) do
       %Plan{verdict: :ok} = plan -> execute(plan, media)
       %Plan{} = refused -> {:error, refused}
     end
@@ -498,23 +540,188 @@ defmodule Ambry.Media.Relink do
   end
 
   # ==========================================================================
+  # The bytes may already be on the destination
+  # ==========================================================================
+
+  @doc """
+  Indexes the audio under every source that shares a filesystem with `root`.
+
+  The input to the twin substitution below, by size, because size is what
+  makes a full comparison worth attempting at all. Costs a walk of each
+  matching source — 3,707 files in the production downloads folder — so build
+  it once for a batch and pass it to `plan/2`.
+
+  Only *sources* are searched. A file already inside a library root is the
+  library's own audio, and rearranging how the library stores itself is a
+  different question from where a recording's bytes come from.
+  """
+  def twin_index(%Root{} = root) do
+    Library.list_sources()
+    |> Enum.filter(&same_filesystem?(&1.path, root.path))
+    |> Enum.flat_map(&audio_under/1)
+    |> Enum.reduce(%{}, fn {path, size}, index ->
+      Map.update(index, size, [path], &[path | &1])
+    end)
+  end
+
+  # A recording whose sources are on the wrong filesystem has to copy them
+  # across — unless the same bytes are *already* sitting on the destination,
+  # which for this library is true of 40 recordings.
+  #
+  # They were downloaded and then imported through the web upload form, which
+  # copies into `source_media/<uuid>/`, so the recording's recorded source is
+  # the copy and the downloaded original — still on the destination NAS, still
+  # seeding — was never recorded anywhere. Copying the uploads-side file over
+  # would write ~18G of bytes that are already there, and leave the library
+  # holding a third copy of them.
+  #
+  # So when every one of a recording's sources has a byte-identical twin on
+  # the destination, the plan relinks *the twins*: one hardlink each, zero
+  # bytes, and the uploads-side originals left untouched for the later pass
+  # that empties that volume.
+  #
+  # **All of them or none.** `Placement.place_all/2` takes one policy for a
+  # recording, and a half-twinned recording would need two; the census found
+  # zero partial matches across the 40, because a release is downloaded and
+  # imported as a unit.
+  defp prefer_twins_on_the_destination(%Plan{problems: [_ | _]} = plan, _opts), do: plan
+
+  defp prefer_twins_on_the_destination(%Plan{root: root} = plan, opts) do
+    case policy(plan.sources, root) do
+      # Already on the destination filesystem: there is nothing a twin could
+      # improve on, and looking for one would be a walk for no reason.
+      {:ok, :hardlink} ->
+        plan
+
+      {:ok, :copy} ->
+        substitute_twins(plan, opts[:twins] || twin_index(root))
+
+      # Reported by `place_into/3`, which asks the same question and has the
+      # words for it.
+      {:error, _undecidable} ->
+        plan
+    end
+  end
+
+  defp substitute_twins(plan, index) do
+    twins = Enum.map(plan.sources, &twin_of(&1, index))
+    found = Enum.count(twins, & &1)
+    plan = %{plan | twins: {found, length(twins)}}
+
+    if found == length(twins),
+      do: %{plan | sources: Enum.map(twins, &source/1)},
+      else: plan
+  end
+
+  # Size indexes, the digest decides. A head and tail of 8MB is what the
+  # reclaim's census used to confirm all 40 twins, and this runs once per
+  # recording rather than on a schedule, so it is the cheap half of a decision
+  # that otherwise moves a gigabyte.
+  defp twin_of(%{path: path}, index) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} ->
+        index |> Map.get(size, []) |> Enum.find(&(digest(&1) == digest(path)))
+
+      {:error, _unreadable} ->
+        nil
+    end
+  end
+
+  defp audio_under(%Source{path: path}) do
+    path
+    |> walk()
+    |> Enum.filter(&(Path.extname(&1) in @extensions))
+    |> Enum.flat_map(fn file ->
+      case File.stat(file) do
+        {:ok, %File.Stat{size: size}} -> [{file, size}]
+        {:error, _unreadable} -> []
+      end
+    end)
+  end
+
+  defp walk(dir) do
+    case File.ls(dir) do
+      {:ok, entries} ->
+        entries
+        |> Enum.map(&Path.join(dir, &1))
+        |> Enum.flat_map(fn path -> if File.dir?(path), do: walk(path), else: [path] end)
+
+      {:error, _unreadable} ->
+        []
+    end
+  end
+
+  defp same_filesystem?(path, root_path) do
+    match?({:ok, true}, Library.same_filesystem?(path, root_path))
+  end
+
+  # `{:unreadable, path, reason}` rather than nil on failure: two files nobody
+  # can read are not the same file, and this comparison is about to decide
+  # which bytes a recording is made of.
+  defp digest(path) do
+    case File.open(path, [:read, :binary, :raw]) do
+      {:ok, io} ->
+        try do
+          :crypto.hash(:sha256, [read_at(io, 0), tail(io, path)])
+        after
+          File.close(io)
+        end
+
+      {:error, reason} ->
+        {:unreadable, path, reason}
+    end
+  end
+
+  defp tail(io, path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} when size > @digest_window ->
+        read_at(io, size - @digest_window)
+
+      _small_or_gone ->
+        ""
+    end
+  end
+
+  defp read_at(io, offset) do
+    case :file.pread(io, offset, @digest_window) do
+      {:ok, bytes} -> bytes
+      _eof_or_error -> ""
+    end
+  end
+
+  # ==========================================================================
   # Where it would go
   # ==========================================================================
+
+  @doc """
+  The root a relink places into.
+
+  There is one root in this deployment and this is not the place to invent a
+  choice between several; the oldest is the answer until something asks a
+  better question. Public because a batch has to build its twin index against
+  the same root every plan will use.
+  """
+  def destination_root do
+    case Library.list_roots() do
+      [] -> :none
+      roots -> {:ok, Enum.min_by(roots, & &1.id)}
+    end
+  end
+
+  defp choose_root(%Plan{problems: [_ | _]} = plan), do: plan
+
+  defp choose_root(plan) do
+    case destination_root() do
+      :none -> problem(plan, "no library root exists to place into")
+      {:ok, root} -> %{plan | root: root}
+    end
+  end
 
   # Only computed for a plan that is otherwise sound: rendering a destination
   # for a recording that cannot be relinked invites reading it as an intention.
   defp propose_destination(%Plan{problems: [_ | _]} = plan, _media), do: plan
 
-  defp propose_destination(plan, media) do
-    case Library.list_roots() do
-      [] ->
-        problem(plan, "no library root exists to place into")
-
-      roots ->
-        root = Enum.min_by(roots, & &1.id)
-        place_into(plan, media, root)
-    end
-  end
+  defp propose_destination(plan, media), do: place_into(plan, media, plan.root)
 
   defp place_into(plan, media, %Root{} = root) do
     values = Books.naming_values(media.book, media)

--- a/lib/ambry/media/relink/console.ex
+++ b/lib/ambry/media/relink/console.ex
@@ -52,6 +52,12 @@ defmodule Ambry.Media.Relink.Console do
 
   A real run pays that twice, once to plan and once to scan what it placed.
   That is the check that the placed bytes are the bytes.
+
+  Before either, a batch walks every source that shares a filesystem with the
+  library root, so a recording whose bytes are already on the destination can
+  hardlink them instead of copying its own copy across. One walk for the
+  batch, seconds, and it is what makes the difference between an 84G transfer
+  and a 102G one.
   """
 
   alias Ambry.Media.Media
@@ -66,12 +72,13 @@ defmodule Ambry.Media.Relink.Console do
   """
   def report(opts \\ []) do
     media_list = select(opts)
+    twins = twin_index()
 
     heading("Planning #{length(media_list)} recording(s) — about #{estimate(media_list)}.")
 
     media_list
     |> Enum.map(fn media ->
-      plan = Relink.plan(media)
+      plan = Relink.plan(media, twins: twins)
       print_plan(plan)
       plan
     end)
@@ -85,7 +92,7 @@ defmodule Ambry.Media.Relink.Console do
   With `dry_run: false` this places files and writes to the database, one
   recording at a time, printing each outcome as it happens rather than at the
   end. Nothing is deleted and nothing is published either way; see
-  `Relink.relink/1`.
+  `Relink.relink/2`.
   """
   def run(opts \\ []) do
     if Keyword.get(opts, :dry_run, true) do
@@ -101,13 +108,14 @@ defmodule Ambry.Media.Relink.Console do
 
   defp perform(opts) do
     media_list = select(opts)
+    twins = twin_index()
     stop_on_error? = Keyword.get(opts, :stop_on_error, true)
 
     heading("Relinking #{length(media_list)} recording(s) — about #{estimate(media_list)}.")
 
     media_list
     |> Enum.reduce_while([], fn media, results ->
-      result = relink_and_print(media)
+      result = relink_and_print(media, twins)
 
       if stop_on_error? and match?({:failed, _id, _reason}, result) do
         heading("Stopped at the first error. Pass stop_on_error: false to carry on regardless.")
@@ -121,14 +129,43 @@ defmodule Ambry.Media.Relink.Console do
     |> tap(&print_run_summary/1)
   end
 
-  defp relink_and_print(media) do
-    case Relink.relink(media) do
+  # Once for the batch, not once per recording: it is a walk of every source
+  # that shares a filesystem with the root — 3,707 files in production — and
+  # every plan asks the same question of it.
+  #
+  # Built even for a batch that turns out not to need it (a server-import
+  # recording's sources are already on the destination, so nothing could
+  # improve on a hardlink). Seconds, once, and knowing in advance which
+  # recordings will need it costs the same walk.
+  defp twin_index do
+    case Relink.destination_root() do
+      {:ok, root} ->
+        index = Relink.twin_index(root)
+
+        index
+        |> Map.values()
+        |> Enum.map(&length/1)
+        |> Enum.sum()
+        |> case do
+          0 -> :nothing_to_say
+          count -> heading("Indexed #{count} file(s) already on the destination filesystem.")
+        end
+
+        index
+
+      :none ->
+        %{}
+    end
+  end
+
+  defp relink_and_print(media, twins) do
+    case Relink.relink(media, twins: twins) do
       {:ok, media, plan} ->
         print_title(plan.media_id, plan.title)
 
         detail(
-          "relinked: #{length(media.media_tracks)} track(s), #{plan.policy}, " <>
-            "#{fmt(plan.probed_duration)}"
+          "relinked: #{length(media.media_tracks)} track(s), #{plan.policy} " <>
+            "#{twins(plan.twins)}#{fmt(plan.probed_duration)}"
         )
 
         print_paths(media.source_files)
@@ -192,7 +229,7 @@ defmodule Ambry.Media.Relink.Console do
 
     detail(
       "era=#{plan.era} files=#{length(plan.sources)} " <>
-        "policy=#{plan.policy || "-"} verdict=#{plan.verdict}"
+        "policy=#{plan.policy || "-"}#{twins(plan.twins)} verdict=#{plan.verdict}"
     )
 
     if plan.stored_duration do
@@ -220,6 +257,14 @@ defmodule Ambry.Media.Relink.Console do
       _all_shown -> :ok
     end
   end
+
+  # The whole recording found on the destination is the interesting case and
+  # says so plainly. A partial match is worth seeing too: it means the plan
+  # is about to copy bytes some of which are already there, which is either a
+  # split release or something worth a look before a batch of 233.
+  defp twins(nil), do: ""
+  defp twins({same, same}), do: "(twinned) "
+  defp twins({found, total}), do: "(twins #{found}/#{total}) "
 
   # Root-relative, because the root prefix is the same on every line and the
   # part that differs is the part being checked.

--- a/test/ambry/media/relink_test.exs
+++ b/test/ambry/media/relink_test.exs
@@ -5,6 +5,20 @@ defmodule Ambry.Media.RelinkTest do
   alias Ambry.Media.Relink
   alias Ambry.Media.Scanner
 
+  # The upload era's shape, found at compile time rather than mocked: its
+  # sources are on the uploads volume and the root is on another NAS, which is
+  # the only arrangement where a twin can save anything. Test fixtures live
+  # under `System.tmp_dir!()`, so the root has to go somewhere else.
+  @other_filesystem Enum.find(["/dev/shm", "/var/tmp"], fn candidate ->
+                      with true <- File.dir?(candidate),
+                           {:ok, %{major_device: theirs}} <- File.stat(candidate),
+                           {:ok, %{major_device: ours}} <- File.stat(System.tmp_dir!()) do
+                        theirs != ours
+                      else
+                        _unusable -> false
+                      end
+                    end)
+
   # Every plan that gets as far as proposing a destination needs a root that
   # actually exists on disk — the filesystem question is asked of the real
   # path, deliberately, so a fabricated one cannot answer it.
@@ -284,6 +298,145 @@ defmodule Ambry.Media.RelinkTest do
       assert plan.verdict == :refused
       assert Enum.any?(plan.problems, &(&1 =~ "already has 1 track"))
     end
+  end
+
+  if @other_filesystem do
+    describe "plan/2 — the bytes may already be on the destination" do
+      # The 40 measured in production: downloaded, then imported through the
+      # web upload form, which copies. The download is still on the
+      # destination NAS, still seeding, and copying the uploads-side file over
+      # would write bytes that are already there.
+      test "hardlinks a twin on the destination instead of copying the original" do
+        %{media: media, twin: twin, source: source} = twinned_media(1)
+
+        plan = Relink.plan(Media.get_media!(media.id))
+
+        assert plan.verdict == :ok
+        assert plan.policy == :hardlink
+        assert plan.twins == {1, 1}
+        assert Enum.map(plan.sources, & &1.path) == [twin]
+        refute source in Enum.map(plan.sources, & &1.path)
+      end
+
+      test "copies the original when nothing on the destination matches it" do
+        %{media: media, source: source} = twinned_media(1, twins: 0)
+
+        plan = Relink.plan(Media.get_media!(media.id))
+
+        assert plan.policy == :copy
+        assert plan.twins == {0, 1}
+        assert Enum.map(plan.sources, & &1.path) == [source]
+      end
+
+      # All of them or none: `Placement.place_all/2` takes one policy for a
+      # recording, and the census found no partial matches — a release is
+      # downloaded and imported as a unit.
+      test "copies everything when only some files have twins" do
+        %{media: media, sources: sources} = twinned_media(2, twins: 1)
+
+        plan = Relink.plan(Media.get_media!(media.id))
+
+        assert plan.policy == :copy
+        assert plan.twins == {1, 2}
+        assert Enum.map(plan.sources, & &1.path) == sources
+      end
+
+      # Size indexes; the digest decides. Same length, different bytes.
+      test "does not take a same-sized file that isn't the same file" do
+        %{media: media, twin: twin, source: source} = twinned_media(1)
+        corrupt_a_byte(twin)
+
+        plan = Relink.plan(Media.get_media!(media.id))
+
+        assert plan.policy == :copy
+        assert plan.twins == {0, 1}
+        assert Enum.map(plan.sources, & &1.path) == [source]
+      end
+    end
+
+    describe "relink/2 — placing a twin" do
+      test "gives the library a second name for bytes already on the NAS", %{} do
+        %{media: media, twin: twin, source: source, root: root} = twinned_media(1)
+
+        assert {:ok, relinked, plan} = Relink.relink(Media.get_media!(media.id))
+
+        assert plan.policy == :hardlink
+        [placed] = Enum.map(relinked.source_files, &Path.join(root.path, &1))
+
+        # one inode, three names, and no bytes written anywhere
+        assert File.stat!(placed).inode == File.stat!(twin).inode
+        assert File.stat!(placed).links == 2
+
+        # and the uploads-side original is still there, untouched: emptying
+        # that volume is a later pass over recordings verified playing
+        assert File.regular?(source)
+      end
+    end
+  end
+
+  # A recording whose sources are on the uploads volume, a root on another
+  # filesystem, and a downloads source alongside the root holding `twins` of
+  # the recording's files byte for byte.
+  defp twinned_media(count, opts \\ []) do
+    Repo.delete_all(Ambry.Library.Root)
+
+    root = insert(:root, path: elsewhere("root"))
+    downloads = elsewhere("downloads")
+    insert(:source, path: downloads)
+
+    media = distinct_file_media(count)
+    sources = Enum.map(media.source_files, &Ambry.Paths.web_to_disk/1)
+
+    twins =
+      sources
+      |> Enum.take(Keyword.get(opts, :twins, count))
+      |> Enum.with_index(1)
+      |> Enum.map(fn {source, index} ->
+        twin = Path.join(downloads, "The Download - #{index}.m4b")
+        File.cp!(source, twin)
+        twin
+      end)
+
+    %{
+      media: media,
+      root: root,
+      sources: sources,
+      source: hd(sources),
+      twin: List.first(twins)
+    }
+  end
+
+  # The standard fixture copies one file `count` times, which for a twin test
+  # would mean every source matches every twin. A recording whose files differ
+  # is what makes "some of them have twins" a state that can exist at all.
+  defp distinct_file_media(1), do: legacy_media(:m4a, 1)
+
+  defp distinct_file_media(2) do
+    media = :media |> build(book: build(:book)) |> with_copied_source_files(:m4a, 1)
+    folder = media.source_files |> hd() |> Ambry.Paths.web_to_disk() |> Path.dirname()
+    second = Path.join(folder, "2-sample.mp3")
+    File.cp!(valid_audio(:mp3), second)
+
+    %{media | source_files: media.source_files ++ [Ambry.Paths.disk_to_web(second)]}
+    |> insert()
+    |> then(&Media.get_media!(&1.id))
+    |> give_it_the_transcode_duration()
+  end
+
+  defp elsewhere(prefix) do
+    path = Path.join(@other_filesystem, "ambry-relink-#{prefix}-#{Ecto.UUID.generate()}")
+    File.mkdir_p!(path)
+    on_exit(fn -> File.rm_rf(path) end)
+    path
+  end
+
+  # Same length, different bytes.
+  defp corrupt_a_byte(path) do
+    contents = File.read!(path)
+    at = div(byte_size(contents), 2)
+    <<head::binary-size(^at), byte, tail::binary>> = contents
+
+    File.write!(path, <<head::binary, Bitwise.bxor(byte, 0xFF), tail::binary>>)
   end
 
   defp legacy_media(type, count) do


### PR DESCRIPTION
A recording's *recorded* source is not always the nearest copy of its audio.
40 of the upload era's recordings were downloaded first and then imported
through the web upload form, which copies into `source_media/<uuid>/` -- so
the recording points at a copy on the uploads volume while the original is
still sitting on the destination NAS, still seeding, unrecorded anywhere.

Placing the recorded source copies ~18G across the wire to write bytes that
are already on the other end, and leaves the library holding a third copy of
them. There is no reason to keep a copy of a file we can prove we already
have: when every one of a recording's sources has a byte-identical twin on the
destination filesystem, the plan relinks the twins. One hardlink each, no
bytes, no transfer.

This is what the reclaim plan already decided ("hardlink the twin, delete the
uploads copy") and what the relink did not do.

## Finding a twin

`twin_index/1` walks every registered source that shares a filesystem with the
library root and keys its audio by size. Size is what makes a full comparison
worth attempting; an 8MB head-and-tail digest is what decides it -- the same
confirmation the census used on all 40, paid once per recording against a
decision that otherwise moves a gigabyte.

The index is a walk of 3,707 files in production, so `plan/2` takes it as an
option and the console builds it once per batch. A plan whose sources are
already on the destination never asks for it: nothing can improve on a
hardlink.

**All of a recording's files or none of them.** `Placement.place_all/2` takes
one policy for a recording and a half-twinned one would need two. The census
found no partial matches -- a release is downloaded and imported as a unit --
and a partial match now prints as `twins 3/5`, which is worth seeing before a
batch of 233 rather than silently half-honoured.

## Where the substitution sits

Before the duration gate, deliberately. The root is chosen earlier now
(`choose_root/1`, which `propose_destination/2` used to do inline) so the twin
search knows what filesystem it is aiming at, and the gate then probes the
files that will actually be placed rather than the ones the database happens
to name. What gets verified is what gets used.

Nothing else changes: the uploads-side originals are untouched, no artifacts
are cleared, and emptying that volume is still a later pass over recordings
verified playing.

Stacked on #1253 (and so on #1252).

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ