### PR TITLE
One search path for every typeahead

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -43,6 +43,7 @@ defmodule Ambry.Books do
   alias Ambry.Books.SeriesFlat
   alias Ambry.Books.Universe
   alias Ambry.Books.UniverseFlat
+  alias Ambry.Ecto.NameSearch
   alias Ambry.Media.Media
   alias Ambry.PubSub
   alias Ambry.Repo
@@ -353,21 +354,51 @@ defmodule Ambry.Books do
   end
 
   @doc """
-  Returns all books for use in `Select` components, as rich options: cover,
+  Books matching what somebody typed into a picker, as rich options: cover,
   title, and the authors — the fact that tells two same-titled books apart.
+
+  **Keyword-scored, not substring-matched** (`BookFlat.by_keywords/2`), so
+  "sanderson kings" finds The Way of Kings and a term that misses costs
+  nothing. That search was built for matching a file against the library and
+  it is the better answer here too: a person typing knows the author's name
+  more often than they know the exact title.
+
+  With nothing typed, the first page by title — a box that has just been
+  focused should show what is there, not nothing.
   """
-  def books_for_select do
-    BookFlat
-    |> order_by(asc: :title)
+  def search_books(phrase, limit) do
+    case match_keywords(phrase) do
+      [] -> BookFlat |> order_by(asc: :title) |> limit(^limit)
+      terms -> BookFlat.by_keywords(terms, limit)
+    end
     |> Repo.all()
-    |> Enum.map(
-      &%{
-        id: &1.id,
-        label: &1.title,
-        image: List.first(&1.thumbnails || []),
-        detail: book_select_detail(&1)
-      }
-    )
+    |> Enum.map(&book_option/1)
+  end
+
+  @doc """
+  One book as a picker option, or nil.
+
+  What lets a picker name the book it is already holding. The preloaded list
+  it replaced was providing this silently, which is most of why it was
+  preloaded at all.
+  """
+  def book_option(nil), do: nil
+  def book_option(""), do: nil
+
+  def book_option(id) when is_binary(id) or is_integer(id) do
+    case Repo.get(BookFlat, id) do
+      nil -> nil
+      book -> book_option(book)
+    end
+  end
+
+  def book_option(%BookFlat{} = book) do
+    %{
+      id: book.id,
+      label: book.title,
+      image: List.first(book.thumbnails || []),
+      detail: book_select_detail(book)
+    }
   end
 
   defp book_select_detail(%BookFlat{authors: authors}) do
@@ -595,13 +626,19 @@ defmodule Ambry.Books do
   end
 
   @doc """
-  Returns all series for use in `Select` components.
+  Series matching what somebody typed into a picker.
   """
-  def series_for_select do
-    query = from s in Series, select: {s.name, s.id}, order_by: s.name
-
-    Repo.all(query)
+  def search_series(phrase, limit) do
+    Series
+    |> NameSearch.narrow(:name, phrase, limit)
+    |> select([s], {s.name, s.id})
+    |> Repo.all()
   end
+
+  @doc """
+  One series as a picker option, or nil.
+  """
+  def series_option(id), do: name_option(Series, id)
 
   @doc """
   Subscribes to all series CRUD messages.
@@ -737,12 +774,29 @@ defmodule Ambry.Books do
   end
 
   @doc """
-  Returns all universes for use in `Select` components.
+  Universes matching what somebody typed into a picker.
   """
-  def universes_for_select do
-    query = from u in Universe, select: {u.name, u.id}, order_by: u.name
+  def search_universes(phrase, limit) do
+    Universe
+    |> NameSearch.narrow(:name, phrase, limit)
+    |> select([u], {u.name, u.id})
+    |> Repo.all()
+  end
 
-    Repo.all(query)
+  @doc """
+  One universe as a picker option, or nil.
+  """
+  def universe_option(id), do: name_option(Universe, id)
+
+  # Both of the above hold nothing but a name, so their option is the same
+  # `{label, id}` pair the picker takes for any simple list.
+  defp name_option(_schema, blank) when blank in [nil, ""], do: nil
+
+  defp name_option(schema, id) do
+    case Repo.get(schema, id) do
+      nil -> nil
+      record -> {record.name, record.id}
+    end
   end
 
   @doc """

--- a/lib/ambry/ecto/name_search.ex
+++ b/lib/ambry/ecto/name_search.ex
@@ -1,0 +1,69 @@
+defmodule Ambry.Ecto.NameSearch do
+  @moduledoc """
+  Narrowing a typeahead's options to what somebody typed, in one place.
+
+  Every picker in the admin asks the same question of a different table — "the
+  records whose name looks like this, best first" — and it used to be asked in
+  Elixir over a preloaded list of every row in that table. That works until
+  the table is the library: a resolver over books loaded every book, with its
+  cover, on every form mount.
+
+  Two properties are worth keeping from the version this replaces, because
+  losing either would be a visible regression:
+
+    * **Accents fold.** "Rodriguez" finds "Patricia Rodríguez" — the library's
+      spelling and a file's are one narrator. `unaccent` is the SQL twin of
+      the NFD fold, the same pairing `Ambry.Inbox.AutoMatch.person_key/1` and
+      its `@name_key_sql` already rely on.
+    * **A prefix beats a substring.** Typing "Kra" puts "Kramer" above
+      "Michael Kramer" rather than sorting them alphabetically together.
+
+  An empty phrase is not a failed search: it's a box the operator has just
+  focused, and what belongs there is the first page of records rather than
+  nothing.
+  """
+
+  import Ecto.Query
+
+  @doc """
+  Narrows `queryable` to rows whose `field` looks like `phrase`, best first.
+  """
+  def narrow(queryable, field, phrase, limit) do
+    case String.trim(phrase || "") do
+      "" -> queryable |> order_by(asc: ^field) |> limit(^limit)
+      trimmed -> queryable |> matching(field, trimmed) |> limit(^limit)
+    end
+  end
+
+  @doc """
+  The `LIKE` pattern for a phrase, for a caller whose searchable expression
+  isn't a single column.
+
+  A recording's label is `coalesce(title, book.title)` — two columns and a
+  fallback — which no field-name parameter can express, so those callers write
+  the fragment and take the escaping from here.
+  """
+  def pattern(phrase), do: "%#{escape(String.trim(phrase || ""))}%"
+
+  defp matching(queryable, field, phrase) do
+    anywhere = "%#{escape(phrase)}%"
+    leading = "#{escape(phrase)}%"
+
+    queryable
+    |> where([r], fragment("unaccent(?) ILIKE unaccent(?)", field(r, ^field), ^anywhere))
+    |> order_by([r],
+      asc:
+        fragment(
+          "CASE WHEN unaccent(?) ILIKE unaccent(?) THEN 0 ELSE 1 END",
+          field(r, ^field),
+          ^leading
+        ),
+      asc: field(r, ^field)
+    )
+  end
+
+  # A name is operator input and `%` is a legal character in one, so the
+  # wildcards have to be ours alone — otherwise typing a percent sign matches
+  # every row in the table.
+  defp escape(phrase), do: String.replace(phrase, ~r/[\\%_]/, "\\\\\\0")
+end

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -32,6 +32,7 @@ defmodule Ambry.Media do
   import Ecto.Query
 
   alias Ambry.Books
+  alias Ambry.Ecto.NameSearch
   alias Ambry.Library
   alias Ambry.Media.Audit
   alias Ambry.Media.Media
@@ -147,31 +148,108 @@ defmodule Ambry.Media do
   end
 
   @doc """
-  Recordings matching a phrase, best-known-first, for a typeahead.
+  Recordings matching what somebody typed into a picker, as rich options.
 
-  The import form's replace decision needs to reach any audiobook in the
-  library by title, book, author or narrator — the same search the index
-  offers, without its pagination.
+  Reaches any audiobook in the library by title, book, author, narrator,
+  series or universe — the same search the index offers, without its
+  pagination. With nothing typed, the first page by book.
   """
-  def match_media(phrase, limit \\ 10)
-  def match_media(phrase, _limit) when phrase in [nil, ""], do: []
-
-  def match_media(phrase, limit) do
+  def search_media(phrase, limit) do
     MediaFlat
-    |> MediaFlat.filter(%{search: phrase})
+    |> media_matching(phrase)
     |> order_by([m], asc: m.book, asc: m.part_number, asc: m.id)
     |> limit(^limit)
     |> Repo.all()
+    |> Enum.map(&media_option/1)
   end
 
   @doc """
-  One recording's flat row, or nil.
+  The same, within one book: what a set may hold.
 
-  For a surface that already speaks that shape: the import form renders the
-  replacement it proposed and the ones a search returned with one component,
-  because they are the same answer.
+  A set belongs to a book the way its members do, so its member picker offers
+  that book's recordings and nothing else.
   """
-  def get_media_flat(id), do: Repo.get(MediaFlat, id)
+  def search_book_media(book_id, phrase, limit)
+  def search_book_media(blank, _phrase, _limit) when blank in [nil, ""], do: []
+
+  def search_book_media(book_id, phrase, limit) do
+    MediaFlat
+    |> where([m], m.book_id == ^book_id)
+    |> media_matching(phrase)
+    |> order_by([m], asc: m.part_number, asc: m.id)
+    |> limit(^limit)
+    |> Repo.all()
+    |> Enum.map(&media_option/1)
+  end
+
+  defp media_matching(query, phrase) do
+    case String.trim(phrase || "") do
+      "" -> query
+      typed -> MediaFlat.filter(query, :search, typed)
+    end
+  end
+
+  @doc """
+  One recording as a picker option, or nil.
+
+  What lets a picker name the recording it is already holding — the preloaded
+  list this replaced was answering that silently, since the id was in it.
+
+  Built off the flat view rather than the record so that every surface
+  describes a recording the same way: its display title, its cover, and what
+  actually tells two recordings of one book apart.
+  """
+  def media_option(blank) when blank in [nil, ""], do: nil
+
+  def media_option(%MediaFlat{} = media) do
+    %{
+      id: media.id,
+      label: media_option_label(media),
+      image: media.thumbnail,
+      detail: media_option_detail(media)
+    }
+  end
+
+  def media_option(id), do: MediaFlat |> Repo.get(id) |> media_option()
+
+  # The book's title unless this recording overrides it, plus its place in a
+  # set — the composition `Media.display_title/1` makes, off the view's own
+  # columns.
+  defp media_option_label(%MediaFlat{} = media) do
+    title = media.title || media.book
+
+    case Media.part_label(media) do
+      nil -> title
+      part -> "#{title} (#{part})"
+    end
+  end
+
+  # The credit stack on one line, in the joins the vocabulary uses, then the
+  # facts that separate two readings of one book. "Streaming only" is in here
+  # because which recordings still cost double the disk is the whole reason
+  # somebody is looking at this list.
+  defp media_option_detail(%MediaFlat{} = media) do
+    [
+      names(media.narrators) && "read by #{names(media.narrators)}",
+      media.publisher,
+      media.published && media.published.year,
+      media.duration && format_duration(media.duration),
+      !media.direct_play && "streaming only"
+    ]
+    |> Enum.filter(&(is_binary(&1) or is_integer(&1)))
+    |> Enum.map_join(" · ", &to_string/1)
+    |> presence()
+  end
+
+  defp names([]), do: nil
+  defp names(nil), do: nil
+  defp names(people), do: people |> Enum.map_join(", ", & &1.name) |> presence()
+
+  # hh:mm, which is how long an audiobook is talked about.
+  defp format_duration(seconds) do
+    total = seconds |> Decimal.round() |> Decimal.to_integer()
+    "#{div(total, 3600)}h #{total |> rem(3600) |> div(60)}m"
+  end
 
   @doc """
   The recording these files were imported into, if any.
@@ -1018,55 +1096,6 @@ defmodule Ambry.Media do
     end)
   end
 
-  @doc """
-  Returns one book's recordings for `Select` components, as rich options:
-  cover, display title, and what actually tells two recordings of one book
-  apart — publisher, year, and the narrator when the cast is small (a
-  full-cast roster reads as noise, so it collapses to a count).
-  """
-  def media_for_select(nil), do: []
-  def media_for_select(""), do: []
-
-  def media_for_select(book_id) do
-    query =
-      from m in Media,
-        where: m.book_id == ^book_id,
-        order_by: m.id,
-        preload: [:book, :recording_group, media_narrators: :narrator]
-
-    query
-    |> Repo.all()
-    |> Enum.map(
-      &%{
-        id: &1.id,
-        label: &1.title || &1.book.title,
-        image: &1.thumbnails && &1.thumbnails.extra_small,
-        detail: media_select_detail(&1)
-      }
-    )
-  end
-
-  defp media_select_detail(%Media{} = media) do
-    narrators = Enum.map(media.media_narrators, & &1.narrator.name)
-
-    [
-      media.publisher,
-      media.published && media.published.year,
-      case narrators do
-        [] -> nil
-        [one] -> one
-        [one, two] -> "#{one}, #{two}"
-        [first | rest] -> "#{first} +#{length(rest)}"
-      end,
-      # picking a grouped recording MOVES it — the one membership fact
-      # that's a warning rather than decoration
-      media.recording_group && "in “#{media.recording_group.name}”"
-    ]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.map_join(" · ", &to_string/1)
-    |> presence()
-  end
-
   defp presence(""), do: nil
   defp presence(other), do: other
 
@@ -1087,26 +1116,35 @@ defmodule Ambry.Media do
   empty group is offerable because the FK carries the book even before
   any member does.
   """
-  def recording_groups_for_select(nil), do: []
-  def recording_groups_for_select(""), do: []
+  def search_recording_groups(book_id, phrase, limit)
+  def search_recording_groups(nil, _phrase, _limit), do: []
+  def search_recording_groups("", _phrase, _limit), do: []
 
-  def recording_groups_for_select(book_id) do
-    query =
-      from g in RecordingGroup,
-        where: g.book_id == ^book_id,
-        order_by: g.id,
-        preload: :media
-
-    query
+  def search_recording_groups(book_id, phrase, limit) do
+    RecordingGroup
+    |> where([g], g.book_id == ^book_id)
+    |> NameSearch.narrow(:name, phrase, limit)
+    |> preload(:media)
     |> Repo.all()
-    |> Enum.map(
-      &%{
-        id: &1.id,
-        label: &1.name,
-        image: first_member_thumbnail(&1),
-        detail: parts_progress(&1)
-      }
-    )
+    |> Enum.map(&recording_group_option/1)
+  end
+
+  @doc """
+  One recording group as a picker option, or nil.
+  """
+  def recording_group_option(blank) when blank in [nil, ""], do: nil
+
+  def recording_group_option(%RecordingGroup{} = group) do
+    %{
+      id: group.id,
+      label: group.name,
+      image: first_member_thumbnail(group),
+      detail: parts_progress(group)
+    }
+  end
+
+  def recording_group_option(id) do
+    RecordingGroup |> preload(:media) |> Repo.get(id) |> recording_group_option()
   end
 
   defp first_member_thumbnail(%RecordingGroup{media: media}) do

--- a/lib/ambry/media/media_flat.ex
+++ b/lib/ambry/media/media_flat.ex
@@ -9,6 +9,7 @@ defmodule Ambry.Media.MediaFlat do
   alias Ambry.People.PersonName
 
   schema "media_flat" do
+    field :book_id, :id
     field :title, :string
     field :part_number, :integer
     field :parts_total, :integer

--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -21,6 +21,7 @@ defmodule Ambry.People do
   import Ambry.Utils
   import Ecto.Query
 
+  alias Ambry.Ecto.NameSearch
   alias Ambry.Paths
   alias Ambry.People.Author
   alias Ambry.People.AuthorPerson
@@ -433,22 +434,35 @@ defmodule Ambry.People do
   def get_narrator!(id), do: Narrator |> preload(:person) |> Repo.get!(id)
 
   @doc """
-  Returns all narrators for use in `Select` components, as rich options:
+  Narrators matching what somebody typed into a picker, as rich options:
   the person's portrait, and their real name when the stage name hides it.
   """
-  def narrators_for_select do
+  def search_narrators(phrase, limit) do
     Narrator
+    |> NameSearch.narrow(:name, phrase, limit)
     |> preload(:person)
-    |> order_by(asc: :name)
     |> Repo.all()
-    |> Enum.map(
-      &%{
-        id: &1.id,
-        label: &1.name,
-        image: portrait(List.wrap(&1.person)),
-        detail: backing(&1.name, List.wrap(&1.person))
-      }
-    )
+    |> Enum.map(&narrator_option/1)
+  end
+
+  @doc """
+  One narrator as a picker option, or nil.
+  """
+  def narrator_option(blank) when blank in [nil, ""], do: nil
+
+  def narrator_option(%Narrator{} = narrator) do
+    people = List.wrap(narrator.person)
+
+    %{
+      id: narrator.id,
+      label: narrator.name,
+      image: portrait(people),
+      detail: backing(narrator.name, people)
+    }
+  end
+
+  def narrator_option(id) do
+    Narrator |> preload(:person) |> Repo.get(id) |> narrator_option()
   end
 
   # Authors
@@ -461,22 +475,33 @@ defmodule Ambry.People do
   def get_author!(id), do: Author |> preload(:people) |> Repo.get!(id)
 
   @doc """
-  Returns all authors for use in `Select` components, as rich options: a
+  Authors matching what somebody typed into a picker, as rich options: a
   portrait, and the human(s) behind a pen name when that's worth saying.
   """
-  def authors_for_select do
+  def search_authors(phrase, limit) do
     Author
+    |> NameSearch.narrow(:name, phrase, limit)
     |> preload(:people)
-    |> order_by(asc: :name)
     |> Repo.all()
-    |> Enum.map(
-      &%{
-        id: &1.id,
-        label: &1.name,
-        image: portrait(&1.people),
-        detail: backing(&1.name, &1.people)
-      }
-    )
+    |> Enum.map(&author_option/1)
+  end
+
+  @doc """
+  One author as a picker option, or nil.
+  """
+  def author_option(blank) when blank in [nil, ""], do: nil
+
+  def author_option(%Author{} = author) do
+    %{
+      id: author.id,
+      label: author.name,
+      image: portrait(author.people),
+      detail: backing(author.name, author.people)
+    }
+  end
+
+  def author_option(id) do
+    Author |> preload(:people) |> Repo.get(id) |> author_option()
   end
 
   defp portrait(people) do
@@ -518,23 +543,32 @@ defmodule Ambry.People do
   end
 
   @doc """
-  Returns all people for use in `Select` components.
+  People matching what somebody typed into a picker.
 
   People rather than identities: this is what the import form's "who is behind
   this credit" control picks from, where the answer is a human, not a name
   they publish under.
   """
-  def people_for_select do
+  def search_people(phrase, limit) do
     Person
-    |> order_by(asc: :name)
+    |> NameSearch.narrow(:name, phrase, limit)
     |> Repo.all()
-    |> Enum.map(
-      &%{
-        id: &1.id,
-        label: &1.name,
-        image: &1.thumbnails && &1.thumbnails.extra_small,
-        detail: nil
-      }
-    )
+    |> Enum.map(&person_option/1)
   end
+
+  @doc """
+  One person as a picker option, or nil.
+  """
+  def person_option(blank) when blank in [nil, ""], do: nil
+
+  def person_option(%Person{} = person) do
+    %{
+      id: person.id,
+      label: person.name,
+      image: person.thumbnails && person.thumbnails.extra_small,
+      detail: nil
+    }
+  end
+
+  def person_option(id), do: Person |> Repo.get(id) |> person_option()
 end

--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -508,32 +508,6 @@ defmodule Ambry.People do
     Enum.find_value(people, &(&1.thumbnails && &1.thumbnails.extra_small))
   end
 
-  @doc """
-  Who is really behind each identity, when that's worth saying.
-
-  Maps identity id to the backing people's names, only for identities where
-  the names add something — a pen name's real names, a stage name's real
-  person, a shared pen name's several humans. An identity whose person is
-  simply named the same is omitted; repeating the name is noise.
-  """
-  def author_backing_names do
-    Author
-    |> preload(:people)
-    |> Repo.all()
-    |> Map.new(fn author -> {author.id, backing(author.name, author.people)} end)
-    |> Map.reject(fn {_id, names} -> names == nil end)
-  end
-
-  def narrator_backing_names do
-    Narrator
-    |> preload(:person)
-    |> Repo.all()
-    |> Map.new(fn narrator ->
-      {narrator.id, backing(narrator.name, List.wrap(narrator.person))}
-    end)
-    |> Map.reject(fn {_id, names} -> names == nil end)
-  end
-
   defp backing(identity_name, people) do
     case Enum.map(people, & &1.name) do
       [] -> nil

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -20,12 +20,15 @@ defmodule AmbryWeb.Admin.Decisions do
 
   import AmbryWeb.CoreComponents
 
+  alias Ambry.Books
   alias Ambry.Inbox.Draft.Credit
   alias Ambry.Inbox.Draft.Field
   alias Ambry.Inbox.Draft.GroupLink
   alias Ambry.Inbox.Draft.PersonDecision
   alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.Draft.Tier
+  alias Ambry.Media
+  alias Ambry.People
   alias AmbryWeb.Components.EntityResolver
 
   attr :outcomes, :list, required: true
@@ -354,50 +357,29 @@ defmodule AmbryWeb.Admin.Decisions do
     """
   end
 
-  attr :recording, :map, required: true, doc: "%{id:, label:, facts:, direct_play:}"
-  attr :chosen, :boolean, required: true
+  attr :recording, :map, required: true, doc: "an `Ambry.Media.media_option/1` map"
 
   @doc """
   An audiobook in the library these files might be a better copy of.
 
   The work level's local-book costume, one level down and answering the
   question one level up: not "which book is this" but "is this an audiobook
-  you already have, in better files". Same anatomy on purpose — the proposal
-  the path evidence makes and a recording found by searching are the same
-  answer, and a row that looked different depending on which had produced it
-  would be claiming a difference that isn't there.
+  you already have, in better files".
+
+  **Only ever a proposal.** Once the operator has answered, the answer lives in
+  the picker beside this — a row and a filled box both claiming to hold it is
+  one answer rendered twice, free to disagree about which is the real one. So
+  this offers, and the box states.
   """
   def local_recording_row(assigns) do
     ~H"""
-    <div
-      class={[
-        "flex items-start gap-3 rounded-md p-3",
-        @chosen && "bg-brand-dark/10 ring-brand-dark/50 ring-2 ring-inset",
-        !@chosen && "bg-zinc-800/60"
-      ]}
-      data-role="local-recording"
-      data-chosen={@chosen && "true"}
-    >
+    <div class="bg-zinc-800/60 flex items-start gap-3 rounded-md p-3" data-role="local-recording">
       <div class="min-w-0 flex-grow">
-        <div class="flex items-baseline gap-2 text-sm font-semibold">
-          <span class="min-w-0 truncate">{@recording.label}</span>
-
-          <%!-- Which recordings still cost double the disk is the whole
-              reason somebody is on this form, so the row says it. --%>
-          <.badge
-            :if={!@recording.direct_play}
-            color={:gray}
-            class="flex-none text-xs font-normal"
-            data-role="streaming-only"
-          >
-            streaming only
-          </.badge>
-        </div>
-        <p class="truncate text-xs text-zinc-400">{@recording.facts}</p>
+        <p class="truncate text-sm font-semibold">{@recording.label}</p>
+        <p class="truncate text-xs text-zinc-400">{@recording.detail}</p>
       </div>
 
       <button
-        :if={!@chosen}
         type="button"
         phx-click="replace-recording"
         phx-value-id={@recording.id}
@@ -405,8 +387,6 @@ defmodule AmbryWeb.Admin.Decisions do
       >
         Yes, replace its files
       </button>
-
-      <span :if={@chosen} class="flex-none text-xs text-zinc-400">replacing this</span>
     </div>
     """
   end
@@ -804,18 +784,8 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :credit, Credit, required: true
   attr :index, :integer, required: true
   attr :section, :string, required: true
-  attr :identities, :list, required: true
   attr :verb, :string, required: true, doc: ~s(the visible label — "Written by")
-
-  attr :identity_backing, :map,
-    default: %{},
-    doc: "identity id => the backing people's names, where they add something"
-
   attr :persons, :list, required: true, doc: "the PersonDecisions this credit references"
-
-  attr :people, :list,
-    default: [],
-    doc: "the library's people, so a linked person's chip shows the library's own name and face"
 
   attr :count, :integer,
     default: 1,
@@ -874,7 +844,7 @@ defmodule AmbryWeb.Admin.Decisions do
   end
 
   def credit_row(assigns) do
-    assigns = assign(assigns, :faces, Enum.map(assigns.persons, &person_face(&1, assigns.people)))
+    assigns = assign(assigns, :faces, Enum.map(assigns.persons, &person_face/1))
 
     ~H"""
     <%!-- A decision block, so it wears the state rail like every other one —
@@ -943,7 +913,8 @@ defmodule AmbryWeb.Admin.Decisions do
             id={"credit-#{@section}-#{@index}-resolver"}
             name="identity_id"
             text_name="name"
-            options={@identities}
+            search={identity_search(@credit.kind)}
+            fetch={identity_fetch(@credit.kind)}
             value={if @credit.mode == :link, do: @credit.identity_id}
             text={@credit.name || ""}
             placeholder="name"
@@ -955,11 +926,11 @@ defmodule AmbryWeb.Admin.Decisions do
                 name's real names are worth a line, "already in the library"
                 twice is not. --%>
           <span
-            :if={@credit.mode == :link && @identity_backing[@credit.identity_id]}
+            :if={identity_backing(@credit)}
             class="text-xs text-zinc-400"
             data-role="identity-backing"
           >
-            {@identity_backing[@credit.identity_id]}
+            {identity_backing(@credit)}
           </span>
         </form>
 
@@ -1042,7 +1013,6 @@ defmodule AmbryWeb.Admin.Decisions do
   attr :locals, :list, default: [], doc: "people the library already has by this name"
   attr :outcomes, :list, default: []
   attr :appears, :list, default: []
-  attr :people, :list, default: [], doc: "the library's people, for the typeahead"
 
   attr :query_name, :string,
     default: nil,
@@ -1073,11 +1043,11 @@ defmodule AmbryWeb.Admin.Decisions do
     assigns =
       assign(assigns,
         own_name: assigns.person.own_name or not Credit.simple?(assigns.group.credit),
-        linked: linked_person(assigns.people, assigns.person),
+        linked: linked_person(assigns.person),
         # A linked person is called what the library calls them, here as well
         # as on the credit chip — the staged name is a leftover of finding
         # them, not their name.
-        words: person_words(assigns.person, linked_person(assigns.people, assigns.person))
+        words: person_words(assigns.person, linked_person(assigns.person))
       )
 
     ~H"""
@@ -1177,7 +1147,8 @@ defmodule AmbryWeb.Admin.Decisions do
               id={"person-#{@person.key}-resolver"}
               name="person_id"
               text_name="name"
-              options={@people}
+              search={&People.search_people/2}
+              fetch={&People.person_option/1}
               value={nil}
               text={Field.value(@person.name) || ""}
               placeholder="the person's real name"
@@ -1283,14 +1254,14 @@ defmodule AmbryWeb.Admin.Decisions do
 
   # The library's own row for a person linked from the typeahead rather than
   # from the rows below — enough to say who, and to take it back.
-  defp linked_person(people, %PersonDecision{mode: :link, person_id: id}) do
-    case Enum.find(people, &(&1.id == id)) do
+  defp linked_person(%PersonDecision{mode: :link, person_id: id}) do
+    case People.person_option(id) do
       nil -> %{"id" => id, "name" => "Somebody in your library"}
       person -> %{"id" => person.id, "name" => person.label, "image" => person.image}
     end
   end
 
-  defp linked_person(_people, _person), do: nil
+  defp linked_person(_person), do: nil
 
   @doc """
   What to show for a person: the library's own name and face where this
@@ -1307,8 +1278,8 @@ defmodule AmbryWeb.Admin.Decisions do
   a staged image may be a remote provider URL that has to go through the
   proxy.
   """
-  def person_face(person, people) do
-    case linked_person(people, person) do
+  def person_face(person) do
+    case linked_person(person) do
       nil ->
         %{
           key: person.key,
@@ -1336,6 +1307,29 @@ defmodule AmbryWeb.Admin.Decisions do
 
   defp local_people_words(_person, locals, _kind),
     do: "#{length(locals)} people by this name are already in your library."
+
+  # Which records a control offers is a property of what it is picking, not a
+  # decision the caller makes: a "Written by" row can only ever resolve an
+  # Author. Naming the source here rather than taking a list as an attr is
+  # what let the import form stop loading every author, narrator and person in
+  # the library on mount.
+  defp identity_search(:author), do: &People.search_authors/2
+  defp identity_search(:narrator), do: &People.search_narrators/2
+
+  defp identity_fetch(:author), do: &People.author_option/1
+  defp identity_fetch(:narrator), do: &People.narrator_option/1
+
+  # Who is really behind a linked identity, when the names add something. The
+  # same `detail` the typeahead's rows carry, read off the one record this
+  # credit points at — it used to be a map of every identity in the library.
+  defp identity_backing(%Credit{mode: :link, kind: kind, identity_id: id}) when not is_nil(id) do
+    case identity_fetch(kind).(id) do
+      %{detail: detail} -> detail
+      nil -> nil
+    end
+  end
+
+  defp identity_backing(%Credit{}), do: nil
 
   attr :local, :map, required: true
   attr :person_key, :string, required: true
@@ -1811,7 +1805,6 @@ defmodule AmbryWeb.Admin.Decisions do
 
   attr :link, SeriesLink, required: true
   attr :index, :integer, required: true
-  attr :options, :list, required: true
 
   attr :count, :integer,
     default: 1,
@@ -1924,7 +1917,8 @@ defmodule AmbryWeb.Admin.Decisions do
             id={"series-#{@index}-resolver"}
             name="series_id"
             text_name="name"
-            options={@options}
+            search={&Books.search_series/2}
+            fetch={&Books.series_option/1}
             value={if @link.mode == :link, do: @link.series_id}
             text={@link.name || ""}
             placeholder="series name"
@@ -1970,7 +1964,10 @@ defmodule AmbryWeb.Admin.Decisions do
   end
 
   attr :link, GroupLink, required: true
-  attr :options, :list, required: true
+
+  attr :book_id, :any,
+    default: nil,
+    doc: "the book whose sets this offers — a set belongs to a book the way its members do"
 
   @doc """
   The recording's place in a part set — which group it joins or creates, and
@@ -2064,7 +2061,8 @@ defmodule AmbryWeb.Admin.Decisions do
             id="group-resolver"
             name="recording_group_id"
             text_name="name"
-            options={@options}
+            search={&Media.search_recording_groups(@book_id, &1, &2)}
+            fetch={&Media.recording_group_option/1}
             value={if @link.mode == :link, do: @link.recording_group_id}
             text={@link.name || ""}
             placeholder="set name"

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -425,6 +425,15 @@ defmodule AmbryWeb.CoreComponents do
   attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
+
+  attr :search, :any,
+    default: nil,
+    doc: ~s|autocomplete: `fn phrase, limit -> [option]`, e.g. `&Books.search_books/2`|
+
+  attr :fetch, :any,
+    default: nil,
+    doc: ~s|autocomplete: `fn id -> option \| nil`, so a filled box can name what it holds|
+
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
   attr :class, :string, default: nil, doc: "class overrides"
   attr :container_class, :string, default: nil, doc: "extra classes for the container div"
@@ -521,7 +530,8 @@ defmodule AmbryWeb.CoreComponents do
         module={EntityResolver}
         id={@id}
         name={@name}
-        options={@options}
+        search={@search}
+        fetch={@fetch}
         value={@value}
         class={
           ["py-[7px] px-[11px] block w-full rounded-md", "focus:outline-none focus:ring-4 sm:text-sm sm:leading-6"] ++

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -25,6 +25,31 @@ defmodule AmbryWeb.Components.EntityResolver do
   hook — deliberately not a `<datalist>`, which mobile Firefox does not
   support and which cannot offer a create row.
 
+  ## Where the options come from
+
+  Two functions, passed in:
+
+      search={&Books.search_books/2}   # (phrase, limit) -> [option]
+      fetch={&Books.book_option/1}     #  id             -> option | nil
+
+  **The search runs per keystroke, server-side.** What this replaced took the
+  whole table as a list and filtered it in memory, which meant every form
+  holding a book picker loaded every book — with its cover — on mount, and the
+  filtering was `String.contains?` over one label, so "sanderson kings" found
+  nothing. The context owns the query instead: it can score, join, and stop at
+  a limit.
+
+  **`fetch` is not decoration.** A filled box has to name what it holds, and
+  the preloaded list was answering that silently — the id was in it, so its
+  label was there to find. Without a by-id lookup a pure picker renders blank
+  over a perfectly good value.
+
+  Captured remote functions rather than an MFA tuple or a source atom:
+  `&Mod.fun/arity` is checked at compile time (an undefined one is a warning,
+  and CI runs `--warnings-as-errors`), it is stable across renders so change
+  tracking behaves, and it is greppable — the call site says which queries
+  back the box.
+
   ## Options
 
   Plain `{label, id}` tuples, or maps for richer rows:
@@ -46,7 +71,8 @@ defmodule AmbryWeb.Components.EntityResolver do
   def render(assigns) do
     assigns =
       assigns
-      |> assign(:equery, effective_query(assigns))
+      |> assign(:held, held(assigns))
+      |> then(&assign(&1, :equery, effective_query(&1)))
       |> then(&assign(&1, :matches, matches(&1)))
       |> then(&assign(&1, :imaged, Enum.any?(&1.matches, fn option -> option.image end)))
 
@@ -176,16 +202,6 @@ defmodule AmbryWeb.Components.EntityResolver do
 
   @impl Phoenix.LiveComponent
   def update(assigns, socket) do
-    assigns =
-      case assigns do
-        %{options: options} ->
-          options = Enum.map(options, &normalize_option/1)
-          %{assigns | options: options}
-
-        _no_options ->
-          assigns
-      end
-
     {:ok,
      socket
      |> assign(assigns)
@@ -195,11 +211,6 @@ defmodule AmbryWeb.Components.EntityResolver do
      |> assign_new(:placeholder, fn -> nil end)
      |> assign_new(:class, fn -> nil end)}
   end
-
-  defp normalize_option({label, id}), do: %{id: id, label: label, image: nil, detail: nil}
-
-  defp normalize_option(%{id: _, label: _} = option),
-    do: Map.merge(%{image: nil, detail: nil}, option)
 
   @impl Phoenix.LiveComponent
   def handle_event("open", _params, socket) do
@@ -267,21 +278,19 @@ defmodule AmbryWeb.Components.EntityResolver do
     })
   end
 
-  # While typing, show the query; otherwise the picked record's label, or the
+  # The record this box is holding, so it can say its name. Asked of the
+  # source, because there is no longer a list to find it in — and not asked at
+  # all while the operator is typing, which is the common case and the one
+  # where the answer would be thrown away.
+  defp held(%{query: query}) when is_binary(query), do: nil
+  defp held(%{value: nil}), do: nil
+  defp held(%{value: value, fetch: fetch}), do: normalize(fetch.(value))
+
+  # While typing, show the query; otherwise the held record's label, or the
   # name being created.
   defp display_value(%{query: query}) when is_binary(query), do: query
-
-  defp display_value(%{value: value, options: options, text: text}) do
-    case value do
-      nil ->
-        text
-
-      value ->
-        Enum.find_value(options, text, fn option ->
-          to_string(option.id) == to_string(value) && option.label
-        end)
-    end
-  end
+  defp display_value(%{held: %{label: label}}), do: label
+  defp display_value(%{text: text}), do: text
 
   # What the list filters on: the query while typing, otherwise whatever the
   # field currently holds — an open filled field must never list records that
@@ -289,26 +298,20 @@ defmodule AmbryWeb.Components.EntityResolver do
   defp effective_query(%{query: query}) when is_binary(query), do: query
   defp effective_query(assigns), do: display_value(assigns)
 
-  defp matches(%{equery: query, options: options}) when is_binary(query) and query != "" do
-    folded = fold(query)
+  # Only while the list is open. The search is a database query now, and a
+  # closed box has nothing to show — running one per parent render would be a
+  # query per keystroke of every other field on the form.
+  defp matches(%{open: false}), do: []
 
-    options
-    |> Enum.filter(fn option -> String.contains?(fold(option.label), folded) end)
-    |> Enum.sort_by(fn option ->
-      {!String.starts_with?(fold(option.label), folded), option.label}
-    end)
-    |> Enum.take(@limit)
+  defp matches(%{equery: query, search: search}) do
+    query |> search.(@limit) |> Enum.map(&normalize/1)
   end
 
-  defp matches(%{options: options}), do: Enum.take(options, @limit)
+  defp normalize(nil), do: nil
+  defp normalize({label, id}), do: %{id: id, label: label, image: nil, detail: nil}
 
-  # Case- and accent-insensitive: "Rodriguez" finds "Patricia Rodríguez".
-  defp fold(string) do
-    string
-    |> String.normalize(:nfd)
-    |> String.replace(~r/\p{Mn}/u, "")
-    |> String.downcase()
-  end
+  defp normalize(%{id: _id, label: _label} = option),
+    do: Map.merge(%{image: nil, detail: nil}, option)
 
   defp present?(nil), do: false
   defp present?(string), do: String.trim(string) != ""

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -41,10 +41,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
        retrying: nil,
        chips: %{},
        reverts: %{},
-       provenance_hints: %{},
-       authors: People.authors_for_select(),
-       series: Books.series_for_select(),
-       universes: Books.universes_for_select()
+       provenance_hints: %{}
      )
      |> apply_action(socket.assigns.live_action, params)}
   end
@@ -59,10 +56,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
       book: book
     )
     |> assign_form(changeset)
-    |> assign(
-      evidence:
-        Evidence.new(seed_fields(book, socket.assigns.authors), known: Evidence.known_from(book))
-    )
+    |> assign(evidence: Evidence.new(seed_fields(book), known: Evidence.known_from(book)))
   end
 
   defp apply_action(socket, :new, _params) do
@@ -79,17 +73,14 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   end
 
   # The search the record itself suggests: its title, and its first author.
-  defp seed_fields(book, author_options) do
-    labels = Map.new(author_options, &{&1.id, &1.label})
-
-    author =
-      case book.book_authors do
-        [%{author_id: author_id} | _rest] -> labels[author_id]
-        _empty -> nil
-      end
-
-    %{"title" => book.title, "author" => author}
+  # Read off the loaded credit rather than looked up in a list of every author
+  # in the library, which is what it used to need.
+  defp seed_fields(book) do
+    %{"title" => book.title, "author" => first_author(book)}
   end
+
+  defp first_author(%{book_authors: [%{author: %{name: name}} | _rest]}), do: name
+  defp first_author(_book), do: nil
 
   @impl Phoenix.LiveView
   def handle_params(_params, _url, socket), do: {:noreply, socket}
@@ -261,7 +252,6 @@ defmodule AmbryWeb.Admin.BookLive.Form do
     socket
     |> append_row(:book_authors, %{"author_id" => to_string(author_id)}, ~w(author_id))
     |> assign(
-      authors: People.authors_for_select(),
       provenance_hints:
         ProvenanceHints.for_list(socket.assigns.provenance_hints, "book_authors", proposal.source)
     )
@@ -280,7 +270,6 @@ defmodule AmbryWeb.Admin.BookLive.Form do
     socket
     |> append_row(:series_books, row, ~w(series_id book_number))
     |> assign(
-      series: Books.series_for_select(),
       provenance_hints:
         ProvenanceHints.for_list(socket.assigns.provenance_hints, "series_books", proposal.source)
     )
@@ -379,12 +368,14 @@ defmodule AmbryWeb.Admin.BookLive.Form do
             evidence
             |> Evidence.proposals(:authors)
             |> mark_present(
-              current_labels(form.source, :book_authors, :author_id, socket.assigns.authors)
+              current_labels(form.source, :book_authors, :author_id, &People.author_option/1)
             ),
           series:
             evidence
             |> Evidence.proposals(:series)
-            |> mark_present(current_series_names(form.source, socket.assigns.series))
+            |> mark_present(
+              current_labels(form.source, :series_books, :series_id, &Books.series_option/1)
+            )
         }
       else
         %{}
@@ -396,23 +387,20 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   defp reverts(%{assigns: %{form: form, book: book}}),
     do: Revert.offers(form, book, [:title, :published])
 
-  defp current_labels(changeset, assoc, key, options) do
-    labels = Map.new(options, &{&1.id, &1.label})
-
+  # Which proposals the record already holds, by name, so a chip for one of
+  # them reads as present rather than as an offer. Asked of the context rather
+  # than found in a preloaded list of every author and series in the library —
+  # the same lookup `EntityResolver`'s `fetch` makes, for the same reason.
+  defp current_labels(changeset, assoc, key, fetch) do
     changeset
     |> Changeset.get_field(assoc)
-    |> Enum.map(&labels[Map.get(&1, key)])
+    |> Enum.map(fn row -> row |> Map.get(key) |> fetch.() |> option_label() end)
     |> Enum.reject(&is_nil/1)
   end
 
-  defp current_series_names(changeset, options) do
-    names = Map.new(options, fn {name, id} -> {id, name} end)
-
-    changeset
-    |> Changeset.get_field(:series_books)
-    |> Enum.map(&names[&1.series_id])
-    |> Enum.reject(&is_nil/1)
-  end
+  defp option_label(%{label: label}), do: label
+  defp option_label({label, _id}), do: label
+  defp option_label(nil), do: nil
 
   defp save_book(socket, :edit, book_params) do
     opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -60,7 +60,12 @@
               edges) --%>
           <div class="relative flex items-start gap-2">
             <div class="relative grow">
-              <.input field={book_author_form[:author_id]} type="autocomplete" options={@authors} />
+              <.input
+                field={book_author_form[:author_id]}
+                type="autocomplete"
+                search={&People.search_authors/2}
+                fetch={&People.author_option/1}
+              />
               <.delete_button
                 field={@form[:book_authors_drop]}
                 index={book_author_form.index}
@@ -116,7 +121,8 @@
               <.input
                 field={series_book_form[:series_id]}
                 type="autocomplete"
-                options={@series}
+                search={&Books.search_series/2}
+                fetch={&Books.series_option/1}
               />
               <.delete_button
                 field={@form[:series_books_drop]}
@@ -156,7 +162,12 @@
           <.sort_input field={@form[:book_universes_sort]} index={book_universe_form.index} />
 
           <div class="relative">
-            <.input field={book_universe_form[:universe_id]} type="autocomplete" options={@universes} />
+            <.input
+              field={book_universe_form[:universe_id]}
+              type="autocomplete"
+              search={&Books.search_universes/2}
+              fetch={&Books.universe_option/1}
+            />
             <.delete_button
               field={@form[:book_universes_drop]}
               index={book_universe_form.index}

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -54,7 +54,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Library.Placement
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
-  alias Ambry.People
+  alias AmbryWeb.Components.EntityResolver
   alias Phoenix.LiveView.AsyncResult
 
   require Logger
@@ -67,11 +67,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:ok,
      socket
      |> assign(page_title: InboxItem.name(item))
-     |> assign(series: Books.series_for_select())
-     |> assign(authors: People.authors_for_select(), narrators: People.narrators_for_select())
-     |> assign(author_backing: People.author_backing_names())
-     |> assign(narrator_backing: People.narrator_backing_names())
-     |> assign(people: People.people_for_select())
      |> assign(researching: nil, retrying: nil, enriching: nil)
      # What the in-flight search asked for. The stored query only updates
      # when results land, so a form that renders storage describes the
@@ -84,10 +79,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      # in full. Both view state keyed by person key — the results themselves
      # are evidence and live on the item.
      |> assign(searching_person: nil, photos_expanded: %{})
-     |> assign(library_query: nil, library_results: [], ticking: false)
-     # The replace decision's typeahead. Session state like the library
-     # search above it: what was searched for is not part of the import.
-     |> assign(recording_query: nil, recording_results: [])
+     |> assign(ticking: false)
      # The pending chapter-title fetch, and which ASIN's titles were last
      # poured — the chips' chosen state.
      |> assign(chapter_import: nil, chapters_applied_asin: nil)
@@ -325,6 +317,11 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   # The decision above every other one: these files are a better copy of
   # something the library already has, so nothing below is in question.
+  #
+  # A blank id is the surrounding form reporting itself for some other reason,
+  # not an answer — the way back from a replacement is the chip beside the
+  # box, the same as at the work level. (`EntityResolver` only reports a pure
+  # picker's value when something is picked, so this is belt and braces.)
   def handle_event("replace-recording", %{"id" => id}, socket) do
     case to_int(id) do
       nil -> {:noreply, socket}
@@ -336,32 +333,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.new_recording/1)}
   end
 
-  # The same escape hatch the work level has, for the same reason: a
-  # recording whose provenance was never recorded — or was recorded against a
-  # path that has since moved — is reachable no other way.
-  def handle_event("search-recordings", %{"query" => query}, socket) do
-    results = query |> Media.match_media() |> Enum.map(&local_recording/1)
-    {:noreply, assign(socket, recording_query: query, recording_results: results)}
-  end
-
   def handle_event("link-book", %{"id" => id}, socket) do
     item = socket.assigns.item
-    {:noreply, edit(socket, &Draft.Edit.link_book(&1, item, to_int(id)))}
-  end
 
-  # The escape hatch. Matching finds the ordinary case and cannot be expected
-  # to find every one: a file tagged "HP1 - The Philosopher's Stone" and a book
-  # called "Harry Potter and the Sorcerer's Stone" are the same work and no
-  # string comparison should be asked to know that. Rather than chase it, give
-  # the operator a way to go and look.
-  def handle_event("search-library", %{"query" => query}, socket) do
-    results =
-      case Books.match_keywords(query) do
-        [] -> []
-        terms -> terms |> Books.match_books(10) |> Enum.map(&local_book/1)
-      end
-
-    {:noreply, assign(socket, library_query: query, library_results: results)}
+    case to_int(id) do
+      nil -> {:noreply, socket}
+      book_id -> {:noreply, edit(socket, &Draft.Edit.link_book(&1, item, book_id))}
+    end
   end
 
   def handle_event("new-book", _params, socket) do
@@ -993,10 +971,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       # rather than per render — the hints are parsed out of the release
       # text.
       search_seeds: search_seeds(item),
-      # A recording group is reachable only through its book, so the picker
-      # has options exactly when the work links a library book. A :create
-      # work has no groups yet — the resolver is create-only there.
-      group_options: group_options(item.draft),
       # Where each person is credited, so a row can say "same person as the
       # author". Derived, never stored — one human is one record now, and a
       # second copy of "who is where" is what used to drift.
@@ -1031,10 +1005,15 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   defp direction("up"), do: :up
   defp direction(_down), do: :down
 
-  defp group_options(%Draft{work: %Work{mode: :link, book_id: book_id}}) when not is_nil(book_id),
-    do: Media.recording_groups_for_select(book_id)
+  @doc """
+  The book this import links, if it links one.
 
-  defp group_options(_draft), do: []
+  A set is reachable only through its book, so the set picker offers something
+  exactly when the work links a library book — a `:create` work has no sets
+  yet, and there the resolver is create-only.
+  """
+  def linked_book_id(%Draft{work: %Work{mode: :link, book_id: book_id}}), do: book_id
+  def linked_book_id(_draft), do: nil
 
   defp group_absent?(%Draft{recording: %Recording{recording_group: nil}}), do: true
   defp group_absent?(%Draft{}), do: false
@@ -1271,19 +1250,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def provider_outcomes(_item, _level), do: []
 
   defp replaces(%Draft{replacement: %Replacement{media_id: id}}) when is_integer(id),
-    do: id |> Media.get_media_flat() |> local_recording()
+    do: Media.media_option(id)
 
   defp replaces(_no_proposal), do: nil
-
-  @doc """
-  Search hits, minus the one the card is already showing.
-
-  The chosen recording (or the proposed one) has its own row above the search,
-  and rendering it twice would ask the same question in two places with two
-  different answers to the "is this it" state.
-  """
-  def search_results(results, nil), do: results
-  def search_results(results, shown), do: Enum.reject(results, &(&1.id == shown.id))
 
   # A recording can be deleted between the moment it was chosen and the
   # moment the button is pressed, and the one thing this form may not do is
@@ -1307,59 +1276,6 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   """
   def only_copy?(nil), do: false
   def only_copy?(%{id: id}), do: Media.only_copy?(id)
-
-  # The same shape a searched-for recording arrives in, so the row component
-  # can't tell the proposal from a search hit.
-  defp local_recording(nil), do: nil
-
-  defp local_recording(media) do
-    %{
-      id: media.id,
-      label: recording_label(media),
-      facts: recording_facts(media),
-      direct_play: media.direct_play
-    }
-  end
-
-  # The book's title unless this recording overrides it, plus its place in a
-  # set — the same composition `Media.display_title/1` makes, off the flat
-  # row's own columns.
-  defp recording_label(media) do
-    title = media.title || media.book
-
-    case Media.Media.part_label(media) do
-      nil -> title
-      part -> "#{title} (#{part})"
-    end
-  end
-
-  # The credit stack, on one line, in the joins the vocabulary uses.
-  defp recording_facts(media) do
-    [
-      names(media.authors),
-      names(media.narrators) && "read by #{names(media.narrators)}",
-      format_timecode(media.duration)
-    ]
-    |> Enum.filter(&is_binary/1)
-    |> Enum.join(" · ")
-  end
-
-  defp names([]), do: nil
-  defp names(people), do: people |> Enum.map_join(", ", & &1.name) |> presence()
-
-  defp presence(""), do: nil
-  defp presence(value), do: value
-
-  # Shaped like a stored local record, so the row component can't tell a
-  # searched-for book from a matched one — they are the same answer.
-  defp local_book(book) do
-    %{
-      "id" => book.id,
-      "title" => book.title,
-      "authors" => Enum.map(book.authors || [], & &1.name),
-      "published" => book.published && Date.to_iso8601(book.published)
-    }
-  end
 
   @doc "How a provider record is referred to."
   defdelegate record_ref(record), to: Inbox

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -194,45 +194,23 @@
             This audiobook was imported from these files.
           </p>
 
-          <.local_recording_row
-            :if={@replaces}
-            recording={@replaces}
-            chosen={@replacing}
-          />
+          <.local_recording_row :if={@replaces && !@replacing} recording={@replaces} />
 
           <%!-- The escape hatch, and the only route to an audiobook whose
               provenance was never recorded — every recording uploaded before
               the inbox existed. --%>
-          <form
-            phx-submit="search-recordings"
-            phx-change="search-recordings"
-            id="recording-search"
-            class="flex flex-wrap items-center gap-2 pt-1"
-          >
-            <input
-              type="text"
-              name="query"
-              value={@recording_query}
+          <form id="recording-search" phx-change="replace-recording" class="max-w-xl pt-1">
+            <.live_component
+              module={EntityResolver}
+              id="replace-recording-resolver"
+              name="id"
+              search={&Media.search_media/2}
+              fetch={&Media.media_option/1}
+              value={if @replacing, do: @item.draft.replacement.media_id}
               placeholder="search the library by title, author or narrator"
-              phx-debounce="300"
-              class={input_classes("min-w-64 px-[11px] max-w-xl flex-grow py-2 leading-6")}
+              class={input_classes("w-full")}
             />
-            <.button type="submit" color={:zinc}>Search</.button>
           </form>
-
-          <p
-            :if={@recording_query not in [nil, ""] and @recording_results == []}
-            class="pl-3 text-sm text-zinc-400"
-          >
-            No audiobook in the library matches that.
-          </p>
-
-          <%!-- The row already above is not repeated here. --%>
-          <.local_recording_row
-            :for={recording <- search_results(@recording_results, @replaces)}
-            recording={recording}
-            chosen={false}
-          />
 
           <button
             type="button"
@@ -405,36 +383,21 @@
               copy of Philosopher's Stone is tagged "HP1 - The Philosopher's
               Stone", and the US edition of the same work is called Sorcerer's
               Stone, which no amount of string cleverness should be expected to
-              connect. So there is always a way to go and look. --%>
-          <form
-            phx-submit="search-library"
-            phx-change="search-library"
-            id="library-search"
-            class="flex flex-wrap items-center gap-2 pt-1"
-          >
-            <input
-              type="text"
-              name="query"
-              value={@library_query}
+              connect. So there is always a way to go and look — the same
+              typeahead every other picker in the admin uses, over the same
+              keyword search that produced the rows above. --%>
+          <form id="library-search" phx-change="link-book" class="max-w-xl pt-1">
+            <.live_component
+              module={EntityResolver}
+              id="library-book-resolver"
+              name="id"
+              search={&Books.search_books/2}
+              fetch={&Books.book_option/1}
+              value={if @item.draft.work.mode == :link, do: @item.draft.work.book_id}
               placeholder="search the library by title, author or series"
-              phx-debounce="300"
-              class={input_classes("min-w-64 px-[11px] max-w-xl flex-grow py-2 leading-6")}
+              class={input_classes("w-full")}
             />
-            <.button type="submit" color={:zinc}>Search</.button>
           </form>
-
-          <p
-            :if={@library_query not in [nil, ""] and @library_results == []}
-            class="pl-3 text-sm text-zinc-400"
-          >
-            Nothing in the library matches that.
-          </p>
-
-          <.local_book_row
-            :for={book <- @library_results}
-            book={book}
-            linked={@item.draft.work.mode == :link and @item.draft.work.book_id == book["id"]}
-          />
 
           <button
             type="button"
@@ -515,11 +478,8 @@
             index={index}
             count={length(@item.draft.work.authors)}
             section="work"
-            identities={@authors}
             verb="Written by"
-            identity_backing={@author_backing}
             persons={Draft.people_for(@item.draft, credit)}
-            people={@people}
           />
 
           <.add_button phx-click="add-credit" phx-value-section="work">
@@ -541,7 +501,6 @@
             link={link}
             index={index}
             count={length(@item.draft.work.series)}
-            options={@series}
           />
 
           <.add_button phx-click="add-series">Add a series</.add_button>
@@ -706,7 +665,7 @@
           <.group_row
             :if={@item.draft.recording.recording_group}
             link={@item.draft.recording.recording_group}
-            options={@group_options}
+            book_id={linked_book_id(@item.draft)}
           />
 
           <.add_button :if={group_absent?(@item.draft)} phx-click="add-group">
@@ -726,11 +685,8 @@
             index={index}
             count={length(@item.draft.recording.narrators)}
             section="recording"
-            identities={@narrators}
             verb="Read by"
-            identity_backing={@narrator_backing}
             persons={Draft.people_for(@item.draft, credit)}
-            people={@people}
           />
 
           <.add_button phx-click="add-credit" phx-value-section="recording">
@@ -791,7 +747,6 @@
               outcomes={person_outcomes(@item, person.key)}
               query_name={person_query_name(@item, person.key, @searching_person, @searching_person_name)}
               appears={@appearances[person.key] || []}
-              people={@people}
             />
           </div>
 
@@ -808,7 +763,6 @@
             outcomes={person_outcomes(@item, hd(group.people).key)}
             query_name={person_query_name(@item, hd(group.people).key, @searching_person, @searching_person_name)}
             appears={@appearances[hd(group.people).key] || []}
-            people={@people}
           />
         </div>
       </section>

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -11,6 +11,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   import AmbryWeb.Admin.ParamHelpers
   import AmbryWeb.Admin.UploadHelpers
 
+  alias Ambry.Books
   alias Ambry.Images
   alias Ambry.Inbox
   alias Ambry.Media
@@ -51,9 +52,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
        chapter_import: nil,
        chapters_applied_asin: nil,
        provenance_hints: %{},
-       source_files_expanded: false,
-       narrators: People.narrators_for_select(),
-       books: Ambry.Books.books_for_select()
+       source_files_expanded: false
      )
      |> apply_action(socket.assigns.live_action, params)}
   end
@@ -68,16 +67,13 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     |> assign(
       page_title: Media.Media.display_title(media),
       media: media,
-      recording_groups: Media.recording_groups_for_select(media.book_id),
+      book_id: media.book_id,
       file_stats: Media.get_media_file_details(media),
       # View state, not derived per render: deriving it from the typeahead's
       # value made the row vanish mid-edit the moment the box was cleared.
       group_row_visible: media.recording_group_id != nil or media.part_number != nil
     )
-    |> assign(
-      evidence:
-        Evidence.new(seed_fields(media, socket.assigns), known: Evidence.known_from(media))
-    )
+    |> assign(evidence: Evidence.new(seed_fields(media), known: Evidence.known_from(media)))
   end
 
   # The search the recording itself suggests: its book's title and author, and
@@ -88,20 +84,13 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # and conversation starters: Audible's catalog takes `author` as a real
   # parameter, and the scorer needs it to tell a content farm's companion work
   # from the book.
-  defp seed_fields(media, assigns) do
-    books = Map.new(assigns.books, &{&1.id, &1.label})
-    narrators = Map.new(assigns.narrators, &{&1.id, &1.label})
-
-    narrator =
-      case media.media_narrators do
-        [%{narrator_id: narrator_id} | _rest] -> narrators[narrator_id]
-        _empty -> nil
-      end
+  defp seed_fields(media) do
+    book = Books.book_option(media.book_id)
 
     %{
-      "title" => books[media.book_id],
-      "author" => first_author(assigns.books, media.book_id),
-      "narrator" => narrator
+      "title" => book && book.label,
+      "author" => book && first_author(book),
+      "narrator" => first_narrator(media)
     }
   end
 
@@ -114,18 +103,22 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       else: image_path
   end
 
-  # `books_for_select`'s `detail` is the book's author names, comma-joined for
-  # display. One name, like the inbox's own hints: a query naming every author
-  # of a collaboration matches nothing at a storefront.
-  defp first_author(books, book_id) do
-    case Enum.find(books, &(&1.id == book_id)) do
-      %{detail: detail} when is_binary(detail) ->
-        detail |> String.split(",") |> hd() |> String.trim()
+  # `Books.book_option/1`'s `detail` is the book's author names, comma-joined
+  # for display. One name, like the inbox's own hints: a query naming every
+  # author of a collaboration matches nothing at a storefront.
+  defp first_author(%{detail: detail}) when is_binary(detail),
+    do: detail |> String.split(",") |> hd() |> String.trim()
 
-      _none ->
-        nil
+  defp first_author(_book), do: nil
+
+  defp first_narrator(%{media_narrators: [%{narrator_id: id} | _rest]}) do
+    case People.narrator_option(id) do
+      %{label: label} -> label
+      nil -> nil
     end
   end
+
+  defp first_narrator(_media), do: nil
 
   @impl Phoenix.LiveView
   def handle_params(_params, _url, socket) do
@@ -152,8 +145,8 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
      socket
      |> assign_form(changeset)
      |> assign(
-       # groups follow the chosen book — a set belongs to one book
-       recording_groups: Media.recording_groups_for_select(media_params["book_id"]),
+       # the set picker follows the chosen book — a set belongs to one book
+       book_id: media_params["book_id"],
        provenance_hints: ProvenanceHints.prune(socket.assigns.provenance_hints, media_params)
      )
      |> refresh_chips()}

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -18,7 +18,8 @@
             field={@form[:book_id]}
             label="Book"
             type="autocomplete"
-            options={@books}
+            search={&Books.search_books/2}
+            fetch={&Books.book_option/1}
             container_class="max-w-xl"
           />
 
@@ -116,7 +117,8 @@
                 <.input
                   field={media_narrator_form[:narrator_id]}
                   type="autocomplete"
-                  options={@narrators}
+                  search={&People.search_narrators/2}
+                  fetch={&People.narrator_option/1}
                 />
                 <.delete_button
                   field={@form[:media_narrators_drop]}
@@ -158,7 +160,8 @@
                 <.input
                   field={@form[:recording_group_id]}
                   type="autocomplete"
-                  options={@recording_groups}
+                  search={&Media.search_recording_groups(@book_id, &1, &2)}
+                  fetch={&Media.recording_group_option/1}
                 />
                 <%!-- `flex` is load-bearing, not decoration: it collapses the
                     button to the icon's own box, which is what puts `top-3` on

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -75,7 +75,6 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
        chips: %{},
        reverts: %{},
        provenance_hints: %{},
-       authors: People.authors_for_select(),
        # The escape hatches, once clicked. Data that already diverges reveals
        # itself without them — see `revealed?/2`.
        reveal: MapSet.new()
@@ -534,10 +533,15 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
       author_person_form[:author_id].value not in [nil, ""]
   end
 
-  defp linked_author_name(authors, value) do
-    Enum.find_value(authors, fn option ->
-      to_string(option.id) == to_string(value) && option.label
-    end)
+  # What a linked author is called. Asked of the context rather than found in
+  # a preloaded list, which is the same move `EntityResolver`'s `fetch` makes
+  # and for the same reason: naming a record is a lookup, not a reason to hold
+  # every record of that kind in memory.
+  defp linked_author_name(value) do
+    case People.author_option(value) do
+      %{label: label} -> label
+      nil -> nil
+    end
   end
 
   defp shared_with(author_person_form, person) do

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -132,7 +132,7 @@
                     <.input
                       type="text"
                       name={"linked-author-#{author_person_form.index}"}
-                      value={linked_author_name(@authors, author_person_form[:author_id].value)}
+                      value={linked_author_name(author_person_form[:author_id].value)}
                       disabled
                     />
                     <.delete_button
@@ -183,7 +183,8 @@
                 <.input
                   field={@form[:link_author_id]}
                   type="autocomplete"
-                  options={@authors}
+                  search={&People.search_authors/2}
+                  fetch={&People.author_option/1}
                   label="Or link one that already exists"
                   container_class="min-w-64 grow"
                 />

--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -2,13 +2,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
   @moduledoc false
   use AmbryWeb, :admin_live_view
 
+  alias Ambry.Books
   alias Ambry.Media
   alias Ambry.Media.RecordingGroup
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, books: Ambry.Books.books_for_select())}
+    {:ok, socket}
   end
 
   @impl Phoenix.LiveView
@@ -26,7 +27,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
       # the composed display: the name is local to the book
       page_title: "#{group.name} (#{group.book.title})",
       group: group,
-      media_options: Media.media_for_select(group.book_id)
+      book_id: group.book_id
     )
   end
 
@@ -39,7 +40,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     |> assign(
       page_title: "New Set",
       group: group,
-      media_options: []
+      book_id: nil
     )
   end
 
@@ -53,15 +54,11 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
     {:noreply,
      socket
      |> assign_form(changeset)
-     # Member options follow the chosen book — the set can only hold its
-     # book's recordings. On the edit page with members the book renders as
-     # static text and posts nothing, so fall back to the group's own book:
-     # without it, any keystroke emptied the options and every member
-     # typeahead displayed blank (label lookup by id found nothing).
-     |> assign(
-       media_options:
-         Media.media_for_select(group_params["book_id"] || socket.assigns.group.book_id)
-     )}
+     # The member picker searches within the chosen book — a set can only hold
+     # its own book's recordings. On the edit page with members the book
+     # renders as static text and posts nothing, so this falls back to the
+     # group's own book.
+     |> assign(book_id: group_params["book_id"] || socket.assigns.group.book_id)}
   end
 
   def handle_event("submit", %{"recording_group_form" => group_params}, socket) do

--- a/lib/ambry_web/live/admin/recording_group_live/form.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.html.heex
@@ -10,7 +10,8 @@
           :if={@group.media == []}
           field={@form[:book_id]}
           type="autocomplete"
-          options={@books}
+          search={&Books.search_books/2}
+          fetch={&Books.book_option/1}
           label="Book"
         />
         <div :if={@group.media != []} class="space-y-2">
@@ -55,7 +56,8 @@
             <.input
               field={member_form[:media_id]}
               type="autocomplete"
-              options={@media_options}
+              search={&Media.search_book_media(@book_id, &1, &2)}
+              fetch={&Media.media_option/1}
               container_class="grow"
             />
             <.delete_button

--- a/lib/ambry_web/live/admin/series_live/form.ex
+++ b/lib/ambry_web/live/admin/series_live/form.ex
@@ -7,7 +7,7 @@ defmodule AmbryWeb.Admin.SeriesLive.Form do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, books: Books.books_for_select())}
+    {:ok, socket}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/series_live/form.html.heex
+++ b/lib/ambry_web/live/admin/series_live/form.html.heex
@@ -19,7 +19,8 @@
             <.input
               field={series_book_form[:book_id]}
               type="autocomplete"
-              options={@books}
+              search={&Books.search_books/2}
+              fetch={&Books.book_option/1}
               container_class="grow"
             />
             <.delete_button

--- a/lib/ambry_web/live/admin/universe_live/form.ex
+++ b/lib/ambry_web/live/admin/universe_live/form.ex
@@ -7,7 +7,7 @@ defmodule AmbryWeb.Admin.UniverseLive.Form do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, books: Books.books_for_select())}
+    {:ok, socket}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/universe_live/form.html.heex
+++ b/lib/ambry_web/live/admin/universe_live/form.html.heex
@@ -10,7 +10,12 @@
           <.sort_input field={@form[:book_universes_sort]} index={book_universe_form.index} />
 
           <div class="relative">
-            <.input field={book_universe_form[:book_id]} type="autocomplete" options={@books} />
+            <.input
+              field={book_universe_form[:book_id]}
+              type="autocomplete"
+              search={&Books.search_books/2}
+              fetch={&Books.book_option/1}
+            />
             <.delete_button
               field={@form[:book_universes_drop]}
               index={book_universe_form.index}

--- a/priv/repo/migrations/20260817081551_media_flat_book_id.exs
+++ b/priv/repo/migrations/20260817081551_media_flat_book_id.exs
@@ -1,0 +1,13 @@
+defmodule Ambry.Repo.Migrations.MediaFlatBookId do
+  use Ecto.Migration
+  use Familiar
+
+  # A flat view of media that can't be filtered by its book was missing a
+  # column. The set-member picker needs exactly that — a set holds its own
+  # book's recordings and nothing else — and without it the admin had two
+  # builders for "a recording as a picker option", one reading the view and
+  # one reading the table, free to disagree about how a recording describes
+  # itself.
+  def up, do: update_view("media_flat", version: 16)
+  def down, do: update_view("media_flat", version: 15)
+end

--- a/priv/repo/views/media_flat_v16.sql
+++ b/priv/repo/views/media_flat_v16.sql
@@ -1,0 +1,107 @@
+SELECT
+  media.id,
+  media.book_id,
+  media.status,
+  media.missing_since,
+  media.title,
+  media.part_number,
+  (
+    SELECT
+      recording_group.parts_total
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS parts_total,
+  (
+    SELECT
+      recording_group.part_word
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS part_word,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.position,
+      books_series.id
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      authored_by.position,
+      authored_by.id
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrated_by.position,
+      narrated_by.id
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  EXISTS (
+    SELECT
+    FROM
+      media_tracks AS track
+    WHERE
+      track.media_id = media.id
+  ) AS direct_play,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/test/ambry/books_test.exs
+++ b/test/ambry/books_test.exs
@@ -405,17 +405,52 @@ defmodule Ambry.BooksTest do
     end
   end
 
-  describe "books_for_select/0" do
+  describe "search_books/2" do
     test "returns rich options: title, cover, authors" do
       insert_list(3, :book)
-
-      list = Books.books_for_select()
 
       assert [
                %{id: _, label: _, image: _, detail: _},
                %{id: _, label: _, image: _, detail: _},
                %{id: _, label: _, image: _, detail: _}
-             ] = list
+             ] = Books.search_books("", 10)
+    end
+
+    # Keyword-scored rather than substring-matched, which is the whole reason
+    # this and not an in-memory filter over every book: the author's name is
+    # what a person typing knows, and it isn't in the title.
+    test "finds a book by its author's name" do
+      book =
+        insert(:book,
+          title: "The Way of Kings",
+          book_authors: [
+            build(:book_author, author: build(:author, name: "Brandon Sanderson"))
+          ]
+        )
+
+      assert [%{id: id}] = Books.search_books("sanderson kings", 10)
+      assert id == book.id
+    end
+
+    test "stops at the limit" do
+      insert_list(4, :book)
+
+      assert length(Books.search_books("", 2)) == 2
+    end
+  end
+
+  describe "book_option/1" do
+    # What lets a filled picker name what it holds, which the preloaded list
+    # it replaced was answering silently.
+    test "names one book, and nothing for one that is gone" do
+      book = insert(:book)
+
+      assert %{id: id, label: label} = Books.book_option(book.id)
+      assert id == book.id
+      assert label == book.title
+
+      refute Books.book_option(nil)
+      refute Books.book_option(book.id + 1000)
     end
   end
 
@@ -743,17 +778,47 @@ defmodule Ambry.BooksTest do
     end
   end
 
-  describe "series_for_select/0" do
-    test "returns all series names and ids only" do
+  describe "search_series/2" do
+    test "returns name and id pairs" do
       insert_list(3, :series)
 
-      list = Books.series_for_select()
+      assert [{_, _}, {_, _}, {_, _}] = Books.search_series("", 10)
+    end
 
-      assert [
-               {_, _},
-               {_, _},
-               {_, _}
-             ] = list
+    test "matches on the name, and a prefix outranks a substring" do
+      insert(:series, name: "The Stormlight Archive")
+      insert(:series, name: "Stormlight Shorts")
+
+      assert [{"Stormlight Shorts", _}, {"The Stormlight Archive", _}] =
+               Books.search_series("stormlight", 10)
+    end
+
+    # `unaccent` is the SQL twin of the NFD fold the in-memory filter did, and
+    # losing it would split a narrator or a series across two spellings.
+    test "folds accents" do
+      series = insert(:series, name: "Los Niños")
+
+      assert [{_, id}] = Books.search_series("ninos", 10)
+      assert id == series.id
+    end
+
+    # A name is operator input and `%` is legal in one; unescaped it would
+    # match every row in the table.
+    test "treats a wildcard as a character" do
+      insert(:series, name: "Mistborn")
+
+      assert Books.search_series("%", 10) == []
+    end
+  end
+
+  describe "series_option/1" do
+    test "names one series, and nothing for one that is gone" do
+      series = insert(:series)
+
+      assert {name, id} = Books.series_option(series.id)
+      assert {name, id} == {series.name, series.id}
+
+      refute Books.series_option(nil)
     end
   end
 
@@ -820,10 +885,10 @@ defmodule Ambry.BooksTest do
       assert %{name: "Cosmere", books: 1} = universe_flat
     end
 
-    test "universes_for_select/0 returns name/id tuples" do
+    test "search_universes/2 returns name/id tuples" do
       {:ok, universe} = Books.create_universe(%{name: "Cosmere"})
 
-      assert [{"Cosmere", id}] = Books.universes_for_select()
+      assert [{"Cosmere", id}] = Books.search_universes("", 10)
       assert id == universe.id
     end
 

--- a/test/ambry/ecto/name_search_test.exs
+++ b/test/ambry/ecto/name_search_test.exs
@@ -1,0 +1,67 @@
+defmodule Ambry.Ecto.NameSearchTest do
+  @moduledoc """
+  The one rule every picker in the admin narrows its options by.
+
+  Exercised through `Books.search_series/2`, which is the thinnest caller —
+  what is under test is the shared `narrow/4`, not the series table.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Books
+
+  describe "narrow/4" do
+    test "an empty phrase is the first page, not nothing" do
+      insert(:series, name: "Alpha")
+      insert(:series, name: "Beta")
+
+      assert [{"Alpha", _}, {"Beta", _}] = Books.search_series("", 10)
+      assert [{"Alpha", _}] = Books.search_series("   ", 1)
+    end
+
+    test "matches anywhere in the name, case-blind" do
+      insert(:series, name: "The Stormlight Archive")
+
+      assert [{"The Stormlight Archive", _}] = Books.search_series("STORMLIGHT", 10)
+    end
+
+    # A prefix is the stronger signal, and alphabetical order would bury it:
+    # typing "storm" wants the series that starts with it first.
+    test "a prefix outranks a substring" do
+      insert(:series, name: "The Stormlight Archive")
+      insert(:series, name: "Stormlight Shorts")
+
+      assert [{"Stormlight Shorts", _}, {"The Stormlight Archive", _}] =
+               Books.search_series("stormlight", 10)
+    end
+
+    # `unaccent` is the SQL twin of the NFD fold the in-memory filter did.
+    # Without it the library's spelling and a file's are two records.
+    test "folds accents both ways" do
+      insert(:series, name: "Los Niños")
+
+      assert [{"Los Niños", _}] = Books.search_series("ninos", 10)
+      assert [{"Los Niños", _}] = Books.search_series("niños", 10)
+    end
+
+    # A name is operator input, and `%` and `_` are legal characters in one.
+    test "wildcards are characters, not patterns" do
+      insert(:series, name: "Mistborn")
+
+      assert Books.search_series("%", 10) == []
+      assert Books.search_series("_istborn", 10) == []
+      assert [{"Mistborn", _}] = Books.search_series("Mistborn", 10)
+    end
+
+    test "matches a name that really does hold a wildcard" do
+      insert(:series, name: "100% Wolf")
+
+      assert [{"100% Wolf", _}] = Books.search_series("100%", 10)
+    end
+
+    test "stops at the limit" do
+      insert_list(4, :series)
+
+      assert length(Books.search_series("", 2)) == 2
+    end
+  end
+end

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -392,7 +392,7 @@ defmodule Ambry.MediaTest do
       assert %{part_number: 1, recording_group: %{name: "Season One", parts_total: 3}} = media
 
       assert [%{label: "Season One", detail: "1 of 3 parts"}] =
-               Media.recording_groups_for_select(book_id)
+               Media.search_recording_groups(book_id, "", 10)
     end
 
     test "a part number requires a group" do
@@ -420,7 +420,7 @@ defmodule Ambry.MediaTest do
 
       assert updated.recording_group_id == nil
       assert updated.part_number == nil
-      assert [] = Media.recording_groups_for_select(book_id)
+      assert [] = Media.search_recording_groups(book_id, "", 10)
       assert Ambry.Repo.aggregate(Ambry.Media.RecordingGroup, :count) == 0
     end
 

--- a/test/ambry/people_test.exs
+++ b/test/ambry/people_test.exs
@@ -573,17 +573,44 @@ defmodule Ambry.PeopleTest do
     end
   end
 
-  describe "narrators_for_select/0" do
+  describe "search_narrators/2" do
     test "returns rich options: name, portrait, backing person when it adds something" do
       insert(:person, narrators: build_list(3, :narrator))
-
-      list = People.narrators_for_select()
 
       assert [
                %{id: _, label: _, image: _, detail: _},
                %{id: _, label: _, image: _, detail: _},
                %{id: _, label: _, image: _, detail: _}
-             ] = list
+             ] = People.search_narrators("", 10)
+    end
+
+    test "matches on the name and stops at the limit" do
+      insert(:person, narrators: [build(:narrator, name: "Michael Kramer")])
+      insert(:person, narrators: [build(:narrator, name: "Kate Reading")])
+
+      assert [%{label: "Michael Kramer"}] = People.search_narrators("kramer", 10)
+      assert length(People.search_narrators("", 1)) == 1
+    end
+
+    # The library's "Patricia Rodríguez" and a file's "Patricia Rodriguez" are
+    # one narrator; a picker that couldn't find her by the second spelling is
+    # how a second person of the same name gets created.
+    test "folds accents" do
+      insert(:person, narrators: [build(:narrator, name: "Patricia Rodríguez")])
+
+      assert [%{label: "Patricia Rodríguez"}] = People.search_narrators("Rodriguez", 10)
+    end
+  end
+
+  describe "narrator_option/1" do
+    test "names one narrator, and nothing for one that is gone" do
+      person = insert(:person, narrators: [build(:narrator)])
+      [narrator] = person.narrators
+
+      assert %{id: id, label: label} = People.narrator_option(narrator.id)
+      assert {id, label} == {narrator.id, narrator.name}
+
+      refute People.narrator_option(nil)
     end
   end
 
@@ -602,17 +629,60 @@ defmodule Ambry.PeopleTest do
     end
   end
 
-  describe "authors_for_select/0" do
+  describe "search_authors/2" do
     test "returns rich options: name, portrait, backing people when they add something" do
       insert(:person, authors: build_list(3, :author))
-
-      list = People.authors_for_select()
 
       assert [
                %{id: _, label: _, image: _, detail: _},
                %{id: _, label: _, image: _, detail: _},
                %{id: _, label: _, image: _, detail: _}
-             ] = list
+             ] = People.search_authors("", 10)
+    end
+
+    test "matches on the name" do
+      insert(:person, authors: [build(:author, name: "Brandon Sanderson")])
+      insert(:person, authors: [build(:author, name: "Andy Weir")])
+
+      assert [%{label: "Brandon Sanderson"}] = People.search_authors("sanderson", 10)
+    end
+  end
+
+  describe "author_option/1" do
+    # The `detail` is who is really behind the identity, which is what the
+    # credit row prints beside a linked pen name — it used to come from a map
+    # of every author in the library.
+    test "names one author, and says who is behind a pen name" do
+      person =
+        insert(:person, name: "Jason Pargin", authors: [build(:author, name: "David Wong")])
+
+      [%{author: author}] = person.author_people
+
+      assert %{id: id, label: "David Wong", detail: "Jason Pargin"} =
+               People.author_option(author.id)
+
+      assert id == author.id
+      refute People.author_option(nil)
+    end
+  end
+
+  describe "search_people/2" do
+    test "matches on the name" do
+      insert(:person, name: "Brandon Sanderson")
+      insert(:person, name: "Andy Weir")
+
+      assert [%{label: "Brandon Sanderson"}] = People.search_people("sanderson", 10)
+    end
+  end
+
+  describe "person_option/1" do
+    test "names one person, and nothing for one that is gone" do
+      person = insert(:person)
+
+      assert %{id: id, label: label} = People.person_option(person.id)
+      assert {id, label} == {person.id, person.name}
+
+      refute People.person_option(nil)
     end
   end
 end

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -179,7 +179,9 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       assert html =~ "This audiobook was imported from these files"
       assert has_element?(view, "[data-role='local-recording']", "The Way of Kings")
-      assert has_element?(view, "[data-role='streaming-only']")
+      # which recordings still cost double the disk is the reason somebody is
+      # on this form, so the row says it
+      assert has_element?(view, "[data-role='local-recording']", "streaming only")
 
       assert html =~ "Whether this replaces an audiobook you already have"
       assert has_element?(view, "button[data-role='import'][disabled]")
@@ -231,12 +233,11 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       refute has_element?(view, "[data-role='local-recording']")
 
       view
-      |> element("#recording-search")
-      |> render_change(%{"query" => "Kings"})
+      |> element("#replace-recording-resolver-input")
+      |> render_change(%{"resolver" => %{"replace-recording-resolver" => "Kings"}})
 
-      assert has_element?(view, "[data-role='local-recording']")
-
-      view |> element("[data-role='local-recording'] button") |> render_click()
+      view |> element("#replace-recording-resolver-option-#{media.id}") |> render_click()
+      view |> form("#recording-search") |> render_change()
 
       assert %{mode: :replace, media_id: media_id} =
                Inbox.get_item!(item.id).draft.replacement
@@ -249,9 +250,12 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      html = view |> element("#recording-search") |> render_change(%{"query" => "Neuromancer"})
+      html =
+        view
+        |> element("#replace-recording-resolver-input")
+        |> render_change(%{"resolver" => %{"replace-recording-resolver" => "Neuromancer"}})
 
-      assert html =~ "No audiobook in the library matches that"
+      assert html =~ "No matches"
     end
 
     # The one consequence of a replacement that can't be taken back.
@@ -286,8 +290,13 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       media = library_recording()
 
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
-      view |> element("#recording-search") |> render_change(%{"query" => "Kings"})
-      view |> element("[data-role='local-recording'] button") |> render_click()
+
+      view
+      |> element("#replace-recording-resolver-input")
+      |> render_change(%{"resolver" => %{"replace-recording-resolver" => "Kings"}})
+
+      view |> element("#replace-recording-resolver-option-#{media.id}") |> render_click()
+      view |> form("#recording-search") |> render_change()
 
       {:ok, _deleted} = Ambry.Media.delete_media(Ambry.Media.get_media!(media.id))
 
@@ -424,18 +433,64 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       # reachable from the default state, with nothing matched
       assert html =~ "search the library by title, author or series"
 
-      html =
-        view |> form("#library-search") |> render_change(%{"query" => "sorcerer stone"})
-
-      assert html =~ "Harry Potter and the Sorcerer&#39;s Stone"
-
       view
-      |> element("button[phx-click='link-book'][phx-value-id='#{book.id}']")
-      |> render_click()
+      |> element("#library-book-resolver-input")
+      |> render_change(%{"resolver" => %{"library-book-resolver" => "sorcerer stone"}})
+
+      assert has_element?(view, "#library-book-resolver-option-#{book.id}")
+
+      view |> element("#library-book-resolver-option-#{book.id}") |> render_click()
+      view |> form("#library-search") |> render_change()
 
       draft = Inbox.get_item!(item.id).draft
       assert draft.work.mode == :link
       assert draft.work.book_id == book.id
+    end
+
+    # The keyword search the matched rows come from, not a substring of the
+    # title: the author's name is what a person typing knows.
+    test "a book is reachable by its author's name", %{conn: conn} do
+      book =
+        insert(:book,
+          title: "The Way of Kings",
+          book_authors: [build(:book_author, author: build(:author, name: "Brandon Sanderson"))]
+        )
+
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#library-book-resolver-input")
+      |> render_change(%{"resolver" => %{"library-book-resolver" => "sanderson kings"}})
+
+      assert has_element?(view, "#library-book-resolver-option-#{book.id}")
+    end
+
+    # The `fetch` half of a source, and it is load-bearing: there is no longer
+    # a list of every book to find the linked one's name in, so a picker that
+    # couldn't ask by id would render blank over a real answer.
+    test "the box names the book it is holding, unsearched", %{conn: conn} do
+      book = insert(:book, title: "Harry Potter and the Sorcerer's Stone")
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> element("#library-book-resolver-input")
+      |> render_change(%{"resolver" => %{"library-book-resolver" => "sorcerer"}})
+
+      view |> element("#library-book-resolver-option-#{book.id}") |> render_click()
+      view |> form("#library-search") |> render_change()
+
+      # a fresh mount: nothing has been typed, and the box still says which
+      # book this import is linked to
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html
+             |> Floki.parse_document!()
+             |> Floki.find(~s{input[name="resolver[library-book-resolver]"]})
+             |> Floki.attribute("value") == ["Harry Potter and the Sorcerer's Stone"]
     end
 
     test "says so when the library has nothing like it", %{conn: conn} do
@@ -444,9 +499,11 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
 
       html =
-        view |> form("#library-search") |> render_change(%{"query" => "nothing like this"})
+        view
+        |> element("#library-book-resolver-input")
+        |> render_change(%{"resolver" => %{"library-book-resolver" => "nothing like this"}})
 
-      assert html =~ "Nothing in the library matches that"
+      assert html =~ "No matches"
     end
   end
 

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -87,10 +87,11 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
              |> Floki.attribute("value") == [to_string(media.id)]
     end
 
-    # Regression: validate re-derives member options from the posted book_id,
-    # but the edit page renders the book as static text (posts nothing) — so
-    # any keystroke in any field emptied the options, and every member
-    # typeahead displayed blank (its label lookup by id found nothing).
+    # Regression: the member picker's records follow the posted book_id, but
+    # the edit page renders the book as static text (posts nothing) — so any
+    # keystroke in any field used to leave it scoped to no book at all. What
+    # keeps the box readable now is that naming what it holds is a lookup by
+    # id (`Media.media_option/1`) rather than a search of the current scope.
     test "editing another field leaves the member typeaheads displaying their picks", %{
       conn: conn
     } do
@@ -100,14 +101,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
 
       {:ok, view, html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
 
-      assert resolver_display(html) == "A Court of Thorns and Roses"
+      assert resolver_display(html) == "A Court of Thorns and Roses (Part 1)"
 
       html =
         view
         |> form("#group-form")
         |> render_change(%{recording_group_form: %{name: "Renamed"}})
 
-      assert resolver_display(html) == "A Court of Thorns and Roses"
+      assert resolver_display(html) == "A Court of Thorns and Roses (Part 1)"
     end
 
     test "saving edits facts and the member list together", %{conn: conn} do


### PR DESCRIPTION
Stacked on #1262 — **review that one first**, and this needs retargeting to
`main` once it merges.

Noticed from the other end: the import form's "Existing book?" and "New or a
replacement" cards search server-side but aren't typeaheads, while everything
else in the admin is a typeahead that can't search server-side. The reason
turned out not to be about books — `EntityResolver` filtered a preloaded list
in memory, so **four admin forms already loaded every book in the library,
with covers, on mount**, and a comparable pile of authors, narrators and
people besides. One search path for all of it.

## The component

`options` is gone. A resolver takes two captured functions:

```elixir
search={&Books.search_books/2}   # (phrase, limit) -> [option]
fetch={&Books.book_option/1}     #  id             -> option | nil
```

`fetch` is load-bearing, not decoration: naming what a filled box holds is
what the preloaded list was silently answering, and without a by-id lookup
every pure picker on the edit forms renders blank over a real value. It also
deletes the bug `RecordingGroupLive.Form` carried a comment about — re-deriving
the member options emptied them, and the labels went with them.

Captured remote functions rather than an MFA tuple or a `source: :books` atom:
`&Mod.fun/arity` is compile-checked (CI runs `--warnings-as-errors`), stable
across renders so change tracking behaves, and greppable. Where a picker is
scoped, the scope is closed over — `&Media.search_book_media(@book_id, &1, &2)` —
which is how two forms stopped reloading options on every keystroke.

The search now runs only while the list is open, so a closed box costs
nothing.

## One component, not eight

You floated a function component plus helpers plus a LiveComponent per entity
type. I went the other way, and the reason is what varies: only the two
queries. Open/close, the debounced filter, pick, the create row, the
`existing`/`new` badge, keyboard nav and the `moved` push that stops the
parent mistaking a re-render for an operator edit are identical across all
eight kinds — and that `moved/1` comment is a scar from the behaviour forking
once already. Eight components would duplicate it or need a `__using__` to
stop them drifting, which is more machinery than "the options come from
somewhere else" earns. Where the kind genuinely determines the source, the
component names it itself (`identity_search(:author)`), which is what let the
import form drop seven assigns.

## What survives the move into SQL, and what improves

Two properties would have been silent regressions, both now tested in
`Ambry.Ecto.NameSearchTest`:

- **accents fold** — `unaccent`, already enabled and already used this way by
  `AutoMatch`'s `@name_key_sql`, so "Rodriguez" still finds "Patricia
  Rodríguez";
- **a prefix outranks a substring** — "storm" puts "Stormlight Shorts" above
  "The Stormlight Archive", where alphabetical order buried it.

Plus wildcard escaping, which the in-memory version never needed: `%` is a
legal character in a name, and unescaped it matched every row.

One improves: books are found by `BookFlat.by_keywords/2` — the scored search
matching already uses — so **every** book picker in the admin now answers
"sanderson kings", not just substring-over-title.

## `media_flat` gains `book_id` (view v16)

A flat view of media that can't be filtered by its book was missing a column.
Without it there were two builders for "a recording as a picker option", one
over the view and one over the table, free to disagree about how a recording
describes itself. Now there is one, and it carries the part label, the
narrators, the year and whether the recording is still streaming-only — which
is the fact somebody picking a replacement is actually looking for.

## Deleted

`books_for_select/0`, `series_for_select/0`, `universes_for_select/0`,
`authors_for_select/0`, `narrators_for_select/0`, `people_for_select/0`,
`author_backing_names/0`, `narrator_backing_names/0`, `media_for_select/1`,
`recording_groups_for_select/1`, the eleven mount-time preloads that called
them, the import form's two bespoke search forms with their handlers and
result assigns, and four label-lookup-in-a-list helpers across the book,
media, person and inbox forms.

## Testing

**No CI on this PR** — `ci.yml` triggers only on `pull_request: branches:
[main]`, so a stacked PR gets nothing until it is retargeted. Verified
locally instead: `mix check` clean (format, warnings-as-errors, credo,
dialyzer) and 1761 tests, 23 new or rewritten — the shared search rule,
the search/option pairs per context, the book card and replace card driven as
comboboxes, and the fetch path asserted on a fresh mount with nothing typed.

Not exercised in a browser. Worth a look on the dev server: the dropdown over
the two import-form cards (they're the first pickers there without a create
row), and that the set-member picker on a set with several parts still reads
right now that the label carries "(Part 1)".
