### PR TITLE
A listener pressing pause is not a 500

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -111,6 +111,7 @@ config :sentry,
   enable_source_code_context: true,
   root_source_code_paths: [File.cwd!()],
   client: Ambry.SentryFinchHTTPClient,
+  before_send: {Ambry.SentryFilter, :before_send},
   integrations: [
     oban: [capture_errors: true]
   ]

--- a/lib/ambry/sentry_filter.ex
+++ b/lib/ambry/sentry_filter.ex
@@ -1,0 +1,32 @@
+defmodule Ambry.SentryFilter do
+  @moduledoc """
+  Drops the reports Sentry can do nothing with, before they leave the node.
+
+  Bandit raises `Bandit.TransportError` when a socket write fails, and treats
+  it as routine at its own boundary: the clause of `Bandit.Pipeline.handle_error/7`
+  that matches it deliberately skips the `Logger.error` every other exception
+  gets, because a socket that went away is not a server fault. But
+  `Sentry.PlugCapture` is `use`d on the endpoint, which puts it *inside* that
+  boundary — it sees the exception on its way past and reports it as an
+  unhandled crash before Bandit ever gets to shrug.
+
+  For us that means the direct-play route. `AmbryWeb.FileResponse` answers a
+  track request with `Plug.Conn.send_file/5`, and `sendfile(2)` doesn't return
+  until every byte is on the wire, which for a player consuming a book at
+  playback speed is the length of the listening session. A player that pauses,
+  seeks, or moves to the next track hangs up mid-transfer, the pending write
+  fails with `:closed`, and the exception surfaces at the endpoint. Nothing was
+  owed to the client — it left — and no server-side change would prevent it.
+
+  This is only a Sentry-side filter. The exception still propagates and Bandit
+  still handles it; we just stop paging ourselves about a listener pressing
+  pause.
+  """
+
+  @doc """
+  Sentry's `:before_send` callback. Returns `nil` to drop the event.
+  """
+  @spec before_send(Sentry.Event.t()) :: Sentry.Event.t() | nil
+  def before_send(%Sentry.Event{original_exception: %Bandit.TransportError{}}), do: nil
+  def before_send(%Sentry.Event{} = event), do: event
+end

--- a/lib/ambry_web/file_response.ex
+++ b/lib/ambry_web/file_response.ex
@@ -15,6 +15,30 @@ defmodule AmbryWeb.FileResponse do
   overwrites them in place, and a changed mtime changes the ETag, so
   streaming clients revalidate and pick up the new bytes without any new URL
   or cleanup dance.
+
+  ## A client that hangs up is not an error
+
+  `sendfile(2)` does not return until every byte is on the wire, and TCP
+  backpressure paces that at the rate the player drains its buffer — for a
+  whole book that is the length of the listening session. Pausing, seeking,
+  or moving to the next track makes the player close the connection
+  mid-transfer, and the pending write fails.
+
+  That failure has to be caught here, because the response is already half
+  reported by the time it happens. `Plug.Conn.send_file/5` runs the
+  `before_send` callbacks *first* (so `Plug.Telemetry` has already logged
+  `Sent 206`), then calls the adapter, and only afterwards posts the
+  `{:plug_conn, :sent}` message that tells the rest of Phoenix a response
+  went out. When the adapter raises, that message is never posted, so
+  `Phoenix.Endpoint.RenderErrors` believes nothing has been sent: it renders
+  a full 500 error page onto the closed socket, which runs `before_send`
+  again and logs the same request a second time as `Sent 500 in <the whole
+  transfer>`. Every one of those pairs in the production log is a listener
+  pressing pause.
+
+  So the rescue below reports what actually happened — the response is over —
+  by handing back a conn in the `:sent` state. Nothing escapes to be rendered
+  at, logged twice, or reported to Sentry.
   """
 
   import Plug.Conn
@@ -28,12 +52,21 @@ defmodule AmbryWeb.FileResponse do
   def send(conn, path, content_type) do
     case File.stat(path) do
       {:ok, %File.Stat{type: :regular} = stat} ->
-        send_regular_file(conn, path, content_type, stat)
+        try do
+          send_regular_file(conn, path, content_type, stat)
+        rescue
+          Bandit.TransportError -> hung_up(conn)
+        end
 
       _not_a_file ->
         conn
     end
   end
+
+  # The socket died partway through the response. There is nobody left to
+  # tell, and no second attempt worth making: say the response is finished so
+  # that no later stage tries to write one.
+  defp hung_up(conn), do: %{conn | state: :sent}
 
   defp send_regular_file(conn, path, content_type, stat) do
     etag = etag(stat)

--- a/test/ambry/sentry_filter_test.exs
+++ b/test/ambry/sentry_filter_test.exs
@@ -1,0 +1,25 @@
+defmodule Ambry.SentryFilterTest do
+  use ExUnit.Case, async: true
+
+  alias Ambry.SentryFilter
+
+  describe "before_send/1" do
+    test "drops a transport error raised by a client hanging up mid-send" do
+      event =
+        Sentry.Event.create_event(
+          exception: %Bandit.TransportError{
+            message: "Unrecoverable error: closed",
+            error: :closed
+          }
+        )
+
+      assert SentryFilter.before_send(event) == nil
+    end
+
+    test "keeps everything else" do
+      event = Sentry.Event.create_event(exception: %RuntimeError{message: "boom"})
+
+      assert SentryFilter.before_send(event) == event
+    end
+  end
+end

--- a/test/ambry_web/file_response_hangup_test.exs
+++ b/test/ambry_web/file_response_hangup_test.exs
@@ -1,0 +1,85 @@
+defmodule AmbryWeb.FileResponseHangupTest do
+  @moduledoc """
+  The one behavior that only a real socket can show.
+
+  `Plug.Test`'s adapter buffers the response in memory, so it can never fail
+  the way a client hanging up mid-transfer does. This boots Bandit on a real
+  port, starts a file large enough that `sendfile` blocks on the socket
+  buffer, and closes the connection underneath it.
+  """
+
+  use ExUnit.Case, async: true
+
+  # Comfortably past any socket buffer, so `sendfile` is still writing when
+  # the client goes away.
+  @size 32 * 1024 * 1024
+
+  defmodule TestPlug do
+    @moduledoc false
+    @behaviour Plug
+
+    @impl Plug
+    def init(opts), do: opts
+
+    @impl Plug
+    def call(conn, %{path: path, test: test}) do
+      conn = AmbryWeb.FileResponse.send(conn, path, "audio/mpeg")
+      send(test, {:file_response_returned, conn.state})
+      conn
+    end
+  end
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "hangup-#{System.unique_integer([:positive])}.mp3")
+    File.write!(path, :binary.copy("a", @size))
+    on_exit(fn -> File.rm(path) end)
+
+    {:ok, server} =
+      Bandit.start_link(
+        plug: {TestPlug, %{path: path, test: self()}},
+        scheme: :http,
+        port: 0,
+        startup_log: false
+      )
+
+    {:ok, {_ip, port}} = ThousandIsland.listener_info(server)
+
+    %{port: port}
+  end
+
+  test "returns a sent conn when the client hangs up mid-transfer", %{port: port} do
+    {:ok, socket} =
+      :gen_tcp.connect(~c"localhost", port, [:binary, active: false, packet: :raw])
+
+    :ok = :gen_tcp.send(socket, "GET /files/track HTTP/1.1\r\nHost: localhost\r\n\r\n")
+
+    # Take just enough to know the transfer is under way, then leave. The
+    # unread bytes still in flight make this a hard close, which is what a
+    # player does when it stops caring about the rest of the file.
+    {:ok, _some_bytes} = :gen_tcp.recv(socket, 0, 5000)
+    :ok = :gen_tcp.close(socket)
+
+    # `:sent`, not a raise: the plug ran to completion, so nothing is left to
+    # render a 500 page at, log a second time, or report to Sentry.
+    assert_receive {:file_response_returned, :sent}, 5000
+  end
+
+  test "serves the file normally when the client stays", %{port: port} do
+    {:ok, socket} =
+      :gen_tcp.connect(~c"localhost", port, [:binary, active: false, packet: :raw])
+
+    :ok = :gen_tcp.send(socket, "GET /files/track HTTP/1.1\r\nHost: localhost\r\n\r\n")
+
+    assert drain(socket, 0) >= @size
+
+    assert_receive {:file_response_returned, :file}, 5000
+  end
+
+  defp drain(socket, count) do
+    case :gen_tcp.recv(socket, 0, 5000) do
+      {:ok, bytes} -> drain(socket, count + byte_size(bytes))
+      {:error, :closed} -> count
+      {:error, :timeout} -> count
+    end
+  end
+end


### PR DESCRIPTION
Closes AMBRY-3W (96 events in one day, escalating) and quiets AMBRY-2.

## What you'd see

47 `Sent 500` lines in 8 hours of production logs, and zero `[error]` lines to
explain them. Tracing one request id shows why:

```
02:05:55.045 GMzEFvVrS6z5FWgADFeB [info] GET /files/track/YK/The Hand on the Wall [mO].mp3
02:05:55.046 GMzEFvVrS6z5FWgADFeB [info] Sent 206 in 1ms
02:05:57.191 GMzEFvVrS6z5FWgADFeB [info] Sent 500 in 2146ms
```

One request, logged twice. The worst one ran 1,231,443 ms. Nothing was ever
surfaced to a client — playback works correctly throughout.

## Why

`sendfile(2)` does not return until every byte is on the wire, and TCP
backpressure paces that at the rate the player drains its buffer, so a track
request stays open for the listening session. Pausing, seeking, or moving to
the next track closes the connection mid-transfer and the pending write fails
with `:closed`. Sentry shows the signature clearly: ten events in 54 seconds
from one user, which is a scrubbing session, one abort per seek.

Bandit handles that correctly. `Bandit.Pipeline.handle_error/7` has a clause
for `Bandit.TransportError` that skips the `Logger.error` every other
exception gets, and `send_on_error/2` returns `:ok` without writing anything
back. A socket that went away is not a server fault.

Phoenix never finds out. Three lines of third-party code line up:

1. `Plug.Conn.send_file/5` runs the `before_send` callbacks **first** — that's
   the honest `Sent 206 in 1ms` — then calls the adapter, and only afterwards
   posts `{:plug_conn, :sent}`.
2. `Bandit.Adapter.send_file/6` raises inside `sendfile`, so
   `send(adapter.owner_pid, @already_sent)` on the next line never runs.
3. `Phoenix.Endpoint.RenderErrors.__catch__` decides purely on whether that
   message is in the mailbox. It isn't, so it renders a full 500 HTML error
   page onto the closed socket, running `before_send` a second time and
   logging the same request again.

Twenty minutes of streaming, and at the end of it the server sits down and
composes an error page for someone who left.

## The fix

`AmbryWeb.FileResponse` catches the failure where the response actually ends
and hands back a conn in the `:sent` state:

```elixir
try do
  send_regular_file(conn, path, content_type, stat)
rescue
  Bandit.TransportError -> hung_up(conn)
end
```

`:sent` is what makes it work. `TrackController`'s `with` guard already
accepts it, Bandit's `commit_response!` passes a `:sent` conn straight
through, and because nothing is raised, neither `RenderErrors` nor
`Sentry.PlugCapture` is reached. Full reasoning is in the moduledoc.

## And a Sentry filter, for the part that isn't ours

The same disconnect still reaches Sentry through
`Plug.Static.send_entire_file/3` — `/uploads` images and static assets — which
we don't own and can't rescue inside. `Ambry.SentryFilter` drops
`Bandit.TransportError` at `:before_send`.

Dropping the whole class rather than just `error: :closed` is deliberate: the
type means the transport failed in a way that cannot be signalled to the
client within the request, so there is no reason value under it a server could
act on. `Bandit.HTTPError` is untouched, so AMBRY-3Q (`Request URI is too
long`) still reports.

## Tests

A `Plug.Test` conn buffers the response in memory and can never fail this way,
so `AmbryWeb.FileResponseHangupTest` boots Bandit on a real port, serves a
32 MB file, and closes the socket mid-`sendfile`. Verified as a real
regression test — with the rescue removed it fails with `no matching message
after 5000ms`. A second test asserts a client that stays still gets its whole
file.

`mix check` clean: 1762 tests, credo 0 issues, dialyzer 0 errors.

## Not addressed

One `sendfile` call holding a Bandit process and an fd for a whole listening
session is inherent to direct play, and fine at this scale. Noting it only so
the durations don't read as stalls next time — they're listening sessions.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ
