### PR TITLE
One anatomy for every admin list

### DIFF
--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -111,6 +111,29 @@ the same order internally: the records card first, then the identity and
 field decisions below it (the work section asked "already have it?" above
 the records for a while, which had the operator deciding before seeing).
 
+## 2b. A finished row shows the result, not the process
+
+A queue row is about the work it is asking for, so while the item is open it
+wears the workflow: what matched, how sure the machine was, which files it
+came from, what is still outstanding. **The moment the workflow ends, all of
+that becomes history and the row becomes the thing it produced.** An imported
+inbox row is the audiobook — cover, title, series, credits, the library's own
+state badges — in the same shape the audiobooks list draws, because it is the
+same thing; the release folder and the match tiers are on the item's form,
+one worded action away.
+
+Two things follow. **A settled row is dated by the moment it settled**, not
+by the moment it was found: "Found" is the least interesting date a finished
+row has. And **the status badge goes**, because the row's shape and its date
+already say it — this is §2's "one badge, and it says what varies" arriving
+at its end state, where what varies is the *result's* state (missing files, a
+recording still processing) rather than the item's.
+
+The row must still be able to state that its result is gone: a record that
+outlives the thing it describes says so plainly rather than falling back to
+the process view, which would describe a decision whose outcome no longer
+exists.
+
 ## 3. Geometry
 
 **Two left edges, never three.** Every container has exactly two
@@ -246,6 +269,88 @@ renders as a mystery indent on the first line.
 **Corners share baselines.** A card's right rail aligns its first element
 with the title line and its last with the content's last line
 (`self-stretch` + `justify-between`).
+
+## 3a. One row anatomy, for every list
+
+Ten list pages grew their rows independently inside one anonymous `:row`
+slot, and read like it: four rail widths, three title weights, two places to
+put a state badge, and a facts column that vanished on a phone instead of
+folding. `<.index_row>` is the anatomy, and each thing has exactly one home:
+
+| Slot | What goes in it |
+|---|---|
+| `:cover` | a 64px image at the card's left edge; round for a face, `rounded-sm` for a cover |
+| `:headline` | the title, `font-semibold`, and always the link |
+| default | the credit stack and meta lines under the headline |
+| `:badges` | state, top of the rail, on the headline's baseline |
+| `:facts` | counts and boolean glyphs, nothing that reads as a sentence |
+| `:action` | one entry per verb, worded, right-aligned |
+| `:footer` | **system timestamps only**, at the card's bottom baseline |
+| `:overlay` | a scrim that owns the whole card (`busy_overlay/1`) |
+
+**The footer corner is a record of what the app did, and nothing else** —
+Added, Imported, Joined, Found, Last seen. A duration and a publication date
+are facts about the *work*; putting them in the column that says "Added
+8/17/26" made three lines of date read as three timestamps.
+
+**And what they are instead is a sentence, not a cell.** `record_meta/1` is
+the last line of the content column, under the credits: "Published August 30,
+2022 by Recorded Books · 32 hours and 43 minutes". They passed through the
+facts strip on the way out of the footer, as `8/30/22` and `14:04:02`, which
+is the shape a spreadsheet wants rather than a reader — and the full words
+cost nothing, because that line is a line either way. **The rule that falls
+out: `:facts` holds what you count and glance at, the meta line holds what
+you read.** One helper for both flat views, so the audiobooks list and the
+queue's imported rows cannot phrase it differently again.
+
+**The rail is `w-56` (224px), which is two buttons wide, and actions wrap.**
+Four buttons stacked one per line is tall and ragged; two rows of two is
+neither, and wrapping was never the problem — the 176px rail was. 224px is
+measured, not guessed: the tightest real pair is Playthroughs (120px) beside
+Devices (86px), 211px with the gap, and every other pair on every list is
+under 183px. Three never fit, which is what makes the queue's four verbs a
+clean 2 × 2.
+
+The constraint that falls out lands on the **labels**, so keep them inside
+the budget the rail was sized for — twelve characters, "Playthroughs" being
+the longest — and don't put two long ones side by side. The inbox's second
+action is "Origin" rather than "Import record" for exactly this reason.
+
+(`fit-or-stack` is **not** the tool here. It is for metadata chip rows, where
+the number of chips genuinely varies per record; a rail's verbs are fixed by
+the surface, so its width can just be right.)
+
+**A verb that isn't available yet is disabled, not absent.** The queue's
+Import used to appear only once a row was settled, so the rail's shape and
+the order of its buttons changed from row to row and the primary action moved
+under the cursor as the operator worked down the list. A disabled button in
+its own place says "not yet" without rearranging everything around it — and
+it has to say *why* in its `title`, or it is only a dead button. Note that
+`disabled:` variants are a `:disabled` pseudo-class and a `<span>` can never
+match one, so `row_action` spells the state out and drops the binding.
+
+**The whole card is the link, and it is a real one.** The headline is an
+`<a>` whose `::after` covers the card. The two older idioms each had half of
+this: the library lists made the whole row clickable with `JS.navigate` on
+the div — a big target, but not a link, so no focus, no middle click, no
+open-in-new-tab — and the queue linked only its title, a real link with a
+200px target. It also fixes a defect neither could see: LiveView dispatches a
+click to the *closest* `phx-click` ancestor, so an `<a>` nested inside a
+`JS.navigate` row fired both, which on the users list meant clicking Devices
+also navigated to Playthroughs. Everything clickable therefore sits in a
+`z-10` layer above the pseudo-element; an overlay is `z-20` above both.
+
+**A row that goes nowhere is not a link and wears no pointer.** The old
+container hardcoded `cursor-pointer` on every row whether or not it had a
+destination, so the queue and the devices list invited clicks on dead space.
+
+**The rail needs `self-stretch` or its `justify-between` is decoration.**
+The card is `items-center`, so an unstretched rail is content-height and the
+dates sit jammed under the actions instead of on the card's bottom baseline —
+which is what every pre-redesign list did while writing the rule's classes.
+
+**64px is the row's height floor.** People rows were 48px, so they were
+visibly shorter than every other list's on the same page of the same app.
 
 ## 3b. Forms are blocks, like everything else
 
@@ -386,7 +491,7 @@ primary button and the chosen chip's source tag.
 |---|---|
 | Primary action | solid `bg-brand-dark text-zinc-900` (the loudest thing on the page) |
 | Secondary button | filled `bg-zinc-800 text-zinc-200 hover:bg-zinc-700`, borderless |
-| Quiet row action | filled `bg-white/5 text-zinc-300 hover:bg-white/10`, worded, uniform width per rail |
+| Quiet row action | `<.row_action>`: the `:sm` button costume, always worded, content-sized, right-aligned |
 | Danger | `bg-red-400/10 text-red-300`, or red text revealed on hover |
 | Status badge | `<.badge>`: soft tint + colored text, borderless |
 | Count chip | `bg-white/10 text-zinc-300 tabular-nums` |
@@ -426,12 +531,26 @@ form's ✕. The trash can is reserved for actions that destroy something
 real — the file audit's deletes, an index row's delete — with red revealed
 on hover (§6 danger).
 
-**Documented exception — icon-only actions on dense index rows.** The
-quiet-row-action costume is worded, but an index row carrying five verbs
-(media: chapters, edit, replace, search, delete) would drown its content
-in words; pencils and trash cans on index rows stay icon-only with
-`title` text. Queue cards (the inbox) have room and stakes, and stay
-worded.
+**Row actions are worded, everywhere.** This used to have an exception for
+"an index row carrying five verbs (media: chapters, edit, replace, search,
+delete)", and the exception outlived its case: those five verbs moved onto
+the media form during the redesign, leaving that row with two, while the
+inbox carried four and wore words for them. A rule kept alive only by the
+thing it excepted no longer existing is a rule to delete. `<.row_action>` is
+the one costume — a link when it goes somewhere, a `role="button"` span when
+it fires an event — and the trash can survives only where §6's danger rule
+puts it, on a row that is not itself a link (the file audit's deletes).
+
+**Actions are content-sized and right-aligned, not one fixed width per
+rail.** The fixed width was written when the queue was the only surface with
+a rail and stacked four identical buttons down it. One shared rail across
+every list would force the widest label anywhere onto every "Edit". Right
+alignment is what makes the edge read as a column; the fixed width never was.
+How a rail lays out is decided by its verb count (§3a), never by measurement.
+
+**Every destructive confirm names what dies and what survives.** "Are you
+sure?" was on five index rows, including the one that deletes an audiobook's
+audio files off the disk.
 
 ## 6b. Toasts and ambient chrome
 

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -294,14 +294,32 @@ are facts about the *work*; putting them in the column that says "Added
 8/17/26" made three lines of date read as three timestamps.
 
 **And what they are instead is a sentence, not a cell.** `record_meta/1` is
-the last line of the content column, under the credits: "Published August 30,
-2022 by Recorded Books · 32 hours and 43 minutes". They passed through the
-facts strip on the way out of the footer, as `8/30/22` and `14:04:02`, which
-is the shape a spreadsheet wants rather than a reader — and the full words
-cost nothing, because that line is a line either way. **The rule that falls
-out: `:facts` holds what you count and glance at, the meta line holds what
-you read.** One helper for both flat views, so the audiobooks list and the
-queue's imported rows cannot phrase it differently again.
+the last line of the content column, under the credits. They passed through
+the facts strip on the way out of the footer, as `8/30/22` and `14:04:02`,
+which is the shape a spreadsheet wants rather than a reader — and the full
+words cost nothing, because that line is a line either way. **The rule that
+falls out: `:facts` holds what you count and glance at, the meta line holds
+what you read.** One helper for both flat views, so the audiobooks list and
+the queue's imported rows cannot phrase it differently again.
+
+**Three fixed lines, then one variable one.** Title, authors and narrators
+are what every record has, so a row is always those three; the series, the
+publisher, the publication date and the duration are each only sometimes
+there, so they share the fourth and it collapses to nothing when a record has
+none of them:
+
+> **The Way of Kings**
+> Brandon Sanderson
+> Read by Michael Kramer, Kate Reading
+> The Stormlight Archive #1 · Published August 30, 2022 by Recorded Books · 32 hours and 43 minutes
+
+**This moves the series out of the credit stack, and it is the one place that
+diverges from §8.** The argument is density and not convenience: a series
+that owns a line of its own makes every audiobook row taller to state a fact
+most rows say in four words, and on a row a series reads as a locator
+alongside the publisher rather than as a credit alongside the people. The
+detail pages and the mobile app keep §8's stack intact — the divergence is
+this surface's, and it stops here.
 
 **The rail is `w-56` (224px), which is two buttons wide, and actions wrap.**
 Four buttons stacked one per line is tall and ragged; two rows of two is
@@ -627,7 +645,8 @@ The admin routes follow the words: `/admin/audiobooks`, `/admin/sets`.
 
 **Credits are the mobile app's stack**: title (bold), series
 ("Name #3"), bare author names — no "by" — then "Read by …" muted, with
-size and color carrying the roles. "Narrated by" is retired as a verb;
+size and color carrying the roles. (Index rows are the documented
+exception: the series moves down to their variable line, §3a.) "Narrated by" is retired as a verb;
 the noun "Narrator" stays. When one line must hold it all (page titles,
 match rows, option labels), the joins are words: "The Martian by Andy
 Weir read by R.C. Bray". Names join with commas.

--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -26,6 +26,7 @@ defmodule Ambry.Books do
       PubSub.UniverseDeleted
     ]
 
+  import Ambry.Utils, only: [series_credit: 1]
   import Ecto.Query
 
   alias Ambry.Books.Book
@@ -396,6 +397,9 @@ defmodule Ambry.Books do
     %{
       id: book.id,
       label: book.title,
+      # Where it sits, muted, on the label's own line — the one fact that
+      # tells two books with the same title apart at a glance.
+      trailer: series_credit(book.series),
       image: List.first(book.thumbnails || []),
       detail: book_select_detail(book)
     }

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -80,6 +80,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Library.ImportPreference
   alias Ambry.Library.Root
   alias Ambry.Library.Source
+  alias Ambry.Media.MediaFlat
   alias Ambry.Media.MediaTrack
   alias Ambry.Media.Scanner
   alias Ambry.Media.Scanner.Tags
@@ -973,6 +974,40 @@ defmodule Ambry.Inbox do
   What is happening to each of these items in the background.
   """
   defdelegate progress(items), to: Progress, as: :statuses
+
+  @doc """
+  The audiobooks these items became, keyed by **item** id.
+
+  One query for a page of items, like `progress/1` — the queue renders an
+  imported row as the audiobook it produced, and a query per row is how a
+  list page gets slow quietly.
+
+  An imported item can have no audiobook: deleting one nilifies the link
+  rather than taking the record of the import with it, so a missing key here
+  is a fact the row has to be able to state.
+  """
+  def audiobooks(items) do
+    media_ids = items |> Enum.map(& &1.media_id) |> Enum.reject(&is_nil/1)
+
+    if media_ids == [] do
+      %{}
+    else
+      by_media_id =
+        MediaFlat
+        |> where([m], m.id in ^media_ids)
+        |> Repo.all()
+        |> Map.new(&{&1.id, &1})
+
+      items
+      |> Enum.flat_map(fn item ->
+        case Map.fetch(by_media_id, item.media_id) do
+          {:ok, audiobook} -> [{item.id, audiobook}]
+          :error -> []
+        end
+      end)
+      |> Map.new()
+    end
+  end
 
   @doc """
   What a background job is doing to one item.

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -202,6 +202,12 @@ defmodule Ambry.Media do
     %{
       id: media.id,
       label: media_option_label(media),
+      # What it is *found* by, which its label isn't: the label composes a
+      # part suffix onto the title, and no column holds "A Court of Thorns
+      # and Roses (Part 1 of 2)". A picker reopened on a set member searched
+      # for exactly that and reported "No matches" about the recording it was
+      # already holding.
+      query: media.title || media.book,
       image: media.thumbnail,
       detail: media_option_detail(media)
     }
@@ -225,8 +231,14 @@ defmodule Ambry.Media do
   # facts that separate two readings of one book. "Streaming only" is in here
   # because which recordings still cost double the disk is the whole reason
   # somebody is looking at this list.
+  #
+  # The authors lead it, bare, the way every other credit stack in the app
+  # reads (§8) — this line listed a recording's narrators and never said who
+  # wrote the thing, which is the one credit a picker of audiobooks can be
+  # asked to disambiguate by.
   defp media_option_detail(%MediaFlat{} = media) do
     [
+      names(media.authors),
       names(media.narrators) && "read by #{names(media.narrators)}",
       media.publisher,
       media.published && media.published.year,

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -202,6 +202,10 @@ defmodule Ambry.Media do
     %{
       id: media.id,
       label: media_option_label(media),
+      # Where it sits, muted, on the label's own line: the detail line below
+      # is already carrying five facts, and the series is the one that tells
+      # two same-titled records apart at a glance.
+      trailer: series_credit(media.series),
       # What it is *found* by, which its label isn't: the label composes a
       # part suffix onto the title, and no column holds "A Court of Thorns
       # and Roses (Part 1 of 2)". A picker reopened on a set member searched
@@ -239,7 +243,7 @@ defmodule Ambry.Media do
   defp media_option_detail(%MediaFlat{} = media) do
     [
       names(media.authors),
-      names(media.narrators) && "read by #{names(media.narrators)}",
+      name_credit(media.narrators) && "read by #{name_credit(media.narrators)}",
       media.publisher,
       media.published && media.published.year,
       media.duration && format_duration(media.duration),

--- a/lib/ambry/utils.ex
+++ b/lib/ambry/utils.ex
@@ -52,6 +52,48 @@ defmodule Ambry.Utils do
     end
   end
 
+  @doc """
+  A credit, shortened to the name that identifies it and a count of the rest.
+
+  Long narrator lists are the case this exists for: a GraphicAudio cast runs
+  to a dozen people, and a row or a picker option that prints all twelve
+  buries the title it was meant to help you find. The first name is what
+  tells two recordings of one book apart; the others are a number.
+
+  ## Examples
+
+      iex> Ambry.Utils.name_credit([%{name: "R.C. Bray"}])
+      "R.C. Bray"
+
+      iex> Ambry.Utils.name_credit([%{name: "Kate Reading"}, %{name: "Michael Kramer"}])
+      "Kate Reading and 1 other"
+
+      iex> Ambry.Utils.name_credit([%{name: "A"}, %{name: "B"}, %{name: "C"}])
+      "A and 2 others"
+  """
+  def name_credit(nil), do: nil
+  def name_credit([]), do: nil
+  def name_credit([%{name: name}]), do: name
+
+  def name_credit([%{name: name} | rest]) do
+    case length(rest) do
+      1 -> "#{name} and 1 other"
+      n -> "#{name} and #{n} others"
+    end
+  end
+
+  @doc """
+  Where something sits in its series, in the app's one wording.
+
+  ## Examples
+
+      iex> Ambry.Utils.series_credit([%{name: "Mistborn", number: 2}])
+      "Mistborn #2"
+  """
+  def series_credit(nil), do: nil
+  def series_credit([]), do: nil
+  def series_credit(series), do: Enum.map_join(series, ", ", &"#{&1.name} ##{&1.number}")
+
   defmacro tap_ok(tuple, fun) do
     quote bind_quoted: [fun: fun, tuple: tuple] do
       case tuple do

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -3,6 +3,7 @@ defmodule AmbryWeb.Admin.Components do
 
   use AmbryWeb, :html
 
+  import Ambry.Utils, only: [name_credit: 1, series_credit: 1]
   import AmbryWeb.Gravatar
   import AmbryWeb.TimeUtils, only: [duration_display: 1]
 
@@ -460,11 +461,14 @@ defmodule AmbryWeb.Admin.Components do
     >
       {names(@authors)}
     </p>
+    <%!-- A dozen-strong GraphicAudio cast printed in full buries the title
+          it was meant to help identify, so the row credits the narrator who
+          tells two recordings apart and counts the rest (§8). --%>
     <p
       :if={@narrators != []}
       class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
     >
-      Read by {names(@narrators)}
+      Read by {name_credit(@narrators)}
     </p>
     """
   end
@@ -493,17 +497,13 @@ defmodule AmbryWeb.Admin.Components do
   """
   def record_meta(record) do
     [
-      record |> Map.get(:series) |> series_clause(),
+      record |> Map.get(:series) |> series_credit(),
       published_clause(record),
       record |> Map.get(:duration) |> duration_display()
     ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join(" · ")
   end
-
-  defp series_clause(nil), do: nil
-  defp series_clause([]), do: nil
-  defp series_clause(series), do: Enum.map_join(series, ", ", &"#{&1.name} ##{&1.number}")
 
   defp published_clause(record) do
     case {format_published(record), Map.get(record, :publisher)} do

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -441,23 +441,69 @@ defmodule AmbryWeb.Admin.Components do
   end
 
   @doc """
-  A record's descriptive line: when it came out, who put it out, how long it
-  is.
+  The credit stack's own lines: bare author names, then the narrators muted.
 
-  Lives with the credits in the content column rather than in the rail,
-  because it is prose about the work and reads like it — "Published August
-  30, 2022 by Recorded Books · 32 hours and 43 minutes". These spent a while
-  as terse cells in the rail (`8/30/22`, `14:04:02`), which is the shape a
-  spreadsheet wants, not a reader.
+  What is left of the stack once the series moves to `record_meta/1` — and
+  what is left is exactly the part every record has, which is what lets a row
+  be three fixed lines and one variable one. Names join with commas and
+  nothing is prefixed with "by" (§8); "Read by" is the one word that stays,
+  because a list of names with no label is a list of authors.
+  """
+  attr :authors, :list, default: []
+  attr :narrators, :list, default: []
+
+  def credit_lines(assigns) do
+    ~H"""
+    <p
+      :if={@authors != []}
+      class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300"
+    >
+      {names(@authors)}
+    </p>
+    <p
+      :if={@narrators != []}
+      class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+    >
+      Read by {names(@narrators)}
+    </p>
+    """
+  end
+
+  defp names(people), do: Enum.map_join(people, ", ", & &1.name)
+
+  @doc """
+  A row's last line: where it sits, when it came out, who put it out, how
+  long it is.
+
+  **The row's first lines are what every record has, and this line is
+  everything that varies.** Title, authors and narrators are always there, so
+  they are always three lines; series, publisher, published and duration are
+  each sometimes there, so they share the fourth and it collapses to nothing
+  when a record has none of them. A series that owned a line of its own made
+  every audiobook row taller for a fact most rows state in four words.
+
+  It lives with the credits rather than in the rail because it is prose and
+  reads like it — "The Stormlight Archive #1 · Published August 30, 2022 by
+  Recorded Books · 32 hours and 43 minutes". These spent a while as terse
+  cells in the rail (`8/30/22`, `14:04:02`), which is the shape a spreadsheet
+  wants, not a reader.
 
   Takes either flat view: a book has no publisher and no duration, so it
-  reduces to the published clause on its own.
+  reduces to its series and its date.
   """
   def record_meta(record) do
-    [published_clause(record), record |> Map.get(:duration) |> duration_display()]
+    [
+      record |> Map.get(:series) |> series_clause(),
+      published_clause(record),
+      record |> Map.get(:duration) |> duration_display()
+    ]
     |> Enum.reject(&is_nil/1)
     |> Enum.join(" · ")
   end
+
+  defp series_clause(nil), do: nil
+  defp series_clause([]), do: nil
+  defp series_clause(series), do: Enum.map_join(series, ", ", &"#{&1.name} ##{&1.number}")
 
   defp published_clause(record) do
     case {format_published(record), Map.get(record, :publisher)} do

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -4,6 +4,7 @@ defmodule AmbryWeb.Admin.Components do
   use AmbryWeb, :html
 
   import AmbryWeb.Gravatar
+  import AmbryWeb.TimeUtils, only: [duration_display: 1]
 
   alias Ambry.Accounts.User
   alias Phoenix.HTML.Form
@@ -223,13 +224,17 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  @doc """
+  The shell a list page's rows sit in: the spacing, and what an empty list
+  says.
+
+  The rows themselves are `index_row/1`. This used to own their geometry too,
+  through a `:row` slot and a `row_click` callback, which meant every surface
+  hand-built its own anatomy inside one anonymous slot — and ten of them
+  drifted apart doing it.
+  """
   attr :rows, :list, required: true
   attr :filter, :string, default: nil
-  attr :row_click, :any, default: nil
-
-  attr :row_class, :any,
-    default: nil,
-    doc: "optional fun row -> extra classes; how a row wears per-item state (e.g. a state rail)"
 
   slot :empty
   slot :row, required: true
@@ -245,48 +250,299 @@ defmodule AmbryWeb.Admin.Components do
         <% end %>
       </p>
     <% else %>
-      <.admin_table_container>
-        <.admin_table_row
-          :for={row <- @rows}
-          class={@row_class && @row_class.(row)}
-          phx-click={@row_click && @row_click.(row)}
-        >
-          {render_slot(@row, row)}
-        </.admin_table_row>
-      </.admin_table_container>
+      <%!-- Rows are separate raised cards on the ground, not one bordered slab
+            sliced by hairline dividers — elevation and gaps do the separating. --%>
+      <div class="space-y-3">
+        <div :for={row <- @rows}>{render_slot(@row, row)}</div>
+      </div>
     <% end %>
     """
   end
 
-  slot :inner_block, required: true
+  @doc """
+  One row of a list page, in the one anatomy they all share.
 
-  defp admin_table_container(assigns) do
-    ~H"""
-    <%!-- Rows are separate raised cards on the ground, not one bordered slab
-          sliced by hairline dividers — elevation and gaps do the separating. --%>
-    <div class="space-y-3">
-      {render_slot(@inner_block)}
-    </div>
-    """
+  **The whole card is the link.** The headline is a real `<a>` whose `::after`
+  covers the card, which is the only way to get both halves of what the two
+  older idioms each had half of: the library lists made the whole row
+  clickable with `JS.navigate` on the div (a big target, but not a link — no
+  focus, no middle click, no open-in-new-tab), and the inbox linked only its
+  title (a real link, a 200px target). It also fixes a defect neither idiom
+  could see: LiveView dispatches a click to the *closest* `phx-click`
+  ancestor, so an `<a>` nested inside a `JS.navigate` row fired the anchor
+  **and** the row, which on the users list meant clicking Devices also
+  navigated to Playthroughs.
+
+  Everything the operator can click therefore sits in a `z-10` layer above
+  that pseudo-element; the busy overlay is `z-20` and covers both.
+
+  The slots are the anatomy, and each has exactly one home:
+
+    * `:cover` — a 64px image, at the card's left edge (§3: an image is
+      content, so it sits on the rail like the words beside it).
+    * `:headline` — the title. Always the link, always `font-semibold`.
+    * `:inner_block` — the credit stack and meta lines under the headline.
+    * `:badges` — state, at the top of the right rail, on the headline's
+      baseline. Not under the cover: one home per kind of thing, and the
+      media list was the only surface that put them there.
+    * `:facts` — the glyph-and-count strip. It used to be its own
+      `hidden sm:flex` column, which didn't fold on a phone, it *vanished*.
+    * `:action` — one entry per verb, worded. Never icon-only: §6's exception
+      for that was written for a five-verb media row whose verbs have all
+      since moved onto the form.
+    * `:footer` — **system timestamps only** (added, imported, joined, last
+      seen). A publication date and a duration are facts about the work, not
+      a record of something the app did, and reading them in the column that
+      says "Added 8/17/26" made them look like both.
+
+  **The rail is 224px, which is two buttons wide, and actions wrap.** Four
+  buttons stacked one per line is tall and ragged; two rows of two is neither.
+  So the rail is sized to the pair rather than the label, and the constraint
+  that falls out is on the *labels*: keep them short enough that two fit
+  ("Origin", not "Import record"). One slot entry per verb is what keeps them
+  all in one costume.
+  """
+  attr :navigate, :string, default: nil, doc: "where the whole card goes; omit for a dead row"
+  attr :patch, :string, default: nil, doc: "same, when the destination is a patch (a modal)"
+
+  attr :class, :any,
+    default: nil,
+    doc: "per-item state, e.g. the queue's `border-l-4` rail"
+
+  attr :inert, :boolean,
+    default: false,
+    doc: "takes the row's content out of the tab order, for a row an :overlay owns"
+
+  attr :rest, :global
+
+  slot :overlay, doc: "a scrim over the whole card, e.g. `busy_overlay/1`"
+  slot :cover
+  slot :headline
+  slot :badges
+  slot :facts
+  slot :footer
+  slot :inner_block
+
+  slot :action do
+    attr :navigate, :string
+    attr :patch, :string
+    attr :icon, :string, required: true
+    attr :color, :atom, doc: "one of zinc (default), brand, or red"
+    attr :click, :string, doc: "a phx-click event name"
+    attr :value, :any, doc: "the phx-value-id that rides with it"
+    attr :confirm, :string
+    attr :title, :string
+    attr :disabled, :boolean
+    attr :role, :string, doc: "a data-role, for tests"
   end
 
-  attr :class, :any, default: nil
-  attr :rest, :global
-  slot :inner_block, required: true
-
-  defp admin_table_row(assigns) do
+  def index_row(assigns) do
     ~H"""
-    <%!-- flex-wrap below sm lets a row's right rail drop to a full-width
-          bottom line instead of squeezing the content column on phones. --%>
+    <%!-- flex-wrap below sm lets the right rail drop to a full-width bottom
+          line instead of squeezing the content column on phones. --%>
     <div
       class={[
-        "relative flex cursor-pointer flex-wrap items-center gap-x-4 gap-y-2 rounded-lg bg-zinc-900 p-4 sm:flex-nowrap",
+        "relative flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg bg-zinc-900 p-4 sm:flex-nowrap",
+        (@navigate || @patch) && "hover:bg-zinc-800/50",
         @class
       ]}
       {@rest}
     >
-      {render_slot(@inner_block)}
+      <%!-- A direct child of the card, so its `inset-0` measures the card and
+            nothing clips it: the content column below is `overflow-hidden`,
+            which would have cropped a scrim rendered inside it. --%>
+      {render_slot(@overlay)}
+
+      <div :if={@cover != []} class="flex-none" inert={@inert}>{render_slot(@cover)}</div>
+
+      <div class="min-w-0 flex-grow overflow-hidden" inert={@inert}>
+        <p :if={@headline != []} class="overflow-hidden text-ellipsis whitespace-nowrap font-semibold">
+          <%= if @navigate || @patch do %>
+            <%!-- after:inset-0 against the card's own `relative`: the anchor
+                  stays an ordinary inline element (so the headline still
+                  truncates and wraps normally) and only its pseudo-element
+                  spreads to the card's edges. --%>
+            <.link navigate={@navigate} patch={@patch} class="after:absolute after:inset-0">
+              {render_slot(@headline)}
+            </.link>
+          <% else %>
+            {render_slot(@headline)}
+          <% end %>
+        </p>
+
+        {render_slot(@inner_block)}
+      </div>
+
+      <%!-- The rail's corners share the card's baselines: the badges align
+            with the headline, the dates with the content's last line
+            (self-stretch + justify-between — without the stretch the column
+            is content-height and justify-between does nothing, which is why
+            the older lists' dates sat jammed under their icons). --%>
+      <div
+        :if={[@badges, @facts, @action, @footer] != [[], [], [], []]}
+        class="relative z-10 flex w-full flex-none flex-wrap items-center gap-x-3 gap-y-2 sm:w-56 sm:flex-col sm:items-end sm:justify-between sm:self-stretch"
+        inert={@inert}
+      >
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 sm:flex-col sm:items-end">
+          <div :if={@badges != []} class="flex flex-wrap items-center gap-1.5">
+            {render_slot(@badges)}
+          </div>
+
+          <%!-- The row's measurements: counts, boolean glyphs, a duration, a
+                publication date. Wraps rather than overflowing, because this
+                is the one strip whose contents vary most per surface. --%>
+          <div
+            :if={@facts != []}
+            class="flex flex-wrap items-center justify-end gap-x-3 gap-y-1 text-xs text-zinc-400"
+          >
+            {render_slot(@facts)}
+          </div>
+
+          <%!-- Content-sized and right-aligned, not one fixed width per rail:
+                that rule was written when the queue stacked four identical
+                buttons, and sharing one rail across every list would force
+                the widest label anywhere onto every "Edit". Right alignment
+                is what makes the edge read as a column; the fixed width never
+                was. Which of the two layouts applies is decided by the number
+                of verbs, never by what fits. --%>
+          <div
+            :if={@action != []}
+            class="flex flex-wrap items-center justify-end gap-1.5"
+            data-role="row-actions"
+          >
+            <.row_action
+              :for={action <- @action}
+              navigate={action[:navigate]}
+              patch={action[:patch]}
+              icon={action.icon}
+              color={Map.get(action, :color, :zinc)}
+              disabled={Map.get(action, :disabled, false)}
+              phx-click={action[:click]}
+              phx-value-id={action[:value]}
+              data-confirm={action[:confirm]}
+              data-role={action[:role]}
+              title={action[:title]}
+            >
+              {render_slot(action)}
+            </.row_action>
+          </div>
+        </div>
+
+        <div
+          :if={@footer != []}
+          class="whitespace-nowrap text-right text-xs text-zinc-400"
+          data-role="row-footer"
+        >
+          {render_slot(@footer)}
+        </div>
+      </div>
     </div>
+    """
+  end
+
+  @doc """
+  A record's descriptive line: when it came out, who put it out, how long it
+  is.
+
+  Lives with the credits in the content column rather than in the rail,
+  because it is prose about the work and reads like it — "Published August
+  30, 2022 by Recorded Books · 32 hours and 43 minutes". These spent a while
+  as terse cells in the rail (`8/30/22`, `14:04:02`), which is the shape a
+  spreadsheet wants, not a reader.
+
+  Takes either flat view: a book has no publisher and no duration, so it
+  reduces to the published clause on its own.
+  """
+  def record_meta(record) do
+    [published_clause(record), record |> Map.get(:duration) |> duration_display()]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+  end
+
+  defp published_clause(record) do
+    case {format_published(record), Map.get(record, :publisher)} do
+      {nil, _publisher} -> nil
+      {published, nil} -> "Published #{published}"
+      {published, publisher} -> "Published #{published} by #{publisher}"
+    end
+  end
+
+  @doc """
+  One worded action on a list row, in the one costume they all wear.
+
+  A link when it goes somewhere, a `role="button"` span when it fires an
+  event — the two the older lists spelled out by hand, differently, on every
+  surface. `:red` reveals the danger fill on hover rather than wearing it, so
+  a row of actions doesn't read as a row of warnings (§6).
+  """
+  attr :navigate, :string, default: nil
+  attr :patch, :string, default: nil
+  attr :icon, :string, required: true
+  attr :color, :atom, default: :zinc, doc: "one of zinc, brand, or red"
+
+  attr :disabled, :boolean,
+    default: false,
+    doc: "present but refusing, so the rail keeps its shape and its order"
+
+  attr :rest, :global, include: ~w(title)
+
+  slot :inner_block, required: true
+
+  # A disabled action is still an action: it holds its place and its order.
+  #
+  # `disabled:` variants are a `:disabled` pseudo-class, which a `<span>` can
+  # never match, so the refusing state is spelled out. It also drops the click
+  # binding rather than relying on `pointer-events-none` alone — that stops a
+  # mouse and nothing else.
+  def row_action(%{disabled: true} = assigns) do
+    ~H"""
+    <span
+      role="button"
+      aria-disabled="true"
+      class={[row_action_class(@color), "pointer-events-none opacity-40"]}
+      {Map.drop(@rest, [:"phx-click", :"phx-value-id", :"data-confirm"])}
+    >
+      <.icon name={@icon} class="h-3 w-3 text-current" />{render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  def row_action(%{navigate: nil, patch: nil} = assigns) do
+    ~H"""
+    <span role="button" class={row_action_class(@color)} {@rest}>
+      <.icon name={@icon} class="h-3 w-3 text-current" />{render_slot(@inner_block)}
+    </span>
+    """
+  end
+
+  def row_action(assigns) do
+    ~H"""
+    <.link navigate={@navigate} patch={@patch} class={row_action_class(@color)} {@rest}>
+      <.icon name={@icon} class="h-3 w-3 text-current" />{render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  defp row_action_class(:red),
+    do: [action_classes(:zinc), "hover:bg-red-400/10 hover:text-red-300"]
+
+  defp row_action_class(color), do: action_classes(color)
+
+  @doc """
+  A count with its glyph, for the row rail's facts strip.
+
+  Numbers first, glyph after — the number is what is being read and the
+  glyph says which number it is.
+  """
+  attr :icon, :string, required: true
+  attr :count, :integer, default: nil
+  attr :rest, :global, include: ~w(title)
+
+  def row_fact(assigns) do
+    ~H"""
+    <span class="flex items-center gap-1 tabular-nums" {@rest}>
+      {@count}<.icon name={@icon} class="h-3.5 w-3.5 text-current" />
+    </span>
     """
   end
 

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -151,15 +151,25 @@ defmodule AmbryWeb.Components.EntityResolver do
         role="listbox"
         class="min-w-48 absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-md bg-zinc-800 text-sm shadow-xl"
       >
+        <%!-- The held record is marked, not painted. Being first in the list
+            is most of the signal already, and the input two pixels above it
+            is wearing a lime focus ring — a brand fill and an inset brand
+            ring under that made the whole corner of the form green. So it
+            takes a neutral lift off the list's own ground and one lime
+            check, the app's mark for chosen (§6) at the smallest size it
+            comes in. --%>
         <li
           :for={option <- @matches}
           id={"#{@id}-option-#{option.id}"}
           role="option"
-          aria-selected={to_string(to_string(option.id) == to_string(@value))}
+          aria-selected={to_string(selected?(option, @value))}
           phx-click="pick"
           phx-value-id={option.id}
           phx-target={@myself}
-          class="cursor-pointer px-3 py-2 data-[active]:bg-zinc-700 hover:bg-zinc-700"
+          class={[
+            "cursor-pointer px-3 py-2 data-[active]:bg-zinc-700 hover:bg-zinc-700",
+            if(selected?(option, @value), do: "bg-white/5")
+          ]}
         >
           <div class="flex min-w-0 items-center gap-2.5">
             <img
@@ -175,12 +185,17 @@ defmodule AmbryWeb.Components.EntityResolver do
             >
               {String.first(option.label)}
             </span>
-            <span class="min-w-0">
+            <span class="min-w-0 grow">
               <span class="block truncate">{option.label}</span>
               <span :if={option.detail} class="block truncate text-xs text-zinc-400">
                 {option.detail}
               </span>
             </span>
+            <.icon
+              :if={selected?(option, @value)}
+              name="fa-check"
+              class="text-brand-dark h-3.5 w-3.5 flex-none"
+            />
           </div>
         </li>
         <li
@@ -318,9 +333,30 @@ defmodule AmbryWeb.Components.EntityResolver do
   # query per keystroke of every other field on the form.
   defp matches(%{open: false}), do: []
 
-  defp matches(%{equery: query, search: search}) do
-    query |> search.(@limit) |> Enum.map(&normalize/1)
+  defp matches(%{equery: query, search: search} = assigns) do
+    query
+    |> search.(@limit)
+    |> Enum.map(&normalize/1)
+    |> pin(assigns.held)
   end
+
+  # What the field is already holding leads the list.
+  #
+  # Opening a filled box used to drop its own record somewhere in an
+  # alphabetical run of near-identical siblings — every recording of one book,
+  # every narrator with the same first name — so confirming what was already
+  # chosen meant reading the whole list. It is pinned whether or not the
+  # search surfaced it, which also means a box can no longer say "No matches"
+  # while holding something: an ordering that depends on the query is exactly
+  # what made that possible.
+  #
+  # `held` is nil while the operator is typing, so the pin is for the opened
+  # field, not for a search in progress — once you type, the list is an answer
+  # to what you typed.
+  defp pin(found, nil), do: found
+  defp pin(found, held), do: [held | Enum.reject(found, &same_record?(&1, held))]
+
+  defp same_record?(%{id: left}, %{id: right}), do: to_string(left) == to_string(right)
 
   defp normalize(nil), do: nil
 
@@ -328,6 +364,10 @@ defmodule AmbryWeb.Components.EntityResolver do
 
   defp normalize(%{id: _id, label: _label} = option),
     do: Map.merge(%{image: nil, detail: nil, query: nil}, option)
+
+  defp selected?(_option, nil), do: false
+  defp selected?(_option, ""), do: false
+  defp selected?(%{id: id}, value), do: to_string(id) == to_string(value)
 
   defp present?(nil), do: false
   defp present?(string), do: String.trim(string) != ""

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -60,7 +60,10 @@ defmodule AmbryWeb.Components.EntityResolver do
   `image` renders a thumbnail (cover, portrait), `detail` a muted second
   line — the disambiguation lives there, so labels stay short. When any
   option in a list carries an image, imageless rows hold the space with a
-  lettered placeholder so the column stays aligned.
+  lettered placeholder so the column stays aligned. `trailer` is a muted
+  aside on the label's own line, for the one fact that separates two
+  same-titled records (a series and its number) when the detail line is
+  already full.
 
   An option may also carry `query`: **what the record is found by, when that
   differs from how it is displayed.** A label composed from more than one
@@ -186,7 +189,18 @@ defmodule AmbryWeb.Components.EntityResolver do
               {String.first(option.label)}
             </span>
             <span class="min-w-0 grow">
-              <span class="block truncate">{option.label}</span>
+              <%!-- Where it sits rides the label's line, muted, rather than
+                  joining a detail line already carrying five facts. No middle
+                  dot: the size and colour already separate it, so the dot was
+                  a second mark doing a job that was done. It gives way three
+                  times faster than the title when the row runs out of width,
+                  because meta truncates before content (§7). --%>
+              <span class="flex min-w-0 items-baseline gap-1.5">
+                <span class="min-w-0 shrink truncate">{option.label}</span>
+                <span :if={option.trailer} class="shrink-[3] min-w-0 truncate text-xs text-zinc-500">
+                  {option.trailer}
+                </span>
+              </span>
               <span :if={option.detail} class="block truncate text-xs text-zinc-400">
                 {option.detail}
               </span>
@@ -360,10 +374,10 @@ defmodule AmbryWeb.Components.EntityResolver do
 
   defp normalize(nil), do: nil
 
-  defp normalize({label, id}), do: %{id: id, label: label, image: nil, detail: nil, query: nil}
+  @defaults %{image: nil, detail: nil, trailer: nil, query: nil}
 
-  defp normalize(%{id: _id, label: _label} = option),
-    do: Map.merge(%{image: nil, detail: nil, query: nil}, option)
+  defp normalize({label, id}), do: Map.merge(@defaults, %{id: id, label: label})
+  defp normalize(%{id: _id, label: _label} = option), do: Map.merge(@defaults, option)
 
   defp selected?(_option, nil), do: false
   defp selected?(_option, ""), do: false

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -61,6 +61,15 @@ defmodule AmbryWeb.Components.EntityResolver do
   line — the disambiguation lives there, so labels stay short. When any
   option in a list carries an image, imageless rows hold the space with a
   lettered placeholder so the column stays aligned.
+
+  An option may also carry `query`: **what the record is found by, when that
+  differs from how it is displayed.** A label composed from more than one
+  column has no column to match against, so reopening a filled box searched
+  for a string that could not exist and answered "No matches" about the very
+  record it was holding — an audiobook in a set is labelled "A Court of
+  Thorns and Roses (Part 1 of 2)" and titled "A Court of Thorns and Roses".
+  The label is for reading and the query is for finding; a label that is
+  itself a column needs no `query`.
   """
 
   use AmbryWeb, :live_component
@@ -292,10 +301,16 @@ defmodule AmbryWeb.Components.EntityResolver do
   defp display_value(%{held: %{label: label}}), do: label
   defp display_value(%{text: text}), do: text
 
-  # What the list filters on: the query while typing, otherwise whatever the
+  # What the list filters on: what is being typed, otherwise whatever the
   # field currently holds — an open filled field must never list records that
   # don't match what's in it.
-  defp effective_query(%{query: query}) when is_binary(query), do: query
+  #
+  # A held record answers with its own `query` when it has one, because its
+  # label may be composed rather than stored (see the moduledoc). Note the
+  # two different `query`s in play: the assign is the operator's keystrokes,
+  # `held.query` is the record's own search term.
+  defp effective_query(%{query: typed}) when is_binary(typed), do: typed
+  defp effective_query(%{held: %{query: term}}) when is_binary(term), do: term
   defp effective_query(assigns), do: display_value(assigns)
 
   # Only while the list is open. The search is a database query now, and a
@@ -308,10 +323,11 @@ defmodule AmbryWeb.Components.EntityResolver do
   end
 
   defp normalize(nil), do: nil
-  defp normalize({label, id}), do: %{id: id, label: label, image: nil, detail: nil}
+
+  defp normalize({label, id}), do: %{id: id, label: label, image: nil, detail: nil, query: nil}
 
   defp normalize(%{id: _id, label: _label} = option),
-    do: Map.merge(%{image: nil, detail: nil}, option)
+    do: Map.merge(%{image: nil, detail: nil, query: nil}, option)
 
   defp present?(nil), do: false
   defp present?(string), do: String.trim(string) != ""

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -148,11 +148,20 @@ defmodule AmbryWeb.Components.EntityResolver do
       >
         new
       </span>
+      <%!-- Flush against the box that opened it: the list is that box's
+          contents spilling downward, not a panel that happens to be nearby.
+          Square on top, rounded below.
+
+          The input keeps its own radius. Squaring its bottom corners to meet
+          the list was tried and looked worse (operator, 2026-08-18): the two
+          are not the same width, so the input's corners stay visible either
+          side of the seam, and squaring them removed a curve that was doing
+          no harm to close a join nobody could see. --%>
       <ul
         :if={@open}
         id={"#{@id}-list"}
         role="listbox"
-        class="min-w-48 absolute z-50 mt-1 max-h-64 w-full overflow-auto rounded-md bg-zinc-800 text-sm shadow-xl"
+        class="min-w-48 absolute z-50 max-h-64 w-full overflow-auto rounded-b-md bg-zinc-800 text-sm shadow-xl"
       >
         <%!-- The held record is marked, not painted. Being first in the list
             is most of the signal already, and the input two pixels above it

--- a/lib/ambry_web/live/admin/audit_live/index.html.heex
+++ b/lib/ambry_web/live/admin/audit_live/index.html.heex
@@ -33,7 +33,7 @@
                 type="button"
                 phx-click="delete-file"
                 phx-value-id={file.id}
-                data-confirm="Are you sure?"
+                data-confirm="Delete this file from disk? Nothing in the library references it."
                 title="Delete this file"
               >
                 <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-400" />
@@ -64,7 +64,7 @@
                 type="button"
                 phx-click="delete-folder"
                 phx-value-id={folder.id}
-                data-confirm="Are you sure?"
+                data-confirm="Delete this folder from disk? Nothing in the library references it."
                 title="Delete this folder"
               >
                 <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-400" />

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -36,29 +36,18 @@
           <span data-role="book-title">{book.title}</span>
         </:headline>
 
-        <%!-- The credit stack's one order: series, then bare author names
-              (§8). This list read title / authors / series for years, which
-              put the same three facts in a different order on every surface
-              that showed them. --%>
-        <p
-          :if={book.series != []}
-          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
-          data-role="book-series"
-        >
-          {book.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}
-        </p>
-        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300" data-role="book-authors">
-          {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
-        </p>
+        <div data-role="book-authors">
+          <.credit_lines authors={book.authors} />
+        </div>
 
-        <%!-- When it came out is prose about the book, so it reads like it
-              and sits with the credits. It spent a while as "Published
-              8/30/22" in the corner that says "Added 8/17/26", where two
-              dates in one column read as two timestamps. --%>
+        <%!-- Everything that varies, on one line: the series it sits in and
+              when it came out. Each owned a line of its own once, which cost
+              every row two lines to state facts most rows say in a dozen
+              words. --%>
         <p
           :if={record_meta(book) != ""}
           class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
-          data-role="book-published"
+          data-role="book-series"
         >
           {record_meta(book)}
         </p>

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -18,11 +18,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@books}
-    filter={@list_opts.filter}
-    row_click={fn book -> JS.navigate(~p"/admin/books/#{book}/edit") end}
-  >
+  <.flex_table rows={@books} filter={@list_opts.filter}>
     <:empty>
       No books yet.
       <.brand_link navigate={~p"/admin/books/new"}>
@@ -31,44 +27,70 @@
     </:empty>
 
     <:row :let={book}>
-      <div class="flex-shrink-0">
-        <.multi_image paths={book.thumbnails} />
-      </div>
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis" data-role="book-title">{book.title}</p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="book-authors">
-          {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
-        </p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="book-series">
+      <.index_row navigate={~p"/admin/books/#{book}/edit"}>
+        <:cover>
+          <.multi_image paths={book.thumbnails} />
+        </:cover>
+
+        <:headline>
+          <span data-role="book-title">{book.title}</span>
+        </:headline>
+
+        <%!-- The credit stack's one order: series, then bare author names
+              (§8). This list read title / authors / series for years, which
+              put the same three facts in a different order on every surface
+              that showed them. --%>
+        <p
+          :if={book.series != []}
+          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+          data-role="book-series"
+        >
           {book.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}
         </p>
-      </div>
-      <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <div class="flex gap-4">
-          <span :if={book.media > 0} title="# of audiobooks" data-role="book-media-count">
-            {book.media} <.icon name="fa-file-audio" class="h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
-      <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
-        <div class="flex gap-2 pb-2">
-          <.link navigate={~p"/admin/books/#{book}/edit"} data-role="edit-book">
-            <.icon
-              name="fa-pencil"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-          <span phx-click="delete" phx-value-id={book.id} data-confirm="Are you sure?" data-role="delete-book">
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-        <p class="text-sm text-zinc-400" data-role="book-published">
-          Published {format_published(book, :short)}
+        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300" data-role="book-authors">
+          {book.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-        <p class="text-sm text-zinc-400" data-role="book-added">
-          Added {Calendar.strftime(book.inserted_at, "%x")}
+
+        <%!-- When it came out is prose about the book, so it reads like it
+              and sits with the credits. It spent a while as "Published
+              8/30/22" in the corner that says "Added 8/17/26", where two
+              dates in one column read as two timestamps. --%>
+        <p
+          :if={record_meta(book) != ""}
+          class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+          data-role="book-published"
+        >
+          {record_meta(book)}
         </p>
-      </div>
+
+        <:facts>
+          <.row_fact
+            :if={book.media > 0}
+            icon="fa-file-audio"
+            count={book.media}
+            title="# of audiobooks"
+            data-role="book-media-count"
+          />
+        </:facts>
+
+        <:action navigate={~p"/admin/books/#{book}/edit"} icon="fa-pencil" role="edit-book">
+          Edit
+        </:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={book.id}
+          confirm="Delete this book? A book that has audiobooks can't be deleted."
+          role="delete-book"
+        >
+          Delete
+        </:action>
+
+        <:footer>
+          <span data-role="book-added">Added {Calendar.strftime(book.inserted_at, "%x")}</span>
+        </:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -146,6 +146,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       items: items,
       # one query for the page, not one per row
       progress: Inbox.progress(items),
+      audiobooks: Inbox.audiobooks(items),
       counts: Inbox.count_by_status(),
       status: status,
       list_opts: list_opts,
@@ -311,22 +312,6 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     ]
   end
 
-  # Row actions wear words. An unlabeled 16px icon is neither a label nor a
-  # touch target, and the queue's actions are consequential enough to name.
-  # The same small-action costume every other card action wears, widened to a
-  # uniform column so the right rail reads as a column rather than a rag.
-  defp action_class(tone) do
-    [
-      action_classes(button_color(tone), "sm:w-28"),
-      tone == :danger && "hover:bg-red-400/10 hover:text-red-300"
-    ]
-  end
-
-  # Import is the row's primary action and wears the primary costume; the
-  # rest are ordinary secondaries, with Ignore revealing red on hover.
-  defp button_color(:brand), do: :brand
-  defp button_color(_quiet), do: :zinc
-
   @doc """
   The row's one badge: what this item is, in the words that vary from row to
   row.
@@ -356,6 +341,26 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   defp status_color(:imported), do: :brand
   defp status_color(:ignored), do: :gray
+
+  @doc """
+  What the Import button promises, or why it won't.
+
+  A disabled control that doesn't say what is missing is just a dead button;
+  the count comes from the same `Draft.unresolved/1` the form lists in full.
+  """
+  def import_title(%InboxItem{ready: false, draft: nil}),
+    do: "Nothing has been proposed for this yet"
+
+  def import_title(%InboxItem{ready: false, draft: draft}) do
+    case length(Draft.unresolved(draft)) do
+      1 -> "Open it and settle 1 decision first"
+      n -> "Open it and settle #{n} decisions first"
+    end
+  end
+
+  def import_title(item) do
+    if replacing?(item), do: "Replace this audiobook's files", else: "Add to the library"
+  end
 
   @doc """
   Whether this item replaces an audiobook the library already has.
@@ -502,4 +507,33 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   def candidate_origin(%{"provider_name" => name}) when is_binary(name), do: name
   def candidate_origin(%{"source" => "provider:" <> id}), do: id
   def candidate_origin(_candidate), do: nil
+
+  @doc """
+  When the operator imported this item.
+
+  `updated_at` is the moment the status changed, and nothing writes to an
+  item afterwards — a scan skips imported items outright, and every write
+  path refuses one. It is already what the imported tab sorts by.
+  """
+  def imported_at(%InboxItem{updated_at: at}), do: at
+
+  # The library's own state, which only an imported row can have: the badges
+  # the audiobooks list wears, in the same colors, on the cover it belongs to.
+  # `:ready` renders nothing — every audiobook is meant to be ready, so saying
+  # it on all of them hides the ones that aren't.
+  defp library_status_color(:pending), do: :yellow
+  defp library_status_color(:processing), do: :blue
+  defp library_status_color(:error), do: :red
+
+  @doc """
+  Bare names, comma joined: the credit stack's author and narrator lines
+  (design language §8).
+  """
+  def person_names(people), do: people |> Enum.map_join(", ", & &1.name)
+
+  @doc """
+  The series line of the credit stack, "Name #3", comma joined when a book
+  sits in more than one.
+  """
+  def series_words(series), do: series |> Enum.map_join(", ", &"#{&1.name} ##{&1.number}")
 end

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -524,16 +524,4 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp library_status_color(:pending), do: :yellow
   defp library_status_color(:processing), do: :blue
   defp library_status_color(:error), do: :red
-
-  @doc """
-  Bare names, comma joined: the credit stack's author and narrator lines
-  (design language §8).
-  """
-  def person_names(people), do: people |> Enum.map_join(", ", & &1.name)
-
-  @doc """
-  The series line of the credit stack, "Name #3", comma joined when a book
-  sits in more than one.
-  """
-  def series_words(series), do: series |> Enum.map_join(", ", &"#{&1.name} ##{&1.number}")
 end

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -95,26 +95,7 @@
 
             <:headline>{media_display_title(audiobook)}</:headline>
 
-            <%!-- The credit stack, in its one order: series, bare author
-                  names, narrators muted underneath (§8). --%>
-            <p
-              :if={audiobook.series != []}
-              class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
-            >
-              {series_words(audiobook.series)}
-            </p>
-            <p
-              :if={audiobook.authors != []}
-              class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300"
-            >
-              {person_names(audiobook.authors)}
-            </p>
-            <p
-              :if={audiobook.narrators != []}
-              class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
-            >
-              Read by {person_names(audiobook.narrators)}
-            </p>
+            <.credit_lines authors={audiobook.authors} narrators={audiobook.narrators} />
 
             <%!-- No "imported" badge: the footer's date already says it, and
                   what varies from one imported row to the next is the state

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -60,7 +60,7 @@
     </div>
   </:subheader>
 
-  <.flex_table rows={@items} filter={@list_opts.filter} row_class={&rail_class/1}>
+  <.flex_table rows={@items} filter={@list_opts.filter}>
     <:empty>
       <%= if words = problem_empty_words(@list_opts[:problem]) do %>
         {words}
@@ -69,131 +69,257 @@
       <% end %>
     </:empty>
 
+    <%!-- An imported row stops being a candidate. What matched it, how sure
+          the machine was, and which files it came from are the record of a
+          decision already taken — they live on the item's own form, and
+          leaving them on the row makes finished work read like work. So the
+          row becomes the audiobook it produced, in the audiobooks list's own
+          cover-and-credits shape, because it is the same thing. --%>
     <:row :let={item}>
-      <%!-- A job is about to change this row underneath whoever is reading
-            it, so it says so over the whole row rather than in a corner. --%>
-      <.busy_overlay busy={busy?(@progress[item.id])} label={progress_label(@progress[item.id])} />
-
-      <div class="min-w-0 flex-grow overflow-hidden" inert={busy?(@progress[item.id])}>
-        <.link navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"} class="hover:underline">
-          <p class="overflow-hidden text-ellipsis whitespace-nowrap font-semibold">
-            {item_name(item)}
-          </p>
-        </.link>
-
-        <%!-- One meta line, not two: what the tags say and what the probe
-              measured are both identity, and each extra line raises the
-              card's density for free. --%>
-        <p
-          :if={Enum.any?([tag_summary(item), probe_summary(item)], &(&1 != ""))}
-          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
-        >
-          {[tag_summary(item), probe_summary(item)] |> Enum.reject(&(&1 == "")) |> Enum.join(" · ")}
-        </p>
-
-        <%!-- The annotated rows — matches and the files' source — share one
-              label column, so every badge and chip starts on the same rail
-              (design language §1). The value cell owns its own wrapping: when
-              width runs out the meta drops a line INSIDE the column, and the
-              candidate title is the last thing to ellipsize. --%>
-        <div class="mt-2 space-y-0.5">
-          <div
-            :for={match <- match_summary(item)}
-            class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2 text-sm"
+      <%= if item.status == :imported do %>
+        <%= if audiobook = @audiobooks[item.id] do %>
+          <.index_row
+            navigate={~p"/admin/audiobooks/#{audiobook.id}/edit"}
+            class={rail_class(item)}
           >
-            <span class="text-xs text-zinc-400">{level_word(match.level)}</span>
-            <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
-              <%!-- The form's rail, in words, because a row is one line and has
-                  nowhere to put a 4px edge per level. Same four states, same
-                  vocabulary — the queue and the form drifted apart when they
-                  each had their own. --%>
+            <:cover>
+              <div class={["h-16 w-16 rounded-sm", if(!audiobook.thumbnail, do: "bg-zinc-800")]}>
+                <img
+                  :if={audiobook.thumbnail}
+                  src={audiobook.thumbnail}
+                  alt=""
+                  class="h-full w-full rounded-sm"
+                />
+              </div>
+            </:cover>
+
+            <:headline>{media_display_title(audiobook)}</:headline>
+
+            <%!-- The credit stack, in its one order: series, bare author
+                  names, narrators muted underneath (§8). --%>
+            <p
+              :if={audiobook.series != []}
+              class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+            >
+              {series_words(audiobook.series)}
+            </p>
+            <p
+              :if={audiobook.authors != []}
+              class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300"
+            >
+              {person_names(audiobook.authors)}
+            </p>
+            <p
+              :if={audiobook.narrators != []}
+              class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+            >
+              Read by {person_names(audiobook.narrators)}
+            </p>
+
+            <%!-- No "imported" badge: the footer's date already says it, and
+                  what varies from one imported row to the next is the state
+                  of the audiobook, which is what these say. --%>
+            <:badges>
               <.badge
-                color={elem(tier_words(match.tier), 1)}
+                :if={audiobook.status != :ready}
+                color={library_status_color(audiobook.status)}
                 class="text-xs"
-                title={match.confidence && "match score #{match.confidence}"}
               >
-                {elem(tier_words(match.tier), 0)}
+                {audiobook.status}
               </.badge>
-              <%!-- basis-48 + grow keeps the title from being shrunk out of
-                    existence (meta wraps down instead); max-w-fit stops the grow
-                    at the title's own width so the provenance stays beside it.
-
-                    Nothing here when nothing was found: the badge beside it
-                    already says so, and printing "no match" next to it was
-                    half of the line that read "matched · no match". --%>
-              <span
-                :if={match.best}
-                class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap"
+              <.badge
+                :if={audiobook.missing_since}
+                color={:red}
+                class="text-xs"
+                title={"Files couldn't be read since #{Calendar.strftime(audiobook.missing_since, "%x %X")}"}
+                data-role="audiobook-missing"
               >
-                {candidate_label(match.best)}
-              </span>
-              <span :if={candidate_origin(match.best)} class="flex-none text-xs text-zinc-400">
-                ({candidate_origin(match.best)})
-              </span>
-              <span :if={match.alternatives > 0} class="flex-none text-xs text-zinc-400">
-                +{match.alternatives} other{if match.alternatives > 1, do: "s"}
-              </span>
-            </div>
-          </div>
+                missing
+              </.badge>
+            </:badges>
 
-          <p
-            :if={progress_label(@progress[item.id])}
-            class="text-xs text-zinc-400"
-            data-role="item-progress"
+            <%!-- The audiobooks list's line, verbatim: same helper, same
+                  place, same words. It was an inline middle-dot line here and
+                  a footer column there, which is two answers to one question. --%>
+            <p
+              :if={record_meta(audiobook) != ""}
+              class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+            >
+              {record_meta(audiobook)}
+            </p>
+
+            <:facts>
+              <.row_fact
+                :if={audiobook.chapters > 0}
+                icon="fa-book-bookmark"
+                count={audiobook.chapters}
+                title="# of chapters"
+              />
+            </:facts>
+
+            <:action
+              navigate={~p"/admin/audiobooks/#{audiobook.id}/edit"}
+              icon="fa-pencil"
+              title="Edit this audiobook"
+            >
+              Edit
+            </:action>
+
+            <%!-- The way back to where it came from — the files, the matches,
+                  the decisions that produced it. Off the row by design, one
+                  click away because a wrong import is diagnosed there. --%>
+            <:action
+              navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+              icon="fa-inbox"
+              title="What was imported, and from where"
+            >
+              Import record
+            </:action>
+
+            <:footer>Imported {Calendar.strftime(imported_at(item), "%x")}</:footer>
+          </.index_row>
+        <% else %>
+          <%!-- Deleting an audiobook nilifies the link rather than taking the
+                record of the import with it, so the row outlives the thing it
+                describes. It says that, instead of falling back to matching
+                details for a result that is gone. --%>
+          <.index_row
+            navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+            class={rail_class(item)}
           >
-            {progress_label(@progress[item.id])}
+            <:headline>
+              <span class="text-zinc-400">{item_name(item)}</span>
+            </:headline>
+
+            <p class="text-sm text-zinc-400">The audiobook this became has been deleted.</p>
+
+            <:action
+              navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+              icon="fa-inbox"
+              title="What was imported, and from where"
+            >
+              Import record
+            </:action>
+
+            <:footer>Imported {Calendar.strftime(imported_at(item), "%x")}</:footer>
+          </.index_row>
+        <% end %>
+      <% else %>
+        <.index_row
+          navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+          class={rail_class(item)}
+          inert={busy?(@progress[item.id])}
+        >
+          <%!-- A job is about to change this row underneath whoever is
+                reading it, so it says so over the whole row rather than in a
+                corner. --%>
+          <:overlay>
+            <.busy_overlay
+              busy={busy?(@progress[item.id])}
+              label={progress_label(@progress[item.id])}
+            />
+          </:overlay>
+
+          <:headline>{item_name(item)}</:headline>
+
+          <%!-- One meta line, not two: what the tags say and what the probe
+                measured are both identity, and each extra line raises the
+                card's density for free. --%>
+          <p
+            :if={Enum.any?([tag_summary(item), probe_summary(item)], &(&1 != ""))}
+            class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+          >
+            {[tag_summary(item), probe_summary(item)] |> Enum.reject(&(&1 == "")) |> Enum.join(" · ")}
           </p>
 
-          <%!-- Which watched folder this came from, on the same rail as the
-                match badges above it. What import will do to the bytes is
-                deliberately not here: it is a per-import decision, stated
-                in full on the item's own destination card, and no item can
-                be imported without going through that card. --%>
-          <div class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2">
-            <span class="text-xs text-zinc-400">source</span>
-            <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400">
-              <span class={["mr-1 rounded-sm px-1 py-0.5", source_color(item.source)]}>
-                {source_label(item.source)}
-              </span>
-              <span class="font-mono">{item.path}</span>
+          <%!-- The annotated rows — matches and the files' source — share one
+                label column, so every badge and chip starts on the same rail
+                (design language §1). The value cell owns its own wrapping: when
+                width runs out the meta drops a line INSIDE the column, and the
+                candidate title is the last thing to ellipsize. --%>
+          <div class="mt-2 space-y-0.5">
+            <div
+              :for={match <- match_summary(item)}
+              class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2 text-sm"
+            >
+              <span class="text-xs text-zinc-400">{level_word(match.level)}</span>
+              <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                <%!-- The form's rail, in words, because a row is one line and has
+                    nowhere to put a 4px edge per level. Same four states, same
+                    vocabulary — the queue and the form drifted apart when they
+                    each had their own. --%>
+                <.badge
+                  color={elem(tier_words(match.tier), 1)}
+                  class="text-xs"
+                  title={match.confidence && "match score #{match.confidence}"}
+                >
+                  {elem(tier_words(match.tier), 0)}
+                </.badge>
+                <%!-- basis-48 + grow keeps the title from being shrunk out of
+                      existence (meta wraps down instead); max-w-fit stops the grow
+                      at the title's own width so the provenance stays beside it.
+
+                      Nothing here when nothing was found: the badge beside it
+                      already says so, and printing "no match" next to it was
+                      half of the line that read "matched · no match". --%>
+                <span
+                  :if={match.best}
+                  class="min-w-0 max-w-fit grow basis-48 overflow-hidden text-ellipsis whitespace-nowrap"
+                >
+                  {candidate_label(match.best)}
+                </span>
+                <span :if={candidate_origin(match.best)} class="flex-none text-xs text-zinc-400">
+                  ({candidate_origin(match.best)})
+                </span>
+                <span :if={match.alternatives > 0} class="flex-none text-xs text-zinc-400">
+                  +{match.alternatives} other{if match.alternatives > 1, do: "s"}
+                </span>
+              </div>
+            </div>
+
+            <p
+              :if={progress_label(@progress[item.id])}
+              class="text-xs text-zinc-400"
+              data-role="item-progress"
+            >
+              {progress_label(@progress[item.id])}
+            </p>
+
+            <%!-- Which watched folder this came from, on the same rail as the
+                  match badges above it. What import will do to the bytes is
+                  deliberately not here: it is a per-import decision, stated
+                  in full on the item's own destination card, and no item can
+                  be imported without going through that card. --%>
+            <div class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2">
+              <span class="text-xs text-zinc-400">source</span>
+              <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400">
+                <span class={["mr-1 rounded-sm px-1 py-0.5", source_color(item.source)]}>
+                  {source_label(item.source)}
+                </span>
+                <span class="font-mono">{item.path}</span>
+              </p>
+            </div>
+
+            <%!-- The blocker reads last: it's the row's verdict, not one fact
+                  among the others, and the eye leaves the card on it. --%>
+            <p
+              :if={item.issue}
+              class="mt-2 flex items-baseline gap-1.5 overflow-hidden text-ellipsis text-sm text-red-400"
+            >
+              <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
+              <span class="min-w-0">{item.issue}</span>
             </p>
           </div>
 
-          <%!-- The blocker reads last: it's the row's verdict, not one fact
-                among the others, and the eye leaves the card on it. --%>
-          <p
-            :if={item.issue}
-            class="mt-2 flex items-baseline gap-1.5 overflow-hidden text-ellipsis text-sm text-red-400"
-          >
-            <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
-            <span class="min-w-0">{item.issue}</span>
-          </p>
-        </div>
-      </div>
-
-      <%!-- One rail with fixed slots — status, meta, actions, date — instead
-            of two competing columns. On phones it drops to a full-width
-            bottom line (the row container wraps) rather than squeezing the
-            titles; the actions carry words because a 16px icon is neither a
-            label nor a touch target. --%>
-      <%!-- The rail's corners share the card's baselines: status aligns with
-            the title line, the date with the content's last line
-            (self-stretch + justify-between). Actions are uniform width so
-            the right edge reads as a column, not a rag. --%>
-      <div
-        class="flex w-full flex-none flex-wrap items-center gap-x-3 gap-y-2 sm:w-44 sm:flex-col sm:items-end sm:justify-between sm:self-stretch"
-        inert={busy?(@progress[item.id])}
-      >
-        <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 sm:flex-col sm:items-end">
           <%!-- One badge. Inside a tab named for the status, printing the
                 status on every row says nothing; what the row owes does. --%>
-          <div class="flex items-center gap-2">
+          <:badges>
             <.badge color={elem(state_words(item), 1)} class="text-xs" data-role="item-state">
               {elem(state_words(item), 0)}
             </.badge>
-          </div>
+          </:badges>
 
-          <div class="flex items-center gap-2 text-xs text-zinc-400">
+          <:facts>
             <span
               :if={file_count(item) > 1}
               title="Audio files"
@@ -207,97 +333,94 @@
             <span :if={item.tags && item.tags["has_cover_art"]} title="Embedded cover art">
               <.icon name="fa-image" class="h-3.5 w-3.5 text-current" />
             </span>
-          </div>
+          </:facts>
 
-          <div class="flex flex-wrap items-center gap-1.5 sm:justify-end">
-            <%!-- Only a settled item can be imported from here — the queue
-                has no way to say what's outstanding, and the form's whole job
-                is to. Import is the *extra* a settled row earns, though, not
-                a replacement for Open: these two were once mutually
-                exclusive, which left a ready item's action rail with no way
-                into its own form. Reviewing a draft before importing it is
-                the normal path, not the exception. --%>
-            <%!-- A replacement is not an addition, and this button acts
-                without the form being opened, so it says which it is. --%>
-            <span
-              :if={item.status == :pending and item.ready}
-              role="button"
-              phx-click="import"
-              phx-value-id={item.id}
-              title={
-                if replacing?(item),
-                  do: "Replace this audiobook's files",
-                  else: "Add to the library"
-              }
-              data-confirm={
-                if replacing?(item),
-                  do: "Replace this audiobook's files with these?",
-                  else: "Add this to the library?"
-              }
-              class={action_class(:brand)}
-            >
-              <.icon name="fa-check" class="h-3 w-3 text-current" />
-              {if replacing?(item), do: "Replace", else: "Import"}
-            </span>
+          <%!-- Import is on every pending row, and refuses on the ones that
+              aren't settled yet. It used to be absent until a row was ready,
+              so the rail's shape and the order of its buttons changed from
+              row to row and the primary action moved under the cursor. A
+              disabled button in its own place says the same thing — not yet —
+              without rearranging everything around it, and its title says
+              what is missing.
 
-            <.link
-              :if={item.status == :pending}
-              navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
-              title="Look the draft over"
-              class={action_class(:neutral)}
-            >
-              <%!-- fa-pencil, the app's edit glyph — pen-to-square isn't in
-                  the vendored set, and a missing name renders a blank mask. --%>
-              <.icon name="fa-pencil" class="h-3 w-3 text-current" /> Open
-            </.link>
+              Only a settled item can actually be imported from here: the
+              queue has no way to say what's outstanding, and the form's
+              whole job is to. Import is the *extra* a settled row earns,
+              though, not a replacement for Open — these two were once
+              mutually exclusive, which left a ready item's action rail with
+              no way into its own form. --%>
+          <%!-- A replacement is not an addition, and this button acts
+              without the form being opened, so it says which it is. --%>
+          <:action
+            :if={item.status == :pending}
+            icon="fa-check"
+            color={:brand}
+            disabled={!item.ready}
+            click="import"
+            value={item.id}
+            title={import_title(item)}
+            confirm={
+              if replacing?(item),
+                do: "Replace this audiobook's files with these?",
+                else: "Add this to the library?"
+            }
+          >
+            {if replacing?(item), do: "Replace", else: "Import"}
+          </:action>
 
-            <%!-- One action, because "re-read the files" and "look for matches
-                again" were never separable: the tags matching leans on come
-                out of the probe, so asking again without re-reading asks the
-                same question. Re-reads the folder, re-probes, and re-queries
-                every provider with the cache bypassed. --%>
-            <span
-              :if={item.status != :imported}
-              role="button"
-              phx-click="rescan"
-              phx-value-id={item.id}
-              title="Re-read the files and ask the providers again"
-              class={action_class(:neutral)}
-            >
-              <.icon name="fa-rotate" class="h-3 w-3 text-current" /> Re-match
-            </span>
+          <%!-- fa-pencil, the app's edit glyph — pen-to-square isn't in
+              the vendored set, and a missing name renders a blank mask. --%>
+          <:action
+            :if={item.status == :pending}
+            navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+            icon="fa-pencil"
+            title="Look the draft over"
+          >
+            Open
+          </:action>
 
-            <%!-- Only a pending item can be ignored: an ignored one already
-                is, and ignoring an imported one is nonsense — it's in the
-                library. --%>
-            <span
-              :if={item.status == :pending}
-              role="button"
-              phx-click="ignore"
-              phx-value-id={item.id}
-              title="Ignore (files are not touched)"
-              class={action_class(:danger)}
-            >
-              <.icon name="fa-xmark" class="h-3 w-3 text-current" /> Ignore
-            </span>
+          <%!-- One action, because "re-read the files" and "look for matches
+              again" were never separable: the tags matching leans on come
+              out of the probe, so asking again without re-reading asks the
+              same question. Re-reads the folder, re-probes, and re-queries
+              every provider with the cache bypassed. --%>
+          <:action
+            icon="fa-rotate"
+            click="rescan"
+            value={item.id}
+            title="Re-read the files and ask the providers again"
+          >
+            Re-match
+          </:action>
 
-            <span
-              :if={item.status == :ignored}
-              role="button"
-              phx-click="restore"
-              phx-value-id={item.id}
-              title="Put back in the queue"
-              class={action_class(:brand)}
-            >
-              <.icon name="fa-rotate-left" class="h-3 w-3 text-current" /> Restore
-            </span>
-          </div>
-        </div>
+          <%!-- Only a pending item can be ignored: an ignored one already
+              is, and ignoring an imported one is nonsense — it's in the
+              library. --%>
+          <:action
+            :if={item.status == :pending}
+            icon="fa-xmark"
+            color={:red}
+            click="ignore"
+            value={item.id}
+            title="Ignore (files are not touched)"
+          >
+            Ignore
+          </:action>
 
-        <p class="text-xs text-zinc-400">
-          Found {Calendar.strftime(item.inserted_at, "%x")}
-        </p>
-      </div>
+          <:action
+            :if={item.status == :ignored}
+            icon="fa-rotate-left"
+            color={:brand}
+            click="restore"
+            value={item.id}
+            title="Put back in the queue"
+          >
+            Restore
+          </:action>
+
+          <:footer>Found {Calendar.strftime(item.inserted_at, "%x")}</:footer>
+        </.index_row>
+      <% end %>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/location_live/index.html.heex
+++ b/lib/ambry_web/live/admin/location_live/index.html.heex
@@ -55,36 +55,38 @@
             </p>
           </div>
 
-          <div class="flex flex-none gap-3">
-            <span
+          <%!-- Worded, like every other card's actions: an unlabeled 16px
+                glyph is neither a label nor a touch target, and "the eye"
+                never said which way it was about to go. --%>
+          <div class="flex flex-none flex-wrap justify-end gap-1.5">
+            <.row_action
+              icon={(source.enabled && "fa-eye-slash") || "fa-eye"}
               phx-click="toggle"
               phx-value-id={source.id}
-              class="cursor-pointer"
-              title={(source.enabled && "Pause") || "Resume"}
+              title={(source.enabled && "Stop scanning this folder") || "Scan this folder again"}
               data-role="toggle-source"
             >
-              <.icon
-                name={(source.enabled && "fa-eye") || "fa-eye-slash"}
-                class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-              />
-            </span>
+              {(source.enabled && "Pause") || "Resume"}
+            </.row_action>
 
-            <.link navigate={~p"/admin/locations/sources/#{source}/edit"} data-role="edit-source">
-              <.icon
-                name="fa-pencil"
-                class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-              />
-            </.link>
+            <.row_action
+              navigate={~p"/admin/locations/sources/#{source}/edit"}
+              icon="fa-pencil"
+              data-role="edit-source"
+            >
+              Edit
+            </.row_action>
 
-            <span
+            <.row_action
+              icon="fa-trash"
+              color={:red}
               phx-click="delete-source"
               phx-value-id={source.id}
               data-confirm="Remove this source? Files on disk are left alone."
-              class="cursor-pointer"
               data-role="delete-source"
             >
-              <.icon name="fa-trash" class="h-4 w-4 text-current transition-colors hover:text-red-600" />
-            </span>
+              Remove
+            </.row_action>
           </div>
         </div>
       </div>
@@ -135,23 +137,25 @@
             </p>
           </div>
 
-          <div class="flex flex-none gap-3">
-            <.link navigate={~p"/admin/locations/roots/#{root}/edit"} data-role="edit-root">
-              <.icon
-                name="fa-pencil"
-                class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-              />
-            </.link>
+          <div class="flex flex-none flex-wrap justify-end gap-1.5">
+            <.row_action
+              navigate={~p"/admin/locations/roots/#{root}/edit"}
+              icon="fa-pencil"
+              data-role="edit-root"
+            >
+              Edit
+            </.row_action>
 
-            <span
+            <.row_action
+              icon="fa-trash"
+              color={:red}
               phx-click="delete-root"
               phx-value-id={root.id}
               data-confirm="Remove this root? Files on disk are left alone."
-              class="cursor-pointer"
               data-role="delete-root"
             >
-              <.icon name="fa-trash" class="h-4 w-4 text-current transition-colors hover:text-red-600" />
-            </span>
+              Remove
+            </.row_action>
           </div>
         </div>
       </div>

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -154,6 +154,14 @@
               Not part of a set.
             </p>
 
+            <%!-- The removal has to be *stated*, not merely stopped being
+                mentioned. Hiding the row took its two inputs out of the DOM,
+                so the submit posted neither key and `cast` changes only what
+                it is handed — the picker vanished, Save reported success, and
+                the recording came back still in its set. --%>
+            <.input :if={!@group_row_visible} type="hidden" field={@form[:recording_group_id]} />
+            <.input :if={!@group_row_visible} type="hidden" field={@form[:part_number]} />
+
             <div :if={@group_row_visible} class="flex items-start gap-2">
               <.input field={@form[:part_number]} placeholder="no." container_class="w-14 flex-none" />
               <div class="relative grow">

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -6,7 +6,6 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
-  import AmbryWeb.TimeUtils
 
   alias Ambry.Media
   alias Ambry.Media.PubSub.MediaCreated

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -32,11 +32,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@media}
-    filter={@list_opts.filter}
-    row_click={fn media -> JS.navigate(~p"/admin/audiobooks/#{media}/edit") end}
-  >
+  <.flex_table rows={@media} filter={@list_opts.filter}>
     <:empty>
       <%= if words = problem_empty_words(@list_opts[:problem]) do %>
         {words}
@@ -49,77 +45,88 @@
     </:empty>
 
     <:row :let={media}>
-      <div class="flex flex-shrink-0 flex-col items-start">
-        <div class={["h-16 w-16", if(!media.thumbnail, do: "bg-zinc-800")]}>
-          <img :if={media.thumbnail} src={media.thumbnail} class="h-full w-full" />
-        </div>
-        <.badge :if={media.status != :ready} color={status_color(media.status)} class="!px-0 w-16 text-center text-xs">
-          {media.status}
-        </.badge>
-        <.badge
-          :if={media.missing_since}
-          color={:red}
-          class="!px-0 w-16 text-center text-xs"
-          title={"Files couldn't be read since #{Calendar.strftime(media.missing_since, "%x %X")}"}
-          data-role="media-missing"
-        >
-          missing
-        </.badge>
-      </div>
+      <.index_row navigate={~p"/admin/audiobooks/#{media}/edit"}>
+        <:cover>
+          <div class={["h-16 w-16 rounded-sm", if(!media.thumbnail, do: "bg-zinc-800")]}>
+            <img :if={media.thumbnail} src={media.thumbnail} alt="" class="h-full w-full rounded-sm" />
+          </div>
+        </:cover>
 
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis">{media_display_title(media)}</p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
-          {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
-        </p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
-          read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
-        </p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
+        <:headline>{media_display_title(media)}</:headline>
+
+        <%!-- The credit stack's one order: series, bare author names, then
+              the narrators muted (§8). This list read authors / read by /
+              series, which is neither the mobile app's order nor the inbox's. --%>
+        <p :if={media.series != []} class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
           {media.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}
         </p>
-      </div>
-
-      <div class="hidden w-36 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <div class="flex gap-4">
-          <span :if={!media.has_description} title="Missing description">
-            <.icon name="fa-paragraph" class="h-4 w-4 text-red-600" />
-          </span>
-          <span :if={media.abridged} title="Abridged">
-            <.icon name="fa-clock" class="h-4 w-4 text-current" />
-          </span>
-          <span :if={media.full_cast} title="Full cast">
-            <.icon name="fa-users" class="h-4 w-4 text-current" />
-          </span>
-          <span :if={media.chapters > 0} title="# of chapters">
-            {media.chapters} <.icon name="fa-book-bookmark" class="h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
-
-      <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
-        <div class="flex gap-2 pb-2">
-          <.link navigate={~p"/admin/audiobooks/#{media}/edit"}>
-            <.icon
-              name="fa-pencil"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-          <span phx-click="delete" phx-value-id={media.id} data-confirm="Are you sure?">
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-
-        <p :if={media.duration} class="text-sm text-zinc-400">
-          Duration {format_timecode(media.duration)}
+        <p :if={media.authors != []} class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300">
+          {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-        <p :if={media.published} class="text-sm text-zinc-400">
-          Published {format_published(media, :short)}
+        <p :if={media.narrators != []} class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
+          Read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-        <p class="text-sm text-zinc-400">
-          Added {Calendar.strftime(media.inserted_at, "%x")}
+
+        <%!-- State badges belong on the rail with every other list's, not
+              tucked under the cover where this was the only surface to put
+              them. --%>
+        <:badges>
+          <.badge :if={media.status != :ready} color={status_color(media.status)} class="text-xs">
+            {media.status}
+          </.badge>
+          <.badge
+            :if={media.missing_since}
+            color={:red}
+            class="text-xs"
+            title={"Files couldn't be read since #{Calendar.strftime(media.missing_since, "%x %X")}"}
+            data-role="media-missing"
+          >
+            missing
+          </.badge>
+        </:badges>
+
+        <%!-- When it came out, who put it out, how long it is: prose about
+              the recording, so it reads like prose and sits with the credits.
+              These were terse cells in the rail ("8/30/22", "14:04:02"),
+              which is the shape a spreadsheet wants, not a reader. --%>
+        <p
+          :if={record_meta(media) != ""}
+          class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+        >
+          {record_meta(media)}
         </p>
-      </div>
+
+        <:facts>
+          <.row_fact
+            :if={media.chapters > 0}
+            icon="fa-book-bookmark"
+            count={media.chapters}
+            title="# of chapters"
+          />
+          <span :if={!media.has_description} class="flex items-center" title="Missing description">
+            <.icon name="fa-paragraph" class="h-3.5 w-3.5 text-amber-300" />
+          </span>
+          <span :if={media.abridged} class="flex items-center" title="Abridged">
+            <.icon name="fa-clock" class="h-3.5 w-3.5 text-current" />
+          </span>
+          <span :if={media.full_cast} class="flex items-center" title="Full cast">
+            <.icon name="fa-users" class="h-3.5 w-3.5 text-current" />
+          </span>
+        </:facts>
+
+        <:action navigate={~p"/admin/audiobooks/#{media}/edit"} icon="fa-pencil">Edit</:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={media.id}
+          confirm="Delete this audiobook? Its audio files are deleted from disk too."
+        >
+          Delete
+        </:action>
+
+        <:footer>Added {Calendar.strftime(media.inserted_at, "%x")}</:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -54,18 +54,7 @@
 
         <:headline>{media_display_title(media)}</:headline>
 
-        <%!-- The credit stack's one order: series, bare author names, then
-              the narrators muted (§8). This list read authors / read by /
-              series, which is neither the mobile app's order nor the inbox's. --%>
-        <p :if={media.series != []} class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
-          {media.series |> Enum.map(&"#{&1.name} ##{&1.number}") |> Enum.join(", ")}
-        </p>
-        <p :if={media.authors != []} class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300">
-          {media.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
-        </p>
-        <p :if={media.narrators != []} class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
-          Read by {media.narrators |> Enum.map(& &1.name) |> Enum.join(", ")}
-        </p>
+        <.credit_lines authors={media.authors} narrators={media.narrators} />
 
         <%!-- State badges belong on the rail with every other list's, not
               tucked under the cover where this was the only surface to put
@@ -85,10 +74,10 @@
           </.badge>
         </:badges>
 
-        <%!-- When it came out, who put it out, how long it is: prose about
-              the recording, so it reads like prose and sits with the credits.
-              These were terse cells in the rail ("8/30/22", "14:04:02"),
-              which is the shape a spreadsheet wants, not a reader. --%>
+        <%!-- Everything that varies, on one line: the series, when it came
+              out, who put it out, how long it is. The three lines above are
+              what every audiobook has, so they are always three lines and
+              this is always the fourth. --%>
         <p
           :if={record_meta(media) != ""}
           class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -72,27 +72,56 @@
         <div class="space-y-4">
           <%!-- ── writes ─────────────────────────────────────────────── --%>
           <div class="space-y-2">
-            <button
-              type="button"
-              role="checkbox"
-              aria-checked={to_string(@writes)}
-              phx-click="toggle-credit"
-              phx-value-kind="author"
-              class="flex items-center gap-2 pl-3"
-            >
-              <span class={[
-                "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
-                (@writes && "bg-brand-dark") || "bg-zinc-800"
-              ]}>
-                <.icon :if={@writes} name="fa-check" class="h-2.5 w-2.5 text-zinc-900" />
-              </span>
-              <%!-- The label absorbs the "as": revealed, the names below it
-                  are what it is credited as, so the line reads into them
-                  rather than repeating the person's name beside the box. --%>
-              <span class="text-sm text-zinc-200">
-                Writes books{if revealed?(assigns, :author), do: " as"}
-              </span>
-            </button>
+            <%!-- The hatch rides the question it qualifies rather than
+                sitting on a line of its own underneath: two ticks and two
+                hatches was four lines to ask two questions. Baseline, not
+                centre — the two texts are different sizes (§3). --%>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={to_string(@writes)}
+                phx-click="toggle-credit"
+                phx-value-kind="author"
+                class="flex items-center gap-2 pl-3"
+              >
+                <%!-- The tick is always in the box, hidden rather than
+                    absent. A flex container takes its baseline from its first
+                    item, and an *empty* box has no item to take one from — so
+                    it synthesized one from its own bottom edge instead, three
+                    pixels lower, and the link beside it stepped down every
+                    time the box was unticked. --%>
+                <span class={[
+                  "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
+                  (@writes && "bg-brand-dark") || "bg-zinc-800"
+                ]}>
+                  <.icon
+                    name="fa-check"
+                    class={["h-2.5 w-2.5 text-zinc-900", !@writes && "invisible"]}
+                  />
+                </span>
+                <%!-- The label absorbs the "as": revealed, the names below it
+                    are what it is credited as, so the line reads into them
+                    rather than repeating the person's name beside the box. --%>
+                <span class="text-sm text-zinc-200">
+                  Writes books{if revealed?(assigns, :author), do: " as"}
+                </span>
+              </button>
+
+              <%!-- Offered whether or not the box is ticked: linking a
+                  shared pen name is how a person becomes an author at all in
+                  the composite case, and routing that through "tick, then
+                  delete the author it made" is not a route. --%>
+              <button
+                :if={not revealed?(assigns, :author)}
+                type="button"
+                phx-click="reveal-credit"
+                phx-value-kind="author"
+                class="text-xs text-zinc-400 underline"
+              >
+                Writes under a pen name?
+              </button>
+            </div>
 
             <%!-- Collapsed, the credits still ride along. A card that renders
                 nothing says nothing, and "said nothing" is indistinguishable
@@ -204,20 +233,6 @@
                 </button>
               </div>
             </div>
-
-            <%!-- Offered whether or not the box is ticked: linking a
-                shared pen name is how a person becomes an author at all in
-                the composite case, and routing that through "tick, then
-                delete the author it made" is not a route. --%>
-            <button
-              :if={not revealed?(assigns, :author)}
-              type="button"
-              phx-click="reveal-credit"
-              phx-value-kind="author"
-              class="pl-6 text-xs text-zinc-400 underline"
-            >
-              Writes under a pen name?
-            </button>
           </div>
 
           <%!-- ── narrates ───────────────────────────────────────────── --%>
@@ -225,24 +240,39 @@
               so there is no shared-narrator case to offer. The asymmetry is
               the model's, and stating it beats faking symmetry. --%>
           <div class="space-y-2">
-            <button
-              type="button"
-              role="checkbox"
-              aria-checked={to_string(@narrates)}
-              phx-click="toggle-credit"
-              phx-value-kind="narrator"
-              class="flex items-center gap-2 pl-3"
-            >
-              <span class={[
-                "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
-                (@narrates && "bg-brand-dark") || "bg-zinc-800"
-              ]}>
-                <.icon :if={@narrates} name="fa-check" class="h-2.5 w-2.5 text-zinc-900" />
-              </span>
-              <span class="text-sm text-zinc-200">
-                Narrates audiobooks{if revealed?(assigns, :narrator), do: " as"}
-              </span>
-            </button>
+            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={to_string(@narrates)}
+                phx-click="toggle-credit"
+                phx-value-kind="narrator"
+                class="flex items-center gap-2 pl-3"
+              >
+                <span class={[
+                  "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
+                  (@narrates && "bg-brand-dark") || "bg-zinc-800"
+                ]}>
+                  <.icon
+                    name="fa-check"
+                    class={["h-2.5 w-2.5 text-zinc-900", !@narrates && "invisible"]}
+                  />
+                </span>
+                <span class="text-sm text-zinc-200">
+                  Narrates audiobooks{if revealed?(assigns, :narrator), do: " as"}
+                </span>
+              </button>
+
+              <button
+                :if={not revealed?(assigns, :narrator)}
+                type="button"
+                phx-click="reveal-credit"
+                phx-value-kind="narrator"
+                class="text-xs text-zinc-400 underline"
+              >
+                Narrates under a stage name?
+              </button>
+            </div>
 
             <div :if={not revealed?(assigns, :narrator)} class="hidden">
               <.inputs_for :let={narrator_form} field={@form[:narrators]}>
@@ -284,16 +314,6 @@
                 </button>
               </div>
             </div>
-
-            <button
-              :if={not revealed?(assigns, :narrator)}
-              type="button"
-              phx-click="reveal-credit"
-              phx-value-kind="narrator"
-              class="pl-6 text-xs text-zinc-400 underline"
-            >
-              Narrates under a stage name?
-            </button>
           </div>
         </div>
       </.field_group>

--- a/lib/ambry_web/live/admin/person_live/index.html.heex
+++ b/lib/ambry_web/live/admin/person_live/index.html.heex
@@ -17,11 +17,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@people}
-    filter={@list_opts.filter}
-    row_click={fn person -> JS.navigate(~p"/admin/people/#{person}/edit") end}
-  >
+  <.flex_table rows={@people} filter={@list_opts.filter}>
     <:empty>
       No people yet.
       <.brand_link navigate={~p"/admin/people/new"}>
@@ -30,48 +26,77 @@
     </:empty>
 
     <:row :let={person}>
-      <div class="flex-shrink-0">
-        <div class={["h-12 w-12", if(!person.thumbnail, do: "rounded-full bg-zinc-800")]}>
-          <img :if={person.thumbnail} src={person.thumbnail} class="h-full w-full rounded-full object-cover object-top" />
-        </div>
-      </div>
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis" data-role="person-name">{person.name}</p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="person-aliases">
+      <.index_row navigate={~p"/admin/people/#{person}/edit"}>
+        <%!-- A face is round where a cover is square, but it is the same 64px
+              box: people rows used to be 48px, so they were visibly shorter
+              than every other list's. --%>
+        <:cover>
+          <div class={["h-16 w-16", if(!person.thumbnail, do: "rounded-full bg-zinc-800")]}>
+            <img
+              :if={person.thumbnail}
+              src={person.thumbnail}
+              alt=""
+              class="h-full w-full rounded-full object-cover object-top"
+            />
+          </div>
+        </:cover>
+
+        <:headline>
+          <span data-role="person-name">{person.name}</span>
+        </:headline>
+
+        <p
+          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+          data-role="person-aliases"
+        >
           {(person.writing_as ++ person.narrating_as) |> Enum.filter(&(&1 != person.name)) |> Enum.join(", ")}
         </p>
-      </div>
-      <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <div class="flex gap-4">
+
+        <:facts>
           <%!-- Amber, not red: a missing description wants attention, it
               doesn't block anything (§5) — and never a solid bright fill. --%>
-          <span :if={!person.has_description} title="Missing description" data-role="person-missing-description">
-            <.icon name="fa-paragraph" class="h-4 w-4 text-amber-300" />
+          <span
+            :if={!person.has_description}
+            class="flex items-center"
+            title="Missing description"
+            data-role="person-missing-description"
+          >
+            <.icon name="fa-paragraph" class="h-3.5 w-3.5 text-amber-300" />
           </span>
-          <span :if={person.authored_books > 0} title="# of authored books" data-role="person-authored-count">
-            {person.authored_books} <.icon name="fa-book" class="h-4 w-4 text-current" />
-          </span>
-          <span :if={person.narrated_media > 0} title="# of narrated audiobooks" data-role="person-narrated-count">
-            {person.narrated_media} <.icon name="fa-microphone" class="h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
-      <div class="flex w-32 flex-none flex-col items-end justify-between whitespace-nowrap">
-        <div class="flex gap-2 pb-2">
-          <.link navigate={~p"/admin/people/#{person}/edit"} data-role="edit-person">
-            <.icon
-              name="fa-pencil"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-          <span phx-click="delete" phx-value-id={person.id} data-confirm="Are you sure?" data-role="delete-person">
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-        <p class="text-sm text-zinc-400" data-role="person-added">
-          Added {Calendar.strftime(person.inserted_at, "%x")}
-        </p>
-      </div>
+          <.row_fact
+            :if={person.authored_books > 0}
+            icon="fa-book"
+            count={person.authored_books}
+            title="# of authored books"
+            data-role="person-authored-count"
+          />
+          <.row_fact
+            :if={person.narrated_media > 0}
+            icon="fa-microphone"
+            count={person.narrated_media}
+            title="# of narrated audiobooks"
+            data-role="person-narrated-count"
+          />
+        </:facts>
+
+        <:action navigate={~p"/admin/people/#{person}/edit"} icon="fa-pencil" role="edit-person">
+          Edit
+        </:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={person.id}
+          confirm="Delete this person? Someone with books or audiobooks can't be deleted."
+          role="delete-person"
+        >
+          Delete
+        </:action>
+
+        <:footer>
+          <span data-role="person-added">Added {Calendar.strftime(person.inserted_at, "%x")}</span>
+        </:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/playback_debug_live/index.ex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.ex
@@ -148,26 +148,16 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.Index do
     end
   end
 
-  defp status_badge_class(playthrough) do
-    case playthrough.status do
-      :deleted ->
-        "rounded px-1 bg-red-900 text-red-200"
-
-      :in_progress ->
-        "rounded px-1 bg-blue-900 text-blue-200"
-
-      :finished ->
-        "rounded px-1 bg-green-900 text-green-200"
-
-      :abandoned ->
-        "rounded px-1 bg-orange-900 text-orange-200"
-
-      _ ->
-        "rounded px-1 bg-zinc-700 text-zinc-200"
-    end
-  end
+  # `<.badge>`'s tints, not five hand-rolled solid chips: these were the last
+  # `bg-red-900 text-red-200` slabs in the admin, against §5's soft-tint rule.
+  # Amber for abandoned rather than orange, which is not a color the admin has.
+  defp status_color(:deleted), do: :red
+  defp status_color(:in_progress), do: :blue
+  defp status_color(:finished), do: :brand
+  defp status_color(:abandoned), do: :yellow
+  defp status_color(_unknown), do: :gray
 
   defp status_label(playthrough) do
-    playthrough.status
+    playthrough.status |> to_string() |> String.replace("_", " ")
   end
 end

--- a/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
@@ -30,73 +30,75 @@
   </.modal>
 
   <div class="h-[calc(100vh-10rem)] flex flex-col">
-    <.flex_table
-      rows={@playthroughs}
-      row_click={
-        fn playthrough ->
-          JS.patch(~p"/admin/users/#{@selected_user.id}/playthroughs/#{playthrough.id}")
-        end
-      }
-    >
+    <.flex_table rows={@playthroughs}>
       <:empty>
         No playthroughs found for this user.
       </:empty>
+
       <:row :let={playthrough}>
-        <div class="flex-shrink-0">
-          <div class={[
-            "h-16 w-16",
-            if(!playthrough.media_thumbnail,
-              do: "flex items-center justify-center bg-zinc-800"
-            )
-          ]}>
-            <img
-              :if={playthrough.media_thumbnail}
-              src={playthrough.media_thumbnail}
-              class="h-full w-full object-cover"
-            />
-            <.icon
-              :if={!playthrough.media_thumbnail}
-              name="fa-circle-play"
-              class="h-8 w-8 text-zinc-400"
-            />
-          </div>
-        </div>
-        <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-          <p class="overflow-hidden text-ellipsis font-medium">
-            {playthrough_label(playthrough)}
+        <.index_row patch={~p"/admin/users/#{@selected_user.id}/playthroughs/#{playthrough.id}"}>
+          <:cover>
+            <div class={[
+              "h-16 w-16 rounded-sm",
+              if(!playthrough.media_thumbnail,
+                do: "flex items-center justify-center bg-zinc-800"
+              )
+            ]}>
+              <img
+                :if={playthrough.media_thumbnail}
+                src={playthrough.media_thumbnail}
+                alt=""
+                class="h-full w-full rounded-sm object-cover"
+              />
+              <.icon
+                :if={!playthrough.media_thumbnail}
+                name="fa-circle-play"
+                class="h-8 w-8 text-zinc-400"
+              />
+            </div>
+          </:cover>
+
+          <:headline>{playthrough_label(playthrough)}</:headline>
+
+          <p
+            class="font-mono overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400"
+            title={playthrough.id}
+          >
+            {String.slice(playthrough.id, 0, 8)}
           </p>
-          <div class="flex items-center gap-2 text-xs">
-            <span class={status_badge_class(playthrough)}>
+
+          <%!-- The app's badge, not a bespoke solid chip: these were the last
+                `bg-red-900 text-red-200` slabs in the admin, against §5's
+                soft-tint rule. --%>
+          <:badges>
+            <.badge color={status_color(playthrough.status)} class="text-xs">
               {status_label(playthrough)}
-            </span>
-            <span class="font-mono text-zinc-400" title={playthrough.id}>
-              {String.slice(playthrough.id, 0, 8)}
-            </span>
-          </div>
-        </div>
-        <div class="hidden w-44 flex-none flex-col items-end justify-center gap-1 text-zinc-400 sm:flex">
-          <div class="flex items-center gap-4 text-sm">
-            <span title="Current Position">
-              <span :if={playthrough.progress_percent} class="font-medium text-zinc-100">
+            </.badge>
+          </:badges>
+
+          <:facts>
+            <span title="Current position" class="flex items-center gap-1">
+              <span :if={playthrough.progress_percent} class="font-semibold tabular-nums text-zinc-100">
                 {Decimal.round(playthrough.progress_percent, 1)}%
               </span>
-              <span class="text-xs">
+              <span class="tabular-nums">
                 ({playthrough.position && Decimal.round(playthrough.position, 1)}s)
               </span>
             </span>
-            <span :if={playthrough.rate} title="Playback Rate" class="text-zinc-500">
+            <span :if={playthrough.rate} title="Playback rate" class="tabular-nums text-zinc-500">
               {Decimal.to_string(playthrough.rate)}x
             </span>
-          </div>
-        </div>
-        <div class="flex w-48 flex-none flex-col items-end justify-center whitespace-nowrap">
-          <p class="text-sm text-zinc-400" title={format_full_datetime(playthrough.last_event_at)}>
-            Last event {format_date(playthrough.last_event_at)}
-          </p>
-          <p class="text-sm text-zinc-400" title={format_full_datetime(playthrough.started_at)}>
-            Started {format_date(playthrough.started_at)}
-          </p>
-        </div>
+          </:facts>
+
+          <:footer>
+            <p title={format_full_datetime(playthrough.last_event_at)}>
+              Last event {format_date(playthrough.last_event_at)}
+            </p>
+            <p title={format_full_datetime(playthrough.started_at)}>
+              Started {format_date(playthrough.started_at)}
+            </p>
+          </:footer>
+        </.index_row>
       </:row>
     </.flex_table>
   </div>

--- a/lib/ambry_web/live/admin/recording_group_live/index.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.html.heex
@@ -14,11 +14,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@groups}
-    filter={@list_opts.filter}
-    row_click={fn group -> JS.navigate(~p"/admin/sets/#{group}/edit") end}
-  >
+  <.flex_table rows={@groups} filter={@list_opts.filter}>
     <:empty>
       No sets yet.
       <.brand_link navigate={~p"/admin/sets/new"}>
@@ -27,39 +23,41 @@
     </:empty>
 
     <:row :let={group}>
-      <div class="flex-shrink-0">
-        <.multi_image paths={thumbnails(group)} />
-      </div>
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis" data-role="group-name">{group.name}</p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="group-book">
+      <.index_row navigate={~p"/admin/sets/#{group}/edit"}>
+        <:cover>
+          <.multi_image paths={thumbnails(group)} />
+        </:cover>
+
+        <:headline>
+          <span data-role="group-name">{group.name}</span>
+        </:headline>
+
+        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300" data-role="group-book">
           {book_title(group)}
         </p>
-      </div>
-      <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <span data-role="group-parts">{parts_summary(group)}</span>
-      </div>
-      <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
-        <div class="flex gap-2">
-          <.link navigate={~p"/admin/sets/#{group}/edit"} data-role="edit-group">
-            <.icon
-              name="fa-pencil"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-          <span
-            phx-click="delete"
-            phx-value-id={group.id}
-            data-confirm={"Delete this set? Its #{length(group.media)} audiobooks stay in the library but leave the set, losing their part numbers."}
-            data-role="delete-group"
-          >
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-        <p class="text-sm text-zinc-400" data-role="group-added">
-          Added {Calendar.strftime(group.inserted_at, "%x")}
-        </p>
-      </div>
+
+        <:facts>
+          <span data-role="group-parts">{parts_summary(group)}</span>
+        </:facts>
+
+        <:action navigate={~p"/admin/sets/#{group}/edit"} icon="fa-pencil" role="edit-group">
+          Edit
+        </:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={group.id}
+          confirm={"Delete this set? Its #{length(group.media)} audiobooks stay in the library but leave the set, losing their part numbers."}
+          role="delete-group"
+        >
+          Delete
+        </:action>
+
+        <:footer>
+          <span data-role="group-added">Added {Calendar.strftime(group.inserted_at, "%x")}</span>
+        </:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -16,11 +16,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@series}
-    filter={@list_opts.filter}
-    row_click={fn series -> JS.navigate(~p"/admin/series/#{series}/edit") end}
-  >
+  <.flex_table rows={@series} filter={@list_opts.filter}>
     <:empty>
       No series yet.
       <.brand_link navigate={~p"/admin/series/new"}>
@@ -29,38 +25,46 @@
     </:empty>
 
     <:row :let={series}>
-      <div class="flex-shrink-0">
-        <.multi_image paths={series.thumbnails} />
-      </div>
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis" data-role="series-name">{series.name}</p>
-        <p class="overflow-hidden text-ellipsis text-sm text-zinc-400" data-role="series-authors">
+      <.index_row navigate={~p"/admin/series/#{series}/edit"}>
+        <:cover>
+          <.multi_image paths={series.thumbnails} />
+        </:cover>
+
+        <:headline>
+          <span data-role="series-name">{series.name}</span>
+        </:headline>
+
+        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300" data-role="series-authors">
           {series.authors |> Enum.map(& &1.name) |> Enum.join(", ")}
         </p>
-      </div>
-      <div class="hidden w-12 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <div class="flex gap-4">
-          <span title="# of books" data-role="series-book-count">
-            {series.books} <.icon name="fa-book" class="h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
-      <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
-        <div class="flex gap-2">
-          <.link navigate={~p"/admin/series/#{series}/edit"} data-role="edit-series">
-            <.icon
-              name="fa-pencil"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-          <span phx-click="delete" phx-value-id={series.id} data-confirm="Are you sure?" data-role="delete-series">
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-        <p class="text-sm text-zinc-400" data-role="series-added">
-          Added {Calendar.strftime(series.inserted_at, "%x")}
-        </p>
-      </div>
+
+        <:facts>
+          <.row_fact
+            icon="fa-book"
+            count={series.books}
+            title="# of books"
+            data-role="series-book-count"
+          />
+        </:facts>
+
+        <:action navigate={~p"/admin/series/#{series}/edit"} icon="fa-pencil" role="edit-series">
+          Edit
+        </:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={series.id}
+          confirm="Delete this series? Its books stay in the library and lose their numbers in it."
+          role="delete-series"
+        >
+          Delete
+        </:action>
+
+        <:footer>
+          <span data-role="series-added">Added {Calendar.strftime(series.inserted_at, "%x")}</span>
+        </:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/universe_live/index.html.heex
+++ b/lib/ambry_web/live/admin/universe_live/index.html.heex
@@ -15,11 +15,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@universes}
-    filter={@list_opts.filter}
-    row_click={fn universe -> JS.navigate(~p"/admin/universes/#{universe}/edit") end}
-  >
+  <.flex_table rows={@universes} filter={@list_opts.filter}>
     <:empty>
       No universes yet.
       <.brand_link navigate={~p"/admin/universes/new"}>
@@ -28,35 +24,42 @@
     </:empty>
 
     <:row :let={universe}>
-      <div class="flex-shrink-0">
-        <.multi_image paths={universe.thumbnails} />
-      </div>
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis" data-role="universe-name">{universe.name}</p>
-      </div>
-      <div class="hidden w-12 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <div class="flex gap-4">
-          <span title="# of books" data-role="universe-book-count">
-            {universe.books} <.icon name="fa-book" class="h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
-      <div class="flex w-32 flex-none flex-col items-end justify-between gap-2">
-        <div class="flex gap-2">
-          <.link navigate={~p"/admin/universes/#{universe}/edit"} data-role="edit-universe">
-            <.icon
-              name="fa-pencil"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-          <span phx-click="delete" phx-value-id={universe.id} data-confirm="Are you sure?" data-role="delete-universe">
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-        <p class="text-sm text-zinc-400" data-role="universe-added">
-          Added {Calendar.strftime(universe.inserted_at, "%x")}
-        </p>
-      </div>
+      <.index_row navigate={~p"/admin/universes/#{universe}/edit"}>
+        <:cover>
+          <.multi_image paths={universe.thumbnails} />
+        </:cover>
+
+        <:headline>
+          <span data-role="universe-name">{universe.name}</span>
+        </:headline>
+
+        <:facts>
+          <.row_fact
+            icon="fa-book"
+            count={universe.books}
+            title="# of books"
+            data-role="universe-book-count"
+          />
+        </:facts>
+
+        <:action navigate={~p"/admin/universes/#{universe}/edit"} icon="fa-pencil" role="edit-universe">
+          Edit
+        </:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={universe.id}
+          confirm="Delete this universe? Its books stay in the library."
+          role="delete-universe"
+        >
+          Delete
+        </:action>
+
+        <:footer>
+          <span data-role="universe-added">Added {Calendar.strftime(universe.inserted_at, "%x")}</span>
+        </:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/user_devices_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_devices_live/index.html.heex
@@ -25,43 +25,46 @@
       </:empty>
 
       <:row :let={device}>
-        <div class="flex-shrink-0">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-zinc-800">
-            <.icon
-              name={if device.type == :web, do: "fa-desktop", else: "fa-mobile-screen"}
-              class="h-6 w-6 text-zinc-400"
-            />
-          </div>
-        </div>
+        <%!-- A device row goes nowhere: there is no device page. So it is not
+              a link, and it does not wear the pointer cursor every row used
+              to wear whether or not it was clickable. --%>
+        <.index_row>
+          <:cover>
+            <div class="flex h-16 w-16 items-center justify-center rounded-full bg-zinc-800">
+              <.icon
+                name={if device.type == :web, do: "fa-desktop", else: "fa-mobile-screen"}
+                class="h-6 w-6 text-zinc-400"
+              />
+            </div>
+          </:cover>
 
-        <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-          <p class="overflow-hidden text-ellipsis font-medium">
-            {format_device(device)}
-          </p>
-          <p class="overflow-hidden text-ellipsis text-sm text-zinc-400">
+          <:headline>{format_device(device)}</:headline>
+
+          <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
             {device.app_id} {format_app_version(device.app_version, device.app_build)}
           </p>
-          <p class="font-mono overflow-hidden text-ellipsis text-xs text-zinc-400" title={device.id}>
+          <p class="font-mono overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400" title={device.id}>
             {String.slice(device.id, 0, 8)}
           </p>
-        </div>
 
-        <div class="hidden w-32 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-          <div class="flex gap-4">
-            <span :if={device.event_count > 0} title="# of playback events">
-              {device.event_count} <.icon name="fa-bolt" class="h-4 w-4 text-current" />
-            </span>
-          </div>
-        </div>
+          <:facts>
+            <.row_fact
+              :if={device.event_count > 0}
+              icon="fa-bolt"
+              count={device.event_count}
+              title="# of playback events"
+            />
+          </:facts>
 
-        <div class="flex w-48 flex-none flex-col items-end justify-center whitespace-nowrap">
-          <p class="text-sm text-zinc-400" title={format_full_datetime(device.last_seen_at)}>
-            Last seen {format_date(device.last_seen_at)}
-          </p>
-          <p class="text-sm text-zinc-400" title={format_full_datetime(device.inserted_at)}>
-            First seen {format_date(device.inserted_at)}
-          </p>
-        </div>
+          <:footer>
+            <p title={format_full_datetime(device.last_seen_at)}>
+              Last seen {format_date(device.last_seen_at)}
+            </p>
+            <p title={format_full_datetime(device.inserted_at)}>
+              First seen {format_date(device.inserted_at)}
+            </p>
+          </:footer>
+        </.index_row>
       </:row>
     </.flex_table>
   </div>

--- a/lib/ambry_web/live/admin/user_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_live/index.html.heex
@@ -19,106 +19,104 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table
-    rows={@users}
-    filter={@list_opts.filter}
-    row_click={fn user -> JS.navigate(~p"/admin/users/#{user}/playthroughs") end}
-  >
+  <.flex_table rows={@users} filter={@list_opts.filter}>
     <:row :let={user}>
-      <div class="flex-shrink-0">
-        <div class="h-16 w-16">
-          <img class="h-full w-full rounded-full" src={gravatar_url(user.email)} />
-        </div>
-      </div>
+      <.index_row navigate={~p"/admin/users/#{user}/playthroughs"}>
+        <:cover>
+          <img class="h-16 w-16 rounded-full" src={gravatar_url(user.email)} alt="" />
+        </:cover>
 
-      <div class="min-w-0 flex-grow overflow-hidden text-ellipsis whitespace-nowrap">
-        <p class="overflow-hidden text-ellipsis" data-role="user-email">{user.email}</p>
-      </div>
+        <:headline>
+          <span data-role="user-email">{user.email}</span>
+        </:headline>
 
-      <div class="hidden w-44 flex-none flex-col items-end gap-1 text-zinc-400 sm:flex">
-        <div class="flex gap-4">
-          <span :if={user.admin} title="Admin" data-role="is-admin">
-            <.icon name="fa-lock" class="h-4 w-4 text-current" />
-          </span>
+        <%!-- Admin is the one state that changes what this row can do to the
+              rest of the app, so it is the badge. Whether the invite was
+              accepted is a fact about the account, and rides with the other
+              facts. --%>
+        <:badges>
+          <.badge :if={user.admin} color={:brand} class="text-xs" data-role="is-admin">admin</.badge>
+        </:badges>
 
+        <:facts>
+          <%!-- flex items-center, like `row_fact` beside it: a bare inline
+                span sits on the text baseline, so the glyph rode a couple of
+                pixels low against the counts it shares the strip with. --%>
           <span
+            class="flex items-center"
             title={if user.confirmed, do: "Confirmed", else: "Unconfirmed"}
             data-role={if user.confirmed, do: "is-confirmed", else: "is-unconfirmed"}
           >
             <.icon
               name={if user.confirmed, do: "fa-envelope-open", else: "fa-envelope"}
-              class="h-4 w-4 text-current"
+              class={["h-3.5 w-3.5", if(user.confirmed, do: "text-current", else: "text-amber-300")]}
             />
           </span>
+          <.row_fact
+            :if={user.media_in_progress > 0}
+            icon="fa-book-bookmark"
+            count={user.media_in_progress}
+            title="# of in-progress audiobooks"
+            data-role="user-in-progress"
+          />
+          <.row_fact
+            :if={user.media_finished > 0}
+            icon="fa-book"
+            count={user.media_finished}
+            title="# of finished audiobooks"
+            data-role="user-finished"
+          />
+        </:facts>
 
-          <span :if={user.media_in_progress > 0} title="# of in-progress audiobooks" data-role="user-in-progress">
-            {user.media_in_progress} <.icon name="fa-book-bookmark" class="h-4 w-4 text-current" />
-          </span>
+        <%!-- The card's own destination is a button too, exactly as Edit is
+              on every other list. --%>
+        <:action navigate={~p"/admin/users/#{user}/playthroughs"} icon="fa-play">
+          Playthroughs
+        </:action>
+        <:action navigate={~p"/admin/users/#{user}/devices"} icon="fa-mobile-screen">
+          Devices
+        </:action>
 
-          <span :if={user.media_finished > 0} title="# of finished audiobooks" data-role="user-finished">
-            {user.media_finished} <.icon name="fa-book" class="h-4 w-4 text-current" />
-          </span>
-        </div>
-      </div>
+        <%!-- Nobody can demote or delete themselves out of the admin. --%>
+        <:action
+          :if={user.admin and user.id != @current_user.id}
+          icon="fa-unlock"
+          click="demote"
+          value={user.id}
+          confirm="Demote this user? They lose the admin area; their library and progress are untouched."
+          role="demote-admin"
+        >
+          Demote
+        </:action>
+        <:action
+          :if={!user.admin and user.id != @current_user.id}
+          icon="fa-lock"
+          click="promote"
+          value={user.id}
+          confirm="Promote this user? They get the whole admin area."
+          role="promote-admin"
+        >
+          Promote
+        </:action>
+        <:action
+          :if={user.id != @current_user.id}
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={user.id}
+          confirm="Delete this user? Their playthroughs and bookmarks go with them; the library is untouched."
+          role="delete-user"
+        >
+          Delete
+        </:action>
 
-      <div class="flex w-36 flex-none flex-col items-end justify-between whitespace-nowrap">
-        <div class="flex gap-2 pb-2 text-zinc-400">
-          <.link navigate={~p"/admin/users/#{user}/playthroughs"} title="Playthroughs">
-            <.icon
-              name="fa-play"
-              class="h-4 w-4 text-current transition-colors hover:text-brand-dark"
-            />
-          </.link>
-
-          <.link navigate={~p"/admin/users/#{user}/devices"} title="Devices">
-            <.icon
-              name="fa-mobile-screen"
-              class="h-4 w-4 text-current transition-colors hover:text-lime-400"
-            />
-          </.link>
-
-          <%= if user.id != @current_user.id do %>
-            <%= if user.admin do %>
-              <.button
-                type="button"
-                color={:yellow}
-                class="flex h-4 items-center text-xs"
-                phx-click="demote"
-                phx-value-id={user.id}
-                data-role="demote-admin"
-              >
-                Demote <.icon name="fa-unlock" class="ml-1 h-3 w-3 text-current" />
-              </.button>
-            <% else %>
-              <.button
-                type="button"
-                color={:yellow}
-                class="flex h-4 items-center text-xs"
-                phx-click="promote"
-                phx-value-id={user.id}
-                data-role="promote-admin"
-              >
-                Promote <.icon name="fa-lock" class="ml-1 h-3 w-3 text-current" />
-              </.button>
-            <% end %>
-          <% end %>
-          <span
-            :if={user.id != @current_user.id}
-            phx-click="delete"
-            phx-value-id={user.id}
-            data-confirm="Are you sure?"
-            data-role="delete-user"
-          >
-            <.icon name="fa-trash" class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-600" />
-          </span>
-        </div>
-        <p :if={user.last_login_at} class="text-sm text-zinc-400" data-role="user-last-login">
-          Last login {Calendar.strftime(user.last_login_at, "%x")}
-        </p>
-        <p class="text-sm text-zinc-400" data-role="user-joined">
-          Joined {Calendar.strftime(user.inserted_at, "%x")}
-        </p>
-      </div>
+        <:footer>
+          <p :if={user.last_login_at} data-role="user-last-login">
+            Last login {Calendar.strftime(user.last_login_at, "%x")}
+          </p>
+          <p data-role="user-joined">Joined {Calendar.strftime(user.inserted_at, "%x")}</p>
+        </:footer>
+      </.index_row>
     </:row>
   </.flex_table>
 </.layout>

--- a/lib/ambry_web/time_utils.ex
+++ b/lib/ambry_web/time_utils.ex
@@ -26,6 +26,9 @@ defmodule AmbryWeb.TimeUtils do
 
   @doc """
   Formats a decimal number of seconds into a human readable string.
+
+  Counts agree with their nouns: this rendered "1 hours and 1 minutes" for as
+  long as it was only ever read on one page.
   """
   def duration_display(nil), do: nil
 
@@ -37,9 +40,12 @@ defmodule AmbryWeb.TimeUtils do
     minutes = div(remainder, 60)
 
     if hours == 0 do
-      "#{minutes} minutes"
+      count(minutes, "minute")
     else
-      "#{hours} hours and #{minutes} minutes"
+      "#{count(hours, "hour")} and #{count(minutes, "minute")}"
     end
   end
+
+  defp count(1, noun), do: "1 #{noun}"
+  defp count(n, noun), do: "#{n} #{noun}s"
 end

--- a/test/ambry/utils_test.exs
+++ b/test/ambry/utils_test.exs
@@ -1,0 +1,38 @@
+defmodule Ambry.UtilsTest do
+  @moduledoc """
+  The wordings shared between the contexts and the web layer, which is what
+  keeps a row and a picker option from crediting the same recording two
+  different ways.
+  """
+  use ExUnit.Case, async: true
+
+  doctest Ambry.Utils, only: [name_credit: 1, series_credit: 1, humanize_bytes: 1]
+
+  describe "name_credit/1" do
+    test "says nothing when there is nobody" do
+      assert Ambry.Utils.name_credit([]) == nil
+      assert Ambry.Utils.name_credit(nil) == nil
+    end
+
+    # "and 1 others" is the tell of a count pasted onto a plural.
+    test "agrees with its noun" do
+      assert Ambry.Utils.name_credit([%{name: "A"}, %{name: "B"}]) == "A and 1 other"
+
+      assert Ambry.Utils.name_credit([%{name: "A"}, %{name: "B"}, %{name: "C"}]) ==
+               "A and 2 others"
+    end
+  end
+
+  describe "series_credit/1" do
+    test "joins several with commas" do
+      series = [%{name: "Mistborn", number: 2}, %{name: "The Cosmere", number: 4}]
+
+      assert Ambry.Utils.series_credit(series) == "Mistborn #2, The Cosmere #4"
+    end
+
+    test "says nothing when a record is in no series" do
+      assert Ambry.Utils.series_credit([]) == nil
+      assert Ambry.Utils.series_credit(nil) == nil
+    end
+  end
+end

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -202,9 +202,30 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
            |> has_element?()
   end
 
+  # The rail's shape and the order of its buttons used to change from row to
+  # row as Import appeared and disappeared, which moved the primary action
+  # under the cursor while the operator worked down the list.
+  test "Import holds its place on a row that isn't settled yet", %{conn: conn} do
+    {:ok, _item} = probed_item() |> Inbox.prepare_draft()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox")
+
+    assert has_element?(view, "span[aria-disabled='true']", "Import")
+    refute has_element?(view, "span[phx-click='import']")
+  end
+
+  test "Import is live once the row is settled", %{conn: conn} do
+    _settled = probed_item() |> settle()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox")
+
+    assert has_element?(view, "span[phx-click='import']", "Import")
+    refute has_element?(view, "span[aria-disabled='true']")
+  end
+
   # An imported item's draft is the record of what was imported; re-matching
-  # would rebuild it. The row keeps Open-by-title for looking, loses the
-  # actions that write.
+  # would rebuild it. The row keeps a way into the record for looking, loses
+  # the actions that write.
   test "an imported item's row offers no re-match", %{conn: conn} do
     item = probed_item() |> settle()
     {:ok, _media} = Ambry.Inbox.import_item(item)
@@ -212,6 +233,56 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=imported")
 
     refute has_element?(view, "span[phx-click='rescan'][phx-value-id='#{item.id}']")
+    assert has_element?(view, "a[href^='/admin/inbox/#{item.id}']")
+  end
+
+  # Once it is imported, what the operator cares about is the audiobook, not
+  # the release folder it arrived in. The matching details describe a decision
+  # already taken and only make finished work read like work.
+  test "an imported row is the audiobook it became", %{conn: conn} do
+    item = probed_item() |> settle()
+    {:ok, media} = Ambry.Inbox.import_item(item)
+
+    {:ok, view, html} = live(conn, ~p"/admin/inbox?status=imported")
+
+    # the library record, in the credit stack's words
+    assert html =~ "The Way of Kings"
+    assert html =~ "Brandon Sanderson"
+    assert has_element?(view, "a[href='/admin/audiobooks/#{media.id}/edit']")
+
+    # and none of the matching details, nor the files it came from
+    refute html =~ item.path
+    refute html =~ "reviewed"
+    assert item_states(html) == []
+  end
+
+  # "Found" is when discovery tripped over the folder, which for a finished
+  # row is the least interesting date it has. `updated_at` is stamped by the
+  # status change and nothing writes to an imported item afterwards.
+  test "an imported row is dated by the import, not the discovery", %{conn: conn} do
+    item = probed_item() |> settle()
+    {:ok, _media} = Ambry.Inbox.import_item(item)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/inbox?status=imported")
+
+    assert html =~ "Imported #{Calendar.strftime(Inbox.get_item!(item.id).updated_at, "%x")}"
+    refute html =~ "Found "
+  end
+
+  # Deleting an audiobook nilifies the link rather than taking the record of
+  # the import with it, so the row outlives the thing it describes. It says
+  # so, rather than falling back to matching details for a result that is
+  # gone.
+  test "an imported row whose audiobook was deleted says so", %{conn: conn} do
+    item = probed_item() |> settle()
+    {:ok, media} = Ambry.Inbox.import_item(item)
+    {:ok, _deleted} = Ambry.Media.delete_media(media)
+
+    {:ok, view, html} = live(conn, ~p"/admin/inbox?status=imported")
+
+    assert html =~ "The audiobook this became has been deleted."
+    refute has_element?(view, "a[href='/admin/audiobooks/#{media.id}/edit']")
+    assert has_element?(view, "a[href^='/admin/inbox/#{item.id}']")
   end
 
   # `RunMatch` is unique over a 60-second window and Oban answers a conflict

--- a/test/ambry_web/live/admin/index_row_test.exs
+++ b/test/ambry_web/live/admin/index_row_test.exs
@@ -153,6 +153,30 @@ defmodule AmbryWeb.Admin.IndexRowTest do
     end
   end
 
+  # A GraphicAudio cast runs to a dozen people, and a row that prints all
+  # twelve buries the title it was meant to help identify.
+  test "a row credits the first narrator and counts the rest", %{conn: conn} do
+    insert(:media,
+      book: build(:book),
+      media_narrators: [
+        build(:media_narrator,
+          narrator: build(:narrator, name: "Karen Foley", person: build(:person))
+        ),
+        build(:media_narrator,
+          narrator: build(:narrator, name: "Eric Messner", person: build(:person))
+        ),
+        build(:media_narrator,
+          narrator: build(:narrator, name: "Melody Muze", person: build(:person))
+        )
+      ]
+    )
+
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
+
+    assert html =~ "Read by Karen Foley and 2 others"
+    refute html =~ "Melody Muze"
+  end
+
   # In words a person reads, not the cells these were on the way out of the
   # footer ("8/30/22", "14:04:02"), which is the shape a spreadsheet wants.
   # `record_meta/1` is one helper, so the audiobooks list and the queue's

--- a/test/ambry_web/live/admin/index_row_test.exs
+++ b/test/ambry_web/live/admin/index_row_test.exs
@@ -1,0 +1,182 @@
+defmodule AmbryWeb.Admin.IndexRowTest do
+  @moduledoc """
+  The anatomy every admin list row shares (docs/admin-design-language.md §3a).
+
+  These are the guarantees that no per-surface test can see, and that ten
+  hand-built row slots drifted away from once already.
+  """
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_admin_user
+
+  # The library lists made the whole row clickable with `JS.navigate` on the
+  # div, which is a target but not a link; the queue linked only its title,
+  # which is a link but a 200px target. The stretched `::after` is both.
+  test "a row's headline is a real link that covers the card", %{conn: conn} do
+    media = insert(:media, book: build(:book))
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks")
+
+    assert view
+           |> element("a[href='/admin/audiobooks/#{media.id}/edit'].after\\:absolute")
+           |> has_element?()
+  end
+
+  # LiveView dispatches a click to the *closest* phx-click ancestor, so a row
+  # whose destination is a `phx-click` on the container fires it as well as
+  # any anchor nested inside — which is how clicking Devices also navigated
+  # to Playthroughs.
+  test "no row carries its destination as a phx-click on the container", %{conn: conn} do
+    user = insert(:user)
+    insert(:media, book: build(:book))
+
+    for path <- [~p"/admin/audiobooks", ~p"/admin/books", ~p"/admin/people", ~p"/admin/users"] do
+      {:ok, _view, html} = live(conn, path)
+
+      refute html =~ ~s(phx-click="[[&quot;navigate&quot;)
+    end
+
+    {:ok, _view, html} = live(conn, ~p"/admin/users/#{user}/devices")
+    refute html =~ ~s(phx-click="[[&quot;patch&quot;)
+  end
+
+  # The container hardcoded `cursor-pointer` on every row whether or not it
+  # had anywhere to go, so the queue and this list invited clicks on dead
+  # space.
+  test "a row with nowhere to go is not a link and wears no pointer", %{conn: conn} do
+    user = insert(:user)
+    device = insert(:device, type: :web, browser: "Firefox", os_name: "Linux")
+    insert(:device_user, device: device, user: user)
+
+    {:ok, _html_doc, rows} = rows(conn, ~p"/admin/users/#{user}/devices")
+
+    assert rows != []
+
+    for row <- rows do
+      assert Floki.find(row, "a") == []
+      refute row |> Floki.attribute("class") |> to_string() =~ "cursor-pointer"
+    end
+  end
+
+  # Every list's actions are worded buttons now: the exception that let index
+  # rows go icon-only was written for a five-verb media row whose verbs have
+  # all since moved onto the form.
+  test "row actions carry words, not bare glyphs", %{conn: conn} do
+    insert(:media, book: build(:book))
+
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
+
+    assert html =~ "Edit"
+    assert html =~ "Delete"
+  end
+
+  # The rail is two buttons wide and the actions wrap into it, so four verbs
+  # are a 2 x 2 rather than a four-storey column. Stacking one per line was
+  # tried and is worse: tall, and ragged down the left.
+  test "an action rail wraps, it never stacks one per line", %{conn: conn} do
+    insert(:media, book: build(:book))
+    insert(:user)
+
+    for path <- [~p"/admin/audiobooks", ~p"/admin/users", ~p"/admin/inbox"] do
+      {:ok, _doc, rails} = find(conn, path, "[data-role='row-actions']")
+
+      for rail <- rails do
+        classes = rail |> Floki.attribute("class") |> to_string()
+
+        assert classes =~ "flex-wrap"
+        refute classes =~ "flex-col"
+      end
+    end
+  end
+
+  # 224px was sized for a pair: Playthroughs (120px) beside Devices (86px) is
+  # the tightest, and "Import record" (124px) beside Edit is the longest
+  # single label. A label past that rags the rail on whatever list grows it,
+  # which is the failure this budget exists to catch. Characters are a proxy
+  # for pixels, which is the best a server-side test can do.
+  @label_budget 13
+
+  test "no action label is longer than the rail was sized for", %{conn: conn} do
+    insert(:media, book: build(:book))
+    insert(:user)
+    insert(:book)
+    insert(:person)
+
+    paths = [
+      ~p"/admin/audiobooks",
+      ~p"/admin/books",
+      ~p"/admin/people",
+      ~p"/admin/users",
+      ~p"/admin/inbox"
+    ]
+
+    labels =
+      Enum.flat_map(paths, fn path ->
+        {:ok, _doc, rails} = find(conn, path, "[data-role='row-actions']")
+
+        for rail <- rails, action <- Floki.find(rail, "a, span[role='button']") do
+          {path, action |> Floki.text() |> String.trim()}
+        end
+      end)
+
+    # Or the loop below passes by finding nothing, which is how a budget stops
+    # being a budget.
+    assert length(labels) > 10
+
+    for {path, label} <- labels do
+      assert String.length(label) <= @label_budget,
+             "#{path}: #{inspect(label)} is wider than the rail was sized for"
+    end
+  end
+
+  # "Added", "Imported", "Joined", "Last seen" — a record of what the app did.
+  # A duration and a publication date are facts about the work, and reading
+  # them in the same column made them look like timestamps too.
+  test "the footer corner holds system timestamps and nothing else", %{conn: conn} do
+    insert(:media, book: build(:book), duration: Decimal.new("3600"))
+
+    {:ok, _doc, footers} = find(conn, ~p"/admin/audiobooks", "[data-role='row-footer']")
+
+    assert footers != []
+
+    for footer <- footers do
+      text = footer |> Floki.text() |> String.trim()
+
+      assert text =~ ~r/^Added /
+      refute text =~ "Duration"
+      refute text =~ "Published"
+    end
+  end
+
+  # In words a person reads, not the cells these were on the way out of the
+  # footer ("8/30/22", "14:04:02"), which is the shape a spreadsheet wants.
+  # `record_meta/1` is one helper, so the audiobooks list and the queue's
+  # imported rows cannot phrase the same three facts differently again.
+  test "the meta line reads as a sentence, with the publisher in it", %{conn: conn} do
+    insert(:media,
+      book: build(:book),
+      published: ~D[2022-08-30],
+      published_format: :full,
+      publisher: "Recorded Books",
+      duration: Decimal.new("117780")
+    )
+
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
+
+    assert html =~ "Published August 30, 2022 by Recorded Books · 32 hours and 43 minutes"
+    refute html =~ "32:43:00"
+  end
+
+  defp rows(conn, path) do
+    find(conn, path, "[class*='rounded-lg'][class*='bg-zinc-900'][class*='p-4']")
+  end
+
+  defp find(conn, path, selector) do
+    {:ok, _view, html} = live(conn, path)
+    document = Floki.parse_document!(html)
+
+    {:ok, document, Floki.find(document, selector)}
+  end
+end

--- a/test/ambry_web/live/admin/index_row_test.exs
+++ b/test/ambry_web/live/admin/index_row_test.exs
@@ -9,6 +9,9 @@ defmodule AmbryWeb.Admin.IndexRowTest do
 
   import Phoenix.LiveViewTest
 
+  alias Ambry.Books.SeriesBookType
+  alias AmbryWeb.Admin.Components
+
   setup :register_and_log_in_admin_user
 
   # The library lists made the whole row clickable with `JS.navigate` on the
@@ -153,10 +156,13 @@ defmodule AmbryWeb.Admin.IndexRowTest do
   # In words a person reads, not the cells these were on the way out of the
   # footer ("8/30/22", "14:04:02"), which is the shape a spreadsheet wants.
   # `record_meta/1` is one helper, so the audiobooks list and the queue's
-  # imported rows cannot phrase the same three facts differently again.
+  # imported rows cannot phrase the same facts differently again.
   test "the meta line reads as a sentence, with the publisher in it", %{conn: conn} do
+    series = insert(:series)
+    book = insert(:book, series_books: [build(:series_book, series: series, book_number: 1)])
+
     insert(:media,
-      book: build(:book),
+      book: book,
       published: ~D[2022-08-30],
       published_format: :full,
       publisher: "Recorded Books",
@@ -165,8 +171,56 @@ defmodule AmbryWeb.Admin.IndexRowTest do
 
     {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
 
-    assert html =~ "Published August 30, 2022 by Recorded Books · 32 hours and 43 minutes"
+    assert html =~
+             "#{series.name} #1 · Published August 30, 2022 by Recorded Books · " <>
+               "32 hours and 43 minutes"
+
     refute html =~ "32:43:00"
+  end
+
+  # Title, authors and narrators are what every record has, so they are always
+  # three lines; the series, the publisher, the date and the duration are each
+  # sometimes there, so they share the fourth — and it disappears entirely
+  # when a record has none of them. A series owning a line of its own is what
+  # made these rows tall.
+  describe "the variable line" do
+    test "puts the series in front and keeps one order" do
+      full = %{
+        series: [%SeriesBookType{name: "The Stormlight Archive", number: Decimal.new(1)}],
+        published: ~D[2022-08-30],
+        published_format: :full,
+        publisher: "Recorded Books",
+        duration: Decimal.new("117780")
+      }
+
+      assert Components.record_meta(full) ==
+               "The Stormlight Archive #1 · Published August 30, 2022 by Recorded Books · " <>
+                 "32 hours and 43 minutes"
+    end
+
+    test "collapses to nothing when nothing varies" do
+      bare = %{
+        series: [],
+        published: nil,
+        published_format: nil,
+        publisher: nil,
+        duration: nil
+      }
+
+      assert Components.record_meta(bare) == ""
+    end
+
+    # A book has neither of the audiobook-only halves, so the same helper
+    # reduces rather than rendering empty joins.
+    test "reduces for a record with no publisher and no duration" do
+      book = %{
+        series: [%SeriesBookType{name: "Mistborn", number: Decimal.new(2)}],
+        published: ~D[2007-08-21],
+        published_format: :year
+      }
+
+      assert Components.record_meta(book) == "Mistborn #2 · Published 2007"
+    end
   end
 
   defp rows(conn, path) do

--- a/test/ambry_web/live/admin/media_live/set_picker_test.exs
+++ b/test/ambry_web/live/admin/media_live/set_picker_test.exs
@@ -26,6 +26,27 @@ defmodule AmbryWeb.Admin.MediaLive.SetPickerTest do
       refute html =~ "Create “"
     end
 
+    # Hiding the row stopped the form *mentioning* the set rather than saying
+    # it was gone, and `cast` only changes the keys it is handed — so the
+    # picker vanished, Save reported success, and the recording came back
+    # still in its set.
+    test "taking an audiobook out of a set sticks", %{conn: conn} do
+      book = insert(:book)
+      group = insert(:recording_group, book: book, name: "Graphic Audio")
+      media = insert(:media, book: book, recording_group: group, part_number: 2)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+      view |> element("button[phx-click='remove-group-row']") |> render_click()
+
+      view |> form("#media-form") |> render_submit()
+
+      reloaded = Ambry.Media.get_media!(media.id)
+
+      assert reloaded.recording_group_id == nil
+      assert reloaded.part_number == nil
+    end
+
     test "opens with an empty option list after filtering everything out", %{conn: conn} do
       book = insert(:book)
       insert(:recording_group, book: book, name: "Unabridged")

--- a/test/ambry_web/live/admin/playback_debug_live/index_test.exs
+++ b/test/ambry_web/live/admin/playback_debug_live/index_test.exs
@@ -22,7 +22,8 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.IndexTest do
 
       assert html =~ "Playthroughs for debug_user@example.com"
       assert html =~ "Test Book"
-      assert html =~ "in_progress"
+      # The badge wears the status in words, not the schema atom (§8)
+      assert html =~ "in progress"
     end
 
     test "clicking a playthrough opens the events modal", %{conn: conn} do
@@ -39,9 +40,9 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.IndexTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/users/#{user.id}/playthroughs")
 
-      # Click the row - target the div with the phx-click attribute
+      # The whole card is a real link now, not a div carrying JS.patch
       view
-      |> element("[phx-click*='#{playthrough.id}']")
+      |> element("a[href*='#{playthrough.id}']")
       |> render_click()
 
       # Assert modal is shown and contains the event

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -111,6 +111,49 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       assert resolver_display(html) == "A Court of Thorns and Roses (Part 1)"
     end
 
+    # The label composes a part suffix onto the title, and no column holds
+    # "A Court of Thorns and Roses (Part 1 of 2)" — so opening the box
+    # searched for exactly that and reported "No matches" about the recording
+    # it was already holding.
+    test "opening a member picker finds the recording it is holding", %{conn: conn} do
+      book = insert(:book, title: "A Court of Thorns and Roses")
+      group = insert(:recording_group, name: "Graphic Audio", book: book, parts_total: 2)
+      held = insert(:media, book: book, part_number: 1, recording_group: group)
+      sibling = insert(:media, book: book, part_number: 2, recording_group: group)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
+
+      html =
+        view
+        |> element("#recording_group_form_members_0_media_id-input")
+        |> render_focus()
+
+      refute html =~ "No matches"
+      assert html =~ ~s(phx-value-id="#{held.id}")
+      assert html =~ ~s(phx-value-id="#{sibling.id}")
+    end
+
+    # The one credit a picker of audiobooks can be asked to disambiguate by,
+    # and the row listed everything except it.
+    test "a member picker's rows name the author", %{conn: conn} do
+      author = insert(:author, name: "Sarah J. Maas")
+
+      book =
+        insert(:book, title: "A Court of Thorns and Roses", book_authors: [%{author: author}])
+
+      group = insert(:recording_group, name: "Graphic Audio", book: book)
+      insert(:media, book: book, part_number: 1, recording_group: group)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
+
+      html =
+        view
+        |> element("#recording_group_form_members_0_media_id-input")
+        |> render_focus()
+
+      assert html =~ "Sarah J. Maas"
+    end
+
     test "saving edits facts and the member list together", %{conn: conn} do
       book = insert(:book)
       group = insert(:recording_group, name: "Before", book: book)

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -185,6 +185,64 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       assert html =~ "Sarah J. Maas"
     end
 
+    # A GraphicAudio cast runs to a dozen people, and a row that prints all
+    # twelve buries the title it was meant to help identify.
+    test "a picker row credits the first narrator and counts the rest", %{conn: conn} do
+      book = insert(:book, title: "A Court of Thorns and Roses")
+      group = insert(:recording_group, name: "Graphic Audio", book: book)
+
+      insert(:media,
+        book: book,
+        part_number: 1,
+        recording_group: group,
+        media_narrators: [
+          build(:media_narrator,
+            narrator: build(:narrator, name: "Karen Foley", person: build(:person))
+          ),
+          build(:media_narrator,
+            narrator: build(:narrator, name: "Eric Messner", person: build(:person))
+          ),
+          build(:media_narrator,
+            narrator: build(:narrator, name: "Melody Muze", person: build(:person))
+          )
+        ]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
+
+      html =
+        view
+        |> element("#recording_group_form_members_0_media_id-input")
+        |> render_focus()
+
+      assert html =~ "read by Karen Foley and 2 others"
+      refute html =~ "Melody Muze"
+    end
+
+    # The detail line already carries five facts, so where a recording sits
+    # rides the label's own line instead, muted.
+    test "a picker row trails its series on the label line", %{conn: conn} do
+      series = insert(:series, name: "A Court of Thorns and Roses")
+
+      book =
+        insert(:book,
+          title: "A Court of Thorns and Roses",
+          series_books: [build(:series_book, series: series, book_number: 1)]
+        )
+
+      group = insert(:recording_group, name: "Graphic Audio", book: book)
+      insert(:media, book: book, part_number: 1, recording_group: group)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
+
+      html =
+        view
+        |> element("#recording_group_form_members_0_media_id-input")
+        |> render_focus()
+
+      assert html =~ "A Court of Thorns and Roses #1"
+    end
+
     test "saving edits facts and the member list together", %{conn: conn} do
       book = insert(:book)
       group = insert(:recording_group, name: "Before", book: book)

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -133,6 +133,37 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
       assert html =~ ~s(phx-value-id="#{sibling.id}")
     end
 
+    # Opening a filled box used to drop its own record somewhere in an
+    # alphabetical run of near-identical siblings, so confirming what was
+    # already chosen meant reading the whole list.
+    test "the held recording leads the list and says it is the held one", %{conn: conn} do
+      book = insert(:book, title: "A Court of Thorns and Roses")
+      group = insert(:recording_group, name: "Graphic Audio", book: book, parts_total: 3)
+      _first = insert(:media, book: book, part_number: 1, recording_group: group)
+      _second = insert(:media, book: book, part_number: 2, recording_group: group)
+      third = insert(:media, book: book, part_number: 3, recording_group: group)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/sets/#{group.id}/edit")
+
+      # the third member's box holds part 3, which the search orders last
+      html =
+        view
+        |> element("#recording_group_form_members_2_media_id-input")
+        |> render_focus()
+
+      options =
+        html
+        |> Floki.parse_document!()
+        |> Floki.find("#recording_group_form_members_2_media_id-list li[role='option']")
+
+      assert options |> List.first() |> Floki.attribute("phx-value-id") == [to_string(third.id)]
+      assert options |> List.first() |> Floki.attribute("aria-selected") == ["true"]
+
+      # and it is the only one carrying the chosen mark
+      assert Enum.count(options, &(Floki.find(&1, ".fa-check") != [])) == 1
+      assert Enum.count(options, &(Floki.attribute(&1, "aria-selected") == ["true"])) == 1
+    end
+
     # The one credit a picker of audiobooks can be asked to disambiguate by,
     # and the row listed everything except it.
     test "a member picker's rows name the author", %{conn: conn} do

--- a/test/ambry_web/time_utils_test.exs
+++ b/test/ambry_web/time_utils_test.exs
@@ -27,7 +27,9 @@ defmodule AmbryWeb.TimeUtilsTest do
     end
 
     test "with hours" do
-      assert "1 hours and 35 minutes" = TimeUtils.duration_display(5755)
+      assert "1 hour and 35 minutes" = TimeUtils.duration_display(5755)
+      assert "1 hour and 1 minute" = TimeUtils.duration_display(3661)
+      assert "1 minute" = TimeUtils.duration_display(60)
     end
   end
 end


### PR DESCRIPTION
Ten admin list pages grew their rows independently inside one anonymous `:row` slot and read like it: four rail widths, three title weights, two places to put a state badge, and a facts column that vanished on a phone instead of folding. `<.index_row>` is the anatomy now; `flex_table` is only the list shell.

It started as "an imported inbox row should show the audiobook, not the matching details" and turned into the consistency pass that implied.

## The merge

The two idioms each had half of what a row wants, so this takes both halves.

| From the library lists | From the queue cards |
|---|---|
| the whole card is the click target | worded actions, one costume |
| the cover, the glyph-and-count facts | the rail's fixed slots and state badges |
| the `data-role` instrumentation | a rail that folds rather than vanishing |

**Rows are three fixed lines and one variable one.** Title, authors and narrators are what every record has; the series, publisher, date and duration are each only sometimes there, so they share the fourth and it disappears when a record has none of them. The footer corner is system timestamps only — Added, Imported, Joined, Last seen.

**An imported inbox row is the audiobook it became** — cover, credits, the library's own state badges — dated by the import rather than by the discovery. The matching tiers and the release folder describe a decision already taken; they stay one click away on the item's form.

## Bugs found on the way

Only one of these was reported.

- **Clicking Devices on the users list also navigated to Playthroughs.** LiveView dispatches a click to the *closest* `phx-click` ancestor, so an `<a>` nested inside a `JS.navigate` row fired both. The headline is a stretched-link `<a>` now, which is a real link *and* the whole card.
- **A filled audiobook picker answered "No matches" about the record it was holding.** Its label is composed (`"…(Part 1 of 2)"`) and no column holds that string. An option may now carry `query` — what it is found by, as distinct from how it is displayed.
- **Taking an audiobook out of a set didn't save.** Hiding the picker row took its inputs out of the DOM, so the submit posted neither key and `cast` changes only what it is handed.
- **The person form's credit checkbox moved its neighbour when unticked.** A flex container takes its baseline from its first item, and an empty tick box has none, so it synthesized one three pixels lower.
- **`cursor-pointer` was hardcoded on every row**, and the rails' `justify-between` was inert without `self-stretch`.

## Also

Picker rows credit the first narrator and count the rest ("Karen Foley and 2 others") and trail their series on the label line; the held record is pinned to the top of its list and marked. Playthrough status chips became `<.badge>`; every bare "Are you sure?" now names what dies and what survives, including the audiobook one, which deletes audio files off the disk and never said so.

`docs/admin-design-language.md` gains §3a for the row anatomy and loses §6's icon-only exception, which was written for a five-verb media row whose verbs had all since moved onto the form.

## Testing

`mix check` clean; 1796 tests pass. `test/ambry_web/live/admin/index_row_test.exs` pins the structural guarantees no per-surface test can see. Every bug fix has a regression test that was confirmed to fail with the fix reverted.

Two changes have no automated coverage and want a human eye: the inline pen-name hatches and the tick-box baseline on `/admin/people/:id/edit`.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ
