### PR TITLE
The admin remembers where you were

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -9,3 +9,21 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 56 28' width='56' height='28'%3E%3Cpath fill='%2327272a' fill-opacity='1' d='M56 26v2h-7.75c2.3-1.27 4.94-2 7.75-2zm-26 2a2 2 0 1 0-4 0h-4.09A25.98 25.98 0 0 0 0 16v-2c.67 0 1.34.02 2 .07V14a2 2 0 0 0-2-2v-2a4 4 0 0 1 3.98 3.6 28.09 28.09 0 0 1 2.8-3.86A8 8 0 0 0 0 6V4a9.99 9.99 0 0 1 8.17 4.23c.94-.95 1.96-1.83 3.03-2.63A13.98 13.98 0 0 0 0 0h7.75c2 1.1 3.73 2.63 5.1 4.45 1.12-.72 2.3-1.37 3.53-1.93A20.1 20.1 0 0 0 14.28 0h2.7c.45.56.88 1.14 1.29 1.74 1.3-.48 2.63-.87 4-1.15-.11-.2-.23-.4-.36-.59H26v.07a28.4 28.4 0 0 1 4 0V0h4.09l-.37.59c1.38.28 2.72.67 4.01 1.15.4-.6.84-1.18 1.3-1.74h2.69a20.1 20.1 0 0 0-2.1 2.52c1.23.56 2.41 1.2 3.54 1.93A16.08 16.08 0 0 1 48.25 0H56c-4.58 0-8.65 2.2-11.2 5.6 1.07.8 2.09 1.68 3.03 2.63A9.99 9.99 0 0 1 56 4v2a8 8 0 0 0-6.77 3.74c1.03 1.2 1.97 2.5 2.79 3.86A4 4 0 0 1 56 10v2a2 2 0 0 0-2 2.07 28.4 28.4 0 0 1 2-.07v2c-9.2 0-17.3 4.78-21.91 12H30zM7.75 28H0v-2c2.81 0 5.46.73 7.75 2zM56 20v2c-5.6 0-10.65 2.3-14.28 6h-2.7c4.04-4.89 10.15-8 16.98-8zm-39.03 8h-2.69C10.65 24.3 5.6 22 0 22v-2c6.83 0 12.94 3.11 16.97 8zm15.01-.4a28.09 28.09 0 0 1 2.8-3.86 8 8 0 0 0-13.55 0c1.03 1.2 1.97 2.5 2.79 3.86a4 4 0 0 1 7.96 0zm14.29-11.86c1.3-.48 2.63-.87 4-1.15a25.99 25.99 0 0 0-44.55 0c1.38.28 2.72.67 4.01 1.15a21.98 21.98 0 0 1 36.54 0zm-5.43 2.71c1.13-.72 2.3-1.37 3.54-1.93a19.98 19.98 0 0 0-32.76 0c1.23.56 2.41 1.2 3.54 1.93a15.98 15.98 0 0 1 25.68 0zm-4.67 3.78c.94-.95 1.96-1.83 3.03-2.63a13.98 13.98 0 0 0-22.4 0c1.07.8 2.09 1.68 3.03 2.63a9.99 9.99 0 0 1 16.34 0z'%3E%3C/path%3E%3C/svg%3E");
 }
 
+
+/* The row a form just sent you back to (see hooks/focus-row.js). A keyframe
+   rather than a hook adding and removing ring classes: the animation cleans
+   up after itself, and the ring can fade out instead of blinking off.
+   `ring-2 ring-inset` in §1's terms, drawn as the box-shadow a ring already
+   is. */
+@keyframes ambry-row-flash {
+  from {
+    box-shadow: inset 0 0 0 2px theme(colors.brand.dark);
+  }
+  to {
+    box-shadow: inset 0 0 0 2px transparent;
+  }
+}
+
+.row-flash {
+  animation: ambry-row-flash 1.6s ease-out;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,7 @@ import { AutoDismissHook } from "./hooks/auto-dismiss"
 import { ComboboxNavHook } from "./hooks/combobox-nav"
 import { EntityResolverInputHook } from "./hooks/entity-resolver-input"
 import { FitOrStackHook } from "./hooks/fit-or-stack"
+import { FocusRowHook } from "./hooks/focus-row"
 import { HeaderScrollspyHook } from "./hooks/header-scrollspy"
 import { ImageSizeHook } from "./hooks/image-size"
 import { InfiniteScrollHook } from "./hooks/infinite-scroll"
@@ -52,6 +53,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     "combobox-nav": ComboboxNavHook,
     "entity-resolver-input": EntityResolverInputHook,
     "fit-or-stack": FitOrStackHook,
+    "focus-row": FocusRowHook,
     "image-size": ImageSizeHook,
     "scroll-match": ScrollMatchHook,
     "paste-image": PasteImageHook,

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -28,6 +28,7 @@ import { FitOrStackHook } from "./hooks/fit-or-stack"
 import { HeaderScrollspyHook } from "./hooks/header-scrollspy"
 import { ImageSizeHook } from "./hooks/image-size"
 import { InfiniteScrollHook } from "./hooks/infinite-scroll"
+import { ListScrollResetHook } from "./hooks/list-scroll-reset"
 import { MainTainAttrsHook } from "./hooks/maintain-attrs"
 import { PasteImageHook } from "./hooks/paste-image"
 import { ReadMoreHook } from "./hooks/read-more"
@@ -47,6 +48,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     "scroll-into-view": ScrollIntoViewHook,
     "maintain-attrs": MainTainAttrsHook,
     "infinite-scroll": InfiniteScrollHook,
+    "list-scroll-reset": ListScrollResetHook,
     "combobox-nav": ComboboxNavHook,
     "entity-resolver-input": EntityResolverInputHook,
     "fit-or-stack": FitOrStackHook,

--- a/assets/js/hooks/focus-row.js
+++ b/assets/js/hooks/focus-row.js
@@ -1,0 +1,36 @@
+// Coming back from a form, put the operator back at the record they were
+// editing rather than at the top of page one.
+//
+// It anchors to the record, not to a scroll offset, because those are
+// different answers whenever the edit changed the sort key: rename a book
+// while the list is sorted by title and its row moves, and the pixel the
+// operator left from now belongs to somebody else. If the row is gone —
+// deleted, or filtered out by what was just saved — this does nothing and
+// they land at the top, which is the honest result.
+export const FocusRowHook = {
+  mounted() {
+    this.focus()
+  },
+
+  updated() {
+    this.focus()
+  },
+
+  focus() {
+    const id = this.el.dataset.focus
+    // Once per arrival: a re-render (a PubSub refresh, a tick) must not drag
+    // the page back to a row the operator has since scrolled away from.
+    if (!id || id === this.focused) return
+    this.focused = id
+
+    const row = document.getElementById(`row-${id}`)
+    if (!row) return
+
+    // After paint, or the row's geometry is whatever it was mid-patch.
+    requestAnimationFrame(() => {
+      row.scrollIntoView({ block: "center", behavior: "instant" })
+      row.classList.add("row-flash")
+      row.addEventListener("animationend", () => row.classList.remove("row-flash"), { once: true })
+    })
+  },
+}

--- a/assets/js/hooks/header-scrollspy.js
+++ b/assets/js/hooks/header-scrollspy.js
@@ -1,31 +1,46 @@
+// Two jobs, both of which belong to whoever knows how tall the header is.
+//
+// 1. The hairline under the header, drawn only once there is something above
+//    the fold. This used to be mounted on `#main-content` and read
+//    `this.el.scrollTop`, back when that div was a scrollport; the document
+//    is the scroller now, so it watches the window. The header carries its
+//    own `border-zinc-900` and this only toggles `border-b`, so the color is
+//    stated once, next to the rest of the header's costume.
+//
+// 2. `scroll-padding-top` on the root element, so an in-page anchor
+//    (`href="#unresolved"`) doesn't park its target underneath a sticky
+//    header. Measured rather than guessed: the header is one row on a form
+//    and three on a list, and it reflows with the window.
 export const HeaderScrollspyHook = {
   mounted() {
-    this.navHeader = document.getElementById("nav-header")
+    this.onScroll = () => this.el.classList.toggle("border-b", window.scrollY > 0)
+    this.onResize = () => this.publishHeight()
 
-    this.callback = (event) => {
-      if (this.el.scrollTop > 0) {
-        this.scrolled()
-      } else {
-        this.notScrolled()
-      }
-    }
+    window.addEventListener("scroll", this.onScroll, { passive: true })
+    window.addEventListener("phx:page-loading-stop", this.onScroll)
+    window.addEventListener("resize", this.onResize)
 
-    this.el.addEventListener("scroll", this.callback)
-    window.addEventListener("phx:page-loading-stop", this.callback)
-    this.notScrolled()
+    this.observer = new ResizeObserver(this.onResize)
+    this.observer.observe(this.el)
+
+    this.onScroll()
+    this.publishHeight()
+  },
+
+  updated() {
+    this.onScroll()
+    this.publishHeight()
   },
 
   destroyed() {
-    this.el.removeEventListener("click", this.callback)
-    window.removeEventListener("phx:page-loading-stop", this.callback)
-    this.notScrolled()
+    window.removeEventListener("scroll", this.onScroll)
+    window.removeEventListener("phx:page-loading-stop", this.onScroll)
+    window.removeEventListener("resize", this.onResize)
+    this.observer.disconnect()
+    document.documentElement.style.scrollPaddingTop = ""
   },
 
-  scrolled() {
-    this.navHeader?.classList.add("border-b")
-  },
-
-  notScrolled() {
-    this.navHeader?.classList.remove("border-b")
+  publishHeight() {
+    document.documentElement.style.scrollPaddingTop = `${this.el.offsetHeight}px`
   },
 }

--- a/assets/js/hooks/list-scroll-reset.js
+++ b/assets/js/hooks/list-scroll-reset.js
@@ -1,0 +1,26 @@
+// Asking for the next page and arriving at the bottom of it is the oldest
+// complaint about these lists. A page change is a `patch`, which morphs the
+// DOM rather than replacing it, so the scroll offset survives untouched while
+// fifty different rows appear underneath it — and the operator lands wherever
+// they happened to be, which after clicking a "next" button at the foot of
+// the list is the very end.
+//
+// Keyed on the whole list state, not just the page: changing the sort or the
+// search reorders everything, and staying halfway down someone else's
+// ordering is the same non-sequitur.
+//
+// `instant`, deliberately: this is a new page of results, not a movement
+// within one, and smooth-scrolling half a screen of rows the operator never
+// asked to see reads as the page fighting them.
+export const ListScrollResetHook = {
+  mounted() {
+    this.state = this.el.dataset.listState
+  },
+
+  updated() {
+    if (this.el.dataset.listState === this.state) return
+
+    this.state = this.el.dataset.listState
+    window.scrollTo({ top: 0, behavior: "instant" })
+  },
+}

--- a/assets/js/hooks/sticky-footer.js
+++ b/assets/js/hooks/sticky-footer.js
@@ -1,20 +1,21 @@
 // The form footer is a sticky slab with square bottom corners, which is
-// right whenever it is actually stuck to the bottom of the scrollport — but
+// right whenever it is actually stuck to the bottom of the viewport — but
 // a form shorter than the window never sticks, and there the slab just sits
 // mid-page wearing corners (and a floating shadow) that promise an edge that
-// isn't there. CSS has no :stuck selector, so the scroller is measured: if it
+// isn't there. CSS has no :stuck selector, so the page is measured: if it
 // has nothing to scroll, the slab is an ordinary card and dresses like one.
+//
+// The document is the scroller, so that measurement is the document's. This
+// used to measure `#main-content`, which was the scrollport until the shell
+// was flattened.
 export const StickyFooterHook = {
   mounted() {
-    this.scroller = this.el.closest("#main-content") || document.getElementById("main-content")
     this.onResize = () => this.apply()
     window.addEventListener("resize", this.onResize)
-    if (this.scroller) {
-      this.observer = new ResizeObserver(() => this.apply())
-      // observing the scroller's first child tracks content growing/shrinking
-      this.observer.observe(this.scroller)
-      if (this.scroller.firstElementChild) this.observer.observe(this.scroller.firstElementChild)
-    }
+    // The body's box tracks content growing and shrinking; the root element's
+    // is what `scrollHeight` is measured against.
+    this.observer = new ResizeObserver(() => this.apply())
+    this.observer.observe(document.body)
     this.apply()
   },
   updated() {
@@ -23,11 +24,11 @@ export const StickyFooterHook = {
   },
   destroyed() {
     window.removeEventListener("resize", this.onResize)
-    if (this.observer) this.observer.disconnect()
+    this.observer.disconnect()
   },
   apply() {
-    if (!this.scroller) return
-    const floats = this.scroller.scrollHeight <= this.scroller.clientHeight + 1
+    const root = document.documentElement
+    const floats = root.scrollHeight <= root.clientHeight + 1
 
     this.el.classList.toggle("rounded-b-lg", floats)
     this.el.classList.toggle("shadow-none", floats)

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -20,22 +20,6 @@ module.exports = {
         },
       },
     },
-    // fix mobile browser viewport height shenanigans.
-    // https://www.markusantonwolf.com/blog/solution-to-the-mobile-viewport-height-issue-with-tailwind-css/
-    // see root.html.heex for other half
-    height: (theme) => ({
-      auto: "auto",
-      ...theme("spacing"),
-      full: "100%",
-      screen: "calc(var(--vh) * 100)",
-    }),
-    minHeight: (theme) => ({
-      0: "0",
-      ...theme("spacing"),
-      full: "100%",
-      screen: "calc(var(--vh) * 100)",
-    }),
-    // end viewport fix
   },
   plugins: [
     require("@tailwindcss/forms"),

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -399,19 +399,31 @@ which is what every pre-redesign list did while writing the rule's classes.
 **64px is the row's height floor.** People rows were 48px, so they were
 visibly shorter than every other list's on the same page of the same app.
 
-**Paging lives under the last row, and it carries numbers.** The header holds
-what *narrows* a list (search, sort, and the one button that adds to it);
-`pagination_footer/1` holds what *moves through* it. Two bare chevrons in the
-top right corner was the old arrangement, and it was wrong three ways: the
-control for moving through a list sat as far from the list as the page
-allows, it never said which page you were on or how many there were, and
-because the header doesn't move, clicking "next" left the scroll where it was
-so the operator arrived looking at the bottom of the page they had just asked
-for. The footer states the range and the total ("Showing 51 to 100 of 435",
-"Page 2 of 9"), its steps are worded like every other action (§3a), an
-unavailable step is dead rather than absent so the bar keeps its shape at both
-ends, and `list-scroll-reset` takes the page back to the top whenever the
-page, the sort or the search changes.
+**Paging is the list's own sticky footer.** The header holds what *narrows* a
+list (search, sort, and the one button that adds to it); `pagination_footer/1`
+holds what *moves through* it. Two bare chevrons in the top right corner was
+the old arrangement, and it was wrong three ways: the control for moving
+through a list sat as far from the rows as the page allows, it never said
+which page you were on or how many there were, and because the header doesn't
+move, clicking "next" left the scroll where it was so the operator arrived
+looking at the bottom of the page they had just asked for.
+
+**Sticky, not merely in the flow** — this is the correction worth recording,
+because putting the bar at the foot of the rows and stopping there only trades
+one kind of "far away" for another. A page is 50 rows, two or three screens,
+so reaching page 3 from the top of a list would mean scrolling to the bottom
+to find a control that used to be one click away. It wears `form_footer/1`'s
+costume, from `sticky_slab_classes/0`, because it is the same object doing the
+same job: the thing the page is *for*, at the end of the thing, reachable
+without hunting. Both bars settle into place at the end of the scroll, and the
+`sticky-footer` hook undresses them into ordinary cards when the page has
+nothing to scroll.
+
+The footer states the range and the total ("Showing 51 to 100 of 435", "Page 2
+of 9"), its steps are worded like every other action (§3a), an unavailable
+step is dead rather than absent so the bar keeps its shape at both ends, and
+`list-scroll-reset` takes the page back to the top whenever the page, the sort
+or the search changes.
 
 **A page is 50 rows.** It was 10 for years, which made a 435-audiobook
 library 44 pages deep with no way to tell which one you were on.

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -262,14 +262,40 @@ reach through that box's own padding.)
 
 **Content passes behind the chrome, so the chrome is opaque and above it.**
 The header paints `bg-zinc-950`, and there is one z-index ladder for the whole
-admin, stated on `layout_header/1`: 10/20 for a row's rail and busy overlay,
-30 for the header, 40 for the drawer's scrim, 50 for the drawer, 60 for a
-modal, 70 for the lightbox. Rows matter here because `index_row` is `relative`
-with no z-index of its own, so its layers are not scoped to the card — a row
-that scrolls under a header of the same index paints straight over it. **A
-full-viewport overlay goes above the nav, not beside it**: the modal sat at 40
-for a while and rendered underneath the sidebar, because a nav that is `fixed`
-is a peer of everything now rather than a column the content sits next to.
+admin, stated once on `layout_header/1`, in tens with the gaps left in on
+purpose:
+
+| z | what |
+|---|---|
+| 10 | the clickable layer inside a card (a row's action rail) |
+| 20 | a busy scrim over a single card |
+| 30 | the sticky page footers (`sticky_slab_classes/0`) |
+| 35 | a typeahead's popup |
+| 40 | a page-wide busy scrim |
+| 50 | the page header, admin and public |
+| 60 | the drawer's scrim |
+| 70 | the side nav drawer |
+| 80 | a modal |
+| 90 | the image lightbox |
+| 100 | flash toasts |
+
+Rows matter here because `index_row` is `relative` with no z-index of its own,
+so its layers are **not** scoped to the card and compete directly with the
+page's chrome. That is what a bar with no z-index at all looks like: the
+sticky pagination footer painted above a row's card body and *underneath* the
+same row's action rail, so its controls flickered in and out of view depending
+which part of the list they crossed. **Anything pinned over the page needs a
+number, not a DOM position** — a tie falls back to document order, and page
+content always comes after the header.
+
+Two rules the renumbering was worth writing down. **A full-viewport overlay
+goes above the nav, not beside it**: the modal sat below the sidebar for a
+while, because a nav that is `fixed` is a peer of everything rather than a
+column the content sits next to. And **a scrim has to cover the control it is
+protecting the operator from** — the import form's page-wide scrim is 40
+rather than `busy_overlay/1`'s own 20 precisely so it covers the sticky Save,
+and stays under the header so the job indicator explaining the wait is still
+lit.
 
 **The header's separator is a hairline, drawn only when there is something
 above it.** `border-b border-zinc-900`, toggled by the `header-scrollspy`

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -416,6 +416,20 @@ page, the sort or the search changes.
 **A page is 50 rows.** It was 10 for years, which made a 435-audiobook
 library 44 pages deep with no way to tell which one you were on.
 
+**A form goes back where it came from, to the record it just saved.** Every
+form used to end with `push_navigate(to: ~p"/admin/books")` — the front of an
+unfiltered, default-sorted page one, whoever you were and wherever you had
+been. `AmbryWeb.Admin.ReturnTo` is the two halves of the fix: a list writes
+its state into every row link, and the form reads it back and returns there,
+naming the record so the list can scroll to it and flash it (`focus-row`).
+It anchors to the **record**, not to a scroll offset, because those are
+different answers the moment an edit changes the sort key — rename a book on
+a title-sorted list and its row moves, so the pixel the operator left from
+belongs to somebody else now. A row that is gone or off-page focuses nothing
+and they land at the top, which is the honest result. The "New" button
+deliberately carries no list state: a record that doesn't exist yet cannot be
+on the page you were filtering.
+
 **Counted where the rows are queried, from the same filters.** A total
 assembled anywhere else eventually describes a different query from the rows
 above it. The flat views make this cheap when nothing is filtering: their

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -40,7 +40,9 @@ Rules that fall out of this:
 - **No 1px container borders.** A box is a fill. If an edge must be drawn,
   it is ≥2px: a `ring-2 ring-inset` for selection, a `border-l-4` rail for
   state, a `border-l-2` indent guide. Dashed 1px borders are allowed only on
-  ghost escape hatches, where looking faint is the point.
+  ghost escape hatches, where looking faint is the point. The header's
+  scroll-spy seam is the other exception, and it is not a container edge —
+  see §3.
 - **Dashed means "drop here" or "not chosen" — never "here is a fact".**
   Dropzones and ghost hatches wear dashes; a read-only file list is a plain
   card (`<.file_list>`: mono, muted, the common directory printed once).
@@ -240,14 +242,41 @@ rather than `py-2`, and the inbox's segmented filter bar (`p-1` + `py-1.5`
 segments) lands on it too. §7 says adjacent bar controls share exact height;
 this is the number.
 
-**A sticky bar has to be told about the scroller's padding.** `#main-content`
-scrolls with `p-4`, and a sticky offset is measured from the scrollport's
-**content** box — so `bottom-0` parks a bar 16px shy of the window edge with
-the page showing through underneath. A sticky box also can't leave its
+**The document is the scroller, and the chrome is sticky.** There is no app
+shell: the body scrolls, the side nav is `fixed inset-y-0`, the page header is
+`sticky top-0`, and the content clears the nav with `lg:pl-64`. This is not a
+style preference — LiveView sets `history.scrollRestoration = "manual"` and
+then saves and restores `window.scrollY` and nothing else, so an admin whose
+scrolling happened inside `#main-content` could not restore a position on
+back, forward, or anything else. `#main-content` survives as an id and its
+`p-4`, because the hooks and the arithmetic below name it.
+
+**A sticky bar still has to be told about its containing block.** The offset
+itself is now the simple half: the viewport has no padding, so `bottom-0` puts
+a bar flush with the bottom of the window. But a sticky box can't leave its
 containing block, so at the end of the scroll that block's own bottom edge
-holds it up by the same 16px again. Both halves need saying: `-bottom-4` on
-the bar, `-mb-4` on the page's content wrapper. Measured in Chrome — 16px,
-then 80px at the bottom of the page, before the fix; 0 and 0 after.
+holds the bar up by `#main-content`'s 16px — which is what `-mb-4` on the
+page's content wrapper is for, and it is still required. (It was `-bottom-4`
+plus `-mb-4` when `#main-content` was the scrollport and the offset had to
+reach through that box's own padding.)
+
+**Content passes behind the chrome, so the chrome is opaque and above it.**
+The header paints `bg-zinc-950`, and there is one z-index ladder for the whole
+admin, stated on `layout_header/1`: 10/20 for a row's rail and busy overlay,
+30 for the header, 40 for the drawer's scrim, 50 for the drawer, 60 for a
+modal, 70 for the lightbox. Rows matter here because `index_row` is `relative`
+with no z-index of its own, so its layers are not scoped to the card — a row
+that scrolls under a header of the same index paints straight over it. **A
+full-viewport overlay goes above the nav, not beside it**: the modal sat at 40
+for a while and rendered underneath the sidebar, because a nav that is `fixed`
+is a peer of everything now rather than a column the content sits next to.
+
+**The header's separator is a hairline, drawn only when there is something
+above it.** `border-b border-zinc-900`, toggled by the `header-scrollspy`
+hook against `window.scrollY` — the same treatment as the public header, and
+the one place §1's no-1px-borders rule doesn't hold: this is not a container
+edge, it is the seam where scrolled content passes under the chrome, and an
+elevation step can't draw a seam between two things that overlap.
 
 **A grid or flex item that can hold a long string needs `min-w-0`.** Its
 automatic minimum size is the min-content width of its contents, so one

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -399,6 +399,29 @@ which is what every pre-redesign list did while writing the rule's classes.
 **64px is the row's height floor.** People rows were 48px, so they were
 visibly shorter than every other list's on the same page of the same app.
 
+**Paging lives under the last row, and it carries numbers.** The header holds
+what *narrows* a list (search, sort, and the one button that adds to it);
+`pagination_footer/1` holds what *moves through* it. Two bare chevrons in the
+top right corner was the old arrangement, and it was wrong three ways: the
+control for moving through a list sat as far from the list as the page
+allows, it never said which page you were on or how many there were, and
+because the header doesn't move, clicking "next" left the scroll where it was
+so the operator arrived looking at the bottom of the page they had just asked
+for. The footer states the range and the total ("Showing 51 to 100 of 435",
+"Page 2 of 9"), its steps are worded like every other action (§3a), an
+unavailable step is dead rather than absent so the bar keeps its shape at both
+ends, and `list-scroll-reset` takes the page back to the top whenever the
+page, the sort or the search changes.
+
+**A page is 50 rows.** It was 10 for years, which made a 435-audiobook
+library 44 pages deep with no way to tell which one you were on.
+
+**Counted where the rows are queried, from the same filters.** A total
+assembled anywhere else eventually describes a different query from the rows
+above it. The flat views make this cheap when nothing is filtering: their
+credit arrays are correlated subqueries in the target list and the planner
+drops every one of them for a bare count.
+
 ## 3b. Forms are blocks, like everything else
 
 An edit form is not a special case: it is a page of decisions, so it is a

--- a/lib/ambry/accounts.ex
+++ b/lib/ambry/accounts.ex
@@ -75,9 +75,9 @@ defmodule Ambry.Accounts do
       1
 
   """
-  @spec count_users :: integer()
-  def count_users do
-    Repo.aggregate(User, :count)
+  @spec count_users(map()) :: integer()
+  def count_users(filters \\ %{}) do
+    filters |> UserFlat.count_query() |> Repo.one()
   end
 
   @doc """

--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -169,7 +169,8 @@ defmodule Ambry.Books do
   defdelegate match_keywords(phrase), to: BookFlat, as: :keywords
 
   @doc """
-  Returns the number of books.
+  Returns the number of books, under the same filters `list_books/4` lists
+  with — so a list can say what page it is of.
 
   ## Examples
 
@@ -177,9 +178,9 @@ defmodule Ambry.Books do
       1
 
   """
-  @spec count_books :: integer()
-  def count_books do
-    Repo.aggregate(Book, :count)
+  @spec count_books(map()) :: integer()
+  def count_books(filters \\ %{}) do
+    filters |> BookFlat.count_query() |> Repo.one()
   end
 
   @doc """
@@ -495,9 +496,9 @@ defmodule Ambry.Books do
       iex> count_series()
       1
   """
-  @spec count_series :: integer()
-  def count_series do
-    Repo.aggregate(Series, :count)
+  @spec count_series(map()) :: integer()
+  def count_series(filters \\ %{}) do
+    filters |> SeriesFlat.count_query() |> Repo.one()
   end
 
   @doc """
@@ -690,11 +691,12 @@ defmodule Ambry.Books do
   end
 
   @doc """
-  Returns the number of universes.
+  Returns the number of universes, under the same filters `list_universes/4`
+  lists with.
   """
-  @spec count_universes :: integer()
-  def count_universes do
-    Repo.aggregate(Universe, :count)
+  @spec count_universes(map()) :: integer()
+  def count_universes(filters \\ %{}) do
+    filters |> UniverseFlat.count_query() |> Repo.one()
   end
 
   @doc """

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -132,6 +132,20 @@ defmodule Ambry.Inbox do
   defp newest_first(_pending_or_all), do: [desc: :inserted_at, desc: :id]
 
   @doc """
+  How many items a list would have, under the filters it lists with.
+
+  Takes the same options as `list_items/1` and ignores the paging ones, so
+  the queue's "of 355" cannot drift from what the queue is showing.
+  """
+  def count_items(opts \\ []) do
+    InboxItem
+    |> filter_by_status(opts[:status])
+    |> filter_by_path(opts[:filter])
+    |> filter_by_issue(opts[:issue])
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
   Counts items per status, for at-a-glance badges.
   """
   def count_by_status do

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -357,7 +357,8 @@ defmodule Ambry.Media do
   end
 
   @doc """
-  Returns the number of uploaded media.
+  Returns the number of recordings, under the same filters `list_media/4`
+  lists with — so a list can say what page it is of.
 
   ## Examples
 
@@ -365,9 +366,9 @@ defmodule Ambry.Media do
       1
 
   """
-  @spec count_media :: integer()
-  def count_media do
-    Repo.aggregate(Media, :count)
+  @spec count_media(map()) :: integer()
+  def count_media(filters \\ %{}) do
+    filters |> MediaFlat.count_query() |> Repo.one()
   end
 
   @doc """
@@ -920,17 +921,22 @@ defmodule Ambry.Media do
   defp recording_group_filter(query, _filters), do: query
 
   # accepts the pagination helpers' `{field, dir}` shape as well as plain
-  # keyword orders, like the flat schemas' order/2 does
-  defp recording_group_order(query, {field, dir}), do: order_by(query, [{^dir, ^field}])
-  defp recording_group_order(query, nil), do: order_by(query, asc: :name)
-  defp recording_group_order(query, order), do: order_by(query, ^order)
+  # keyword orders, like the flat schemas' order/2 does — including their
+  # `id` tiebreaker, without which two groups sharing a name have no defined
+  # order between two queries and can swap across a page boundary
+  defp recording_group_order(query, {field, dir}),
+    do: order_by(query, ^[{dir, field}, {:asc, :id}])
+
+  defp recording_group_order(query, nil), do: order_by(query, asc: :name, asc: :id)
+  defp recording_group_order(query, order), do: order_by(query, ^(order ++ [asc: :id]))
 
   @doc """
-  Returns the number of recording groups.
+  Returns the number of recording groups, under the same filters
+  `list_recording_groups/4` lists with.
   """
-  @spec count_recording_groups :: integer()
-  def count_recording_groups do
-    Repo.aggregate(RecordingGroup, :count)
+  @spec count_recording_groups(map()) :: integer()
+  def count_recording_groups(filters \\ %{}) do
+    RecordingGroup |> recording_group_filter(filters) |> Repo.aggregate(:count)
   end
 
   @doc """

--- a/lib/ambry/people.ex
+++ b/lib/ambry/people.ex
@@ -80,19 +80,21 @@ defmodule Ambry.People do
   end
 
   @doc """
-  Returns the number of people (authors & narrators).
+  How many people the library holds, and how many of them write and read.
 
-  Note that `total` will not always be `authors` + `narrators`, because people
-  are sometimes both.
+  Named for what it is rather than `count_people`, which now answers the
+  list's question — one number, under the list's filters. Note that `total`
+  will not always be `authors` + `narrators`, because people are sometimes
+  both, which is the other reason this was never a count.
 
   ## Examples
 
-      iex> count_people()
+      iex> people_summary()
       %{authors: 3, narrators: 2, total: 4}
 
   """
-  @spec count_people :: %{total: integer(), authors: integer(), narrators: integer()}
-  def count_people do
+  @spec people_summary :: %{total: integer(), authors: integer(), narrators: integer()}
+  def people_summary do
     Repo.one(
       from p in PersonFlat,
         select: %{
@@ -101,6 +103,19 @@ defmodule Ambry.People do
           narrators: count(fragment("CASE WHEN ? THEN 1 END", p.is_narrator))
         }
     )
+  end
+
+  @doc """
+  Returns the number of people, under the same filters `list_people/4` lists
+  with — so a list can say what page it is of.
+
+  A plain integer, and a different question from `people_summary/0`: that one
+  answers "what is in the library" for the overview, in three numbers that
+  deliberately don't add up (a person is often both an author and a narrator).
+  """
+  @spec count_people(map()) :: integer()
+  def count_people(filters \\ %{}) do
+    filters |> PersonFlat.count_query() |> Repo.one()
   end
 
   @doc """

--- a/lib/ambry/playback.ex
+++ b/lib/ambry/playback.ex
@@ -102,6 +102,13 @@ defmodule Ambry.Playback do
   end
 
   @doc """
+  How many playthroughs a list would have, under the filters it lists with.
+  """
+  def count_playthroughs_flat(filters) do
+    filters |> PlaythroughFlat.count_query() |> Repo.one()
+  end
+
+  @doc """
   Lists devices from the flat view with filtering, sorting, and pagination.
   """
   def list_devices_flat(offset, limit, filters, order_by) do
@@ -120,6 +127,13 @@ defmodule Ambry.Playback do
     else
       {results, false}
     end
+  end
+
+  @doc """
+  How many devices a list would have, under the filters it lists with.
+  """
+  def count_devices_flat(filters) do
+    filters |> DeviceFlat.count_query() |> Repo.one()
   end
 
   @doc """

--- a/lib/ambry/repo/flat_schema.ex
+++ b/lib/ambry/repo/flat_schema.ex
@@ -17,9 +17,48 @@ defmodule Ambry.Repo.FlatSchema do
         end)
       end
 
-      def order(query, {field, :asc}), do: from(p in query, order_by: [asc: ^field])
-      def order(query, {field, :desc}), do: from(p in query, order_by: [desc: ^field])
-      def order(query, field), do: from(p in query, order_by: ^field)
+      @doc """
+      How many rows a list would have, under the filters it is listing with.
+
+      Built from the same `filter/2` chain as the page itself, because a total
+      that disagrees with what is on screen is worse than no total at all.
+
+      Cheap when nothing is filtering: the flat views put their credit arrays
+      in the target list as correlated subqueries, and the planner drops every
+      one of them for a bare count — measured, it is a plain seq scan of the
+      base table. A *searched* count does build them, because the search reads
+      them, which makes it the same work the page query is already doing.
+      """
+      def count_query(filters \\ %{}) do
+        from r in filter(__MODULE__, filters), select: count(r.id)
+      end
+
+      # Every ordering ends in `id`, and that is not a tidiness point.
+      # Two rows with the same sort key have no defined order between two
+      # queries, and OFFSET pagination over an undefined order silently
+      # duplicates rows onto one page and skips them off another. It is
+      # certain on a boolean sort — `admin` on the users list puts every
+      # record into one of two buckets — and reachable on `inserted_at`
+      # whenever an import stamps a batch of rows inside the same second.
+      #
+      # Two tuple shapes arrive here and both are real, which is why the
+      # direction is matched literally rather than by position:
+      # `PaginationHelpers.sort_to_order/2` builds `{field, direction}`, and
+      # Ecto's own keyword shape is `{direction, field}`. Ordering the clauses
+      # this way is what tells them apart; it used to be an accident of the
+      # fallback clause accepting whatever was left.
+      def order(query, nil), do: from(r in query, order_by: [asc: :id])
+
+      def order(query, {field, :asc}), do: from(r in query, order_by: [asc: ^field, asc: :id])
+
+      def order(query, {field, :desc}), do: from(r in query, order_by: [desc: ^field, asc: :id])
+
+      def order(query, fields) when is_list(fields),
+        do: from(r in query, order_by: ^(fields ++ [asc: :id]))
+
+      def order(query, {dir, field}), do: from(r in query, order_by: ^[{dir, field}, {:asc, :id}])
+
+      def order(query, field), do: from(r in query, order_by: ^[{:asc, field}, {:asc, :id}])
     end
   end
 end

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -37,12 +37,17 @@ defmodule AmbryWeb.Admin.Components do
             a scroll position: LiveView's restoration reads and writes
             `window.scrollY` and nothing else.
 
-            `overflow-x-clip` is what's left of the `overflow-x-hidden` it used
-            to carry. `hidden` on one axis forces the other to `auto`, which
-            would quietly make this a scrollport again and re-break every
-            sticky box inside it; `clip` guards a stray wide child without
-            becoming a scroll container. --%>
-      <main id="main-content" class="overflow-x-clip p-4">
+            It carries no horizontal overflow guard, and that is deliberate.
+            `overflow-x-hidden` can't come back — `hidden` on one axis forces
+            the other to `auto`, which would quietly make this a scrollport
+            again and re-break every sticky box inside it — and `overflow-x:
+            clip` would put an untested clipping ancestor between every sticky
+            bar in the admin and the viewport it is positioned against, to
+            defend against a stray wide child that may not exist. §3's
+            `min-w-0` rule is where that defect actually gets fixed; a
+            horizontal scrollbar is the signal to go and apply it, which is
+            exactly what the old guard was suppressing. --%>
+      <main id="main-content" class="p-4">
         {render_slot(@inner_block)}
       </main>
 
@@ -246,20 +251,31 @@ defmodule AmbryWeb.Admin.Components do
   @doc """
   Where a list says how far through it you are, and moves you.
 
-  Under the last row, in the scroll flow, because that is where the operator
-  is when they want it — and because a control that never moves cannot say
-  "you have reached the end of this page", which is the whole cue for using
-  it. It carries the numbers the chevrons never had: which rows these are,
-  how many there are, and which page of how many.
+  The list's own footer, sticky, in `form_footer/1`'s costume — because it is
+  the same object doing the same job. Paging belongs to the list, so it sits
+  at the list's end rather than in a corner of the header, where two bare
+  chevrons used to sit as far from the rows as the page allows. But a page is
+  50 rows, which is two or three screens, so a bar purely *in* the flow would
+  trade one kind of "far away" for another: reaching page 3 from the top of
+  the list would mean scrolling to the bottom first, to find a control that
+  used to be one click away.
 
-  A `zinc-900` bar, so it reads as a peer of `sort_button_bar/1` at the other
-  end of the list rather than as another row.
+  Sticky answers both. It rides the bottom of the window while there are rows
+  below it, and settles into place at the end of the scroll — and the
+  sticky-footer hook takes off its shadow and rounds its bottom corners when
+  the page has nothing to scroll, so a single-page list gets an ordinary card
+  rather than a slab promising an edge that isn't there.
+
+  It carries the numbers the chevrons never had: which rows these are, how
+  many there are, and which page of how many.
   """
   def pagination_footer(assigns) do
     ~H"""
     <div
       :if={@has_prev or @has_next}
-      class="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg bg-zinc-900 px-4 py-3"
+      id="pagination"
+      phx-hook="sticky-footer"
+      class={[sticky_slab_classes(), "mt-3 -mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-3"]}
       data-role="pagination"
     >
       <%!-- "1 to 50", not "1&ndash;50": §8 keeps en dashes out of rendered
@@ -1106,6 +1122,28 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  @doc """
+  The costume a bar wears when it is pinned to the bottom of the page.
+
+  Two of them: `form_footer/1`, where a form is saved, and
+  `pagination_footer/1`, which moves through a list. Stated once so they
+  cannot drift, because they are the same object doing the same job — the
+  thing this page is *for*, at the end of the thing, reachable without
+  scrolling to find it.
+
+  `bottom-0` because a sticky box is positioned against its scrollport and the
+  viewport has no padding. (It was `-bottom-4` when `#main-content` was the
+  scrollport, reaching through that box's own `p-4`.) `-mb-4` is the other
+  half: a sticky box can't leave its containing block, so without it the
+  block's bottom edge holds the bar 16px up at the end of the scroll, with the
+  page's ground showing through underneath. A form puts that negative margin
+  on its content wrapper, since the wrapper is the containing block there; the
+  pagination bar is a direct child of `#main-content` and wears it itself.
+  """
+  def sticky_slab_classes do
+    "shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900"
+  end
+
   attr :id, :string, default: "form-footer", doc: "the sticky-footer hook needs one"
   attr :class, :any, default: nil
   attr :rest, :global
@@ -1133,12 +1171,7 @@ defmodule AmbryWeb.Admin.Components do
     <%!-- The sticky-footer hook rounds the bottom corners (and drops the
         floating shadow) whenever the page has nothing to scroll — a slab
         that never sticks is an ordinary card and dresses like one. --%>
-    <section
-      id={@id}
-      phx-hook="sticky-footer"
-      class={["shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900 p-4", @class]}
-      {@rest}
-    >
+    <section id={@id} phx-hook="sticky-footer" class={[sticky_slab_classes(), "p-4", @class]} {@rest}>
       <div class="flex flex-wrap items-center gap-2">
         {render_slot(@inner_block)}
       </div>

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -56,12 +56,12 @@ defmodule AmbryWeb.Admin.Components do
           by any [data-zoomable] magnifier (see app.js); click or Escape
           closes. phx-update="ignore": it's pure client state.
 
-          Top of the ladder on layout_header/1: it opens from inside content
-          that a modal may itself be covering. --%>
+          Near the top of the ladder on layout_header/1: it opens from inside
+          content that a modal may itself be covering. --%>
       <div
         id="image-lightbox"
         phx-update="ignore"
-        class="bg-black/85 z-[70] fixed inset-0 hidden cursor-zoom-out items-center justify-center p-8 backdrop-blur"
+        class="bg-black/85 z-[90] fixed inset-0 hidden cursor-zoom-out items-center justify-center p-8 backdrop-blur"
       >
         <img class="max-h-full max-w-full rounded-sm object-contain shadow-2xl" />
       </div>
@@ -75,26 +75,39 @@ defmodule AmbryWeb.Admin.Components do
 
   slot :inner_block, required: true
 
-  # The z-index ladder, now that content scrolls *under* the chrome instead of
-  # inside a box below it. Everything here shares the root stacking context —
-  # an `index_row` is `relative` with no z-index, so its `z-10` rail and `z-20`
-  # busy overlay are not scoped to the card, and a row that scrolled under a
-  # z-10 header would have painted straight over it (same index, later in the
-  # DOM, later wins).
+  # **The z-index ladder for the whole admin.** One list, here, because content
+  # scrolls *under* the chrome now instead of sitting in a box below it, and
+  # almost all of this shares the root stacking context: an `index_row` is
+  # `relative` with no z-index of its own, so its layers are not scoped to the
+  # card and compete directly with the page's chrome.
   #
-  #   10/20  row internals (rail, busy overlay)
-  #   30     this header
-  #   40     the drawer's scrim
-  #   50     the side nav drawer
-  #   60     a modal — it covers the viewport, and the nav is part of what it
-  #          is covering, so it sits above the nav rather than beside it
-  #   70     the image lightbox, which opens from inside a modal's content
+  #   10   the clickable layer inside a card (a row's action rail)
+  #   20   a busy scrim over a single card
+  #   30   the sticky page footers — `sticky_slab_classes/0`
+  #   35   a typeahead's popup: clear of the sticky footer it may open over,
+  #        under the scrims that mean the form is not yours right now
+  #   40   a page-wide busy scrim (the import form's), which has to cover the
+  #        Save button or it is only advisory
+  #   50   this header, and the public one
+  #   60   the drawer's scrim
+  #   70   the side nav drawer
+  #   80   a modal — it covers the viewport, and the nav is part of what it is
+  #        covering, so it sits above the nav rather than beside it
+  #   90   the image lightbox, which opens from inside a modal's content
+  #   100  flash toasts, which are the one thing that outranks everything
+  #
+  # Gaps in the tens are deliberate: the ladder has been renumbered twice in
+  # one branch already, and each of those was a value that had nowhere to go.
+  #
+  # A tie is not a tie — equal z-index falls back to DOM order, and page
+  # content always comes after the header. So anything that must stay above
+  # the page needs a strictly greater number, not an equal one.
   defp layout_header(assigns) do
     ~H"""
     <header
       id="nav-header"
       phx-hook="header-scrollspy"
-      class="sticky top-0 z-30 space-y-4 border-zinc-900 bg-zinc-950 p-4"
+      class="sticky top-0 z-50 space-y-4 border-zinc-900 bg-zinc-950 p-4"
     >
       <div class="flex items-center gap-3">
         <span class="cursor-pointer lg:hidden" phx-click={open_sidebar()}>
@@ -1141,7 +1154,7 @@ defmodule AmbryWeb.Admin.Components do
   pagination bar is a direct child of `#main-content` and wears it itself.
   """
   def sticky_slab_classes do
-    "shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900"
+    "shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 z-30 rounded-t-lg bg-zinc-900"
   end
 
   attr :id, :string, default: "form-footer", doc: "the sticky-footer hook needs one"

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -132,13 +132,19 @@ defmodule AmbryWeb.Admin.Components do
   attr :search_form, Form, default: nil
   attr :new_path, :string, default: nil
   attr :new_text, :string, default: "New"
-  attr :has_next, :boolean, default: false
-  attr :has_prev, :boolean, default: false
-  attr :next_page_path, :string, default: nil
-  attr :prev_page_path, :string, default: nil
 
   slot :inner_block
 
+  @doc """
+  The header's controls: how you narrow a list, and how you add to it.
+
+  Paging used to live here too, as two bare chevrons in the top right corner.
+  That put the control for moving through a list as far from the list as the
+  page allows, gave no page number and no total, and — because the header
+  doesn't move — meant a "next page" click left the scroll where it was, so
+  the operator arrived looking at the *bottom* of the page they just asked
+  for. It is `pagination_footer/1` now, under the last row.
+  """
   def list_controls(assigns) do
     ~H"""
     <div class="flex items-end gap-4">
@@ -153,12 +159,6 @@ defmodule AmbryWeb.Admin.Components do
         <.button navigate={@new_path}>
           <.icon name="fa-plus" class="mr-2 h-4 w-4 text-current" />{@new_text}
         </.button>
-      </div>
-      <div :if={@prev_page_path}>
-        <.pagination_chevron active={@has_prev} name="fa-chevron-left" to={@prev_page_path} />
-      </div>
-      <div :if={@next_page_path}>
-        <.pagination_chevron active={@has_next} name="fa-chevron-right" to={@next_page_path} />
       </div>
     </div>
     """
@@ -237,21 +237,87 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
-  attr :active, :boolean, required: true
-  attr :name, :string, required: true
-  attr :to, :string, required: true
+  attr :info, :map, required: true, doc: "from `PaginationHelpers.page_info/3`"
+  attr :has_next, :boolean, required: true
+  attr :has_prev, :boolean, required: true
+  attr :next_page_path, :string, required: true
+  attr :prev_page_path, :string, required: true
 
-  defp pagination_chevron(assigns) do
+  @doc """
+  Where a list says how far through it you are, and moves you.
+
+  Under the last row, in the scroll flow, because that is where the operator
+  is when they want it — and because a control that never moves cannot say
+  "you have reached the end of this page", which is the whole cue for using
+  it. It carries the numbers the chevrons never had: which rows these are,
+  how many there are, and which page of how many.
+
+  A `zinc-900` bar, so it reads as a peer of `sort_button_bar/1` at the other
+  end of the list rather than as another row.
+  """
+  def pagination_footer(assigns) do
+    ~H"""
+    <div
+      :if={@has_prev or @has_next}
+      class="mt-3 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-lg bg-zinc-900 px-4 py-3"
+      data-role="pagination"
+    >
+      <%!-- "1 to 50", not "1&ndash;50": §8 keeps en dashes out of rendered
+            text and joins with words instead. --%>
+      <p class="text-sm text-zinc-400" data-role="pagination-range">
+        <%= if @info.first do %>
+          Showing {@info.first} to {@info.last}{if @info.total, do: " of #{@info.total}"}
+        <% else %>
+          Nothing on this page
+        <% end %>
+      </p>
+
+      <div class="flex items-center gap-2">
+        <.pagination_step active={@has_prev} to={@prev_page_path} icon="fa-chevron-left">
+          Previous
+        </.pagination_step>
+
+        <%!-- Tabular figures, so the number doesn't jitter the buttons
+              sideways as the operator pages through. --%>
+        <p class="px-1 text-sm tabular-nums text-zinc-400" data-role="pagination-page">
+          Page {@info.page}{if @info.pages, do: " of #{@info.pages}"}
+        </p>
+
+        <.pagination_step active={@has_next} to={@next_page_path} icon="fa-chevron-right" trailing>
+          Next
+        </.pagination_step>
+      </div>
+    </div>
+    """
+  end
+
+  attr :active, :boolean, required: true
+  attr :to, :string, required: true
+  attr :icon, :string, required: true
+  attr :trailing, :boolean, default: false, doc: "put the glyph after the word"
+  slot :inner_block, required: true
+
+  # Worded, like every other action in this admin (§3a): two bare chevrons in
+  # a corner were the only control on a list page that made you know what a
+  # glyph meant. An unavailable step is present and dead rather than absent,
+  # so the bar keeps its shape at both ends of the list.
+  defp pagination_step(assigns) do
     ~H"""
     <%= if @active do %>
-      <.link patch={@to} class="cursor-pointer">
-        <.icon
-          name={@name}
-          class="h-5 w-5 text-zinc-500 hover:text-zinc-100"
-        />
+      <.link
+        patch={@to}
+        class="flex items-center gap-2 rounded-lg bg-zinc-800 px-3 py-1.5 text-sm font-semibold text-zinc-100 hover:bg-zinc-700"
+      >
+        <.icon :if={!@trailing} name={@icon} class="h-3 w-3 text-current" />
+        {render_slot(@inner_block)}
+        <.icon :if={@trailing} name={@icon} class="h-3 w-3 text-current" />
       </.link>
     <% else %>
-      <.icon name={@name} class="h-5 w-5 text-zinc-900" />
+      <span class="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-semibold text-zinc-600">
+        <.icon :if={!@trailing} name={@icon} class="h-3 w-3 text-current" />
+        {render_slot(@inner_block)}
+        <.icon :if={@trailing} name={@icon} class="h-3 w-3 text-current" />
+      </span>
     <% end %>
     """
   end
@@ -265,29 +331,39 @@ defmodule AmbryWeb.Admin.Components do
   hand-built its own anatomy inside one anonymous slot — and ten of them
   drifted apart doing it.
   """
+  attr :id, :string, default: "list", doc: "the list-scroll-reset hook needs one"
   attr :rows, :list, required: true
   attr :filter, :string, default: nil
+
+  attr :list_state, :any,
+    default: nil,
+    doc: "what identifies this view (page, filter, sort). A change scrolls back to the top."
 
   slot :empty
   slot :row, required: true
 
   def flex_table(assigns) do
     ~H"""
-    <%= if @rows == [] do %>
-      <p :if={@empty} class="text-lg font-semibold" data-role="empty-message">
-        <%= if @filter do %>
-          No results for "{@filter}"
-        <% else %>
-          {render_slot(@empty)}
-        <% end %>
-      </p>
-    <% else %>
-      <%!-- Rows are separate raised cards on the ground, not one bordered slab
-            sliced by hairline dividers — elevation and gaps do the separating. --%>
-      <div class="space-y-3">
-        <div :for={row <- @rows}>{render_slot(@row, row)}</div>
-      </div>
-    <% end %>
+    <%!-- The hook lives out here rather than on the rows, so it survives a
+          filter that empties the list and is still mounted when the next one
+          fills it again. --%>
+    <div id={@id} phx-hook="list-scroll-reset" data-list-state={inspect(@list_state)}>
+      <%= if @rows == [] do %>
+        <p :if={@empty} class="text-lg font-semibold" data-role="empty-message">
+          <%= if @filter do %>
+            No results for "{@filter}"
+          <% else %>
+            {render_slot(@empty)}
+          <% end %>
+        </p>
+      <% else %>
+        <%!-- Rows are separate raised cards on the ground, not one bordered slab
+              sliced by hairline dividers — elevation and gaps do the separating. --%>
+        <div class="space-y-3">
+          <div :for={row <- @rows}>{render_slot(@row, row)}</div>
+        </div>
+      <% end %>
+    </div>
     """
   end
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -25,25 +25,38 @@ defmodule AmbryWeb.Admin.Components do
 
   def layout(assigns) do
     ~H"""
-    <div class="relative flex h-screen min-w-0 grow flex-col">
+    <div class="min-w-0">
       <.layout_header user={@user} title={@title} socket={@socket}>
         {render_slot(@subheader)}
       </.layout_header>
 
-      <main class="flex grow flex-col overflow-hidden">
-        <div id="main-content" class="grow overflow-y-auto overflow-x-hidden p-4" phx-hook="header-scrollspy">
-          {render_slot(@inner_block)}
-        </div>
+      <%!-- `#main-content` keeps its id and its `p-4` — the sticky-footer hook
+            and §3's sticky-bar arithmetic both name it — but it is no longer a
+            scrollport. It was `overflow-y-auto` inside an `h-screen` shell,
+            and that one declaration is why nothing in the admin could remember
+            a scroll position: LiveView's restoration reads and writes
+            `window.scrollY` and nothing else.
+
+            `overflow-x-clip` is what's left of the `overflow-x-hidden` it used
+            to carry. `hidden` on one axis forces the other to `auto`, which
+            would quietly make this a scrollport again and re-break every
+            sticky box inside it; `clip` guards a stray wide child without
+            becoming a scroll container. --%>
+      <main id="main-content" class="overflow-x-clip p-4">
+        {render_slot(@inner_block)}
       </main>
 
       <%!-- The image lightbox — tiny previews and chips are for telling
           records apart, and sometimes that takes the full-size art. Opened
           by any [data-zoomable] magnifier (see app.js); click or Escape
-          closes. phx-update="ignore": it's pure client state. --%>
+          closes. phx-update="ignore": it's pure client state.
+
+          Top of the ladder on layout_header/1: it opens from inside content
+          that a modal may itself be covering. --%>
       <div
         id="image-lightbox"
         phx-update="ignore"
-        class="bg-black/85 fixed inset-0 z-50 hidden cursor-zoom-out items-center justify-center p-8 backdrop-blur"
+        class="bg-black/85 z-[70] fixed inset-0 hidden cursor-zoom-out items-center justify-center p-8 backdrop-blur"
       >
         <img class="max-h-full max-w-full rounded-sm object-contain shadow-2xl" />
       </div>
@@ -57,9 +70,27 @@ defmodule AmbryWeb.Admin.Components do
 
   slot :inner_block, required: true
 
+  # The z-index ladder, now that content scrolls *under* the chrome instead of
+  # inside a box below it. Everything here shares the root stacking context —
+  # an `index_row` is `relative` with no z-index, so its `z-10` rail and `z-20`
+  # busy overlay are not scoped to the card, and a row that scrolled under a
+  # z-10 header would have painted straight over it (same index, later in the
+  # DOM, later wins).
+  #
+  #   10/20  row internals (rail, busy overlay)
+  #   30     this header
+  #   40     the drawer's scrim
+  #   50     the side nav drawer
+  #   60     a modal — it covers the viewport, and the nav is part of what it
+  #          is covering, so it sits above the nav rather than beside it
+  #   70     the image lightbox, which opens from inside a modal's content
   defp layout_header(assigns) do
     ~H"""
-    <header id="nav-header" class="space-y-4 p-4">
+    <header
+      id="nav-header"
+      phx-hook="header-scrollspy"
+      class="sticky top-0 z-30 space-y-4 border-zinc-900 bg-zinc-950 p-4"
+    >
       <div class="flex items-center gap-3">
         <span class="cursor-pointer lg:hidden" phx-click={open_sidebar()}>
           <.icon name="fa-bars" class="h-6 w-6 text-current lg:h-7 lg:w-7" />
@@ -999,9 +1030,14 @@ defmodule AmbryWeb.Admin.Components do
   ground after the last card. The chapters form is the argument — 47 rows
   long, with the Save at the bottom of the scroll.
 
-  §3's sticky-bar rule applies: the scroller pads `p-4`, so the slab wears
-  `-bottom-4` and the page's content wrapper must wear `-mb-4`, or the bar
-  parks 16px shy of the window with the page showing through underneath.
+  §3's sticky-bar rule applies, and the document being the scroller is what
+  sets the offset: a sticky box is positioned against its scrollport, and the
+  viewport has no padding, so `bottom-0` puts the slab flush with the bottom
+  of the window. (It was `-bottom-4` when `#main-content` was the scrollport,
+  reaching through that box's own `p-4`.) The page's content wrapper still
+  wears `-mb-4`, for the other half: a sticky box can't leave its containing
+  block, so without it the wrapper's bottom edge holds the bar 16px up at the
+  end of the scroll.
   """
   def form_footer(assigns) do
     ~H"""
@@ -1011,7 +1047,7 @@ defmodule AmbryWeb.Admin.Components do
     <section
       id={@id}
       phx-hook="sticky-footer"
-      class={["shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky -bottom-4 rounded-t-lg bg-zinc-900 p-4", @class]}
+      class={["shadow-[0_-12px_32px_rgba(0,0,0,0.55)] sticky bottom-0 rounded-t-lg bg-zinc-900 p-4", @class]}
       {@rest}
     >
       <div class="flex flex-wrap items-center gap-2">

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -339,6 +339,10 @@ defmodule AmbryWeb.Admin.Components do
     default: nil,
     doc: "what identifies this view (page, filter, sort). A change scrolls back to the top."
 
+  attr :focus, :any,
+    default: nil,
+    doc: "a record to scroll to and light up, named by a form the operator is returning from"
+
   slot :empty
   slot :row, required: true
 
@@ -348,6 +352,9 @@ defmodule AmbryWeb.Admin.Components do
           filter that empties the list and is still mounted when the next one
           fills it again. --%>
     <div id={@id} phx-hook="list-scroll-reset" data-list-state={inspect(@list_state)}>
+      <%!-- A second hook needs a second element; they are different jobs on
+            the same list and the scroll reset must not fire for a focus. --%>
+      <div id={"#{@id}-focus"} phx-hook="focus-row" data-focus={@focus} class="hidden" />
       <%= if @rows == [] do %>
         <p :if={@empty} class="text-lg font-semibold" data-role="empty-message">
           <%= if @filter do %>
@@ -410,6 +417,11 @@ defmodule AmbryWeb.Admin.Components do
   ("Origin", not "Import record"). One slot entry per verb is what keeps them
   all in one costume.
   """
+  attr :record_id, :any,
+    default: nil,
+    doc:
+      "the row's record, so a form can send the operator back to it (see `AmbryWeb.Admin.ReturnTo`)"
+
   attr :navigate, :string, default: nil, doc: "where the whole card goes; omit for a dead row"
   attr :patch, :string, default: nil, doc: "same, when the destination is a patch (a modal)"
 
@@ -449,6 +461,7 @@ defmodule AmbryWeb.Admin.Components do
     <%!-- flex-wrap below sm lets the right rail drop to a full-width bottom
           line instead of squeezing the content column on phones. --%>
     <div
+      id={@record_id && "row-#{@record_id}"}
       class={[
         "relative flex flex-wrap items-center gap-x-4 gap-y-2 rounded-lg bg-zinc-900 p-4 sm:flex-nowrap",
         (@navigate || @patch) && "hover:bg-zinc-800/50",

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -14,7 +14,7 @@ defmodule AmbryWeb.Admin.Layouts do
     ~H"""
     <%!-- Scrim behind the drawer on small screens — without it the drawer
           floats over full-brightness content and doesn't read as a layer. --%>
-    <div id="side-bar-scrim" class="bg-black/40 fixed inset-0 z-40 hidden lg:hidden" aria-hidden="true" />
+    <div id="side-bar-scrim" class="bg-black/40 z-[60] fixed inset-0 hidden lg:hidden" aria-hidden="true" />
     <%!-- `fixed`, not a flex child of an `h-screen` shell: the nav is the one
           thing on the page that genuinely doesn't scroll, and saying so here
           is what lets the document scroll everywhere else. `inset-y-0` is a
@@ -22,7 +22,7 @@ defmodule AmbryWeb.Admin.Layouts do
           custom property. --%>
     <nav
       id="side-bar"
-      class="fixed inset-y-0 left-0 z-50 flex w-64 -translate-x-full transform flex-col bg-zinc-900 opacity-0 duration-100 ease-out lg:transform-none lg:opacity-100"
+      class="z-[70] fixed inset-y-0 left-0 flex w-64 -translate-x-full transform flex-col bg-zinc-900 opacity-0 duration-100 ease-out lg:transform-none lg:opacity-100"
       phx-click-away={Components.close_sidebar()}
       phx-window-keydown={Components.close_sidebar()}
       phx-key="escape"

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -14,10 +14,15 @@ defmodule AmbryWeb.Admin.Layouts do
     ~H"""
     <%!-- Scrim behind the drawer on small screens — without it the drawer
           floats over full-brightness content and doesn't read as a layer. --%>
-    <div id="side-bar-scrim" class="z-[9] bg-black/40 fixed inset-0 hidden lg:hidden" aria-hidden="true" />
+    <div id="side-bar-scrim" class="bg-black/40 fixed inset-0 z-40 hidden lg:hidden" aria-hidden="true" />
+    <%!-- `fixed`, not a flex child of an `h-screen` shell: the nav is the one
+          thing on the page that genuinely doesn't scroll, and saying so here
+          is what lets the document scroll everywhere else. `inset-y-0` is a
+          real viewport height now that `h-screen` is no longer a JS-measured
+          custom property. --%>
     <nav
       id="side-bar"
-      class="absolute inset-0 z-10 h-screen w-64 shrink-0 -translate-x-full transform bg-zinc-900 opacity-0 duration-100 ease-out lg:relative lg:transform-none lg:opacity-100"
+      class="fixed inset-y-0 left-0 z-50 flex w-64 -translate-x-full transform flex-col bg-zinc-900 opacity-0 duration-100 ease-out lg:transform-none lg:opacity-100"
       phx-click-away={Components.close_sidebar()}
       phx-window-keydown={Components.close_sidebar()}
       phx-key="escape"
@@ -31,94 +36,101 @@ defmodule AmbryWeb.Admin.Layouts do
           <.title class="h-6 lg:h-7" />
         </.link>
       </div>
-      <%!-- Grouped by how the admin is actually used: the daily intake loop,
-            the catalog it feeds, and the once-a-quarter machinery — instead
-            of twelve peers in one flat list. --%>
-      <div class="py-3">
-        <.link navigate={~p"/admin"} class={nav_class(@active_path == "/admin")}>
-          <.icon name="fa-binoculars" class="h-5 w-5 text-current" />
-          <p>Overview</p>
-        </.link>
+      <%!-- The links scroll, the logo and the way out don't. The nav is
+            ~720px of items, so on a short laptop window it used to be
+            silently clipped by the shell's `overflow-hidden` — and the way
+            out was an `absolute bottom-0` block sitting on top of whatever
+            it overlapped. --%>
+      <div class="grow overflow-y-auto">
+        <%!-- Grouped by how the admin is actually used: the daily intake loop,
+              the catalog it feeds, and the once-a-quarter machinery — instead
+              of twelve peers in one flat list. --%>
+        <div class="py-3">
+          <.link navigate={~p"/admin"} class={nav_class(@active_path == "/admin")}>
+            <.icon name="fa-binoculars" class="h-5 w-5 text-current" />
+            <p>Overview</p>
+          </.link>
 
-        <p class={group_class()}>Intake</p>
-        <.link navigate={~p"/admin/inbox"} class={nav_class(@active_path =~ "/admin/inbox")}>
-          <.icon name="fa-inbox" class="h-5 w-5 text-current" />
-          <p>Inbox</p>
-          <%!-- The one count in the nav, because the inbox is the one item
+          <p class={group_class()}>Intake</p>
+          <.link navigate={~p"/admin/inbox"} class={nav_class(@active_path =~ "/admin/inbox")}>
+            <.icon name="fa-inbox" class="h-5 w-5 text-current" />
+            <p>Inbox</p>
+            <%!-- The one count in the nav, because the inbox is the one item
                 that is a queue. Amber only while there is something in it;
                 a zero would just be a badge that never goes away. --%>
-          <span
-            :if={@inbox_pending > 0}
-            class="bg-amber-400/15 ml-auto rounded-full px-1.5 text-xs font-bold tabular-nums text-amber-300"
-            data-role="inbox-pending-badge"
+            <span
+              :if={@inbox_pending > 0}
+              class="bg-amber-400/15 ml-auto rounded-full px-1.5 text-xs font-bold tabular-nums text-amber-300"
+              data-role="inbox-pending-badge"
+            >
+              {@inbox_pending}
+            </span>
+          </.link>
+          <.link navigate={~p"/admin/locations"} class={nav_class(@active_path =~ "/admin/locations")}>
+            <.icon name="fa-folder-tree" class="h-5 w-5 text-current" />
+            <p>Locations</p>
+          </.link>
+
+          <p class={group_class()}>Library</p>
+          <.link navigate={~p"/admin/books"} class={nav_class(@active_path =~ "/admin/books")}>
+            <.icon name="fa-book" class="h-5 w-5 text-current" />
+            <p>Books</p>
+          </.link>
+          <.link navigate={~p"/admin/people"} class={nav_class(@active_path =~ "/admin/people")}>
+            <.icon name="fa-user-group" class="h-5 w-5 text-current" />
+            <p>Authors & Narrators</p>
+          </.link>
+          <.link navigate={~p"/admin/series"} class={nav_class(@active_path =~ "/admin/series")}>
+            <.icon name="fa-book-journal-whills" class="h-5 w-5 text-current" />
+            <p>Series</p>
+          </.link>
+          <.link navigate={~p"/admin/sets"} class={nav_class(@active_path =~ "/admin/sets")}>
+            <.icon name="fa-layer-group" class="h-5 w-5 text-current" />
+            <p>Sets</p>
+          </.link>
+          <.link navigate={~p"/admin/universes"} class={nav_class(@active_path =~ "/admin/universes")}>
+            <.icon name="fa-globe" class="h-5 w-5 text-current" />
+            <p>Universes</p>
+          </.link>
+          <.link navigate={~p"/admin/audiobooks"} class={nav_class(@active_path =~ "/admin/audiobooks")}>
+            <.icon name="fa-file-audio" class="h-5 w-5 text-current" />
+            <p>Audiobooks</p>
+          </.link>
+
+          <p class={group_class()}>System</p>
+          <.link navigate={~p"/admin/audit"} class={nav_class(@active_path =~ "/admin/audit")}>
+            <.icon name="fa-file-waveform" class="h-5 w-5 text-current" />
+            <p>File Audit</p>
+          </.link>
+          <.link
+            navigate={~p"/admin/metadata-providers"}
+            class={nav_class(@active_path =~ "/admin/metadata-providers")}
           >
-            {@inbox_pending}
-          </span>
-        </.link>
-        <.link navigate={~p"/admin/locations"} class={nav_class(@active_path =~ "/admin/locations")}>
-          <.icon name="fa-folder-tree" class="h-5 w-5 text-current" />
-          <p>Locations</p>
-        </.link>
-
-        <p class={group_class()}>Library</p>
-        <.link navigate={~p"/admin/books"} class={nav_class(@active_path =~ "/admin/books")}>
-          <.icon name="fa-book" class="h-5 w-5 text-current" />
-          <p>Books</p>
-        </.link>
-        <.link navigate={~p"/admin/people"} class={nav_class(@active_path =~ "/admin/people")}>
-          <.icon name="fa-user-group" class="h-5 w-5 text-current" />
-          <p>Authors & Narrators</p>
-        </.link>
-        <.link navigate={~p"/admin/series"} class={nav_class(@active_path =~ "/admin/series")}>
-          <.icon name="fa-book-journal-whills" class="h-5 w-5 text-current" />
-          <p>Series</p>
-        </.link>
-        <.link navigate={~p"/admin/sets"} class={nav_class(@active_path =~ "/admin/sets")}>
-          <.icon name="fa-layer-group" class="h-5 w-5 text-current" />
-          <p>Sets</p>
-        </.link>
-        <.link navigate={~p"/admin/universes"} class={nav_class(@active_path =~ "/admin/universes")}>
-          <.icon name="fa-globe" class="h-5 w-5 text-current" />
-          <p>Universes</p>
-        </.link>
-        <.link navigate={~p"/admin/audiobooks"} class={nav_class(@active_path =~ "/admin/audiobooks")}>
-          <.icon name="fa-file-audio" class="h-5 w-5 text-current" />
-          <p>Audiobooks</p>
-        </.link>
-
-        <p class={group_class()}>System</p>
-        <.link navigate={~p"/admin/audit"} class={nav_class(@active_path =~ "/admin/audit")}>
-          <.icon name="fa-file-waveform" class="h-5 w-5 text-current" />
-          <p>File Audit</p>
-        </.link>
-        <.link
-          navigate={~p"/admin/metadata-providers"}
-          class={nav_class(@active_path =~ "/admin/metadata-providers")}
-        >
-          <.icon name="fa-screwdriver-wrench" class="h-5 w-5 text-current" />
-          <p>Metadata Providers</p>
-        </.link>
-        <.link navigate={~p"/admin/settings"} class={nav_class(@active_path =~ "/admin/settings")}>
-          <.icon name="fa-sliders" class="h-5 w-5 text-current" />
-          <p>Settings</p>
-        </.link>
-        <.link navigate={~p"/admin/users"} class={nav_class(@active_path =~ "/admin/users")}>
-          <.icon name="fa-users-gear" class="h-5 w-5 text-current" />
-          <p>Manage Users</p>
-        </.link>
+            <.icon name="fa-screwdriver-wrench" class="h-5 w-5 text-current" />
+            <p>Metadata Providers</p>
+          </.link>
+          <.link navigate={~p"/admin/settings"} class={nav_class(@active_path =~ "/admin/settings")}>
+            <.icon name="fa-sliders" class="h-5 w-5 text-current" />
+            <p>Settings</p>
+          </.link>
+          <.link navigate={~p"/admin/users"} class={nav_class(@active_path =~ "/admin/users")}>
+            <.icon name="fa-users-gear" class="h-5 w-5 text-current" />
+            <p>Manage Users</p>
+          </.link>
+        </div>
+        <div class="py-3">
+          <%!-- Phoenix's own dashboard, like Oban's, is a different application
+                wearing the same auth. Sending the operator there in the same tab
+                costs them whatever they were on; the icon is what says so before
+                they click. --%>
+          <.link href={~p"/admin/dashboard"} target="_blank" rel="noopener" class={nav_class()}>
+            <.icon name="fa-brands-phoenix-framework" class="h-5 w-5 text-current" />
+            <p>Phoenix Dashboard</p>
+            <.icon name="fa-arrow-up-right-from-square" class="ml-auto h-3 w-3 text-current" />
+          </.link>
+        </div>
       </div>
-      <div class="py-3">
-        <%!-- Phoenix's own dashboard, like Oban's, is a different application
-              wearing the same auth. Sending the operator there in the same tab
-              costs them whatever they were on; the icon is what says so before
-              they click. --%>
-        <.link href={~p"/admin/dashboard"} target="_blank" rel="noopener" class={nav_class()}>
-          <.icon name="fa-brands-phoenix-framework" class="h-5 w-5 text-current" />
-          <p>Phoenix Dashboard</p>
-          <.icon name="fa-arrow-up-right-from-square" class="ml-auto h-3 w-3 text-current" />
-        </.link>
-      </div>
-      <div class="absolute bottom-0 w-full py-3">
+      <div class="flex-none py-3">
         <.link navigate={~p"/"} class={nav_class()}>
           <.icon name="fa-arrow-right-from-bracket" class="scale-[-1] h-5 w-5 text-current" />
           <p>Exit Admin</p>

--- a/lib/ambry_web/components/admin/layouts/app.html.heex
+++ b/lib/ambry_web/components/admin/layouts/app.html.heex
@@ -1,7 +1,11 @@
 <.flash_group flash={@flash} />
 
-<div class="flex h-screen overflow-hidden">
-  <.side_nav active_path={@admin_nav_active_path} inbox_pending={@admin_inbox_pending} />
+<.side_nav active_path={@admin_nav_active_path} inbox_pending={@admin_inbox_pending} />
 
+<%!-- The nav is `fixed`, so it is out of flow and the content has to be told
+      to clear it. It used to be a flex row inside an `h-screen` shell, which
+      is the other way to keep a sidebar still — and it cost the whole admin
+      its document scroll. --%>
+<div class="lg:pl-64">
   {@inner_content}
 </div>

--- a/lib/ambry_web/components/admin/layouts/root.html.heex
+++ b/lib/ambry_web/components/admin/layouts/root.html.heex
@@ -5,7 +5,7 @@
 <html lang="en" style="scrollbar-gutter: stable; color-scheme: dark;">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <link rel="icon" type="image/svg+xml" href={~p"/favicon.svg"} />
     <link rel="icon" type="image/png" href={~p"/favicon.png"} sizes="16x16" />
@@ -17,33 +17,17 @@
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
-    <script type="text/javascript">
-      // fix mobile browser viewport height shenanigans.
-      // https://www.markusantonwolf.com/blog/solution-to-the-mobile-viewport-height-issue-with-tailwind-css/
-      // see tailwind.config.js for other half
-
-      function setViewHeight() {
-        const vh = window.innerHeight * 0.01
-        document.documentElement.style.setProperty('--vh', `${vh}px`)
-      }
-
-      setViewHeight()
-
-      window.addEventListener('resize', () => {
-        this.setViewHeight()
-      })
-
-      // end viewport fix
-    </script>
   </head>
   <%!-- zinc-950 ground, not black: pure black under 1px lines is what made
         borders look harsh and "mushy" on high-DPI — the new admin system
         separates surfaces by elevation (bg contrast), not hairlines. --%>
+  <%!-- No app-shell wrapper: the document is the scroller. An `h-screen`
+        shell with an `overflow-hidden` child was what made `#main-content`
+        the scrollport, and LiveView only ever saves and restores
+        `window.scrollY` (it sets `history.scrollRestoration = "manual"`, so
+        the browser won't do it either) — which meant nothing in the admin
+        could remember where you were. --%>
   <body class="bg-zinc-950 text-zinc-300 antialiased selection:bg-brand-dark selection:text-black">
-    <div class="flex h-screen flex-col">
-      <div class="grow overflow-hidden">
-        {@inner_content}
-      </div>
-    </div>
+    {@inner_content}
   </body>
 </html>

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -75,12 +75,17 @@ defmodule AmbryWeb.CoreComponents do
 
   def modal(assigns) do
     ~H"""
+    <%!-- Above the admin's side nav (z-50), not below it: this covers the whole
+          viewport, and the nav is one of the things it is covering. The wrapper
+          is `relative` with a z-index, so it is a stacking context and the one
+          number here is what the whole modal is worth. See the ladder on
+          `AmbryWeb.Admin.Components.layout_header/1`. --%>
     <div
       id={@id}
       phx-mounted={@show && show_modal(@id)}
       phx-remove={hide_modal(@id)}
       data-cancel={JS.exec(@on_cancel, "phx-remove")}
-      class="relative z-40 hidden"
+      class="z-[60] relative hidden"
     >
       <div
         id={"#{@id}-bg"}

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -75,7 +75,7 @@ defmodule AmbryWeb.CoreComponents do
 
   def modal(assigns) do
     ~H"""
-    <%!-- Above the admin's side nav (z-50), not below it: this covers the whole
+    <%!-- Above the admin's side nav, not below it: this covers the whole
           viewport, and the nav is one of the things it is covering. The wrapper
           is `relative` with a z-index, so it is a stacking context and the one
           number here is what the whole modal is worth. See the ladder on
@@ -85,7 +85,7 @@ defmodule AmbryWeb.CoreComponents do
       phx-mounted={@show && show_modal(@id)}
       phx-remove={hide_modal(@id)}
       data-cancel={JS.exec(@on_cancel, "phx-remove")}
-      class="z-[60] relative hidden"
+      class="z-[80] relative hidden"
     >
       <div
         id={"#{@id}-bg"}
@@ -228,7 +228,7 @@ defmodule AmbryWeb.CoreComponents do
     ~H"""
     <div
       id={@id}
-      class="pointer-events-none fixed top-4 left-1/2 z-50 flex w-full max-w-md -translate-x-1/2 flex-col items-center gap-2 px-4"
+      class="z-[100] pointer-events-none fixed top-4 left-1/2 flex w-full max-w-md -translate-x-1/2 flex-col items-center gap-2 px-4"
     >
       <.flash kind={:info} flash={@flash} dismiss_after={@info_dismiss_after} />
       <.flash kind={:error} flash={@flash} dismiss_after={@error_dismiss_after} />

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -157,11 +157,15 @@ defmodule AmbryWeb.Components.EntityResolver do
           are not the same width, so the input's corners stay visible either
           side of the seam, and squaring them removed a curve that was doing
           no harm to close a join nobody could see. --%>
+      <%!-- `z-[35]` is a rung on the ladder in
+            `AmbryWeb.Admin.Components.layout_header/1`: clear of the sticky
+            footer this may open over near the bottom of a form, under the
+            scrims that mean the form is not the operator's right now. --%>
       <ul
         :if={@open}
         id={"#{@id}-list"}
         role="listbox"
-        class="min-w-48 absolute z-50 max-h-64 w-full overflow-auto rounded-b-md bg-zinc-800 text-sm shadow-xl"
+        class="min-w-48 z-[35] absolute max-h-64 w-full overflow-auto rounded-b-md bg-zinc-800 text-sm shadow-xl"
       >
         <%!-- The held record is marked, not painted. Being first in the list
             is most of the signal already, and the input two pixels above it

--- a/lib/ambry_web/components/layouts.ex
+++ b/lib/ambry_web/components/layouts.ex
@@ -31,7 +31,11 @@ defmodule AmbryWeb.Layouts do
 
   def nav_header(assigns) do
     ~H"""
-    <header id="nav-header" class="border-zinc-900">
+    <%!-- Sticky rather than a fixed row in an `h-screen` shell: same result —
+          the header stays put while the page moves under it — without taking
+          the scroll off the document. `bg-black` matches the body, because
+          content now passes behind it. --%>
+    <header id="nav-header" phx-hook="header-scrollspy" class="sticky top-0 z-30 border-zinc-900 bg-black">
       <div class="flex p-4 text-zinc-500">
         <div class="flex-1">
           <.link navigate={~p"/"} class="flex">

--- a/lib/ambry_web/components/layouts.ex
+++ b/lib/ambry_web/components/layouts.ex
@@ -35,7 +35,7 @@ defmodule AmbryWeb.Layouts do
           the header stays put while the page moves under it — without taking
           the scroll off the document. `bg-black` matches the body, because
           content now passes behind it. --%>
-    <header id="nav-header" phx-hook="header-scrollspy" class="sticky top-0 z-30 border-zinc-900 bg-black">
+    <header id="nav-header" phx-hook="header-scrollspy" class="sticky top-0 z-50 border-zinc-900 bg-black">
       <div class="flex p-4 text-zinc-500">
         <div class="flex-1">
           <.link navigate={~p"/"} class="flex">

--- a/lib/ambry_web/components/layouts/app.html.heex
+++ b/lib/ambry_web/components/layouts/app.html.heex
@@ -6,6 +6,6 @@
       it) but nothing else: it was `grow overflow-y-auto` inside an `h-full`
       column, which is what took scroll restoration away from every page on
       the public side too. --%>
-<main id="main-content" class="overflow-x-clip">
+<main id="main-content">
   {@inner_content}
 </main>

--- a/lib/ambry_web/components/layouts/app.html.heex
+++ b/lib/ambry_web/components/layouts/app.html.heex
@@ -1,9 +1,11 @@
 <.flash_group flash={@flash} />
 
-<div class="flex h-full flex-col">
-  <.nav_header user={@current_user} active_path={@nav_active_path} query={@query} />
+<.nav_header user={@current_user} active_path={@nav_active_path} query={@query} />
 
-  <main id="main-content" class="grow overflow-y-auto overflow-x-hidden lg:justify-center" phx-hook="header-scrollspy">
-    {@inner_content}
-  </main>
-</div>
+<%!-- `#main-content` keeps its id (it is the skip-target and the hooks name
+      it) but nothing else: it was `grow overflow-y-auto` inside an `h-full`
+      column, which is what took scroll restoration away from every page on
+      the public side too. --%>
+<main id="main-content" class="overflow-x-clip">
+  {@inner_content}
+</main>

--- a/lib/ambry_web/components/layouts/root.html.heex
+++ b/lib/ambry_web/components/layouts/root.html.heex
@@ -5,7 +5,7 @@
 <html lang="en" style="scrollbar-gutter: stable; color-scheme: dark;">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="csrf-token" content={get_csrf_token()} />
     <link rel="icon" type="image/svg+xml" href={~p"/favicon.svg"} />
     <link rel="icon" type="image/png" href={~p"/favicon.png"} sizes="16x16" />
@@ -24,36 +24,13 @@
         window.location = 'ambry://media/' + globalId;
       })();
     </script>
-    <script type="text/javascript">
-      // fix mobile browser viewport height shenanigans.
-      // https://www.markusantonwolf.com/blog/solution-to-the-mobile-viewport-height-issue-with-tailwind-css/
-      // see tailwind.config.js for other half
-
-      function setViewHeight() {
-        const vh = window.innerHeight * 0.01
-        document.documentElement.style.setProperty('--vh', `${vh}px`)
-      }
-
-      setViewHeight()
-
-      window.addEventListener('resize', () => {
-        this.setViewHeight()
-      })
-
-      // end viewport fix
-    </script>
   </head>
   <body class="bg-black text-zinc-200 selection:bg-brand-dark selection:text-black">
-    <%= if @current_user do %>
-      <%!-- Root layout for the app --%>
-      <div class="flex h-screen flex-col">
-        <div class="grow overflow-hidden">
-          {@inner_content}
-        </div>
-      </div>
-    <% else %>
-      <%!-- Root layout for auth pages --%>
-      {@inner_content}
-    <% end %>
+    <%!-- Both branches are now just the content: the document is the scroller
+          everywhere. The signed-in branch used to be an `h-screen` shell whose
+          child was `overflow-hidden`, which made `#main-content` the scrollport
+          — and LiveView only ever restores `window.scrollY`, so back from a
+          book's page always landed at the top of the library. --%>
+    {@inner_content}
   </body>
 </html>

--- a/lib/ambry_web/components/preview/layouts/root.html.heex
+++ b/lib/ambry_web/components/preview/layouts/root.html.heex
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href={~p"/favicon.svg"} />
     <link rel="icon" type="image/png" href={~p"/favicon.png"} sizes="16x16" />
     <link rel="icon" type="image/png" href={~p"/favicon-32x32.png"} sizes="32x32" />

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -26,6 +26,7 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   alias AmbryWeb.Admin.Evidence
   alias AmbryWeb.Admin.ProvenanceHints
   alias AmbryWeb.Admin.Reordering
+  alias AmbryWeb.Admin.ReturnTo
   alias AmbryWeb.Admin.Revert
   alias Ecto.Changeset
 
@@ -43,6 +44,9 @@ defmodule AmbryWeb.Admin.BookLive.Form do
        reverts: %{},
        provenance_hints: %{}
      )
+     # The list the operator came from, kept so every way out of this form
+     # goes back to it. See `AmbryWeb.Admin.ReturnTo`.
+     |> assign(list_params: ReturnTo.list_params(params))
      |> apply_action(socket.assigns.live_action, params)}
   end
 
@@ -414,7 +418,9 @@ defmodule AmbryWeb.Admin.BookLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{book.title}")
-         |> push_navigate(to: ~p"/admin/books")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/books", socket.assigns.list_params, book.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -429,7 +435,9 @@ defmodule AmbryWeb.Admin.BookLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{book.title}")
-         |> push_navigate(to: ~p"/admin/books")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/books", socket.assigns.list_params, book.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/ambry_web/live/admin/book_live/index.ex
+++ b/lib/ambry_web/live/admin/book_live/index.ex
@@ -52,32 +52,34 @@ defmodule AmbryWeb.Admin.BookLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {books, has_more?} = list_books(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        books: books,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/books?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/books?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_books(socket, list_opts)
     else
       socket
     end
   end
 
-  defp refresh_books(socket) do
-    list_opts = get_list_opts(socket)
+  defp load_books(socket, list_opts) do
+    {books, has_more?, total} = list_books(list_opts, @default_sort)
 
-    params = %{
-      "filter" => to_string(list_opts.filter),
-      "page" => to_string(list_opts.page)
-    }
-
-    maybe_update_books(socket, params, true)
+    assign(socket,
+      list_opts: list_opts,
+      books: books,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(books), total),
+      next_page_path: ~p"/admin/books?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/books?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
+
+  # The list it is already showing, re-queried — not rebuilt out of string
+  # params. It used to hand `maybe_update_*` a map of `"filter"` and `"page"`
+  # and nothing else, and since a missing `"sort"` parses as `nil` and
+  # `Map.merge` lets the new `nil` win, every PubSub event silently threw the
+  # operator's sort away and put the list back on the default — while the
+  # address bar went on claiming the sort they had chosen.
+  defp refresh_books(socket), do: load_books(socket, get_list_opts(socket))
 
   @impl Phoenix.LiveView
   def handle_event("delete", %{"id" => id}, socket) do
@@ -116,15 +118,21 @@ defmodule AmbryWeb.Admin.BookLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/books?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_books(opts, default_sort) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
 
-    Books.list_books(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {books, has_more?} =
+      Books.list_books(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {books, has_more?, Books.count_books(filters)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/book_live/index.ex
+++ b/lib/ambry_web/live/admin/book_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.BookLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 1]
 
   alias Ambry.Books
   alias Ambry.Books.PubSub.BookCreated
@@ -43,6 +44,8 @@ defmodule AmbryWeb.Admin.BookLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
+     # The record a form just sent the operator back to, if they came from one.
+     |> assign(focus: params["focus"])
      |> maybe_update_books(params)}
   end
 
@@ -139,4 +142,10 @@ defmodule AmbryWeb.Admin.BookLive.Index do
   def handle_info(%BookCreated{}, socket), do: {:noreply, refresh_books(socket)}
   def handle_info(%BookUpdated{}, socket), do: {:noreply, refresh_books(socket)}
   def handle_info(%BookDeleted{}, socket), do: {:noreply, refresh_books(socket)}
+
+  @doc """
+  The list state a row link carries, so the form it opens can come back here
+  rather than to the front of an unfiltered, default-sorted page one.
+  """
+  def return_query(assigns), do: query(assigns.list_opts)
 end

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -14,7 +14,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table list_state={@list_opts} rows={@books} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} focus={@focus} rows={@books} filter={@list_opts.filter}>
     <:empty>
       No books yet.
       <.brand_link navigate={~p"/admin/books/new"}>
@@ -23,7 +23,7 @@
     </:empty>
 
     <:row :let={book}>
-      <.index_row navigate={~p"/admin/books/#{book}/edit"}>
+      <.index_row record_id={book.id} navigate={~p"/admin/books/#{book}/edit?#{return_query(assigns)}"}>
         <:cover>
           <.multi_image paths={book.thumbnails} />
         </:cover>
@@ -58,7 +58,7 @@
           />
         </:facts>
 
-        <:action navigate={~p"/admin/books/#{book}/edit"} icon="fa-pencil" role="edit-book">
+        <:action navigate={~p"/admin/books/#{book}/edit?#{return_query(assigns)}"} icon="fa-pencil" role="edit-book">
           Edit
         </:action>
         <:action

--- a/lib/ambry_web/live/admin/book_live/index.html.heex
+++ b/lib/ambry_web/live/admin/book_live/index.html.heex
@@ -3,10 +3,6 @@
     <.list_controls
       search_form={@search_form}
       new_path={~p"/admin/books/new"}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
     />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="title">Title</.sort_button>
@@ -18,7 +14,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@books} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@books} filter={@list_opts.filter}>
     <:empty>
       No books yet.
       <.brand_link navigate={~p"/admin/books/new"}>
@@ -82,4 +78,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/home_live/index.ex
+++ b/lib/ambry_web/live/admin/home_live/index.ex
@@ -140,7 +140,7 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
   end
 
   defp inventory do
-    people = People.count_people()
+    people = People.people_summary()
 
     %{
       authors: people.authors,

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -54,6 +54,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Library.Placement
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
+  alias AmbryWeb.Admin.ReturnTo
   alias AmbryWeb.Components.EntityResolver
   alias Phoenix.LiveView.AsyncResult
 
@@ -92,17 +93,11 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      |> load(item)}
   end
 
-  # The list state the operator arrived with, echoed back as a path. Only the
-  # keys the index actually reads, so a hand-typed URL can't turn this into an
-  # open redirect or a 500 on a junk param.
-  @list_params ~w(filter page status)
-
-  defp return_to(params) do
-    case Map.take(params, @list_params) do
-      empty when map_size(empty) == 0 -> ~p"/admin/inbox"
-      list -> ~p"/admin/inbox?#{list}"
-    end
-  end
+  # The list state the operator arrived with, echoed back as a path. The
+  # whitelist is `ReturnTo`'s now, which is how this stopped dropping
+  # `problem`: a form opened from a queue narrowed to "Files couldn't be read"
+  # used to return to the whole queue.
+  defp return_to(params), do: ReturnTo.path(~p"/admin/inbox", ReturnTo.list_params(params))
 
   # An imported item's draft is the record of what was imported — the operator
   # already created the library records from it, and an edit here would make

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -4,10 +4,16 @@
           rebuilds an untouched draft when one finally comes back — so a form
           with a job on it is not the operator's to edit yet, and says so
           over the whole thing rather than in a badge. --%>
+    <%!-- `z-40` overrides `busy_overlay/1`'s own `z-20`, which is sized for a
+          scrim over one card. This one owns the whole form, and the form has a
+          sticky footer with the Save in it — at 20 the scrim would have fallen
+          behind the one control it most needs to cover. It stays under the
+          header (50) so the job indicator that explains the wait is still
+          lit. --%>
     <.busy_overlay
       busy={busy?(assigns)}
       label={busy_label(@job)}
-      class="sticky top-0 h-screen"
+      class="sticky top-0 z-40 h-screen"
     />
 
     <div class="-mb-4 max-w-4xl space-y-14" inert={busy?(assigns)}>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -876,15 +876,12 @@
       </section>
 
       <%!-- ==================== THE BUTTON ==================== --%>
-      <%!-- `-bottom-4` and the container's `-mb-4` are one fix, not two.
-          A sticky offset is measured from the scrollport's CONTENT box, so
-          `bottom-0` inside `#main-content`'s `p-4` parks the bar 16px shy of
-          the window with the page showing through underneath; and a sticky box
-          can't leave its containing block, so at the end of the scroll the
-          container's own bottom edge holds it 16px up again. The offset
-          reaches into the scroller's padding, the negative margin lets the
-          containing block reach the same place. Measured in Chrome: 16px then
-          80px of gap before, 0 and 0 after. --%>
+      <%!-- The container's `-mb-4` is half of `form_footer`'s `bottom-0`: a
+          sticky box can't leave its containing block, so without it this
+          wrapper's own bottom edge holds the bar 16px up at the end of the
+          scroll, inside `#main-content`'s `p-4`. The negative margin lets the
+          containing block reach the bottom of the page, where the offset
+          already puts the bar. --%>
       <.form_footer>
         <div class="flex flex-wrap items-baseline gap-x-4 gap-y-2">
           <%!-- Named for what pressing it does. A replacement doesn't add

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -132,14 +132,16 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     list_opts = params |> get_list_opts() |> Map.put(:problem, parse_problem(params))
     status = parse_status(params["status"])
 
+    # One set of options for the page and for the total, so the queue's "of
+    # 355" cannot describe a different query from the rows above it.
+    query = [
+      status: status,
+      filter: list_opts.filter,
+      issue: list_opts.problem == "issue"
+    ]
+
     {items, has_more?} =
-      Inbox.list_items(
-        status: status,
-        filter: list_opts.filter,
-        issue: list_opts.problem == "issue",
-        offset: page_to_offset(list_opts.page),
-        limit: limit()
-      )
+      Inbox.list_items(query ++ [offset: page_to_offset(list_opts.page), limit: limit()])
 
     socket
     |> assign(
@@ -152,6 +154,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
       list_opts: list_opts,
       has_next: has_more?,
       has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(items), Inbox.count_items(query)),
       # Built from the full query, not the shared filter+page helpers —
       # those drop the status, so paging out of "Imported" silently landed
       # back on the default view.

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -11,6 +11,7 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
   import AmbryWeb.Admin.Decisions, only: [tier_words: 1]
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 2]
   import AmbryWeb.TimeUtils
 
   alias Ambry.Inbox
@@ -234,19 +235,15 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   the plain Back button — returns to the tab and page the operator was on.
   Landing them on an unfiltered page one after an import is how "where did my
   queue go" happens.
+
+  The status is stated even when it is "all", because this queue's default tab
+  is not its unfiltered one.
   """
   def return_query(assigns),
     do: page_query(assigns.list_opts, assigns.status, assigns.list_opts.page)
 
   defp page_query(list_opts, status, page) do
-    %{
-      "filter" => list_opts.filter,
-      "page" => to_string(page),
-      "status" => to_string(status || "all"),
-      "problem" => to_string(list_opts[:problem])
-    }
-    |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
-    |> Map.new()
+    query(list_opts, %{"page" => page, "status" => to_string(status || "all")})
   end
 
   # The overview counts queue items carrying an issue, and a count the

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -1,12 +1,6 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
   <:subheader>
-    <.list_controls
-      search_form={@search_form}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
-    />
+    <.list_controls search_form={@search_form} />
     <%!-- The list is narrowed by something the operator chose on the
           overview, so it says which list this is and offers the way out.
           Leaving it keeps the tab and the search — an issue narrows the
@@ -60,7 +54,7 @@
     </div>
   </:subheader>
 
-  <.flex_table rows={@items} filter={@list_opts.filter}>
+  <.flex_table list_state={{@status, @list_opts}} rows={@items} filter={@list_opts.filter}>
     <:empty>
       <%= if words = problem_empty_words(@list_opts[:problem]) do %>
         {words}
@@ -404,4 +398,12 @@
       <% end %>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -24,6 +24,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   alias AmbryWeb.Admin.Evidence
   alias AmbryWeb.Admin.ProvenanceHints
   alias AmbryWeb.Admin.Reordering
+  alias AmbryWeb.Admin.ReturnTo
   alias AmbryWeb.Admin.Revert
   alias Ecto.Changeset
   alias Phoenix.LiveView.AsyncResult
@@ -53,6 +54,9 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
        chapters_applied_asin: nil,
        provenance_hints: %{}
      )
+     # The list the operator came from, kept so every way out of this form
+     # goes back to it. See `AmbryWeb.Admin.ReturnTo`.
+     |> assign(list_params: ReturnTo.list_params(params))
      |> apply_action(socket.assigns.live_action, params)}
   end
 
@@ -597,7 +601,9 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated audiobook for #{media.book.title}")
-         |> push_navigate(to: ~p"/admin/audiobooks")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/audiobooks", socket.assigns.list_params, media.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -78,35 +78,43 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {media, has_more?} = list_media(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        media: media,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/audiobooks?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/audiobooks?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_media(socket, list_opts)
     else
       socket
     end
   end
 
-  # Every rebuild goes back through params, so anything the page is currently
-  # narrowed by has to be restated here or it is silently dropped — a search
-  # inside "Files couldn't be read" would quietly widen to the whole library.
-  defp refresh_media(socket) do
-    list_opts = get_list_opts(socket)
+  defp load_media(socket, list_opts) do
+    {media, has_more?, total} = list_media(list_opts, @default_sort)
 
-    maybe_update_media(socket, current_params(list_opts), true)
+    assign(socket,
+      list_opts: list_opts,
+      media: media,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(media), total),
+      next_page_path: ~p"/admin/audiobooks?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/audiobooks?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
 
-  defp current_params(list_opts, overrides \\ %{}) do
+  # The list it is already showing, re-queried. This used to go back out
+  # through `current_params/2`, which is a lossy round trip: a key it doesn't
+  # restate parses as `nil` and `Map.merge` lets that `nil` win. `problem` was
+  # restated after a search inside "Files couldn't be read" quietly widened to
+  # the whole library; `sort` never was, so any recording created, updated or
+  # deleted anywhere put the operator's sort back to the default underneath
+  # them, with the address bar still naming the sort they had picked.
+  defp refresh_media(socket), do: load_media(socket, get_list_opts(socket))
+
+  # Still a params round trip, because the search box legitimately *changes*
+  # the list state; every key the page can be narrowed by has to be here.
+  defp current_params(list_opts, overrides) do
     %{
       "filter" => to_string(list_opts.filter),
       "page" => to_string(list_opts.page),
+      "sort" => to_string(list_opts.sort),
       "problem" => to_string(list_opts[:problem])
     }
     |> Map.merge(overrides)
@@ -141,18 +149,24 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/audiobooks?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_media(opts, default_sort) do
     filters =
       if opts.filter, do: %{search: opts.filter}, else: %{}
 
     filters = Map.merge(filters, problem_filters(opts[:problem]))
 
-    Media.list_media(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {media, has_more?} =
+      Media.list_media(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {media, has_more?, Media.count_media(filters)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 1]
 
   alias Ambry.Media
   alias Ambry.Media.PubSub.MediaCreated
@@ -69,6 +70,8 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
+     # The record a form just sent the operator back to, if they came from one.
+     |> assign(focus: params["focus"])
      |> maybe_update_media(params)}
   end
 
@@ -210,4 +213,10 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
   defp status_color(:pending), do: :yellow
   defp status_color(:processing), do: :blue
   defp status_color(:error), do: :red
+
+  @doc """
+  The list state a row link carries, so the form it opens can come back here
+  rather than to the front of an unfiltered, default-sorted page one.
+  """
+  def return_query(assigns), do: query(assigns.list_opts)
 end

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -26,7 +26,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table list_state={@list_opts} rows={@media} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} focus={@focus} rows={@media} filter={@list_opts.filter}>
     <:empty>
       <%= if words = problem_empty_words(@list_opts[:problem]) do %>
         {words}
@@ -39,7 +39,7 @@
     </:empty>
 
     <:row :let={media}>
-      <.index_row navigate={~p"/admin/audiobooks/#{media}/edit"}>
+      <.index_row record_id={media.id} navigate={~p"/admin/audiobooks/#{media}/edit?#{return_query(assigns)}"}>
         <:cover>
           <div class={["h-16 w-16 rounded-sm", if(!media.thumbnail, do: "bg-zinc-800")]}>
             <img :if={media.thumbnail} src={media.thumbnail} alt="" class="h-full w-full rounded-sm" />
@@ -97,7 +97,7 @@
           </span>
         </:facts>
 
-        <:action navigate={~p"/admin/audiobooks/#{media}/edit"} icon="fa-pencil">Edit</:action>
+        <:action navigate={~p"/admin/audiobooks/#{media}/edit?#{return_query(assigns)}"} icon="fa-pencil">Edit</:action>
         <:action
           icon="fa-trash"
           color={:red}

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -1,12 +1,6 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
   <:subheader>
-    <.list_controls
-      search_form={@search_form}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
-    />
+    <.list_controls search_form={@search_form} />
     <%!-- The list is narrowed by something the operator chose on another
           page, so it says which list this is and offers the way out. --%>
     <div :if={problem_words(@list_opts[:problem])} class="flex items-baseline gap-2 pt-2">
@@ -32,7 +26,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@media} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@media} filter={@list_opts.filter}>
     <:empty>
       <%= if words = problem_empty_words(@list_opts[:problem]) do %>
         {words}
@@ -118,4 +112,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/pagination_helpers.ex
+++ b/lib/ambry_web/live/admin/pagination_helpers.ex
@@ -3,10 +3,35 @@ defmodule AmbryWeb.Admin.PaginationHelpers do
   Helpers for building paginated / filterable lists.
   """
 
-  @limit 10
+  # 50, not the 10 this shipped with for years. The operator's library is 435
+  # audiobooks: at ten a page that is 44 pages reachable only by clicking a
+  # chevron 44 times, and the page number they are on was never on screen.
+  @limit 50
 
   def limit do
     @limit
+  end
+
+  @doc """
+  What a list's footer says: which rows these are, and how many there are.
+
+  `nil` for `total` is allowed and means "not counted" — the footer then
+  states the page number without claiming a total it doesn't have.
+  """
+  def page_info(list_opts, row_count, total) do
+    first = page_to_offset(list_opts.page) + 1
+
+    %{
+      page: list_opts.page,
+      # A list with no rows at all has no first row, so the range collapses
+      # rather than reading "Showing 1-0 of 0".
+      first: if(row_count > 0, do: first),
+      last: if(row_count > 0, do: first + row_count - 1),
+      total: total,
+      # At least one page, always: "Page 1 of 0" is what an empty list used to
+      # say when the arithmetic was left to `ceil/1` alone.
+      pages: if(total, do: max(1, ceil(total / @limit)))
+    }
   end
 
   def get_list_opts(%Phoenix.LiveView.Socket{} = socket) do

--- a/lib/ambry_web/live/admin/person_live/form.ex
+++ b/lib/ambry_web/live/admin/person_live/form.ex
@@ -56,6 +56,7 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
   alias Ambry.People.Person
   alias AmbryWeb.Admin.Evidence
   alias AmbryWeb.Admin.ProvenanceHints
+  alias AmbryWeb.Admin.ReturnTo
   alias AmbryWeb.Admin.Revert
   alias Ecto.Changeset
 
@@ -79,6 +80,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
        # itself without them — see `revealed?/2`.
        reveal: MapSet.new()
      )
+     # The list the operator came from, kept so every way out of this form
+     # goes back to it. See `AmbryWeb.Admin.ReturnTo`.
+     |> assign(list_params: ReturnTo.list_params(params))
      |> apply_action(socket.assigns.live_action, params)}
   end
 
@@ -363,7 +367,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{person.name}")
-         |> push_navigate(to: ~p"/admin/people")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/people", socket.assigns.list_params, person.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -378,7 +384,9 @@ defmodule AmbryWeb.Admin.PersonLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{person.name}")
-         |> push_navigate(to: ~p"/admin/people")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/people", socket.assigns.list_params, person.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/ambry_web/live/admin/person_live/index.ex
+++ b/lib/ambry_web/live/admin/person_live/index.ex
@@ -51,32 +51,34 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {people, has_more?} = list_people(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        people: people,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/people?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/people?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_people(socket, list_opts)
     else
       socket
     end
   end
 
-  defp refresh_people(socket) do
-    list_opts = get_list_opts(socket)
+  defp load_people(socket, list_opts) do
+    {people, has_more?, total} = list_people(list_opts, @default_sort)
 
-    params = %{
-      "filter" => to_string(list_opts.filter),
-      "page" => to_string(list_opts.page)
-    }
-
-    maybe_update_people(socket, params, true)
+    assign(socket,
+      list_opts: list_opts,
+      people: people,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(people), total),
+      next_page_path: ~p"/admin/people?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/people?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
+
+  # The list it is already showing, re-queried — not rebuilt out of string
+  # params. It used to hand `maybe_update_*` a map of `"filter"` and `"page"`
+  # and nothing else, and since a missing `"sort"` parses as `nil` and
+  # `Map.merge` lets the new `nil` win, every PubSub event silently threw the
+  # operator's sort away and put the list back on the default — while the
+  # address bar went on claiming the sort they had chosen.
+  defp refresh_people(socket), do: load_people(socket, get_list_opts(socket))
 
   @impl Phoenix.LiveView
   def handle_event("delete", %{"id" => id}, socket) do
@@ -123,15 +125,21 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/people?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_people(opts, default_sort) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
 
-    People.list_people(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {people, has_more?} =
+      People.list_people(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {people, has_more?, People.count_people(filters)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/person_live/index.ex
+++ b/lib/ambry_web/live/admin/person_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 1]
 
   alias Ambry.People
   alias Ambry.People.PubSub.PersonCreated
@@ -42,6 +43,8 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
+     # The record a form just sent the operator back to, if they came from one.
+     |> assign(focus: params["focus"])
      |> maybe_update_people(params)}
   end
 
@@ -146,4 +149,10 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
   def handle_info(%PersonCreated{}, socket), do: {:noreply, refresh_people(socket)}
   def handle_info(%PersonUpdated{}, socket), do: {:noreply, refresh_people(socket)}
   def handle_info(%PersonDeleted{}, socket), do: {:noreply, refresh_people(socket)}
+
+  @doc """
+  The list state a row link carries, so the form it opens can come back here
+  rather than to the front of an unfiltered, default-sorted page one.
+  """
+  def return_query(assigns), do: query(assigns.list_opts)
 end

--- a/lib/ambry_web/live/admin/person_live/index.html.heex
+++ b/lib/ambry_web/live/admin/person_live/index.html.heex
@@ -13,7 +13,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table list_state={@list_opts} rows={@people} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} focus={@focus} rows={@people} filter={@list_opts.filter}>
     <:empty>
       No people yet.
       <.brand_link navigate={~p"/admin/people/new"}>
@@ -22,7 +22,7 @@
     </:empty>
 
     <:row :let={person}>
-      <.index_row navigate={~p"/admin/people/#{person}/edit"}>
+      <.index_row record_id={person.id} navigate={~p"/admin/people/#{person}/edit?#{return_query(assigns)}"}>
         <%!-- A face is round where a cover is square, but it is the same 64px
               box: people rows used to be 48px, so they were visibly shorter
               than every other list's. --%>
@@ -75,7 +75,11 @@
           />
         </:facts>
 
-        <:action navigate={~p"/admin/people/#{person}/edit"} icon="fa-pencil" role="edit-person">
+        <:action
+          navigate={~p"/admin/people/#{person}/edit?#{return_query(assigns)}"}
+          icon="fa-pencil"
+          role="edit-person"
+        >
           Edit
         </:action>
         <:action

--- a/lib/ambry_web/live/admin/person_live/index.html.heex
+++ b/lib/ambry_web/live/admin/person_live/index.html.heex
@@ -3,10 +3,6 @@
     <.list_controls
       search_form={@search_form}
       new_path={~p"/admin/people/new"}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
     />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="name">Name</.sort_button>
@@ -17,7 +13,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@people} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@people} filter={@list_opts.filter}>
     <:empty>
       No people yet.
       <.brand_link navigate={~p"/admin/people/new"}>
@@ -99,4 +95,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/playback_debug_live/index.ex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.ex
@@ -70,13 +70,15 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {playthroughs, has_more?} = list_playthroughs(socket.assigns.selected_user.id, list_opts)
+      {playthroughs, has_more?, total} =
+        list_playthroughs(socket.assigns.selected_user.id, list_opts)
 
       assign(socket,
         list_opts: list_opts,
         playthroughs: playthroughs,
         has_next: has_more?,
         has_prev: list_opts.page > 1,
+        page_info: page_info(list_opts, length(playthroughs), total),
         next_page_path:
           ~p"/admin/users/#{socket.assigns.selected_user.id}/playthroughs?#{next_opts(list_opts)}",
         prev_page_path:
@@ -114,16 +116,21 @@ defmodule AmbryWeb.Admin.PlaybackDebugLive.Index do
      )}
   end
 
+  # The page and the total, from one set of filters, so the footer's count can
+  # never describe a different query from the rows above it.
   defp list_playthroughs(user_id, opts) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
     filters = Map.put(filters, :user_id, user_id)
 
-    Playback.list_playthroughs_flat(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || @default_sort, @valid_sort_fields)
-    )
+    {playthroughs, has_more?} =
+      Playback.list_playthroughs_flat(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || @default_sort, @valid_sort_fields)
+      )
+
+    {playthroughs, has_more?, Playback.count_playthroughs_flat(filters)}
   end
 
   defp format_date(nil), do: "-"

--- a/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
@@ -29,77 +29,75 @@
     />
   </.modal>
 
-  <div class="h-[calc(100vh-10rem)] flex flex-col">
-    <.flex_table rows={@playthroughs}>
-      <:empty>
-        No playthroughs found for this user.
-      </:empty>
+  <.flex_table rows={@playthroughs}>
+    <:empty>
+      No playthroughs found for this user.
+    </:empty>
 
-      <:row :let={playthrough}>
-        <.index_row patch={~p"/admin/users/#{@selected_user.id}/playthroughs/#{playthrough.id}"}>
-          <:cover>
-            <div class={[
-              "h-16 w-16 rounded-sm",
-              if(!playthrough.media_thumbnail,
-                do: "flex items-center justify-center bg-zinc-800"
-              )
-            ]}>
-              <img
-                :if={playthrough.media_thumbnail}
-                src={playthrough.media_thumbnail}
-                alt=""
-                class="h-full w-full rounded-sm object-cover"
-              />
-              <.icon
-                :if={!playthrough.media_thumbnail}
-                name="fa-circle-play"
-                class="h-8 w-8 text-zinc-400"
-              />
-            </div>
-          </:cover>
+    <:row :let={playthrough}>
+      <.index_row patch={~p"/admin/users/#{@selected_user.id}/playthroughs/#{playthrough.id}"}>
+        <:cover>
+          <div class={[
+            "h-16 w-16 rounded-sm",
+            if(!playthrough.media_thumbnail,
+              do: "flex items-center justify-center bg-zinc-800"
+            )
+          ]}>
+            <img
+              :if={playthrough.media_thumbnail}
+              src={playthrough.media_thumbnail}
+              alt=""
+              class="h-full w-full rounded-sm object-cover"
+            />
+            <.icon
+              :if={!playthrough.media_thumbnail}
+              name="fa-circle-play"
+              class="h-8 w-8 text-zinc-400"
+            />
+          </div>
+        </:cover>
 
-          <:headline>{playthrough_label(playthrough)}</:headline>
+        <:headline>{playthrough_label(playthrough)}</:headline>
 
-          <p
-            class="font-mono overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400"
-            title={playthrough.id}
-          >
-            {String.slice(playthrough.id, 0, 8)}
+        <p
+          class="font-mono overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400"
+          title={playthrough.id}
+        >
+          {String.slice(playthrough.id, 0, 8)}
+        </p>
+
+        <%!-- The app's badge, not a bespoke solid chip: these were the last
+              `bg-red-900 text-red-200` slabs in the admin, against §5's
+              soft-tint rule. --%>
+        <:badges>
+          <.badge color={status_color(playthrough.status)} class="text-xs">
+            {status_label(playthrough)}
+          </.badge>
+        </:badges>
+
+        <:facts>
+          <span title="Current position" class="flex items-center gap-1">
+            <span :if={playthrough.progress_percent} class="font-semibold tabular-nums text-zinc-100">
+              {Decimal.round(playthrough.progress_percent, 1)}%
+            </span>
+            <span class="tabular-nums">
+              ({playthrough.position && Decimal.round(playthrough.position, 1)}s)
+            </span>
+          </span>
+          <span :if={playthrough.rate} title="Playback rate" class="tabular-nums text-zinc-500">
+            {Decimal.to_string(playthrough.rate)}x
+          </span>
+        </:facts>
+
+        <:footer>
+          <p title={format_full_datetime(playthrough.last_event_at)}>
+            Last event {format_date(playthrough.last_event_at)}
           </p>
-
-          <%!-- The app's badge, not a bespoke solid chip: these were the last
-                `bg-red-900 text-red-200` slabs in the admin, against §5's
-                soft-tint rule. --%>
-          <:badges>
-            <.badge color={status_color(playthrough.status)} class="text-xs">
-              {status_label(playthrough)}
-            </.badge>
-          </:badges>
-
-          <:facts>
-            <span title="Current position" class="flex items-center gap-1">
-              <span :if={playthrough.progress_percent} class="font-semibold tabular-nums text-zinc-100">
-                {Decimal.round(playthrough.progress_percent, 1)}%
-              </span>
-              <span class="tabular-nums">
-                ({playthrough.position && Decimal.round(playthrough.position, 1)}s)
-              </span>
-            </span>
-            <span :if={playthrough.rate} title="Playback rate" class="tabular-nums text-zinc-500">
-              {Decimal.to_string(playthrough.rate)}x
-            </span>
-          </:facts>
-
-          <:footer>
-            <p title={format_full_datetime(playthrough.last_event_at)}>
-              Last event {format_date(playthrough.last_event_at)}
-            </p>
-            <p title={format_full_datetime(playthrough.started_at)}>
-              Started {format_date(playthrough.started_at)}
-            </p>
-          </:footer>
-        </.index_row>
-      </:row>
-    </.flex_table>
-  </div>
+          <p title={format_full_datetime(playthrough.started_at)}>
+            Started {format_date(playthrough.started_at)}
+          </p>
+        </:footer>
+      </.index_row>
+    </:row>
+  </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
+++ b/lib/ambry_web/live/admin/playback_debug_live/index.html.heex
@@ -1,12 +1,6 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
   <:subheader>
-    <.list_controls
-      search_form={@search_form}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
-    />
+    <.list_controls search_form={@search_form} />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="book_title">Title</.sort_button>
       <.sort_button current_sort={@current_sort} sort_field="status">Status</.sort_button>
@@ -29,7 +23,7 @@
     />
   </.modal>
 
-  <.flex_table rows={@playthroughs}>
+  <.flex_table list_state={@list_opts} rows={@playthroughs}>
     <:empty>
       No playthroughs found for this user.
     </:empty>
@@ -100,4 +94,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/recording_group_live/form.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/form.ex
@@ -5,11 +5,14 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
   alias Ambry.Books
   alias Ambry.Media
   alias Ambry.Media.RecordingGroup
+  alias AmbryWeb.Admin.ReturnTo
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    {:ok, socket}
+  def mount(params, _session, socket) do
+    # The list the operator came from, kept so every way out of this form goes
+    # back to it. See `AmbryWeb.Admin.ReturnTo`.
+    {:ok, assign(socket, list_params: ReturnTo.list_params(params))}
   end
 
   @impl Phoenix.LiveView
@@ -71,7 +74,9 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{group.name}")
-         |> push_navigate(to: ~p"/admin/sets")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/sets", socket.assigns.list_params, group.id)
+         )}
 
       {:error, error} ->
         {:noreply, handle_save_error(socket, error)}
@@ -84,7 +89,9 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{group.name}")
-         |> push_navigate(to: ~p"/admin/sets")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/sets", socket.assigns.list_params, group.id)
+         )}
 
       {:error, error} ->
         {:noreply, handle_save_error(socket, error)}

--- a/lib/ambry_web/live/admin/recording_group_live/index.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 1]
 
   alias Ambry.Media
   alias Ambry.Media.PubSub.RecordingGroupCreated
@@ -40,6 +41,8 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
+     # The record a form just sent the operator back to, if they came from one.
+     |> assign(focus: params["focus"])
      |> maybe_update_groups(params)}
   end
 
@@ -145,4 +148,10 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
   def handle_info(%RecordingGroupCreated{}, socket), do: {:noreply, refresh_groups(socket)}
   def handle_info(%RecordingGroupUpdated{}, socket), do: {:noreply, refresh_groups(socket)}
   def handle_info(%RecordingGroupDeleted{}, socket), do: {:noreply, refresh_groups(socket)}
+
+  @doc """
+  The list state a row link carries, so the form it opens can come back here
+  rather than to the front of an unfiltered, default-sorted page one.
+  """
+  def return_query(assigns), do: query(assigns.list_opts)
 end

--- a/lib/ambry_web/live/admin/recording_group_live/index.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.ex
@@ -49,32 +49,34 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {groups, has_more?} = list_groups(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        groups: groups,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/sets?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/sets?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_groups(socket, list_opts)
     else
       socket
     end
   end
 
-  defp refresh_groups(socket) do
-    list_opts = get_list_opts(socket)
+  defp load_groups(socket, list_opts) do
+    {groups, has_more?, total} = list_groups(list_opts, @default_sort)
 
-    params = %{
-      "filter" => to_string(list_opts.filter),
-      "page" => to_string(list_opts.page)
-    }
-
-    maybe_update_groups(socket, params, true)
+    assign(socket,
+      list_opts: list_opts,
+      groups: groups,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(groups), total),
+      next_page_path: ~p"/admin/sets?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/sets?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
+
+  # The list it is already showing, re-queried — not rebuilt out of string
+  # params. It used to hand `maybe_update_*` a map of `"filter"` and `"page"`
+  # and nothing else, and since a missing `"sort"` parses as `nil` and
+  # `Map.merge` lets the new `nil` win, every PubSub event silently threw the
+  # operator's sort away and put the list back on the default — while the
+  # address bar went on claiming the sort they had chosen.
+  defp refresh_groups(socket), do: load_groups(socket, get_list_opts(socket))
 
   @impl Phoenix.LiveView
   def handle_event("delete", %{"id" => id}, socket) do
@@ -103,15 +105,21 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/sets?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_groups(opts, default_sort) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
 
-    Media.list_recording_groups(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {groups, has_more?} =
+      Media.list_recording_groups(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {groups, has_more?, Media.count_recording_groups(filters)}
   end
 
   defp thumbnails(group) do

--- a/lib/ambry_web/live/admin/recording_group_live/index.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.html.heex
@@ -3,10 +3,6 @@
     <.list_controls
       search_form={@search_form}
       new_path={~p"/admin/sets/new"}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
     />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="name">Name</.sort_button>
@@ -14,7 +10,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@groups} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@groups} filter={@list_opts.filter}>
     <:empty>
       No sets yet.
       <.brand_link navigate={~p"/admin/sets/new"}>
@@ -60,4 +56,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/recording_group_live/index.html.heex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.html.heex
@@ -10,7 +10,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table list_state={@list_opts} rows={@groups} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} focus={@focus} rows={@groups} filter={@list_opts.filter}>
     <:empty>
       No sets yet.
       <.brand_link navigate={~p"/admin/sets/new"}>
@@ -19,7 +19,7 @@
     </:empty>
 
     <:row :let={group}>
-      <.index_row navigate={~p"/admin/sets/#{group}/edit"}>
+      <.index_row record_id={group.id} navigate={~p"/admin/sets/#{group}/edit?#{return_query(assigns)}"}>
         <:cover>
           <.multi_image paths={thumbnails(group)} />
         </:cover>
@@ -36,7 +36,7 @@
           <span data-role="group-parts">{parts_summary(group)}</span>
         </:facts>
 
-        <:action navigate={~p"/admin/sets/#{group}/edit"} icon="fa-pencil" role="edit-group">
+        <:action navigate={~p"/admin/sets/#{group}/edit?#{return_query(assigns)}"} icon="fa-pencil" role="edit-group">
           Edit
         </:action>
         <:action

--- a/lib/ambry_web/live/admin/return_to.ex
+++ b/lib/ambry_web/live/admin/return_to.ex
@@ -1,0 +1,69 @@
+defmodule AmbryWeb.Admin.ReturnTo do
+  @moduledoc """
+  How a form knows where the operator came from, and how a list puts them back.
+
+  A form used to end with `push_navigate(to: ~p"/admin/books")` — the front of
+  an unfiltered, default-sorted list, whoever you were and wherever you had
+  been. The queue's form has threaded its list state through the URL since it
+  was written; this is that mechanism, shared, plus the half it didn't have:
+  the record you were editing, scrolled to and lit up.
+
+  Two halves that have to agree:
+
+    * a list writes its state into every row link (`query/2`), and
+    * a form reads it back and returns there (`path/3`), naming the record it
+      just saved so the list can find it again.
+
+  The URL is the carrier because it is the only thing that survives the round
+  trip. A `push_navigate` is a fresh mount with no memory of the socket it
+  came from, and the browser's own back button restores a *scroll offset* —
+  which is the wrong thing to remember anyway. Rename a book and its row moves;
+  what the operator means by "put me back" is the record, not the pixel.
+  """
+
+  @doc """
+  The list state a row link should carry.
+
+  Only the keys a list actually reads. Anything else a hand-typed URL puts in
+  here is dropped rather than echoed back out of a form, which is what keeps
+  this from becoming an open redirect or a 500 on a junk param.
+  """
+  @list_params ~w(filter page sort status problem)
+
+  def query(list_opts, extra \\ %{}) do
+    list_opts
+    |> Map.new(fn {key, value} -> {to_string(key), value} end)
+    |> Map.merge(Map.new(extra, fn {key, value} -> {to_string(key), value} end))
+    |> Map.take(@list_params)
+    |> Enum.reject(fn {_key, value} -> value in [nil, "", 1, "1"] end)
+    |> Map.new(fn {key, value} -> {key, to_string(value)} end)
+  end
+
+  @doc """
+  What a form should keep out of its mount params: the list state, and nothing
+  else. Held in an assign so `path/3` can hand it back at the end.
+  """
+  def list_params(params), do: Map.take(params, @list_params)
+
+  @doc """
+  Where a form goes when it is done.
+
+  `list_params` is what `list_params/1` kept. `focus` is the record just saved,
+  so the list can scroll to it — omitted when there is nothing to point at.
+
+  A form reached from somewhere other than a list (the "New" button, a link
+  from the overview, a bookmark) simply has no list state to hand back, and
+  falls through to the bare list path.
+  """
+  def path(list_path, list_params, focus \\ nil) do
+    query =
+      if focus,
+        do: Map.put(list_params, "focus", to_string(focus)),
+        else: list_params
+
+    case query do
+      empty when map_size(empty) == 0 -> list_path
+      query -> "#{list_path}?#{URI.encode_query(query)}"
+    end
+  end
+end

--- a/lib/ambry_web/live/admin/series_live/form.ex
+++ b/lib/ambry_web/live/admin/series_live/form.ex
@@ -3,11 +3,14 @@ defmodule AmbryWeb.Admin.SeriesLive.Form do
   use AmbryWeb, :admin_live_view
 
   alias Ambry.Books
+  alias AmbryWeb.Admin.ReturnTo
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    {:ok, socket}
+  def mount(params, _session, socket) do
+    # The list the operator came from, kept so every way out of this form goes
+    # back to it. See `AmbryWeb.Admin.ReturnTo`.
+    {:ok, assign(socket, list_params: ReturnTo.list_params(params))}
   end
 
   @impl Phoenix.LiveView
@@ -59,7 +62,9 @@ defmodule AmbryWeb.Admin.SeriesLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{series.name}")
-         |> push_navigate(to: ~p"/admin/series")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/series", socket.assigns.list_params, series.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -72,7 +77,9 @@ defmodule AmbryWeb.Admin.SeriesLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{series.name}")
-         |> push_navigate(to: ~p"/admin/series")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/series", socket.assigns.list_params, series.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/ambry_web/live/admin/series_live/index.ex
+++ b/lib/ambry_web/live/admin/series_live/index.ex
@@ -50,32 +50,34 @@ defmodule AmbryWeb.Admin.SeriesLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {series, has_more?} = list_series(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        series: series,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/series?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/series?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_series(socket, list_opts)
     else
       socket
     end
   end
 
-  defp refresh_series(socket) do
-    list_opts = get_list_opts(socket)
+  defp load_series(socket, list_opts) do
+    {series, has_more?, total} = list_series(list_opts, @default_sort)
 
-    params = %{
-      "filter" => to_string(list_opts.filter),
-      "page" => to_string(list_opts.page)
-    }
-
-    maybe_update_series(socket, params, true)
+    assign(socket,
+      list_opts: list_opts,
+      series: series,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(series), total),
+      next_page_path: ~p"/admin/series?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/series?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
+
+  # The list it is already showing, re-queried — not rebuilt out of string
+  # params. It used to hand `maybe_update_*` a map of `"filter"` and `"page"`
+  # and nothing else, and since a missing `"sort"` parses as `nil` and
+  # `Map.merge` lets the new `nil` win, every PubSub event silently threw the
+  # operator's sort away and put the list back on the default — while the
+  # address bar went on claiming the sort they had chosen.
+  defp refresh_series(socket), do: load_series(socket, get_list_opts(socket))
 
   @impl Phoenix.LiveView
   def handle_event("delete", %{"id" => id}, socket) do
@@ -104,15 +106,21 @@ defmodule AmbryWeb.Admin.SeriesLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/series?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_series(opts, default_sort) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
 
-    Books.list_series(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {series, has_more?} =
+      Books.list_series(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {series, has_more?, Books.count_series(filters)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/series_live/index.ex
+++ b/lib/ambry_web/live/admin/series_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.SeriesLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 1]
 
   alias Ambry.Books
   alias Ambry.Books.PubSub.SeriesCreated
@@ -41,6 +42,8 @@ defmodule AmbryWeb.Admin.SeriesLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
+     # The record a form just sent the operator back to, if they came from one.
+     |> assign(focus: params["focus"])
      |> maybe_update_series(params)}
   end
 
@@ -127,4 +130,10 @@ defmodule AmbryWeb.Admin.SeriesLive.Index do
   def handle_info(%SeriesCreated{}, socket), do: {:noreply, refresh_series(socket)}
   def handle_info(%SeriesUpdated{}, socket), do: {:noreply, refresh_series(socket)}
   def handle_info(%SeriesDeleted{}, socket), do: {:noreply, refresh_series(socket)}
+
+  @doc """
+  The list state a row link carries, so the form it opens can come back here
+  rather than to the front of an unfiltered, default-sorted page one.
+  """
+  def return_query(assigns), do: query(assigns.list_opts)
 end

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -3,10 +3,6 @@
     <.list_controls
       search_form={@search_form}
       new_path={~p"/admin/series/new"}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
     />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="name">Name</.sort_button>
@@ -16,7 +12,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@series} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@series} filter={@list_opts.filter}>
     <:empty>
       No series yet.
       <.brand_link navigate={~p"/admin/series/new"}>
@@ -67,4 +63,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/series_live/index.html.heex
+++ b/lib/ambry_web/live/admin/series_live/index.html.heex
@@ -12,7 +12,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table list_state={@list_opts} rows={@series} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} focus={@focus} rows={@series} filter={@list_opts.filter}>
     <:empty>
       No series yet.
       <.brand_link navigate={~p"/admin/series/new"}>
@@ -21,7 +21,7 @@
     </:empty>
 
     <:row :let={series}>
-      <.index_row navigate={~p"/admin/series/#{series}/edit"}>
+      <.index_row record_id={series.id} navigate={~p"/admin/series/#{series}/edit?#{return_query(assigns)}"}>
         <:cover>
           <.multi_image paths={series.thumbnails} />
         </:cover>
@@ -43,7 +43,11 @@
           />
         </:facts>
 
-        <:action navigate={~p"/admin/series/#{series}/edit"} icon="fa-pencil" role="edit-series">
+        <:action
+          navigate={~p"/admin/series/#{series}/edit?#{return_query(assigns)}"}
+          icon="fa-pencil"
+          role="edit-series"
+        >
           Edit
         </:action>
         <:action

--- a/lib/ambry_web/live/admin/universe_live/form.ex
+++ b/lib/ambry_web/live/admin/universe_live/form.ex
@@ -3,11 +3,14 @@ defmodule AmbryWeb.Admin.UniverseLive.Form do
   use AmbryWeb, :admin_live_view
 
   alias Ambry.Books
+  alias AmbryWeb.Admin.ReturnTo
   alias Ecto.Changeset
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    {:ok, socket}
+  def mount(params, _session, socket) do
+    # The list the operator came from, kept so every way out of this form goes
+    # back to it. See `AmbryWeb.Admin.ReturnTo`.
+    {:ok, assign(socket, list_params: ReturnTo.list_params(params))}
   end
 
   @impl Phoenix.LiveView
@@ -59,7 +62,9 @@ defmodule AmbryWeb.Admin.UniverseLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Updated #{universe.name}")
-         |> push_navigate(to: ~p"/admin/universes")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/universes", socket.assigns.list_params, universe.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
@@ -72,7 +77,9 @@ defmodule AmbryWeb.Admin.UniverseLive.Form do
         {:noreply,
          socket
          |> put_flash(:info, "Created #{universe.name}")
-         |> push_navigate(to: ~p"/admin/universes")}
+         |> push_navigate(
+           to: ReturnTo.path(~p"/admin/universes", socket.assigns.list_params, universe.id)
+         )}
 
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}

--- a/lib/ambry_web/live/admin/universe_live/index.ex
+++ b/lib/ambry_web/live/admin/universe_live/index.ex
@@ -6,6 +6,7 @@ defmodule AmbryWeb.Admin.UniverseLive.Index do
   use AmbryWeb, :admin_live_view
 
   import AmbryWeb.Admin.PaginationHelpers
+  import AmbryWeb.Admin.ReturnTo, only: [query: 1]
 
   alias Ambry.Books
   alias Ambry.Books.PubSub.UniverseCreated
@@ -40,6 +41,8 @@ defmodule AmbryWeb.Admin.UniverseLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
+     # The record a form just sent the operator back to, if they came from one.
+     |> assign(focus: params["focus"])
      |> maybe_update_universes(params)}
   end
 
@@ -126,4 +129,10 @@ defmodule AmbryWeb.Admin.UniverseLive.Index do
   def handle_info(%UniverseCreated{}, socket), do: {:noreply, refresh_universes(socket)}
   def handle_info(%UniverseUpdated{}, socket), do: {:noreply, refresh_universes(socket)}
   def handle_info(%UniverseDeleted{}, socket), do: {:noreply, refresh_universes(socket)}
+
+  @doc """
+  The list state a row link carries, so the form it opens can come back here
+  rather than to the front of an unfiltered, default-sorted page one.
+  """
+  def return_query(assigns), do: query(assigns.list_opts)
 end

--- a/lib/ambry_web/live/admin/universe_live/index.ex
+++ b/lib/ambry_web/live/admin/universe_live/index.ex
@@ -49,32 +49,34 @@ defmodule AmbryWeb.Admin.UniverseLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {universes, has_more?} = list_universes(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        universes: universes,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/universes?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/universes?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_universes(socket, list_opts)
     else
       socket
     end
   end
 
-  defp refresh_universes(socket) do
-    list_opts = get_list_opts(socket)
+  defp load_universes(socket, list_opts) do
+    {universes, has_more?, total} = list_universes(list_opts, @default_sort)
 
-    params = %{
-      "filter" => to_string(list_opts.filter),
-      "page" => to_string(list_opts.page)
-    }
-
-    maybe_update_universes(socket, params, true)
+    assign(socket,
+      list_opts: list_opts,
+      universes: universes,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(universes), total),
+      next_page_path: ~p"/admin/universes?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/universes?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
+
+  # The list it is already showing, re-queried — not rebuilt out of string
+  # params. It used to hand `maybe_update_*` a map of `"filter"` and `"page"`
+  # and nothing else, and since a missing `"sort"` parses as `nil` and
+  # `Map.merge` lets the new `nil` win, every PubSub event silently threw the
+  # operator's sort away and put the list back on the default — while the
+  # address bar went on claiming the sort they had chosen.
+  defp refresh_universes(socket), do: load_universes(socket, get_list_opts(socket))
 
   @impl Phoenix.LiveView
   def handle_event("delete", %{"id" => id}, socket) do
@@ -103,15 +105,21 @@ defmodule AmbryWeb.Admin.UniverseLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/universes?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_universes(opts, default_sort) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
 
-    Books.list_universes(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {universes, has_more?} =
+      Books.list_universes(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {universes, has_more?, Books.count_universes(filters)}
   end
 
   @impl Phoenix.LiveView

--- a/lib/ambry_web/live/admin/universe_live/index.html.heex
+++ b/lib/ambry_web/live/admin/universe_live/index.html.heex
@@ -11,7 +11,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table list_state={@list_opts} rows={@universes} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} focus={@focus} rows={@universes} filter={@list_opts.filter}>
     <:empty>
       No universes yet.
       <.brand_link navigate={~p"/admin/universes/new"}>
@@ -20,7 +20,7 @@
     </:empty>
 
     <:row :let={universe}>
-      <.index_row navigate={~p"/admin/universes/#{universe}/edit"}>
+      <.index_row record_id={universe.id} navigate={~p"/admin/universes/#{universe}/edit?#{return_query(assigns)}"}>
         <:cover>
           <.multi_image paths={universe.thumbnails} />
         </:cover>
@@ -38,7 +38,11 @@
           />
         </:facts>
 
-        <:action navigate={~p"/admin/universes/#{universe}/edit"} icon="fa-pencil" role="edit-universe">
+        <:action
+          navigate={~p"/admin/universes/#{universe}/edit?#{return_query(assigns)}"}
+          icon="fa-pencil"
+          role="edit-universe"
+        >
           Edit
         </:action>
         <:action

--- a/lib/ambry_web/live/admin/universe_live/index.html.heex
+++ b/lib/ambry_web/live/admin/universe_live/index.html.heex
@@ -3,10 +3,6 @@
     <.list_controls
       search_form={@search_form}
       new_path={~p"/admin/universes/new"}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
     />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="name">Name</.sort_button>
@@ -15,7 +11,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@universes} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@universes} filter={@list_opts.filter}>
     <:empty>
       No universes yet.
       <.brand_link navigate={~p"/admin/universes/new"}>
@@ -62,4 +58,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/user_devices_live/index.ex
+++ b/lib/ambry_web/live/admin/user_devices_live/index.ex
@@ -60,13 +60,14 @@ defmodule AmbryWeb.Admin.UserDevicesLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {devices, has_more?} = list_devices(socket.assigns.selected_user.id, list_opts)
+      {devices, has_more?, total} = list_devices(socket.assigns.selected_user.id, list_opts)
 
       assign(socket,
         list_opts: list_opts,
         devices: devices,
         has_next: has_more?,
         has_prev: list_opts.page > 1,
+        page_info: page_info(list_opts, length(devices), total),
         next_page_path:
           ~p"/admin/users/#{socket.assigns.selected_user.id}/devices?#{next_opts(list_opts)}",
         prev_page_path:
@@ -104,16 +105,21 @@ defmodule AmbryWeb.Admin.UserDevicesLive.Index do
      )}
   end
 
+  # The page and the total, from one set of filters, so the footer's count can
+  # never describe a different query from the rows above it.
   defp list_devices(user_id, opts) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
     filters = Map.put(filters, :user_id, user_id)
 
-    Playback.list_devices_flat(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || @default_sort, @valid_sort_fields)
-    )
+    {devices, has_more?} =
+      Playback.list_devices_flat(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || @default_sort, @valid_sort_fields)
+      )
+
+    {devices, has_more?, Playback.count_devices_flat(filters)}
   end
 
   defp format_date(nil), do: "-"

--- a/lib/ambry_web/live/admin/user_devices_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_devices_live/index.html.heex
@@ -18,54 +18,52 @@
     </.sort_button_bar>
   </:subheader>
 
-  <div class="h-[calc(100vh-10rem)] flex flex-col">
-    <.flex_table rows={@devices}>
-      <:empty>
-        No devices found for this user.
-      </:empty>
+  <.flex_table rows={@devices}>
+    <:empty>
+      No devices found for this user.
+    </:empty>
 
-      <:row :let={device}>
-        <%!-- A device row goes nowhere: there is no device page. So it is not
-              a link, and it does not wear the pointer cursor every row used
-              to wear whether or not it was clickable. --%>
-        <.index_row>
-          <:cover>
-            <div class="flex h-16 w-16 items-center justify-center rounded-full bg-zinc-800">
-              <.icon
-                name={if device.type == :web, do: "fa-desktop", else: "fa-mobile-screen"}
-                class="h-6 w-6 text-zinc-400"
-              />
-            </div>
-          </:cover>
-
-          <:headline>{format_device(device)}</:headline>
-
-          <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
-            {device.app_id} {format_app_version(device.app_version, device.app_build)}
-          </p>
-          <p class="font-mono overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400" title={device.id}>
-            {String.slice(device.id, 0, 8)}
-          </p>
-
-          <:facts>
-            <.row_fact
-              :if={device.event_count > 0}
-              icon="fa-bolt"
-              count={device.event_count}
-              title="# of playback events"
+    <:row :let={device}>
+      <%!-- A device row goes nowhere: there is no device page. So it is not
+            a link, and it does not wear the pointer cursor every row used
+            to wear whether or not it was clickable. --%>
+      <.index_row>
+        <:cover>
+          <div class="flex h-16 w-16 items-center justify-center rounded-full bg-zinc-800">
+            <.icon
+              name={if device.type == :web, do: "fa-desktop", else: "fa-mobile-screen"}
+              class="h-6 w-6 text-zinc-400"
             />
-          </:facts>
+          </div>
+        </:cover>
 
-          <:footer>
-            <p title={format_full_datetime(device.last_seen_at)}>
-              Last seen {format_date(device.last_seen_at)}
-            </p>
-            <p title={format_full_datetime(device.inserted_at)}>
-              First seen {format_date(device.inserted_at)}
-            </p>
-          </:footer>
-        </.index_row>
-      </:row>
-    </.flex_table>
-  </div>
+        <:headline>{format_device(device)}</:headline>
+
+        <p class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400">
+          {device.app_id} {format_app_version(device.app_version, device.app_build)}
+        </p>
+        <p class="font-mono overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400" title={device.id}>
+          {String.slice(device.id, 0, 8)}
+        </p>
+
+        <:facts>
+          <.row_fact
+            :if={device.event_count > 0}
+            icon="fa-bolt"
+            count={device.event_count}
+            title="# of playback events"
+          />
+        </:facts>
+
+        <:footer>
+          <p title={format_full_datetime(device.last_seen_at)}>
+            Last seen {format_date(device.last_seen_at)}
+          </p>
+          <p title={format_full_datetime(device.inserted_at)}>
+            First seen {format_date(device.inserted_at)}
+          </p>
+        </:footer>
+      </.index_row>
+    </:row>
+  </.flex_table>
 </.layout>

--- a/lib/ambry_web/live/admin/user_devices_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_devices_live/index.html.heex
@@ -1,12 +1,6 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
   <:subheader>
-    <.list_controls
-      search_form={@search_form}
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
-    />
+    <.list_controls search_form={@search_form} />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="type">Type</.sort_button>
       <.sort_button current_sort={@current_sort} sort_field="brand">Brand</.sort_button>
@@ -18,7 +12,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@devices}>
+  <.flex_table list_state={@list_opts} rows={@devices}>
     <:empty>
       No devices found for this user.
     </:empty>
@@ -66,4 +60,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/lib/ambry_web/live/admin/user_live/index.ex
+++ b/lib/ambry_web/live/admin/user_live/index.ex
@@ -47,20 +47,25 @@ defmodule AmbryWeb.Admin.UserLive.Index do
     list_opts = Map.merge(old_list_opts, new_list_opts)
 
     if list_opts != old_list_opts || force do
-      {users, has_more?} = list_users(list_opts, @default_sort)
-
-      assign(socket,
-        list_opts: list_opts,
-        users: users,
-        has_next: has_more?,
-        has_prev: list_opts.page > 1,
-        next_page_path: ~p"/admin/users?#{next_opts(list_opts)}",
-        prev_page_path: ~p"/admin/users?#{prev_opts(list_opts)}",
-        current_sort: list_opts.sort || @default_sort
-      )
+      load_users(socket, list_opts)
     else
       socket
     end
+  end
+
+  defp load_users(socket, list_opts) do
+    {users, has_more?, total} = list_users(list_opts, @default_sort)
+
+    assign(socket,
+      list_opts: list_opts,
+      users: users,
+      has_next: has_more?,
+      has_prev: list_opts.page > 1,
+      page_info: page_info(list_opts, length(users), total),
+      next_page_path: ~p"/admin/users?#{next_opts(list_opts)}",
+      prev_page_path: ~p"/admin/users?#{prev_opts(list_opts)}",
+      current_sort: list_opts.sort || @default_sort
+    )
   end
 
   @impl Phoenix.LiveView
@@ -146,14 +151,20 @@ defmodule AmbryWeb.Admin.UserLive.Index do
     {:noreply, push_patch(socket, to: ~p"/admin/users?#{patch_opts(list_opts)}")}
   end
 
+  # The page and the total, from one set of filters. Counted here rather than
+  # in the component so the "of 435" can never describe a different query from
+  # the rows above it.
   defp list_users(opts, default_sort) do
     filters = if opts.filter, do: %{search: opts.filter}, else: %{}
 
-    Accounts.list_users(
-      page_to_offset(opts.page),
-      limit(),
-      filters,
-      sort_to_order(opts.sort || default_sort, @valid_sort_fields)
-    )
+    {users, has_more?} =
+      Accounts.list_users(
+        page_to_offset(opts.page),
+        limit(),
+        filters,
+        sort_to_order(opts.sort || default_sort, @valid_sort_fields)
+      )
+
+    {users, has_more?, Accounts.count_users(filters)}
   end
 end

--- a/lib/ambry_web/live/admin/user_live/index.html.heex
+++ b/lib/ambry_web/live/admin/user_live/index.html.heex
@@ -4,10 +4,6 @@
       search_form={@search_form}
       new_path={~p"/admin/users/new"}
       new_text="Invite"
-      has_next={@has_next}
-      has_prev={@has_prev}
-      next_page_path={@next_page_path}
-      prev_page_path={@prev_page_path}
     />
     <.sort_button_bar>
       <.sort_button current_sort={@current_sort} sort_field="email">Email</.sort_button>
@@ -19,7 +15,7 @@
     </.sort_button_bar>
   </:subheader>
 
-  <.flex_table rows={@users} filter={@list_opts.filter}>
+  <.flex_table list_state={@list_opts} rows={@users} filter={@list_opts.filter}>
     <:row :let={user}>
       <.index_row navigate={~p"/admin/users/#{user}/playthroughs"}>
         <:cover>
@@ -119,4 +115,12 @@
       </.index_row>
     </:row>
   </.flex_table>
+
+  <.pagination_footer
+    info={@page_info}
+    has_next={@has_next}
+    has_prev={@has_prev}
+    next_page_path={@next_page_path}
+    prev_page_path={@prev_page_path}
+  />
 </.layout>

--- a/test/ambry/people_test.exs
+++ b/test/ambry/people_test.exs
@@ -94,11 +94,11 @@ defmodule Ambry.PeopleTest do
     end
   end
 
-  describe "count_people/0" do
+  describe "people_summary/0" do
     test "returns the number of people in the database" do
       insert_list(3, :person)
 
-      assert %{authors: 0, narrators: 0, total: 3} = People.count_people()
+      assert %{authors: 0, narrators: 0, total: 3} = People.people_summary()
     end
   end
 

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -169,4 +169,79 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
       assert titles == ["B Book", "A Book"]
     end
   end
+
+  describe "Pagination" do
+    test "says which rows these are and how many there are", %{conn: conn} do
+      for i <- 1..3, do: insert(:book, title: "Book #{i}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books")
+
+      # One page holds them all, so there is nothing to page through and no
+      # bar to say so.
+      refute has_element?(view, "[data-role=pagination]")
+    end
+
+    test "pages at fifty, and says where you are", %{conn: conn} do
+      for i <- 1..51, do: insert(:book, title: "Book #{String.pad_leading(to_string(i), 3, "0")}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books?sort=title")
+
+      assert view |> element("[data-role=pagination-range]") |> render() =~
+               "Showing 1 to 50 of 51"
+
+      assert view |> element("[data-role=pagination-page]") |> render() =~ "Page 1 of 2"
+      assert length(titles(view)) == 50
+
+      view |> element("[data-role=pagination] a", "Next") |> render_click()
+
+      assert view |> element("[data-role=pagination-range]") |> render() =~
+               "Showing 51 to 51 of 51"
+
+      assert view |> element("[data-role=pagination-page]") |> render() =~ "Page 2 of 2"
+      assert titles(view) == ["Book 051"]
+    end
+
+    test "counts under the filter it is listing with", %{conn: conn} do
+      insert(:book, title: "Findable")
+      insert(:book, title: "Other")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books?filter=Findable&page=2")
+
+      # Page 2 of a one-result search: the range collapses rather than
+      # claiming rows it doesn't have, and the total describes the search.
+      assert view |> element("[data-role=pagination-range]") |> render() =~ "Nothing on this page"
+      assert view |> element("[data-role=pagination-page]") |> render() =~ "Page 2 of 1"
+    end
+
+    test "a live update does not throw the operator's sort away", %{conn: conn} do
+      insert(:book, title: "B Book")
+      insert(:book, title: "A Book")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books")
+
+      view |> element("[data-role=sort-button][phx-value-field=title]") |> render_click()
+      assert titles(view) == ["A Book", "B Book"]
+
+      # Anything at all happening to any book used to rebuild the list out of
+      # `%{"filter" => ..., "page" => ...}`, and a missing "sort" parses as
+      # nil, so the list silently went back to the default ordering while the
+      # address bar still said `?sort=title.asc`.
+      insert(:book, title: "C Book")
+      |> Ambry.Books.PubSub.BookCreated.new()
+      |> Ambry.PubSub.broadcast()
+
+      ensure_all_messages_handled(view.pid)
+
+      assert titles(view) == ["A Book", "B Book", "C Book"]
+    end
+  end
+
+  defp titles(view) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find("[data-role=book-title]")
+    |> Floki.text(sep: "|")
+    |> String.split("|")
+  end
 end

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -236,6 +236,48 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
     end
   end
 
+  describe "Returning from a form" do
+    test "a row link carries the list state the operator is looking at", %{conn: conn} do
+      insert(:book, title: "Findable")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books?filter=Findable&sort=title&page=1")
+
+      assert view
+             |> element("[data-role=edit-book]")
+             |> render() =~ "filter=Findable"
+    end
+
+    test "saving comes back to that list, at that record", %{conn: conn} do
+      book = insert(:book, title: "Findable")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit?filter=Findable&sort=title")
+
+      view |> form("#book-form") |> render_submit(%{book: %{title: "Still findable"}})
+
+      {path, _flash} = assert_redirect(view)
+      %{path: path, query: query} = URI.parse(path)
+
+      assert path == "/admin/books"
+
+      # The filter and the sort the operator left, and the record they edited
+      # — it used to be a bare `/admin/books`, the front of an unfiltered,
+      # default-sorted page one.
+      assert %{"filter" => "Findable", "sort" => "title", "focus" => focus} =
+               URI.decode_query(query)
+
+      assert focus == to_string(book.id)
+    end
+
+    test "the row it names is the one the list can find", %{conn: conn} do
+      book = insert(:book, title: "Findable")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books?focus=#{book.id}")
+
+      assert has_element?(view, "#row-#{book.id}")
+      assert has_element?(view, "[data-focus='#{book.id}']")
+    end
+  end
+
   defp titles(view) do
     view
     |> render()

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -73,6 +73,19 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert_redirect(view, ~p"/admin/inbox?page=3&status=pending")
     end
 
+    test "returning keeps the issue the queue was narrowed to", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}?status=pending&problem=issue")
+
+      view |> element("button[data-role='import']") |> render_click()
+
+      # `problem` was missing from this form's whitelist, so importing out of a
+      # queue narrowed to an issue dropped the operator back into the whole
+      # queue.
+      assert_redirect(view, ~p"/admin/inbox?problem=issue&status=pending")
+    end
+
     # A stale tab can still send the event twice, and the second one must not
     # queue a second copy of a multi-gigabyte placement.
     test "a second import click doesn't queue a second job", %{conn: conn} do

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -197,9 +197,17 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   test "the page links keep the status filter", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/admin/inbox?status=ignored&page=2")
 
-    assert view
-           |> element("a[href*='status=ignored'][href*='page=1']")
-           |> has_element?()
+    # No `page=1`: that is the default, and stating it is what `patch_opts/1`
+    # has always dropped. The status is the part that has to survive.
+    assert hrefs(view, "[data-role=pagination] a") == ["/admin/inbox?status=ignored"]
+  end
+
+  defp hrefs(view, selector) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find(selector)
+    |> Enum.flat_map(&Floki.attribute(&1, "href"))
   end
 
   # The rail's shape and the order of its buttons used to change from row to

--- a/test/ambry_web/live/admin/recording_group_live/form_test.exs
+++ b/test/ambry_web/live/admin/recording_group_live/form_test.exs
@@ -30,7 +30,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         }
       })
 
-      assert_redirect(view, "/admin/sets")
+      assert_returns_to_sets(view)
 
       {[group], false} = Media.list_recording_groups()
       assert %{name: "Season One", parts_total: 2, part_word: "episode"} = group
@@ -49,7 +49,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         recording_group_form: %{name: "Awaiting Parts", book_id: to_string(book.id)}
       })
 
-      assert_redirect(view, "/admin/sets")
+      assert_returns_to_sets(view)
 
       {[group], false} = Media.list_recording_groups()
       assert %{name: "Awaiting Parts", media: []} = group
@@ -262,7 +262,7 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
         }
       })
 
-      assert_redirect(view, "/admin/sets")
+      assert_returns_to_sets(view)
 
       updated = Media.get_recording_group!(group.id)
       assert %{name: "After", show_label: true} = updated
@@ -280,5 +280,18 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.FormTest do
     |> Floki.find(~s{input[name="resolver[recording_group_form_members_0_media_id]"]})
     |> Floki.attribute("value")
     |> List.first()
+  end
+
+  # Saving returns to the sets list naming the record it saved, so the list can
+  # scroll to it and light it up. It used to be a bare `/admin/sets` — the
+  # front of an unfiltered, default-sorted page one, whoever you were and
+  # wherever you had been.
+  defp assert_returns_to_sets(view) do
+    {path, _flash} = assert_redirect(view)
+    %{path: path, query: query} = URI.parse(path)
+
+    assert path == "/admin/sets"
+    assert %{"focus" => focus} = URI.decode_query(query || "")
+    assert focus != ""
   end
 end


### PR DESCRIPTION
Nothing anywhere in Ambry has ever remembered where you were, and the reason
was one declaration. Both shells were an `h-screen` box whose child was
`overflow-hidden`, which made `#main-content` the scrollport — and LiveView
sets `history.scrollRestoration = "manual"` and then saves and restores
`window.scrollY` and nothing else. In an app whose window never scrolls that
is a no-op in both directions, so back and forward always landed at the top,
on the admin and on the public side alike.

So the shells are gone. The body scrolls, the admin's side nav is `fixed
inset-y-0` with the content clearing it on `lg:pl-64`, and both headers are
`sticky top-0`. The semantics are the ones they had: the nav holds still, the
header holds still, a form's footer sticks, and the scroll-spy draws the seam
under the header once there is something above it — a hairline now, matching
the public one, instead of a `border-b` with no color that fell through to
Tailwind's light-gray default.

With the scroll on the document, back and forward restore a position for free,
which turned out to be most of the "clicking save loses my place" problem.
What was left is the rest of this PR.

## Paging belongs under the list, not in the corner

Two bare chevrons in the top right of the header, ten rows to a page, and no
page number anywhere. On a 435-audiobook library that is 44 pages, reachable
only by clicking a chevron 44 times, with no way to tell which one you are on.
And because the header doesn't move, a "next" click left the scroll offset
exactly where it was, so the operator arrived looking at the *bottom* of the
page they had just asked for.

The header keeps what narrows a list — search, sort, and the one button that
adds to it — and `pagination_footer/1` under the last row holds what moves
through it. It says which rows these are and how many there are ("Showing 51
to 100 of 435", "Page 2 of 9"), its steps are worded like every other action,
and a step that isn't available is dead rather than absent so the bar keeps its
shape at both ends. A page is now 50 rows. `list-scroll-reset` takes the page
back to the top whenever the page, the sort or the search changes.

It is **sticky**, in `form_footer/1`'s costume, from a shared
`sticky_slab_classes/0`. Putting the bar at the foot of the rows and stopping
there only trades one kind of "far away" for another: a page is two or three
screens, so reaching page 3 from the top of a list would mean scrolling to the
bottom to find a control that used to be one click away. Both bars settle into
place at the end of the scroll, and the `sticky-footer` hook undresses either
into an ordinary card when the page has nothing to scroll.

## A form goes back where it came from

Every admin form ended with `push_navigate(to: ~p"/admin/books")`. Not the list
you were reading — *the* list, the front of an unfiltered, default-sorted page
one, whoever you were and wherever you had been.

The queue's form has threaded its list state through the URL since it was
written. `AmbryWeb.Admin.ReturnTo` is that mechanism, shared by all seven
forms, plus the half it never had: the record you just saved, scrolled to and
lit up for a moment. It anchors to the **record**, not to a scroll offset,
because those are different answers the moment an edit changes the sort key —
rename a book on a title-sorted list and its row moves, so the pixel you left
from belongs to somebody else now. A row that is gone or off-page focuses
nothing and you land at the top, which is the honest result.

The "New" button deliberately carries no list state: a record that does not
exist yet cannot be on the page you were filtering.

## Six bugs, none of them reported

* **Every PubSub event silently threw away the operator's sort.** The
  `refresh_*` functions rebuilt the list by handing `maybe_update_*` a map of
  `"filter"` and `"page"` — and since a missing `"sort"` parses as nil and
  `Map.merge` lets the new nil win, any book, recording or person created,
  updated or deleted anywhere put the list back on its default ordering
  underneath whoever was reading it, with the address bar still naming the sort
  they had chosen. A refresh no longer round-trips through string params at
  all. The audiobooks list had the same hole in its *search* handler.

* **Page boundaries were not stable.** `FlatSchema.order/2` emitted a bare
  `order_by` with no tiebreaker, and OFFSET pagination over an undefined order
  duplicates rows onto one page and skips them off another. Certain on a
  boolean sort — `admin` on the users list puts every record in one of two
  buckets — and reachable on `inserted_at` whenever an import stamps a batch
  inside the same second. Every ordering now ends in `id`.

* `order/2` accepted `{field, direction}` and `{direction, field}` only by
  accident of its fallback clause taking whatever was left. Both shapes are
  real, so the direction is matched literally now, and a `nil` order is a
  clause rather than an `order_by: ^nil` crash on a junk `?sort=` param.

* **The queue's form dropped `problem`.** Its whitelist was `filter page
  status`, so importing out of a queue narrowed to "Files couldn't be read"
  dropped the operator back into the whole queue. Folding it into `ReturnTo`
  fixed it.

* **The side nav was silently clipped on a short window.** ~720px of items
  inside the shell's `overflow-hidden`, with the way out an `absolute bottom-0`
  block sitting on top of whatever it overlapped. The links scroll now and Exit
  Admin is pinned below them.

* The devices and playthroughs lists wrapped their table in a
  `h-[calc(100vh-10rem)]` box that contained nothing else.

## The mobile viewport hack

`--vh` was a JS-measured custom property standing in for `100vh`, written for a
web player that no longer exists. Its other half in `tailwind.config.js` was
not `theme.extend` but a *replacement* of the whole `height` and `minHeight`
scale, so `h-fit`, `h-min`, `h-max`, `h-dvh` and every fraction silently did
not exist. All three root layouts also asked for `maximum-scale=1.0,
user-scalable=no`, which is how you take pinch-zoom away from someone reading
on a phone. All gone; `h-screen` means `100vh`.

## One z-index ladder

Content passes behind the chrome now, and `index_row` is `relative` with no
z-index of its own — so its layers are not scoped to the card and compete
directly with the page's chrome. Anything pinned over the page needs a number,
not a DOM position; a tie falls back to document order and page content always
comes after the header. Renumbered in tens with the gaps left in on purpose,
stated once on `layout_header/1`:

| z | what |
|---|---|
| 10 | the clickable layer inside a card |
| 20 | a busy scrim over a single card |
| 30 | the sticky page footers |
| 35 | a typeahead's popup |
| 40 | a page-wide busy scrim |
| 50 | the page header, admin and public |
| 60 | the drawer's scrim |
| 70 | the side nav drawer |
| 80 | a modal |
| 90 | the image lightbox |
| 100 | flash toasts |

Two of those are the point of doing it properly rather than bumping one
number. **A full-viewport overlay goes above the nav, not beside it** — a nav
that is `fixed` is a peer of everything rather than a column the content sits
next to. And **a scrim has to cover the control it is protecting the operator
from**: the import form's page-wide scrim overrides `busy_overlay/1`'s 20, a
value sized for a scrim over one card, because the form it owns has a sticky
footer with the Save in it.

## Counts

Totals are taken where the rows are queried, from the same filters: a total
assembled anywhere else eventually describes a different query from the rows
above it. Cheap when nothing is filtering — the flat views' credit arrays are
correlated subqueries in the target list and the planner drops every one of
them for a bare count (measured: a plain seq scan of the base table). A
searched count does build them, which is the same work the page query is
already doing.

`People.count_people/0` was never a count: it returns a three-way breakdown for
the overview whose numbers deliberately don't add up, because a person is often
both an author and a narrator. It is `people_summary/0` now, which frees the
name for the list's question.

## Also

`#main-content` carries no horizontal overflow guard. `overflow-x-hidden` can't
come back — `hidden` on one axis forces the other to `auto`, which would
quietly make it a scrollport again — and `overflow-x: clip` would put an
untested clipping ancestor between every sticky bar in the admin and the
viewport those bars are positioned against, to defend against a stray wide
child that may not exist. §3's `min-w-0` rule is where that defect actually
gets fixed, and a horizontal scrollbar is the signal to go and apply it, which
is exactly what the old guard was suppressing.

`docs/admin-design-language.md` gains the shell, the ladder, the seam, the list
footer and the return, and §1 gains the one place its no-1px-borders rule
doesn't hold.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ
