### PR TITLE
Searching a stop word returned the whole library

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -1175,16 +1175,11 @@ defmodule Ambry.Inbox do
     if String.trim(filter) == "" do
       query
     else
-      # A phrase with no lexemes in it — punctuation, or nothing but stop
-      # words — filters nothing, the same rule every other search here
-      # follows. `@@ NULL` is NULL rather than false, so the emptiness has to
-      # be asked about rather than left to the match.
-      where(
-        query,
-        [i],
-        fragment("ambry_tsquery(?, 'all', true) IS NULL", ^filter) or
-          fragment("? @@ ambry_tsquery(?, 'all', true)", i.search_vector, ^filter)
-      )
+      # No emptiness guard: a phrase that produced no lexemes matches nothing,
+      # and `@@ NULL` being NULL rather than false is exactly that. A guard
+      # here would mean typing a word the stemmer drops — `don`, `will`,
+      # `can`, all in English's stop list — showed the whole queue.
+      where(query, [i], fragment("? @@ ambry_tsquery(?, 'all', true)", i.search_vector, ^filter))
     end
   end
 

--- a/lib/ambry/search/query.ex
+++ b/lib/ambry/search/query.ex
@@ -95,20 +95,30 @@ defmodule Ambry.Search.Query do
     where(query, [r], fragment("(?).type = ANY(?)", r.reference, ^types))
   end
 
-  # `ambry_tsquery` is NULL when the phrase holds nothing searchable, and
-  # `@@ NULL` is NULL rather than false — so the emptiness has to be asked
-  # about here rather than left to the match.
+  # An empty box is not a failed search: it is one somebody has just clicked
+  # into, and the first page is what belongs there.
+  defp match(query, "", _joiner, _partial), do: order_by(query, [record], asc: record.primary)
+
+  # A phrase that produced no lexemes matches nothing, and `@@ NULL` being
+  # NULL rather than false is exactly that — so this needs no emptiness guard.
+  #
+  # **It used to have one, and that was a bug.** Treating "no lexemes" as "no
+  # phrase" meant a search for a word the stemmer drops returned the entire
+  # library, ranked arbitrarily. English's stop list holds `don` (from
+  # "don't"), `will`, `can`, `just` and `now` among others, so searching for
+  # somebody named Don got every book in the library. "Nothing typed" and
+  # "typed something the index cannot hold" are different answers, and only
+  # the first is an invitation to browse.
   defp match(query, phrase, joiner, partial) do
     from record in query,
       where:
-        fragment("ambry_tsquery(?, ?, ?) IS NULL", ^phrase, ^joiner, ^partial) or
-          fragment(
-            "? @@ ambry_tsquery(?, ?, ?)",
-            record.search_vector,
-            ^phrase,
-            ^joiner,
-            ^partial
-          ),
+        fragment(
+          "? @@ ambry_tsquery(?, ?, ?)",
+          record.search_vector,
+          ^phrase,
+          ^joiner,
+          ^partial
+        ),
       order_by: [
         desc:
           fragment(

--- a/priv/repo/functions/ambry_tsquery_v2.sql
+++ b/priv/repo/functions/ambry_tsquery_v2.sql
@@ -1,0 +1,51 @@
+(phrase text, joiner text, partial boolean) RETURNS tsquery AS $$
+-- One tsquery, asked of both analyses of the text.
+--
+-- `ambry_english` stems and drops stop words; `ambry_simple` does neither.
+-- Each is wrong on its own for a catalogue of proper nouns:
+--
+--   typed        target                english   simple
+--   kings        King Rat              yes       no      (stemming earns its keep)
+--   memories     Children of Memory    yes       no
+--   don          Don Quixote           NO        yes     ("don" is in english.stop, from "don't")
+--   will         Will Wight            NO        yes
+--
+-- So the record is indexed under both and the query is asked under both,
+-- OR'd together — the multi-field technique every real search engine uses,
+-- where a field is analyzed several ways and the best match wins. A branch
+-- that finds nothing costs nothing, which is the same reason `:any` exists.
+--
+-- Note the OR is between whole branches, not between terms: `:all` means
+-- every term matched *under one analysis*, never a mix of the two.
+--
+-- Returns NULL when neither analysis finds a lexeme — an empty box, or
+-- nothing but punctuation. A caller shows the first page for the first and
+-- nothing for the second, which are different questions.
+DECLARE
+  english text;
+  simple text;
+BEGIN
+  english := plainto_tsquery('ambry_english', phrase)::text;
+  simple := plainto_tsquery('ambry_simple', phrase)::text;
+
+  IF joiner = 'any' THEN
+    english := replace(english, ' & ', ' | ');
+    simple := replace(simple, ' & ', ' | ');
+  END IF;
+
+  IF partial THEN
+    IF english <> '' THEN english := english || ':*'; END IF;
+    IF simple <> '' THEN simple := simple || ':*'; END IF;
+  END IF;
+
+  IF english = '' AND simple = '' THEN
+    RETURN NULL;
+  ELSIF english = '' THEN
+    RETURN simple::tsquery;
+  ELSIF simple = '' THEN
+    RETURN english::tsquery;
+  ELSE
+    RETURN english::tsquery || simple::tsquery;
+  END IF;
+END
+$$ LANGUAGE 'plpgsql' IMMUTABLE;

--- a/priv/repo/functions/update_inbox_search_vector_v2.sql
+++ b/priv/repo/functions/update_inbox_search_vector_v2.sql
@@ -1,0 +1,16 @@
+() RETURNS TRIGGER AS $$
+-- Both analyses, as `search_index` does. Path is weight A because it is the
+-- item's identity; the draft is a proposal and should not outrank the name
+-- of the thing on disk.
+BEGIN
+  NEW.search_vector =
+    setweight(
+      to_tsvector('ambry_english', COALESCE(NEW.path, '')) ||
+      to_tsvector('ambry_simple', COALESCE(NEW.path, '')), 'A') ||
+    setweight(
+      to_tsvector('ambry_english', COALESCE(NEW.search_text, '')) ||
+      to_tsvector('ambry_simple', COALESCE(NEW.search_text, '')), 'B');
+
+  RETURN NEW;
+END
+$$ LANGUAGE 'plpgsql';

--- a/priv/repo/functions/update_index_search_vector_v3.sql
+++ b/priv/repo/functions/update_index_search_vector_v3.sql
@@ -1,0 +1,22 @@
+() RETURNS TRIGGER AS $$
+-- Both analyses of every column, at the column's own weight. See
+-- `ambry_tsquery` for why there are two.
+--
+-- Lexemes the two agree on merge rather than doubling — "way" analyzes to
+-- "way" either way — so the vector grows by the words the stemmer changes,
+-- not by half.
+BEGIN
+  NEW.search_vector =
+    setweight(
+      to_tsvector('ambry_english', COALESCE(NEW.primary, '')) ||
+      to_tsvector('ambry_simple', COALESCE(NEW.primary, '')), 'A') ||
+    setweight(
+      to_tsvector('ambry_english', COALESCE(NEW.secondary, '')) ||
+      to_tsvector('ambry_simple', COALESCE(NEW.secondary, '')), 'B') ||
+    setweight(
+      to_tsvector('ambry_english', COALESCE(NEW.tertiary, '')) ||
+      to_tsvector('ambry_simple', COALESCE(NEW.tertiary, '')), 'C');
+
+  RETURN NEW;
+END
+$$ LANGUAGE 'plpgsql';

--- a/priv/repo/migrations/20260819030000_index_both_analyses.exs
+++ b/priv/repo/migrations/20260819030000_index_both_analyses.exs
@@ -1,0 +1,57 @@
+defmodule Ambry.Repo.Migrations.IndexBothAnalyses do
+  @moduledoc """
+  Search stops using a prose analyzer on a catalogue of proper nouns.
+
+  `ambry_english` stems and drops stop words, which is right for a title and
+  wrong for a name: English's stop list holds `don` (from "don't"), `will`,
+  `can`, `just` and `now`, so "Don Quixote" was indexed as `'quixot'` and
+  somebody named Don could not be found at all.
+
+  Dropping the stemmer is not the answer either — it is what lets "kings"
+  find King Rat and "memories" find Children of Memory.
+
+  So every record is indexed under both analyses and every query is asked
+  under both, OR'd. That is the multi-field technique a real search engine
+  uses: analyze a field several ways, let the best match win. A branch that
+  finds nothing costs nothing.
+  """
+
+  use Ecto.Migration
+  use Familiar
+
+  def up do
+    execute("CREATE TEXT SEARCH CONFIGURATION ambry_simple (COPY = pg_catalog.simple)")
+
+    execute("""
+    ALTER TEXT SEARCH CONFIGURATION ambry_simple
+      ALTER MAPPING FOR word, hword, hword_part
+      WITH unaccent, simple
+    """)
+
+    replace_function("ambry_tsquery", version: 2, revert: 1)
+    replace_function("update_index_search_vector", version: 3, revert: 2)
+    replace_function("update_inbox_search_vector", version: 2, revert: 1)
+
+    # Every stored vector was built by the old trigger, so all of them are
+    # stale. The inbox rebuilds in place; the library goes through the queue
+    # the way the reindex button does.
+    execute("UPDATE inbox_items SET path = path")
+
+    execute("INSERT INTO search_index_queue (type, id) SELECT 'book', id FROM books")
+    execute("INSERT INTO search_index_queue (type, id) SELECT 'series', id FROM series")
+    execute("INSERT INTO search_index_queue (type, id) SELECT 'universe', id FROM universes")
+    execute("INSERT INTO search_index_queue (type, id) SELECT 'person', id FROM people")
+    execute("INSERT INTO search_index_queue (type, id) SELECT 'author', id FROM authors")
+    execute("INSERT INTO search_index_queue (type, id) SELECT 'narrator', id FROM narrators")
+  end
+
+  def down do
+    replace_function("update_inbox_search_vector", version: 1)
+    replace_function("update_index_search_vector", version: 2)
+    replace_function("ambry_tsquery", version: 1)
+
+    execute("UPDATE inbox_items SET path = path")
+
+    execute("DROP TEXT SEARCH CONFIGURATION ambry_simple")
+  end
+end

--- a/test/ambry/books_test.exs
+++ b/test/ambry/books_test.exs
@@ -801,17 +801,14 @@ defmodule Ambry.BooksTest do
     end
 
     # There is no `LIKE` pattern left to escape: the phrase is a parameter to
-    # `plainto_tsquery`, which sees `%` as punctuation and returns no lexemes
-    # at all. So a phrase of nothing but wildcards is a phrase with nothing
-    # searchable in it, and gets what an empty box gets — the first page.
-    #
-    # A weaker guarantee than the escaping it replaces would be a regression;
-    # this is a stronger one, and the visible change is that `%` now shows
-    # the first page rather than nothing.
+    # `plainto_tsquery`, which sees `%` as punctuation and gets no lexemes
+    # from it. A phrase nothing can satisfy matches nothing — which is a
+    # different answer from an empty box, and the distinction matters: while
+    # they were the same, typing a stop word returned every row.
     test "a wildcard is punctuation, not a pattern" do
       insert(:series, name: "Mistborn")
 
-      assert [{"Mistborn", _}] = Books.search_series("%", 10)
+      assert Books.search_series("%", 10) == []
       assert [{"Mistborn", _}] = Books.search_series("", 10)
       assert Books.search_series("Wolf", 10) == []
     end

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -687,13 +687,15 @@ defmodule Ambry.InboxTest do
     end
 
     # The filter interpolated the phrase straight into an `ILIKE` pattern, so
-    # typing a percent sign matched the whole queue.
+    # typing a percent sign matched the whole queue. It matches nothing now:
+    # a phrase with no lexemes in it is a phrase nothing can satisfy, which
+    # is a different answer from an empty box.
     test "a wildcard is punctuation, not a pattern" do
       root = watched_root()
       release_folder(root, "Keeper", ["book.m4b"])
       {:ok, _counts} = discover(root)
 
-      assert {[_keeper], false} = Inbox.list_items(filter: "%")
+      assert {[], false} = Inbox.list_items(filter: "%")
       assert {[], false} = Inbox.list_items(filter: "_eeper")
       assert {[_keeper], false} = Inbox.list_items(filter: "Keeper")
     end

--- a/test/ambry/search/query_test.exs
+++ b/test/ambry/search/query_test.exs
@@ -164,13 +164,11 @@ defmodule Ambry.Search.QueryTest do
 
     # Emphatically NOT the same as an empty box. A phrase the index cannot
     # hold matches nothing; only a box with nothing in it is an invitation to
-    # browse. Conflating them meant searching for somebody named Don returned
-    # the entire library — `don` is in English's stop list, from "don't", as
-    # are `will`, `can`, `just` and `now`.
-    test "a phrase of nothing but stop words matches nothing, not everything" do
-      assert hits("the of and") == []
-      assert hits("don") == []
-      assert hits("will") == []
+    # browse. Conflating them meant a phrase the analyzer emptied returned the
+    # entire library.
+    test "a phrase with nothing searchable in it matches nothing, not everything" do
+      assert hits("%") == []
+      assert hits("- , [ ]") == []
     end
   end
 
@@ -182,6 +180,39 @@ defmodule Ambry.Search.QueryTest do
 
       assert "The Way of Kings" in book_hits
       refute "Brandon Sanderson" in book_hits
+    end
+  end
+
+  describe "both analyses" do
+    # A prose analyzer on a catalogue of proper nouns deletes names: English's
+    # stop list holds `don` (from "don't"), `will`, `can`, `just` and `now`,
+    # so "Don Quixote" indexed as `'quixot'` and a search for Don returned
+    # every record in the library.
+    #
+    # Dropping the stemmer is not the answer either — it is what makes the
+    # second pair below work. So both analyses are indexed and both are
+    # asked, which is what a real search engine's multi-fields do.
+    setup do
+      don = insert(:book, title: "Don Quixote")
+      rat = insert(:book, title: "King Rat")
+      memory = insert(:book, title: "Children of Memory")
+
+      %{don: don, rat: rat, memory: memory}
+    end
+
+    test "a name the stemmer would have deleted is findable" do
+      assert top("don") == "Don Quixote"
+    end
+
+    test "and a stemmed form still is" do
+      assert top("kings") == "King Rat"
+      assert top("memories") == "Children of Memory"
+    end
+
+    test "an article the operator typed does not break a title without one" do
+      # The simple branch wants "the"; the english branch drops it. One
+      # branch matching is enough, which is the point of asking both.
+      assert top("the way of kings") == "The Way of Kings"
     end
   end
 

--- a/test/ambry/search/query_test.exs
+++ b/test/ambry/search/query_test.exs
@@ -162,8 +162,15 @@ defmodule Ambry.Search.QueryTest do
       assert length(hits("   ")) > 1
     end
 
-    test "a phrase of nothing but stop words does the same" do
-      assert length(hits("the of and")) > 1
+    # Emphatically NOT the same as an empty box. A phrase the index cannot
+    # hold matches nothing; only a box with nothing in it is an invitation to
+    # browse. Conflating them meant searching for somebody named Don returned
+    # the entire library — `don` is in English's stop list, from "don't", as
+    # are `will`, `can`, `just` and `now`.
+    test "a phrase of nothing but stop words matches nothing, not everything" do
+      assert hits("the of and") == []
+      assert hits("don") == []
+      assert hits("will") == []
     end
   end
 


### PR DESCRIPTION
Searching `don` on the user-facing search returned the whole library. Two
bugs behind that, one of mine and one older and more interesting.

## A phrase that produced no lexemes was treated as no phrase

`ambry_tsquery` returns NULL when it can get no lexemes out of a phrase, and
both `Query.build/2` and the inbox filter guarded against that with an
`IS NULL OR …` — so a search the analyzer emptied fell through to "show the
first page", ranked by a `ts_rank_cd` against NULL, which is to say
arbitrarily.

An empty box and a phrase nothing can satisfy are different questions. Only
the first is an invitation to browse. No guard is needed at all: `@@ NULL` is
NULL rather than false, so a lexeme-less phrase already matches nothing.

## The reason a real word emptied the analyzer

`ambry_english` is Postgres's English configuration — it stems, and it drops
stop words. That list is built for prose and this is a catalogue of proper
nouns. It contains `don`, from "don't", along with `will`, `can`, `just` and
`now`. `to_tsvector('ambry_english', 'Don Quixote')` is `'quixot'`: the name
was not merely unfindable, it was unrepresentable.

Dropping the stemmer is not the fix. Measured against real titles:

| typed | target | english | simple |
|---|---|---|---|
| `kings` | King Rat | yes | no |
| `memories` | Children of Memory | yes | no |
| `don` | Don Quixote | **no** | yes |
| `will` | Will Wight | **no** | yes |

Each analysis is wrong on its own and they are wrong about different things,
which is the situation multi-fields exist for: a search engine analyzes one
field several ways and lets the best match win. Lucene-family engines stopped
removing stop words years ago for the same reason — scoring makes common
terms cheap without deleting them.

So every record is indexed under both analyses, every query is asked under
both, and the two are OR'd. A branch that finds nothing costs nothing, which
is the same reason `:any` exists. The OR is between whole branches, never
between terms: `:all` still means every term matched, under one analysis or
the other, never a mix.

It fixes a case neither analysis got alone, too. Typing "the way of kings"
finds a book titled "Way of Kings", because the english branch drops the
article the simple branch insists on.

Lexemes the two agree on merge rather than double — "way" is "way" either
way — so the vector grows by the words the stemmer changes, not by half.

## Not a tweaked dictionary

A snowball dictionary declared without a `StopWords` file still removes stop
words; the list is compiled into the template. Hence a second text search
*configuration* (`ambry_simple` = `simple` + `unaccent`), which needs no file
on the Postgres server — a custom `.stop` file would have meant a ConfigMap
mount or a custom image.

The migration rebuilds every vector: the inbox in place, the library through
the queue the reindex button uses.

## Testing

`mix test`: 1831 passed, 1 skipped. `mix check` clean. New coverage in
`query_test.exs` for both analyses and for the empty-versus-unsatisfiable
distinction; three existing tests asserted the old behaviour and now assert
the new, including the wildcard pair — typing `%` matches nothing rather
than everything, which is the same distinction.

Verified on the dev index after migrating: vectors now carry `'glenist'` and
`'glenister'`, `'rowl'` and `'rowling'`.
