### PR TITLE
A last look before anything is created

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -70,6 +70,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.Importer
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.Lookup
+  alias Ambry.Inbox.Preflight
   alias Ambry.Inbox.Progress
   alias Ambry.Inbox.ReleaseName
   alias Ambry.Inbox.RunDiscovery
@@ -909,10 +910,35 @@ defmodule Ambry.Inbox do
 
   Refuses an item that is already in the library, since the queued job would
   only rediscover that a minute later and write it onto the row as an issue.
-  """
-  def import_item_async(%InboxItem{status: :imported}), do: {:error, :already_imported}
 
-  def import_item_async(%InboxItem{} = item) do
+  ## The pre-flight
+
+  Also refuses, once, when the draft would create something the library may
+  already have, returning `{:error, {:collisions, findings}}` — see
+  `Ambry.Inbox.Preflight`. A draft is a snapshot of a library that keeps
+  moving, and this is the last moment anything is asked before rows are
+  created.
+
+  It asks again rather than trusting a flag: pass the findings back as
+  `:acknowledged` and the import proceeds only if the library still says
+  exactly that. Anything that appeared while the operator was reading is a
+  collision they were never shown, so it stops them again.
+  """
+  def import_item_async(item, opts \\ [])
+
+  def import_item_async(%InboxItem{status: :imported}, _opts), do: {:error, :already_imported}
+
+  def import_item_async(%InboxItem{} = item, opts) do
+    case Preflight.check(item) do
+      [] -> enqueue_import(item)
+      findings -> acknowledged(item, findings, Keyword.get(opts, :acknowledged))
+    end
+  end
+
+  defp acknowledged(item, findings, findings), do: enqueue_import(item)
+  defp acknowledged(_item, findings, _stale_or_absent), do: {:error, {:collisions, findings}}
+
+  defp enqueue_import(item) do
     %{inbox_item_id: item.id} |> RunImport.new() |> Oban.insert()
   end
 
@@ -978,6 +1004,16 @@ defmodule Ambry.Inbox do
     count = length(outstanding)
 
     "#{count} thing#{if count > 1, do: "s"} still to settle before this can be imported. " <>
+      "Open it to see what."
+  end
+
+  # What the queue's own import button says. The findings themselves need the
+  # form, which is where the answer ("link that book instead") can be given,
+  # so this counts them and sends the operator there.
+  def describe_error({:collisions, findings}) do
+    count = length(findings)
+
+    "#{count} thing#{if count > 1, do: "s"} here may already be in the library. " <>
       "Open it to see what."
   end
 

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -342,6 +342,56 @@ defmodule Ambry.Inbox.AutoMatch do
   end
 
   @doc """
+  `person_key/1` as an Ecto fragment, for asking the question in SQL.
+
+  Lives beside its Elixir twin because the two have to agree: `unaccent`
+  (enabled by migration) mirrors the NFD fold, and the character class
+  mirrors the strip. Two copies of this in two modules is exactly the drift
+  that puts a second "Patricia Rodriguez" in the library.
+
+      where([a], person_key_sql(a.name) == ^AutoMatch.person_key(name))
+  """
+  defmacro person_key_sql(field) do
+    quote do
+      fragment("regexp_replace(lower(unaccent(?)), '[^[:alnum:]]+', '', 'g')", unquote(field))
+    end
+  end
+
+  # Filler words a series name wears in one source and not another.
+  @series_filler ~w(trilogy series saga duology quartet quintet cycle sequence collection books novels)
+
+  @doc """
+  Whether two spellings name one series.
+
+  Filler words (Trilogy, Saga, Series), punctuation, accents and articles
+  fold; a subtitle head counts the same way it does for titles, so
+  "Kushiel's Legacy: Phedre Trilogy" is "Kushiel's Legacy". The rule lives
+  here with `person_key/1` and `title_key/1` because sameness is one
+  question with one answer per kind of record, wherever it is asked from.
+  """
+  def same_series?(one, other) when is_binary(one) and is_binary(other) do
+    a = series_key(one)
+    b = series_key(other)
+
+    a == b or series_key(series_head(one)) == b or series_key(series_head(other)) == a
+  end
+
+  def same_series?(_one, _other), do: false
+
+  defp series_head(name), do: name |> String.split(~r/\s*:\s/u, parts: 2) |> hd()
+
+  defp series_key(name) do
+    name
+    |> String.normalize(:nfd)
+    |> String.replace(~r/\p{Mn}/u, "")
+    |> String.downcase()
+    |> String.replace(~r/[^\p{L}\p{N}]+/u, " ")
+    |> String.split(" ", trim: true)
+    |> Enum.reject(&(&1 in ["the", "a", "an"] or &1 in @series_filler))
+    |> Enum.join(" ")
+  end
+
+  @doc """
   The photo and biography to propose for one credited human.
 
   Everything the providers returned is kept as evidence; this is the
@@ -2316,8 +2366,16 @@ defmodule Ambry.Inbox.AutoMatch do
 
   # Titles differ in punctuation and subtitle noise far more often than in
   # substance, and none of that should cost a match.
+  #
+  # Accents fold the same way `person_key/1` folds them, and for the same
+  # reason: "Les Miserables" and "Les Misérables" are one book, and the
+  # difference between them was one approval away from a second Book row.
+  # `title_key/1` is an identity comparison, so a fold it doesn't do is a
+  # twin it can't see.
   defp normalize(string) do
     string
+    |> String.normalize(:nfd)
+    |> String.replace(~r/\p{Mn}/u, "")
     |> String.downcase()
     |> String.replace(~r/\b(unabridged|abridged|a novel|audiobook)\b/, " ")
     |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -50,6 +50,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   any source.
   """
 
+  import Ambry.Inbox.AutoMatch, only: [person_key_sql: 1]
   import Ecto.Query
 
   alias Ambry.Books
@@ -1313,7 +1314,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp matching_series(name) do
     Series
     |> Repo.all()
-    |> Enum.filter(&same_series?(&1.name, name))
+    |> Enum.filter(&AutoMatch.same_series?(&1.name, name))
   end
 
   @doc """
@@ -1675,18 +1676,9 @@ defmodule Ambry.Inbox.Draft.Seed do
     end
   end
 
-  # The SQL twin of `AutoMatch.person_key/1`, so "James S.A. Corey" in a
-  # record finds the library's "James S. A. Corey", "T.J. Klune" finds
-  # "TJ Klune", and "Patricia Rodriguez" finds "Patricia Rodríguez"
-  # (`unaccent` — enabled by migration — mirrors the NFD fold on the Elixir
-  # side). Still identity, not similarity — a spelling difference in
-  # punctuation, spacing or accents is the same name, a different word is
-  # not.
-  @name_key_sql "regexp_replace(lower(unaccent(?)), '[^[:alnum:]]+', '', 'g')"
-
   defp identity_matches(name, :author) do
     Author
-    |> where([a], fragment(@name_key_sql, a.name) == ^AutoMatch.person_key(name))
+    |> where([a], person_key_sql(a.name) == ^AutoMatch.person_key(name))
     |> preload(:people)
     |> Repo.all()
     |> Enum.map(fn author ->
@@ -1701,7 +1693,7 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp identity_matches(name, :narrator) do
     Narrator
-    |> where([n], fragment(@name_key_sql, n.name) == ^AutoMatch.person_key(name))
+    |> where([n], person_key_sql(n.name) == ^AutoMatch.person_key(name))
     |> preload(:person)
     |> Repo.all()
     |> Enum.map(fn narrator ->
@@ -1716,7 +1708,7 @@ defmodule Ambry.Inbox.Draft.Seed do
 
   defp person_matches(name) do
     Person
-    |> where([p], fragment(@name_key_sql, p.name) == ^AutoMatch.person_key(name))
+    |> where([p], person_key_sql(p.name) == ^AutoMatch.person_key(name))
     |> Repo.all()
   end
 
@@ -1771,40 +1763,14 @@ defmodule Ambry.Inbox.Draft.Seed do
   defp merge_by_name(proposals) do
     proposals
     |> Enum.reduce([], fn proposal, groups ->
-      case Enum.find_index(groups, fn [held | _rest] -> same_series?(held.name, proposal.name) end) do
+      case Enum.find_index(groups, fn [held | _rest] ->
+             AutoMatch.same_series?(held.name, proposal.name)
+           end) do
         nil -> groups ++ [[proposal]]
         index -> List.update_at(groups, index, &(&1 ++ [proposal]))
       end
     end)
     |> Enum.map(fn group -> Enum.find(group, List.first(group), & &1.number) end)
-  end
-
-  # Two spellings of one series. Filler words (Trilogy, Saga, Series),
-  # punctuation, accents and articles fold; a subtitle head counts the same
-  # way it does for titles, so "Kushiel's Legacy: Phedre Trilogy" is
-  # "Kushiel's Legacy".
-  @series_filler ~w(trilogy series saga duology quartet quintet cycle sequence collection books novels)
-
-  defp same_series?(one, other) when is_binary(one) and is_binary(other) do
-    a = series_key(one)
-    b = series_key(other)
-
-    a == b or series_key(series_head(one)) == b or series_key(series_head(other)) == a
-  end
-
-  defp same_series?(_one, _other), do: false
-
-  defp series_head(name), do: name |> String.split(~r/\s*:\s/u, parts: 2) |> hd()
-
-  defp series_key(name) do
-    name
-    |> String.normalize(:nfd)
-    |> String.replace(~r/\p{Mn}/u, "")
-    |> String.downcase()
-    |> String.replace(~r/[^\p{L}\p{N}]+/u, " ")
-    |> String.split(" ", trim: true)
-    |> Enum.reject(&(&1 in ["the", "a", "an"] or &1 in @series_filler))
-    |> Enum.join(" ")
   end
 
   # The file's series number describes this book's position in the series the

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -22,6 +22,8 @@ defmodule Ambry.Inbox.Lookup do
   is what IS inbox-specific: normalizing hits against the item's hints
   (scoring), and writing evidence into `inbox_items.matches`.
   """
+  import Ecto.Query
+
   alias Ambry.Inbox.AutoMatch
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.InboxItem
@@ -231,7 +233,27 @@ defmodule Ambry.Inbox.Lookup do
     end
   end
 
-  defp update_person(%InboxItem{} = item, key, name, found, outcomes) do
+  # **Re-read under a lock, because two of these run at once.** The form lets
+  # the operator search for as many people as they like without waiting, and
+  # `matches` is one jsonb column holding all of them: each search merged its
+  # person into the item as it was when the button was pressed, then wrote the
+  # whole column back, so the second to finish silently threw away the first's
+  # results. The operator saw two searches fight over the page.
+  #
+  # The row this merges into is therefore the committed one rather than the
+  # caller's, and the lock makes "read, merge, write" atomic across the two
+  # requests. Same shape as `Importer.claim/1`, for the same reason.
+  defp update_person(%InboxItem{id: id}, key, name, found, outcomes) do
+    Repo.transact(fn ->
+      InboxItem
+      |> where([i], i.id == ^id)
+      |> lock("FOR UPDATE")
+      |> Repo.one!()
+      |> merge_person(key, name, found, outcomes)
+    end)
+  end
+
+  defp merge_person(%InboxItem{} = item, key, name, found, outcomes) do
     matches = item.matches || %{}
     people = Map.get(matches, "people") || %{}
     held = Map.get(people, key) || %{"name" => name, "roles" => [], "local" => []}

--- a/lib/ambry/inbox/preflight.ex
+++ b/lib/ambry/inbox/preflight.ex
@@ -1,0 +1,345 @@
+defmodule Ambry.Inbox.Preflight do
+  @moduledoc """
+  What this import is about to create that the library may already have.
+
+  Every `:create` in a draft is a promise to add a row, and a draft is a
+  snapshot of the library taken when the item was matched. Between the
+  snapshot and the button the library moves: a sibling item is imported, a
+  book is added by hand, another edition of the same audiobook lands in the
+  queue. `Seed.relink/2` closes most of that gap by re-pointing a draft at
+  rows that exist now, but it only fires after a sibling import, only on
+  uncurated decisions, and only where exactly one certain match exists. Every
+  case it declines is a duplicate nobody sees until the library has two of
+  something.
+
+  So this is the check at the door: read the draft, ask the library about
+  every name it means to create, and hand back what it found. It runs on the
+  click, before the job is enqueued, and costs a handful of indexed lookups
+  and one small table scan.
+
+  ## It reports, it does not decide
+
+  Nothing here links, merges, edits a draft or refuses an import. A name in
+  common is evidence, and the judgement it feeds — same book, or two books
+  that share a title — is the operator's, exactly as it is everywhere else on
+  this form. Attaching a recording to the wrong existing book is worse than
+  one duplicate Book and much harder to notice, which is why `Draft.Seed`
+  won't automate it either.
+
+  ## Identity, not similarity
+
+  Names fold through `AutoMatch.person_key/1` and titles through
+  `AutoMatch.title_key/1`, so punctuation, spacing, capitalisation, accents
+  and leading articles don't make a different record: "James S. A. Corey"
+  finds "James S.A. Corey", "Rodriguez" finds "Rodríguez", "Truly, Devious"
+  finds "Truly Devious". Nothing looser is asked, because a fuzzy match here
+  would ask the operator to dismiss noise on every import, and a question
+  worth ignoring is a question that gets ignored.
+
+  A book match carries whether it also shares an author. Both are worth
+  showing (a title-key twin under a different author spelling is exactly the
+  duplicate this exists to catch), but only one of them is near-certain, and
+  the form ranks them accordingly rather than hiding either.
+
+  ## The book lookup deliberately avoids the search index
+
+  `Books.match_books/2` reads `search_index`, which `Ambry.Search.Listener`
+  fills asynchronously after the writing transaction commits. Measured on the
+  operator's dev server: a commit is reflected in the index about 9ms later.
+  A check that silently can't see a book created moments ago is worse than no
+  check, so this reads `books` directly and folds titles in Elixir, where the
+  rule is `title_key/1` itself rather than a SQL restatement of it that can
+  drift from it.
+
+  ## One of these is not a duplicate but a failure
+
+  A `:create` set whose name is already taken on the same book violates
+  `recording_groups (book_id, name)` and fails the import outright, with a
+  changeset error nobody asked for. Reporting it here turns a crash into a
+  question.
+  """
+
+  import Ambry.Inbox.AutoMatch, only: [person_key_sql: 1]
+  import Ecto.Query
+
+  alias Ambry.Books.Book
+  alias Ambry.Books.Series
+  alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.GroupLink
+  alias Ambry.Inbox.Draft.PersonDecision
+  alias Ambry.Inbox.Draft.Replacement
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.Work
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Media.RecordingGroup
+  alias Ambry.People.Author
+  alias Ambry.People.Narrator
+  alias Ambry.People.Person
+  alias Ambry.Repo
+
+  @typedoc """
+  One thing this import would create, and what the library already has under
+  that name.
+
+  `certain?` is about the strength of the match, never about what to do with
+  it: a book sharing a title and an author is as sure as this gets, and a
+  book sharing only the title is worth a look.
+  """
+  @type finding :: %{
+          kind: :book | :series | :author | :narrator | :person | :set,
+          section: :work | :recording | :people,
+          label: String.t(),
+          certain?: boolean(),
+          matches: [match()]
+        }
+
+  @type match :: %{
+          label: String.t(),
+          route: {:book | :series | :set | :person, integer()} | nil
+        }
+
+  @doc """
+  Everything this item would create that the library may already have.
+
+  Ordered — book, series, authors, set, narrators, people — because the list
+  is compared for equality when the operator says to go ahead anyway, and
+  "the same collisions I was shown" has to mean the same thing twice.
+  """
+  @spec check(struct() | nil) :: [finding()]
+  def check(nil), do: []
+  def check(%InboxItem{draft: draft}), do: check(draft)
+
+  def check(%Draft{} = draft) do
+    # A replacement creates nothing: the audiobook it replaces already has its
+    # book, its credits and its people, and this import is about its files.
+    if Replacement.replacing?(draft.replacement) do
+      []
+    else
+      book(draft) ++
+        series(draft) ++
+        credits(draft, :author) ++
+        set(draft) ++
+        credits(draft, :narrator) ++
+        people(draft)
+    end
+  end
+
+  ## the book
+
+  defp book(%Draft{work: %Work{mode: :create} = work}) do
+    case Field.value(work.title) do
+      title when is_binary(title) -> books_titled(title, work)
+      _unsettled -> []
+    end
+  end
+
+  defp book(_linked_or_absent), do: []
+
+  defp books_titled(title, %Work{} = work) do
+    key = AutoMatch.title_key(title)
+    credited = credited_keys(work.authors)
+
+    Book
+    |> order_by(:id)
+    |> preload(:authors)
+    |> Repo.all()
+    |> Enum.filter(&(AutoMatch.title_key(&1.title) == key))
+    |> Enum.map(&{&1, shares_author?(&1, credited)})
+    # Certain first: a twin under the same author is what this is looking
+    # for, and a twin under a different one is a question about a coincidence.
+    |> Enum.sort_by(fn {book, shared?} -> {!shared?, book.id} end)
+    |> case do
+      [] ->
+        []
+
+      books ->
+        [
+          %{
+            kind: :book,
+            section: :work,
+            label: "Book: #{title}",
+            certain?: Enum.any?(books, fn {_book, shared?} -> shared? end),
+            matches: Enum.map(books, fn {book, _shared?} -> book_match(book) end)
+          }
+        ]
+    end
+  end
+
+  defp book_match(%Book{} = book) do
+    %{label: credit_line(book.title, book.authors), route: {:book, book.id}}
+  end
+
+  # "The Martian by Andy Weir": when one line must hold it all, the joins are
+  # words.
+  defp credit_line(title, []), do: title
+  defp credit_line(title, authors), do: "#{title} by #{Enum.map_join(authors, ", ", & &1.name)}"
+
+  defp shares_author?(%Book{authors: authors}, credited) do
+    not MapSet.disjoint?(credited, MapSet.new(authors, &AutoMatch.person_key(&1.name)))
+  end
+
+  defp credited_keys(credits) do
+    for %Credit{name: name} <- credits || [],
+        is_binary(name),
+        into: MapSet.new(),
+        do: AutoMatch.person_key(name)
+  end
+
+  ## the series
+
+  defp series(%Draft{work: %Work{series: links}}) do
+    links |> creating() |> Enum.flat_map(&series_named/1)
+  end
+
+  defp series(_absent), do: []
+
+  # Compared by `same_series?/2` over the whole table rather than by a key in
+  # SQL, the same way `Seed` matches them: filler words are what put one
+  # batch's Bill Hodges books under both "Bill Hodges" and "Bill Hodges
+  # Trilogy".
+  defp series_named(%SeriesLink{name: name}) do
+    Series
+    |> order_by(:id)
+    |> Repo.all()
+    |> Enum.filter(&AutoMatch.same_series?(&1.name, name))
+    |> finding(:series, :work, "Series: #{name}", &%{label: &1.name, route: {:series, &1.id}})
+  end
+
+  ## the credits
+
+  defp credits(%Draft{work: %Work{authors: credits}}, :author) do
+    credits |> creating() |> Enum.flat_map(&identities_named(&1, :author))
+  end
+
+  defp credits(%Draft{recording: %{narrators: credits}}, :narrator) do
+    credits |> creating() |> Enum.flat_map(&identities_named(&1, :narrator))
+  end
+
+  defp credits(_absent, _kind), do: []
+
+  defp identities_named(%Credit{name: name}, :author) do
+    Author
+    |> where([a], person_key_sql(a.name) == ^AutoMatch.person_key(name))
+    |> order_by(:id)
+    |> preload(:people)
+    |> Repo.all()
+    |> finding(
+      :author,
+      :work,
+      "Author: #{name}",
+      &%{
+        label: behind(&1.name, &1.people),
+        route: sole_person(&1.people)
+      }
+    )
+  end
+
+  defp identities_named(%Credit{name: name}, :narrator) do
+    Narrator
+    |> where([n], person_key_sql(n.name) == ^AutoMatch.person_key(name))
+    |> order_by(:id)
+    |> preload(:person)
+    |> Repo.all()
+    |> finding(
+      :narrator,
+      :recording,
+      "Narrator: #{name}",
+      &%{
+        label: behind(&1.name, List.wrap(&1.person)),
+        route: sole_person(List.wrap(&1.person))
+      }
+    )
+  end
+
+  # A pen name says who is behind it, because that is the whole question an
+  # identity collision asks: "Sarah J. Maas" twice is a duplicate, while a
+  # second identity backed by somebody else is two authors of one name.
+  defp behind(name, []), do: name
+  defp behind(name, people), do: "#{name} (#{Enum.map_join(people, " and ", & &1.name)})"
+
+  defp sole_person([%Person{id: id}]), do: {:person, id}
+  defp sole_person(_none_or_several), do: nil
+
+  ## the people
+
+  defp people(%Draft{people: decisions}) do
+    decisions
+    |> List.wrap()
+    |> Enum.filter(&(&1.mode == :create))
+    |> Enum.flat_map(&people_named/1)
+  end
+
+  defp people_named(%PersonDecision{} = decision) do
+    case Field.value(decision.name) do
+      name when is_binary(name) ->
+        Person
+        |> where([p], person_key_sql(p.name) == ^AutoMatch.person_key(name))
+        |> order_by(:id)
+        |> Repo.all()
+        |> finding(
+          :person,
+          :people,
+          "Person: #{name}",
+          &%{
+            label: &1.name,
+            route: {:person, &1.id}
+          }
+        )
+
+      _unnamed ->
+        []
+    end
+  end
+
+  ## the set
+
+  # Only reachable on a book the draft links: a set belongs to a book, and a
+  # book this import is about to create has none yet.
+  defp set(%Draft{
+         work: %Work{mode: :link, book_id: book_id},
+         recording: %{recording_group: link}
+       })
+       when not is_nil(book_id) do
+    case creating(List.wrap(link)) do
+      [%GroupLink{name: name}] ->
+        RecordingGroup
+        |> where([g], g.book_id == ^book_id)
+        |> where([g], person_key_sql(g.name) == ^AutoMatch.person_key(name))
+        |> order_by(:id)
+        |> Repo.all()
+        |> finding(:set, :recording, "Set: #{name}", &%{label: &1.name, route: {:set, &1.id}})
+
+      _absent_or_linked ->
+        []
+    end
+  end
+
+  defp set(_no_linked_book), do: []
+
+  ## shared
+
+  # A tombstoned row is the operator saying "not this one" and creates
+  # nothing; a linked one already points at what exists.
+  defp creating(rows) do
+    rows
+    |> List.wrap()
+    |> Enum.filter(&(&1.mode == :create and not &1.removed and is_binary(&1.name)))
+  end
+
+  defp finding([], _kind, _section, _label, _match), do: []
+
+  defp finding(rows, kind, section, label, match) do
+    [
+      %{
+        kind: kind,
+        section: section,
+        label: label,
+        certain?: true,
+        matches: Enum.map(rows, match)
+      }
+    ]
+  end
+end

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -2073,6 +2073,13 @@ defmodule AmbryWeb.Admin.Decisions do
           phx-change="link-group"
           class="min-w-48 flex max-w-md flex-grow items-start gap-2"
         >
+          <%!-- The box has to be stated here, unlike every other control on
+              this row. `@tailwindcss/forms` gives `input`, `select` and
+              `textarea` their padding and border, and `input_classes/1`
+              leans on that; a drop-down's trigger is a `button`, which the
+              plugin never touches, so it collapsed to exactly the height of
+              its own text. These are the plugin's own numbers, so it sits
+              level with the number boxes beside it. --%>
           <.live_component
             :if={@link.candidates != []}
             module={EntityDropdown}
@@ -2080,7 +2087,7 @@ defmodule AmbryWeb.Admin.Decisions do
             name="recording_group_id"
             options={group_options(@link)}
             value={group_choice(@link)}
-            class={input_classes("w-full")}
+            class={input_classes("w-full border px-3 py-2")}
           />
           <input
             :if={@link.mode == :create}

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -346,7 +346,7 @@ defmodule AmbryWeb.Admin.Decisions do
         :if={!@linked}
         type="button"
         phx-click="link-book"
-        phx-value-id={@book["id"]}
+        phx-value-book_id={@book["id"]}
         class={action_classes(:zinc, "flex-none")}
       >
         Yes, another edition of this
@@ -382,7 +382,7 @@ defmodule AmbryWeb.Admin.Decisions do
       <button
         type="button"
         phx-click="replace-recording"
-        phx-value-id={@recording.id}
+        phx-value-media_id={@recording.id}
         class={action_classes(:zinc, "flex-none")}
       >
         Yes, replace its files

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -560,6 +560,12 @@ defmodule AmbryWeb.CoreComponents do
     ~H"""
     <div class={["space-y-2", @container_class]}>
       <.label :if={@label} for={@id} class="pl-3">{@label}</.label>
+      <%!-- `border` is the one class this list carries that the others don't
+          need. `@tailwindcss/forms` gives `input`, `select` and `textarea` a
+          1px border and the rest of the app inherits it silently; a
+          drop-down's trigger is a `button`, which the plugin never touches,
+          so without it this sat 1.6px shorter than the number box beside it
+          in the set form. --%>
       <.live_component
         module={EntityDropdown}
         id={@id}
@@ -567,7 +573,7 @@ defmodule AmbryWeb.CoreComponents do
         options={@options}
         value={@value}
         class={
-          ["py-[7px] px-[11px] block w-full rounded-md", "focus:outline-none focus:ring-4 sm:text-sm sm:leading-6"] ++
+          ["py-[7px] px-[11px] block w-full rounded-md border", "focus:outline-none focus:ring-4 sm:text-sm sm:leading-6"] ++
             input_color_classes(@errors) ++ [@class]
         }
       />

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -68,7 +68,25 @@ defmodule AmbryWeb.Components.EntityResolver do
 
   @limit 10
 
+  # A form control named `id` clobbers `form.id`: HTML's named getter puts the
+  # control on the form object itself, so `form.id` returns the input rather
+  # than the string in the id attribute. LiveView's patcher reads that
+  # property to match nodes, doesn't recognise the form it is looking at, and
+  # appends a second one with the same id — which pushed everything below the
+  # replacement and library pickers down by 12px on every re-render, in a way
+  # that looked like the flash was moving the page.
+  #
+  # Refused rather than documented, because the symptom points nowhere near
+  # the cause. Every other call site already qualifies the name.
+  @clobbers_form ~w(id name action method target elements length)
+
   @impl Phoenix.LiveComponent
+  def render(%{name: name} = _assigns) when name in @clobbers_form do
+    raise ArgumentError, """
+    EntityResolver was given name=#{inspect(name)}, which clobbers the     surrounding form's #{name} property and breaks LiveView's DOM patching.     Qualify it — "book_id", "media_id", "person_id" — and read that key in     the parent's phx-change handler.
+    """
+  end
+
   def render(assigns) do
     assigns =
       assigns

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -55,9 +55,11 @@
           <.sort_input field={@form[:book_authors_sort]} index={book_author_form.index} />
           <.position_input field={book_author_form[:position]} index={book_author_form.index} />
 
-          <%!-- arrows trail the input: a leading column pushed every input
+          <%!-- Controls trail the input: a leading column pushed every input
               off the box edge whenever a list crossed one row (§3, two left
-              edges) --%>
+              edges). Order matches the import form's cards — reorder first,
+              remove last — so the destructive control is at the end of the
+              row rather than in the middle of it. --%>
           <div class="flex items-start gap-2">
             <.input
               field={book_author_form[:author_id]}
@@ -66,13 +68,13 @@
               fetch={&People.author_option/1}
               container_class="grow"
             />
-            <.delete_button field={@form[:book_authors_drop]} index={book_author_form.index} />
             <.move_buttons
               :if={@book_author_count > 1}
               field={:book_authors}
               index={book_author_form.index}
               count={@book_author_count}
             />
+            <.delete_button field={@form[:book_authors_drop]} index={book_author_form.index} />
           </div>
         </.inputs_for>
 
@@ -119,13 +121,13 @@
               fetch={&Books.series_option/1}
               container_class="grow"
             />
-            <.delete_button field={@form[:series_books_drop]} index={series_book_form.index} />
             <.move_buttons
               :if={@series_book_count > 1}
               field={:series_books}
               index={series_book_form.index}
               count={@series_book_count}
             />
+            <.delete_button field={@form[:series_books_drop]} index={series_book_form.index} />
           </div>
         </.inputs_for>
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -75,11 +75,17 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      # the boxes at the click and the scrim names the wrong book. The edit
      # forms have always captured this (`Evidence.begin/2`); this is the same
      # discipline for the staged form.
-     |> assign(research_fields: %{}, searching_person_name: nil)
-     # Which person is being looked up again, and whose photo strip is showing
-     # in full. Both view state keyed by person key — the results themselves
-     # are evidence and live on the item.
-     |> assign(searching_person: nil, photos_expanded: %{})
+     |> assign(research_fields: %{})
+     # Which people are being looked up right now (key => the name asked
+     # about), and whose photo strip is showing in full. Both view state keyed
+     # by person key — the results themselves are evidence and live on the
+     # item.
+     #
+     # A map rather than one key, because a full cast is fifteen people and
+     # the operator does not queue up behind each search. One key meant the
+     # second search stole the first's spinner and the first to land cleared
+     # both.
+     |> assign(searching_people: %{}, photos_expanded: %{})
      |> assign(ticking: false)
      # The pending chapter-title fetch, and which ASIN's titles were last
      # poured — the chips' chosen state.
@@ -284,10 +290,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   `search_fields/3` is: until the results land, storage still describes the
   previous search.
   """
-  def person_query_name(_item, key, key, name) when is_binary(name), do: name
-
-  def person_query_name(item, key, _searching_key, _searching_name),
-    do: get_in(item.matches, ["people", key, "name"])
+  def person_query_name(item, key, searching) do
+    case Map.get(searching, key) do
+      name when is_binary(name) -> name
+      _not_searching -> get_in(item.matches, ["people", key, "name"])
+    end
+  end
 
   @impl Phoenix.LiveView
   def handle_event("validate", %{"inbox_item" => params}, socket) do
@@ -317,7 +325,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # not an answer — the way back from a replacement is the chip beside the
   # box, the same as at the work level. (`EntityResolver` only reports a pure
   # picker's value when something is picked, so this is belt and braces.)
-  def handle_event("replace-recording", %{"id" => id}, socket) do
+  def handle_event("replace-recording", %{"media_id" => id}, socket) do
     case to_int(id) do
       nil -> {:noreply, socket}
       media_id -> {:noreply, edit(socket, &Draft.Edit.replace_recording(&1, media_id))}
@@ -328,7 +336,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply, edit(socket, &Draft.Edit.new_recording/1)}
   end
 
-  def handle_event("link-book", %{"id" => id}, socket) do
+  def handle_event("link-book", %{"book_id" => id}, socket) do
     item = socket.assigns.item
 
     case to_int(id) do
@@ -609,7 +617,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      socket
-     |> assign(searching_person: key, searching_person_name: name)
+     |> update(:searching_people, &Map.put(&1, key, name))
      |> start_async({:person_search, key}, fn -> Inbox.research_person(item, key, name) end)}
   end
 
@@ -709,7 +717,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     {:noreply,
      socket
-     |> assign(searching_person: key, searching_person_name: name)
+     |> update(:searching_people, &Map.put(&1, key, name))
      |> start_async({:person_search, key}, fn -> Inbox.research_person(item, key, name) end)}
   end
 
@@ -850,18 +858,21 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   @impl Phoenix.LiveView
 
-  def handle_async({:person_search, _key}, {:ok, {:ok, item}}, socket) do
+  # Only this person's search is over. `item` is the row as re-read and
+  # merged under `Lookup`'s lock, so it carries whatever a search that
+  # finished a moment ago wrote as well.
+  def handle_async({:person_search, key}, {:ok, {:ok, item}}, socket) do
     {:noreply,
      socket
-     |> assign(searching_person: nil, searching_person_name: nil)
+     |> update(:searching_people, &Map.delete(&1, key))
      |> load(item)
      |> resettle()}
   end
 
   # A provider being down costs its results and nothing else — the person is
   # still perfectly importable without a face.
-  def handle_async({:person_search, _key}, _failed, socket) do
-    {:noreply, assign(socket, searching_person: nil, searching_person_name: nil)}
+  def handle_async({:person_search, key}, _failed, socket) do
+    {:noreply, update(socket, :searching_people, &Map.delete(&1, key))}
   end
 
   def handle_async({:research, _level}, {:ok, {:ok, item}}, socket) do
@@ -894,7 +905,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     {:noreply,
      socket
      |> assign(researching: nil, retrying: nil, enriching: nil)
-     |> assign(research_fields: %{}, searching_person: nil, searching_person_name: nil)
+     |> assign(research_fields: %{}, searching_people: %{})
      |> put_flash(:error, "That provider couldn't be reached just now.")}
   end
 

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -812,8 +812,12 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   #
   # Now the server owns it. The operator goes back to the list they came from
   # and the row wears the same busy overlay every other job gives it.
+  # The pre-flight is what `@collisions` carries, and passing it back is what
+  # says "yes, those ones". A first click sends the empty list, so anything
+  # found stops it; a second sends what the operator just read, and if the
+  # library moved in between the lists differ and it stops them again.
   def handle_event("import", _params, socket) do
-    case Inbox.import_item_async(socket.assigns.item) do
+    case Inbox.import_item_async(socket.assigns.item, acknowledged: socket.assigns.collisions) do
       {:ok, job} ->
         message =
           cond do
@@ -826,6 +830,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
          socket
          |> put_flash(:info, message)
          |> push_navigate(to: socket.assigns.return_to)}
+
+      {:error, {:collisions, findings}} ->
+        {:noreply, assign(socket, collisions: findings)}
 
       {:error, :already_imported} ->
         {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_imported))}
@@ -991,10 +998,39 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       busy: Inbox.busy?(job),
       # Roots are configuration and can change between seeding a draft and
       # approving it, so they're read now rather than frozen into the draft.
-      roots: Ambry.Library.list_roots()
+      roots: Ambry.Library.list_roots(),
+      # What the pre-flight found when Add was last pressed. Cleared here on
+      # purpose: any change to the draft is a change to what it would create,
+      # so an answer given about the old one may not be an answer about this
+      # one.
+      collisions: []
     )
     |> schedule_tick()
   end
+
+  @doc """
+  What the button does, which changes once the pre-flight has spoken.
+
+  Named for what pressing it does, same as it always was: after a collision
+  the thing it does is override an objection, and a button that still said
+  "Add to the library" would hide that pressing it again is the answer.
+  """
+  def import_words(true, _collisions), do: "Replace the files"
+  def import_words(false, []), do: "Add to the library"
+  def import_words(false, _collisions), do: "Add it anyway"
+
+  @doc """
+  Where a pre-flight match lives, so the operator can go and look at it.
+
+  `Ambry.Inbox.Preflight` names the record and leaves the route alone: it
+  runs nowhere near a web layer, and an author or a narrator is edited on
+  the person behind them rather than on a page of their own.
+  """
+  def collision_path({:book, id}), do: ~p"/admin/books/#{id}/edit"
+  def collision_path({:series, id}), do: ~p"/admin/series/#{id}/edit"
+  def collision_path({:set, id}), do: ~p"/admin/sets/#{id}/edit"
+  def collision_path({:person, id}), do: ~p"/admin/people/#{id}/edit"
+  def collision_path(nil), do: nil
 
   defp atom("folder"), do: :folder
   defp atom("file"), do: :file

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -164,6 +164,42 @@
         </ul>
       </section>
 
+      <%!-- What the library already has under a name this import would create.
+          Only ever after Add is pressed: before that it is an answer to a
+          question nobody asked, and on most items the sibling relink settles
+          it before it is ever true. --%>
+      <section
+        :if={@collisions != []}
+        class="border-amber-400/80 rounded-lg border-l-4 bg-zinc-900 p-4"
+        id="collisions"
+        data-role="collisions"
+      >
+        <p class="font-bold">Possible duplicates</p>
+        <p class="max-w-prose pt-1 text-sm text-zinc-400">
+          Check each of the possible duplicates found below. You can bypass this check by clicking "Add it anyway".
+        </p>
+        <ul class="mt-3 space-y-3">
+          <li :for={collision <- @collisions}>
+            <div class="flex items-baseline gap-2 text-sm">
+              <.link href={"##{collision.section}"} class="font-bold hover:underline">
+                {collision.label}
+              </.link>
+              <span :if={!collision.certain?} class="text-xs text-zinc-500">
+                same title, different author
+              </span>
+            </div>
+            <ul class="mt-1 space-y-1 pl-4">
+              <li :for={match <- collision.matches} class="text-sm text-zinc-400">
+                <.brand_link :if={collision_path(match.route)} navigate={collision_path(match.route)}>
+                  {match.label}
+                </.brand_link>
+                <span :if={!collision_path(match.route)}>{match.label}</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+
       <%!-- ==================== NEW OR A REPLACEMENT ==================== --%>
       <%!-- Asked before anything else, because answering it yes settles
           everything below: the audiobook already has its book, its credits,
@@ -899,7 +935,7 @@
             disabled={@unresolved != [] or @blocker != nil}
             data-role="import"
           >
-            {if @replacing, do: "Replace the files", else: "Add to the library"}
+            {import_words(@replacing, @collisions)}
           </.button>
 
           <.button :if={!@read_only} type="button" color={:zinc} phx-click="ignore">Ignore</.button>
@@ -928,6 +964,17 @@
           <p :if={@unresolved == [] and @blocker} class="text-sm text-red-400">
             Everything is settled, but this can't be imported yet. The reason is above.
           </p>
+
+          <%!-- Sticky, like the outstanding count and for the same reason: the
+              block itself is at the top of a long page, and the button that
+              would go past it is down here. --%>
+          <.link
+            :if={@collisions != []}
+            href="#collisions"
+            class="text-sm text-amber-400 underline hover:text-amber-200"
+          >
+            {length(@collisions)} thing{if length(@collisions) > 1, do: "s"} here may already be in the library.
+          </.link>
         </div>
       </.form_footer>
     </div>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -245,7 +245,7 @@
             <.live_component
               module={EntityResolver}
               id="replace-recording-resolver"
-              name="id"
+              name="media_id"
               search={&Media.search_media/2}
               fetch={&Media.media_option/1}
               value={if @replacing, do: @item.draft.replacement.media_id}
@@ -432,7 +432,7 @@
             <.live_component
               module={EntityResolver}
               id="library-book-resolver"
-              name="id"
+              name="book_id"
               search={&Books.search_books/2}
               fetch={&Books.book_option/1}
               value={if @item.draft.work.mode == :link, do: @item.draft.work.book_id}
@@ -782,12 +782,12 @@
               group={group}
               person_index={person_index}
               removable={true}
-              searching={@searching_person == person.key}
+              searching={Map.has_key?(@searching_people, person.key)}
               photos_expanded={@photos_expanded[person.key] || false}
               records={person_records(@item, person.key)}
               locals={person_locals(@item, person.key)}
               outcomes={person_outcomes(@item, person.key)}
-              query_name={person_query_name(@item, person.key, @searching_person, @searching_person_name)}
+              query_name={person_query_name(@item, person.key, @searching_people)}
               appears={@appearances[person.key] || []}
             />
           </div>
@@ -798,12 +798,12 @@
             group={group}
             person_index={0}
             removable={false}
-            searching={@searching_person == hd(group.people).key}
+            searching={Map.has_key?(@searching_people, hd(group.people).key)}
             photos_expanded={@photos_expanded[hd(group.people).key] || false}
             records={person_records(@item, hd(group.people).key)}
             locals={person_locals(@item, hd(group.people).key)}
             outcomes={person_outcomes(@item, hd(group.people).key)}
-            query_name={person_query_name(@item, hd(group.people).key, @searching_person, @searching_person_name)}
+            query_name={person_query_name(@item, hd(group.people).key, @searching_people)}
             appears={@appearances[hd(group.people).key] || []}
           />
         </div>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -85,6 +85,12 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
 
         {:noreply, socket |> put_flash(:info, message) |> reload()}
 
+      # The queue can refuse, but it can't ask: weighing "is this the same
+      # book" needs the records side by side, and the answer to it ("link
+      # that one instead") can only be given on the form.
+      {:error, {:collisions, _findings} = reason} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(reason))}
+
       {:error, :already_imported} ->
         {:noreply, put_flash(socket, :error, Inbox.describe_error(:already_imported))}
     end

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -110,8 +110,10 @@
             <.sort_input field={@form[:media_narrators_sort]} index={media_narrator_form.index} />
             <.position_input field={media_narrator_form[:position]} index={media_narrator_form.index} />
 
-            <%!-- arrows trail the input: a leading column pushed every input
-                off the box edge whenever a list crossed one row (§3) --%>
+            <%!-- Controls trail the input: a leading column pushed every input
+                off the box edge whenever a list crossed one row (§3). Order
+                matches the import form's cards — reorder first, remove last —
+                so the destructive control is at the end of the row. --%>
             <div class="flex items-start gap-2">
               <.input
                 field={media_narrator_form[:narrator_id]}
@@ -120,15 +122,15 @@
                 fetch={&People.narrator_option/1}
                 container_class="grow"
               />
-              <.delete_button
-                field={@form[:media_narrators_drop]}
-                index={media_narrator_form.index}
-              />
               <.move_buttons
                 :if={@media_narrator_count > 1}
                 field={:media_narrators}
                 index={media_narrator_form.index}
                 count={@media_narrator_count}
+              />
+              <.delete_button
+                field={@form[:media_narrators_drop]}
+                index={media_narrator_form.index}
               />
             </div>
           </.inputs_for>

--- a/test/ambry/inbox/auto_match_test.exs
+++ b/test/ambry/inbox/auto_match_test.exs
@@ -74,6 +74,62 @@ defmodule Ambry.Inbox.AutoMatchTest do
     end
   end
 
+  # The three sameness rules, which are the answer to "do two spellings mean
+  # one record" wherever it is asked — matching, relinking and the import
+  # pre-flight all go through these rather than carrying their own idea of it.
+  describe "the sameness rules" do
+    test "a name folds punctuation, spacing, case and accents" do
+      same = [
+        {"James S.A. Corey", "James S. A. Corey"},
+        {"TJ Klune", "T.J. Klune"},
+        {"Patricia Rodríguez", "Patricia Rodriguez"},
+        {"R.C. Bray", "rc bray"}
+      ]
+
+      for {one, other} <- same do
+        assert AutoMatch.person_key(one) == AutoMatch.person_key(other),
+               "expected #{one} and #{other} to be one person"
+      end
+
+      # Still identity: a different word is a different human.
+      refute AutoMatch.person_key("Sarah J. Maas") == AutoMatch.person_key("Sarah Maas")
+    end
+
+    test "a title folds punctuation, case, articles, edition words and accents" do
+      same = [
+        {"Truly, Devious", "Truly Devious"},
+        {"The Princess Bride", "Princess Bride"},
+        {"Neuromancer (Unabridged)", "Neuromancer"},
+        # Accents were the one fold titles didn't do, so the library's "Les
+        # Misérables" and a file's "Les Miserables" were two books.
+        {"Les Misérables", "Les Miserables"}
+      ]
+
+      for {one, other} <- same do
+        assert AutoMatch.title_key(one) == AutoMatch.title_key(other),
+               "expected #{one} and #{other} to be one book"
+      end
+
+      # Deliberately exact beyond the folds: a sequel is not its predecessor,
+      # and a retitling is a judgement rather than a fold.
+      refute AutoMatch.title_key("Dune Messiah") == AutoMatch.title_key("Dune")
+
+      refute AutoMatch.title_key("Harry Potter and the Philosopher's Stone") ==
+               AutoMatch.title_key("Harry Potter and the Sorcerer's Stone")
+    end
+
+    test "a series folds filler words and a subtitle head" do
+      assert AutoMatch.same_series?("Bill Hodges", "Bill Hodges Trilogy")
+      assert AutoMatch.same_series?("Kushiel's Legacy: Phedre Trilogy", "Kushiel's Legacy")
+      assert AutoMatch.same_series?("The Expanse", "Expanse")
+
+      # Goodreads-shaped sources list both of these, and only one of them
+      # belongs on the book.
+      refute AutoMatch.same_series?("The Expanse", "The Expanse (Chronological)")
+      refute AutoMatch.same_series?(nil, "The Expanse")
+    end
+  end
+
   describe "editions_for/3 outcomes" do
     # Asking Hardcover about four of its own work records is four calls but
     # one answer. Reported separately it read as nonsense across a row —

--- a/test/ambry/inbox/lookup_test.exs
+++ b/test/ambry/inbox/lookup_test.exs
@@ -73,6 +73,43 @@ defmodule Ambry.Inbox.LookupTest do
     end
   end
 
+  describe "research_person/3 with more than one in flight" do
+    # The form does not make the operator queue up behind each search, and a
+    # full cast is fifteen people. `matches` is one jsonb column holding all
+    # of them, so two searches that each merged into the item as it was when
+    # the button was pressed, and then wrote the whole column back, meant the
+    # second to land threw away the first's results.
+    test "two searches at once both survive" do
+      item = item_with_records()
+
+      patch(Ambry.Metadata.Search, :people, fn name, _opts ->
+        {[person_match(name)], [%{"id" => "test", "name" => "Test", "status" => "ok"}]}
+      end)
+
+      # Both start from the same snapshot, which is exactly what the form
+      # hands them: the item as it was when each button was pressed.
+      [alice, bob] =
+        ["Alice Adams", "Bob Brown"]
+        |> Enum.map(fn name ->
+          Task.async(fn -> Inbox.research_person(item, name_key(name), name) end)
+        end)
+        |> Task.await_many(5000)
+
+      assert {:ok, _} = alice
+      assert {:ok, _} = bob
+
+      people = Inbox.get_item!(item.id).matches["people"]
+
+      assert Map.keys(people) |> Enum.sort() == [name_key("Alice Adams"), name_key("Bob Brown")]
+
+      for name <- ["Alice Adams", "Bob Brown"] do
+        held = people[name_key(name)]
+        assert held["name"] == name
+        assert [%{"name" => ^name}] = held["candidates"]
+      end
+    end
+  end
+
   describe "retry_provider/3" do
     # A rate limit during matching used to cost an item that provider's records
     # until somebody re-ran the whole match.
@@ -200,6 +237,19 @@ defmodule Ambry.Inbox.LookupTest do
 
       assert {:ok, _item} = Inbox.hydrate_record(item, "work", {"provider:hardcover", "hc-1"})
     end
+  end
+
+  defp name_key(name), do: Ambry.Inbox.AutoMatch.person_key(name)
+
+  defp person_match(name) do
+    %Ambry.Metadata.PersonSearch.Match{
+      provider_id: "test",
+      provider_name: "Test",
+      id: "p-#{name_key(name)}",
+      name: name,
+      images: [],
+      description: nil
+    }
   end
 
   defp item_with_records(opts \\ []) do

--- a/test/ambry/inbox/preflight_test.exs
+++ b/test/ambry/inbox/preflight_test.exs
@@ -1,0 +1,307 @@
+defmodule Ambry.Inbox.PreflightTest do
+  @moduledoc """
+  The check at the door: what this import would create that the library has.
+
+  A draft is a snapshot of a library that keeps moving, so these tests are
+  mostly about the gap between the two — a name settled when nothing of that
+  name existed, asked again when something does.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.GroupLink
+  alias Ambry.Inbox.Draft.PersonDecision
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.Replacement
+  alias Ambry.Inbox.Draft.SeriesLink
+  alias Ambry.Inbox.Draft.Work
+  alias Ambry.Inbox.Preflight
+
+  describe "check/1 on a book" do
+    test "an empty library collides with nothing" do
+      assert Preflight.check(draft(work: creating("Leviathan Wakes", ["James S.A. Corey"]))) == []
+    end
+
+    test "a book of the same title and author is found" do
+      book = book_titled("Leviathan Wakes", "James S.A. Corey")
+
+      assert [finding] = book_findings(creating("Leviathan Wakes", ["James S.A. Corey"]))
+      assert finding.kind == :book
+      assert finding.section == :work
+      assert finding.label == "Book: Leviathan Wakes"
+      assert finding.certain?
+      assert [%{label: label, route: {:book, id}}] = finding.matches
+      assert id == book.id
+      assert label == "Leviathan Wakes by James S.A. Corey"
+    end
+
+    # The spellings the providers actually disagree about. None of these is a
+    # different book, and every one of them used to be a second Book row.
+    test "punctuation, capitalisation, articles and accents do not make a different book" do
+      book_titled("The Princess Bride", "William Goldman")
+
+      for title <- ["princess bride", "Princess Bride", "The  Princess: Bride"] do
+        assert [_found] = book_findings(creating(title, ["William Goldman"])),
+               "expected #{title} to find The Princess Bride"
+      end
+    end
+
+    test "an accented title finds its unaccented twin" do
+      book_titled("Les Misérables", "Victor Hugo")
+
+      assert [_found] = book_findings(creating("Les Miserables", ["Victor Hugo"]))
+    end
+
+    test "the author is spelled the way the other provider spells it" do
+      book_titled("Leviathan Wakes", "James S. A. Corey")
+
+      assert [finding] = book_findings(creating("Leviathan Wakes", ["James S.A. Corey"]))
+      assert finding.certain?
+    end
+
+    # Two books really can share a title, so this is shown and marked rather
+    # than hidden: the operator is the one who knows which it is.
+    test "a title twin by somebody else is offered, but not as a certainty" do
+      book_titled("Persuasion", "Jane Austen")
+
+      assert [finding] = book_findings(creating("Persuasion", ["Someone Else"]))
+      refute finding.certain?
+    end
+
+    test "the certain match is listed first" do
+      _other = book_titled("Persuasion", "Someone Else")
+      mine = book_titled("Persuasion", "Jane Austen")
+
+      assert [finding] = book_findings(creating("Persuasion", ["Jane Austen"]))
+      assert [%{route: {:book, first}}, %{route: {:book, _second}}] = finding.matches
+      assert first == mine.id
+    end
+
+    test "a different book is not a collision" do
+      book_titled("Dune Messiah", "Frank Herbert")
+
+      assert book_findings(creating("Dune", ["Frank Herbert"])) == []
+    end
+
+    # The whole point of linking: the operator already said which book this
+    # is, so there is nothing left to warn about.
+    test "a work that links an existing book creates no book" do
+      book = book_titled("Leviathan Wakes", "James S.A. Corey")
+
+      work = %{creating("Leviathan Wakes", ["James S.A. Corey"]) | mode: :link, book_id: book.id}
+
+      assert book_findings(work) == []
+    end
+
+    test "a work with no settled title asks nothing" do
+      book_titled("Leviathan Wakes", "James S.A. Corey")
+
+      work = %{creating("Leviathan Wakes", []) | title: %Field{value: nil}}
+
+      assert Preflight.check(draft(work: work)) == []
+    end
+  end
+
+  describe "check/1 on the credits and the people" do
+    test "an identity of the same name is found, with whoever is behind it" do
+      person = insert(:person, name: "Sarah J. Maas")
+      author = insert(:author, name: "Sarah J. Maas", person: person)
+
+      draft = draft(work: %{creating("Some Book", ["Sarah  J.  Maas"]) | title: %Field{}})
+
+      assert [finding] = Preflight.check(draft)
+      assert finding.kind == :author
+      assert finding.label == "Author: Sarah  J.  Maas"
+      assert [%{label: label, route: {:person, person_id}}] = finding.matches
+      assert person_id == person.id
+      assert label == "#{author.name} (#{person.name})"
+    end
+
+    test "a narrator of the same name is found" do
+      insert(:narrator, name: "R.C. Bray", person: insert(:person))
+
+      draft =
+        draft(
+          work: bare_work(),
+          recording: %Recording{narrators: [%Credit{name: "RC Bray", kind: :narrator}]}
+        )
+
+      assert [finding] = Preflight.check(draft)
+      assert finding.kind == :narrator
+      assert finding.section == :recording
+    end
+
+    test "a person of the same name is found" do
+      person = insert(:person, name: "Patricia Rodríguez")
+
+      draft =
+        draft(
+          work: bare_work(),
+          people: [
+            %PersonDecision{key: "patriciarodriguez", name: %Field{value: "Patricia Rodriguez"}}
+          ]
+        )
+
+      assert [finding] = Preflight.check(draft)
+      assert finding.kind == :person
+      assert finding.section == :people
+      assert [%{route: {:person, id}}] = finding.matches
+      assert id == person.id
+    end
+
+    # A tombstone is the operator saying "not this one". It creates nothing,
+    # so it can collide with nothing.
+    test "a removed credit creates nothing" do
+      insert(:author, name: "Sarah J. Maas")
+
+      credit = %Credit{name: "Sarah J. Maas", kind: :author, removed: true}
+      draft = draft(work: %{bare_work() | authors: [credit]})
+
+      assert Preflight.check(draft) == []
+    end
+
+    test "a linked credit creates nothing" do
+      author = insert(:author, name: "Sarah J. Maas")
+
+      credit = %Credit{name: "Sarah J. Maas", kind: :author, mode: :link, identity_id: author.id}
+      draft = draft(work: %{bare_work() | authors: [credit]})
+
+      assert Preflight.check(draft) == []
+    end
+  end
+
+  describe "check/1 on the series and the set" do
+    test "a series of the same name is found, filler words and all" do
+      series = insert(:series, name: "Bill Hodges Trilogy")
+
+      link = %SeriesLink{name: "Bill Hodges"}
+      draft = draft(work: %{bare_work() | series: [link]})
+
+      assert [finding] = Preflight.check(draft)
+      assert finding.kind == :series
+      assert [%{route: {:series, id}}] = finding.matches
+      assert id == series.id
+    end
+
+    # This one is not a duplicate waiting to happen but an import that fails:
+    # `recording_groups (book_id, name)` is unique, so creating it raises a
+    # constraint error out of the middle of the transaction.
+    test "a set the linked book already has is found" do
+      book = book_titled("Leviathan Wakes", "James S.A. Corey")
+      group = insert(:recording_group, book: book, name: "Graphic Audio LLC")
+
+      draft =
+        draft(
+          work: %{bare_work() | mode: :link, book_id: book.id},
+          recording: %Recording{recording_group: %GroupLink{name: "Graphic  Audio  LLC"}}
+        )
+
+      assert [finding] = Preflight.check(draft)
+      assert finding.kind == :set
+      assert [%{route: {:set, id}}] = finding.matches
+      assert id == group.id
+    end
+
+    # A set belongs to a book, so a book that doesn't exist yet has none of
+    # them to collide with — whatever else is called that elsewhere.
+    test "a set on a book this import would create is not compared to other books' sets" do
+      other = book_titled("Something Else", "Someone")
+      insert(:recording_group, book: other, name: "Graphic Audio LLC")
+
+      draft =
+        draft(
+          work: bare_work(),
+          recording: %Recording{recording_group: %GroupLink{name: "Graphic Audio LLC"}}
+        )
+
+      assert Preflight.check(draft) == []
+    end
+  end
+
+  describe "check/1 overall" do
+    test "nothing is asked about a replacement, which creates nothing" do
+      book_titled("Leviathan Wakes", "James S.A. Corey")
+      media = insert(:media, book: insert(:book))
+
+      draft =
+        draft(
+          work: creating("Leviathan Wakes", ["James S.A. Corey"]),
+          replacement: %Replacement{mode: :replace, media_id: media.id, approved: true}
+        )
+
+      assert Preflight.check(draft) == []
+    end
+
+    # One import, several kinds of thing to make, each asked about separately.
+    test "every kind of collision is reported together, in a fixed order" do
+      book = book_titled("Leviathan Wakes", "James S.A. Corey")
+      insert(:series, name: "The Expanse")
+      insert(:narrator, name: "Jefferson Mays", person: insert(:person))
+      insert(:person, name: "Jefferson Mays")
+      insert(:recording_group, book: book, name: "Graphic Audio LLC")
+
+      draft =
+        draft(
+          work: %{
+            creating("Leviathan Wakes", ["James S.A. Corey"])
+            | mode: :link,
+              book_id: book.id,
+              series: [%SeriesLink{name: "The Expanse"}]
+          },
+          recording: %Recording{
+            narrators: [%Credit{name: "Jefferson Mays", kind: :narrator}],
+            recording_group: %GroupLink{name: "Graphic Audio LLC"}
+          },
+          people: [%PersonDecision{key: "jeffersonmays", name: %Field{value: "Jefferson Mays"}}]
+        )
+
+      assert [:series, :author, :set, :narrator, :person] =
+               draft |> Preflight.check() |> Enum.map(& &1.kind)
+    end
+
+    test "a nil draft asks nothing" do
+      assert Preflight.check(nil) == []
+    end
+
+    # The list is compared for equality when the operator says to go ahead
+    # anyway, so it has to be the same list twice.
+    test "the same draft against the same library gives the same answer" do
+      book_titled("Persuasion", "Jane Austen")
+      book_titled("Persuasion", "Someone Else")
+      insert(:author, name: "Jane Austen")
+
+      draft = draft(work: creating("Persuasion", ["Jane Austen"]))
+
+      assert Preflight.check(draft) == Preflight.check(draft)
+    end
+  end
+
+  # The book tests are about books. A draft that means to create an author the
+  # library also has is a real collision and gets its own test above; here it
+  # is noise.
+  defp book_findings(work) do
+    work |> then(&draft(work: &1)) |> Preflight.check() |> Enum.filter(&(&1.kind == :book))
+  end
+
+  defp draft(fields) do
+    struct!(%Draft{work: bare_work(), recording: %Recording{}, people: []}, fields)
+  end
+
+  defp bare_work, do: %Work{mode: :create, title: %Field{}, authors: [], series: []}
+
+  defp creating(title, authors) do
+    %Work{
+      mode: :create,
+      title: %Field{value: title},
+      authors: Enum.map(authors, &%Credit{name: &1, kind: :author}),
+      series: []
+    }
+  end
+
+  defp book_titled(title, author_name) do
+    author = insert(:author, name: author_name)
+    insert(:book, title: title, book_authors: [build(:book_author, author: author)])
+  end
+end

--- a/test/ambry/inbox/run_import_test.exs
+++ b/test/ambry/inbox/run_import_test.exs
@@ -14,6 +14,11 @@ defmodule Ambry.Inbox.RunImportTest do
   use Ambry.DataCase
 
   alias Ambry.Inbox
+  alias Ambry.Inbox.Draft
+  alias Ambry.Inbox.Draft.Credit
+  alias Ambry.Inbox.Draft.Field
+  alias Ambry.Inbox.Draft.Recording
+  alias Ambry.Inbox.Draft.Work
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.RunImport
 
@@ -69,6 +74,79 @@ defmodule Ambry.Inbox.RunImportTest do
 
       assert {:error, :already_imported} = Inbox.import_item_async(item)
     end
+  end
+
+  describe "import_item_async/2 and the pre-flight" do
+    # The gap the whole check exists for: the draft was seeded when nothing of
+    # this name existed, and by the time Add is pressed something does.
+    test "a draft that would create a book the library already has is refused" do
+      have_book("The Martian", "Andy Weir")
+      item = item_creating("The Martian", "Andy Weir")
+
+      assert {:error, {:collisions, [finding]}} = Inbox.import_item_async(item)
+      assert finding.kind == :book
+      refute_enqueued(worker: RunImport)
+    end
+
+    # Pressing Add again is the answer, and what makes it an answer rather
+    # than a flag is that it names what was answered.
+    test "handing the same findings back is what lets it through" do
+      have_book("The Martian", "Andy Weir")
+      item = item_creating("The Martian", "Andy Weir")
+
+      assert {:error, {:collisions, findings}} = Inbox.import_item_async(item)
+      assert {:ok, _job} = Inbox.import_item_async(item, acknowledged: findings)
+      assert_enqueued(worker: RunImport, args: %{inbox_item_id: item.id})
+    end
+
+    # A second twin turning up while the operator read the first is a
+    # collision they were never shown, so it is not one they can have agreed
+    # to.
+    test "a collision that appeared since is asked about again" do
+      have_book("The Martian", "Andy Weir")
+      item = item_creating("The Martian", "Andy Weir")
+
+      assert {:error, {:collisions, findings}} = Inbox.import_item_async(item)
+
+      have_book("The Martian", "Somebody Else")
+
+      assert {:error, {:collisions, fresh}} =
+               Inbox.import_item_async(item, acknowledged: findings)
+
+      assert fresh != findings
+      refute_enqueued(worker: RunImport)
+    end
+
+    test "an item in the library is refused before anything is looked up" do
+      have_book("The Martian", "Andy Weir")
+      item = item_creating("The Martian", "Andy Weir")
+      {:ok, item} = Inbox.update_item(item, %{status: :imported})
+
+      assert {:error, :already_imported} = Inbox.import_item_async(item)
+    end
+  end
+
+  defp have_book(title, author_name) do
+    author = insert(:author, name: author_name)
+    insert(:book, title: title, book_authors: [build(:book_author, author: author)])
+  end
+
+  defp item_creating(title, author_name) do
+    Repo.insert!(%InboxItem{
+      path: title,
+      files: ["#{title}/book.m4b"],
+      source_id: insert(:source).id,
+      draft: %Draft{
+        work: %Work{
+          mode: :create,
+          title: %Field{value: title},
+          authors: [%Credit{name: author_name, kind: :author, mode: :link, identity_id: 0}],
+          series: []
+        },
+        recording: %Recording{},
+        people: []
+      }
+    })
   end
 
   # Deliberately thin: an item with no probe and no draft can only be refused,

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -111,7 +111,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
       html = view |> element("button[data-role='import']") |> render_click()
 
-      assert html =~ "You may already have this"
+      assert html =~ "Possible duplicates"
       assert html =~ "Book: The Way of Kings"
       assert has_element?(view, "[data-role='collisions']")
       assert has_element?(view, "button[data-role='import']", "Add it anyway")
@@ -144,7 +144,7 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
       html = render_click(view, "new-book", %{})
 
-      refute html =~ "You may already have this"
+      refute html =~ "Possible duplicates"
       refute has_element?(view, "[data-role='collisions']")
     end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -100,6 +100,54 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert [_only_one] = all_enqueued(worker: RunImport)
     end
 
+    # The library moved between the draft being settled and Add being pressed,
+    # which is the whole gap the pre-flight exists to cover. The order here is
+    # the order it happens in: settle against a library that has nothing, then
+    # something turns up.
+    test "a book that arrived since the draft was settled stops the import", %{conn: conn} do
+      item = probed_item() |> settle()
+      have_way_of_kings()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      html = view |> element("button[data-role='import']") |> render_click()
+
+      assert html =~ "You may already have this"
+      assert html =~ "Book: The Way of Kings"
+      assert has_element?(view, "[data-role='collisions']")
+      assert has_element?(view, "button[data-role='import']", "Add it anyway")
+
+      # nothing queued, nothing created, and the operator is still on the form
+      refute_enqueued(worker: RunImport)
+      assert %{status: :pending} = Inbox.get_item!(item.id)
+    end
+
+    test "pressing Add again is the answer, and it goes through", %{conn: conn} do
+      item = probed_item() |> settle()
+      have_way_of_kings()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      view |> element("button[data-role='import']") |> render_click()
+      view |> element("button[data-role='import']") |> render_click()
+
+      assert_redirect(view, ~p"/admin/inbox")
+      assert_enqueued(worker: RunImport, args: %{inbox_item_id: item.id})
+    end
+
+    # Editing anything changes what the import would create, so the answer
+    # given about the old draft is not an answer about this one.
+    test "changing the draft puts the question back", %{conn: conn} do
+      item = probed_item() |> settle()
+      have_way_of_kings()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      view |> element("button[data-role='import']") |> render_click()
+
+      html = render_click(view, "new-book", %{})
+
+      refute html =~ "You may already have this"
+      refute has_element?(view, "[data-role='collisions']")
+    end
+
     test "each outstanding decision is named, not just counted", %{conn: conn} do
       item = probed_item()
 
@@ -2430,6 +2478,13 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(draft))
 
     %{item: item, book: book, group: group}
+  end
+
+  defp have_way_of_kings do
+    insert(:book,
+      title: "The Way of Kings",
+      book_authors: [build(:book_author, author: build(:author, name: "Brandon Sanderson"))]
+    )
   end
 
   defp probed_item(opts \\ []) do

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -374,6 +374,27 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert File.exists?(file)
   end
 
+  # The queue can refuse but it cannot ask: weighing "is this the same book"
+  # needs the two records side by side, and the answer to it lives on the
+  # form.
+  test "a row whose import may duplicate something sends the operator to the form", %{conn: conn} do
+    item = probed_item() |> settle()
+
+    insert(:book,
+      title: "The Way of Kings",
+      book_authors: [build(:book_author, author: build(:author, name: "Brandon Sanderson"))]
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/admin/inbox")
+
+    html =
+      view |> element("span[phx-click='import'][phx-value-id='#{item.id}']") |> render_click()
+
+    assert html =~ "may already be in the library"
+    refute_enqueued(worker: RunImport)
+    assert Inbox.get_item!(item.id).status == :pending
+  end
+
   # A row handed to an import wears the same cover every other background job
   # gives it, and says which job it is — "Working on it" over a row you just
   # pressed Add on says nothing about whether the press landed.


### PR DESCRIPTION
The inbox's duplicate protection was all upstream of the button: matching offers local books, seeding links what it is certain about, and `Seed.relink/2` re-points a queued draft when a sibling import moves the library under it. That machinery works — measured live on the operator's two-part A Court of Mist and Fury, importing part 1 relinked part 2's work *and* its set with nobody touching it.

What it doesn't have is a check at the door. Every case relink declines — a curated decision, a title spelled differently, a book added by hand, anything that arrived after the last relink ran — is a duplicate nobody sees until the library has two of something.

So: read the draft on the click, ask the library about every `:create` in it, and say what it found.

## What's here

**`Ambry.Inbox.Preflight`** covers the book, the series, the author and narrator identities, the people, and the set. It reports and decides nothing — a name in common is evidence, and "same book, or two books that share a title" is the judgement this form exists to put in front of a human. About 3.6ms per item on real data.

**The gate is `import_item_async/2`**, which both the form footer and the queue row already go through. It asks again rather than trusting a flag: findings come back as `:acknowledged` and the import proceeds only if the library still says exactly that, so a collision that appeared while the operator was reading stops them again. Editing the draft clears the answer.

**The form** renders the findings as their own block, each match linking to the record it found, and the button becomes "Add it anyway". **The queue row** can refuse but can't ask — weighing two records needs them side by side — so it says so and leaves the operator to open it.

## Identity, not similarity

Names fold through `person_key/1` and titles through `title_key/1`, so punctuation, spacing, capitalisation, accents and leading articles don't make a different record. The one concession: a book matching by title but not by author is shown and ranked below the certain ones rather than hidden.

Which surfaced a real gap — **`title_key/1` didn't fold accents while `person_key/1` did**, so titles were held to a stricter rule than names. `relink_work/2` fetches candidates by full-text search (which unaccents) and then filters on exact `title_key/1` equality, so an accented book was found and then discarded, and the failure looked exactly like "you don't have this book". Fixed in its own commit, which also moves the SQL name-key and the series sameness rule out of `Seed` and next to their Elixir twins in `AutoMatch`, where the docs already claim the role.

## Two notes for review

- The book lookup deliberately avoids `Books.match_books/2`. That reads `search_index`, which `Search.Listener` fills asynchronously after the writing transaction commits — measured about 9ms behind on the dev server. A check that can't see a book created moments ago is worse than no check.
- A `:create` set whose name is already taken on the same book violates `recording_groups (book_id, name)` and currently *fails the import* with a changeset error from the middle of the transaction. This turns that crash into a question.

## Five fixes found while testing it

Two of them were not what they looked like.

- **The set picker collapsed to the height of its own text.** `@tailwindcss/forms` gives `input`, `select` and `textarea` their padding and border and `input_classes/1` leans on that; a drop-down's trigger is a `button`, which the plugin never touches. 20px beside a 38px number box. The same root cause one layer up made `<.input type="dropdown">` sit 1.6px shorter than its neighbour in the set form, which is why series pairs looked right and set pairs didn't.
- **"The flash pushes the inputs down" was DOM clobbering.** A form control named `id` puts itself on the form object via HTML's named getter, so `form.id` returned that input instead of the string in the id attribute. LiveView's patcher reads that property to match nodes, didn't recognise the form, and appended a second empty one with the same id — 12px of shift on every re-render, which a flash reliably causes. Both pickers now name their field the way every other resolver does, and `EntityResolver` refuses the clobbering names outright.
- **Two person searches fought over the page**, and the loser's results were gone for good: `matches` is one jsonb column, and each search merged into the item as captured at click time and wrote the whole column back. It re-reads under `FOR UPDATE` now. The single `searching_person` assign became a map, so each row shows and clears its own spinner. The regression test fails without the fix, in the shape it was reported.
- **The ✕ sat in the middle of re-orderable rows** on the book and media forms, with the reorder arrows after it. They read reorder-then-remove now, like the import form's cards.

## Verified

`mix check` clean, 1864 tests pass. The pre-flight was exercised end to end on the operator's dev server against the live A Court of Mist and Fury pair, and confirmed by the operator by undoing a relink and attempting the duplicate import, which was caught. The two layout fixes were measured in the browser.

## Not in scope

Deliberately left, in rough order of value: the sibling filter's un-normalized `ILIKE` scan over every pending draft (423ms, and it misses pairs that don't share an author spelling), relink skipping curated works, relink running only after a sibling import rather than on every prepare, relink as a job rather than inline in `RunImport`, a looser advisory tier for subtitles and retitlings, and the de-dup audit tool for what is already in the library.

https://claude.ai/code/session_01PXFb3yiAWDmi9aZPdBJDoQ
