### PR TITLE
Search the way people type

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -159,10 +159,16 @@ defmodule Ambry.Books do
   No `partial`, unlike `search_books/2`. A prefix on the last word is for
   somebody who has not finished typing it; a filename has no half-typed word,
   and opening its last token to prefixes only buys noise.
+
+  And `:any` explicitly, rather than the `:narrowing` a picker gets. Nobody
+  is typing here, so there is no "I will add a word to cut this down" to
+  serve — and narrowing would hand back the one row that happened to match
+  every token where this wants the ranked field of candidates a matcher
+  scores.
   """
   @spec match_books(String.t() | nil, pos_integer()) :: [struct()]
   def match_books(phrase, limit \\ 10) do
-    Query.matching(BookFlat, phrase, :book, limit: limit, partial: false)
+    Query.matching(BookFlat, phrase, :book, limit: limit, partial: false, joiner: :any)
   end
 
   @doc """

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -149,14 +149,41 @@ defmodule Ambry.Media do
   Reaches any audiobook in the library by title, book, author, narrator,
   series or universe — the same search the index offers, without its
   pagination. With nothing typed, the first page by book.
+
+  Ranked, which it has to be spelled out to be. This asked `Query.ids/3`
+  once, and that function drops the `ORDER BY` deliberately — it is the admin
+  list filter's, where the operator has already chosen a sort. A picker has
+  not chosen one: ranking *is* the answer. Sorting the candidates
+  alphabetically and then taking ten meant "mars" showed the ten
+  alphabetically-first of 69 candidate books, and Red Mars, ranked first, was
+  not among them.
+
+  The recordings of one book stay together and in part order, since which
+  book it is decides the match and the parts are a menu within it.
   """
   def search_media(phrase, limit) do
-    MediaFlat
-    |> media_matching(phrase)
-    |> order_by([m], asc: m.book, asc: m.part_number, asc: m.id)
-    |> limit(^limit)
-    |> Repo.all()
-    |> Enum.map(&media_option/1)
+    case String.trim(phrase || "") do
+      "" ->
+        # Nothing typed: the first page, by book. There is no ranking to keep.
+        MediaFlat
+        |> order_by([m], asc: m.book, asc: m.part_number, asc: m.id)
+        |> limit(^limit)
+        |> Repo.all()
+        |> Enum.map(&media_option/1)
+
+      typed ->
+        ranked_book_ids =
+          Query.ranked_ids(typed, limit, joiner: :narrowing, partial: true, types: [:book])
+
+        rank = ranked_book_ids |> Enum.with_index() |> Map.new()
+
+        MediaFlat
+        |> where([m], m.book_id in ^ranked_book_ids)
+        |> Repo.all()
+        |> Enum.sort_by(&{Map.fetch!(rank, &1.book_id), &1.part_number || 0, &1.id})
+        |> Enum.take(limit)
+        |> Enum.map(&media_option/1)
+    end
   end
 
   @doc """
@@ -175,24 +202,6 @@ defmodule Ambry.Media do
     |> order_by([m], asc: m.part_number, asc: m.id)
     |> Repo.all()
     |> Enum.map(&media_option/1)
-  end
-
-  # Deliberately not `MediaFlat.filter(:search, …)`, which is the admin
-  # list's filter and asks a stricter question: every word has to match, and
-  # a half-typed one matches nothing. Sharing it made "sander" find no
-  # recordings at all. A picker gets the picker's knobs.
-  defp media_matching(query, phrase) do
-    case String.trim(phrase || "") do
-      "" ->
-        query
-
-      typed ->
-        where(
-          query,
-          [m],
-          m.book_id in subquery(Query.ids(typed, :book, joiner: :any, partial: true))
-        )
-    end
   end
 
   @doc """

--- a/lib/ambry/search/query.ex
+++ b/lib/ambry/search/query.ex
@@ -16,7 +16,7 @@ defmodule Ambry.Search.Query do
   it — hydrate it, `EXISTS` against it, limit it, join to it — is the
   caller's business.
 
-  ## Two knobs, not five modes
+  ## Two knobs and a policy, not five modes
 
     * **`:joiner`** — `:all` (every term must match) or `:any` (a term that
       misses costs nothing, a term that hits improves the rank). `:any` is
@@ -32,6 +32,14 @@ defmodule Ambry.Search.Query do
       Sanderson, per the operator, 2026-08-18. A mid-word match is what an
       `ILIKE '%…%'` buys and nobody wanted it.
 
+    * **`:narrowing`** is not a third joiner so much as the picker's policy
+      over the two: ask `:all`, and widen to `:any` only if nothing answers.
+      It exists because `:any` alone gets the relationship backwards —
+      every word you add *adds* results, when the whole reason you kept
+      typing was to remove some. Under `:narrowing` a term narrows right up
+      until the constraint is unsatisfiable, and then the box falls back to
+      the best partial matches rather than going empty.
+
   Plus `:types`, to scope to books, or people, or whatever one kind a picker
   is picking.
 
@@ -45,6 +53,21 @@ defmodule Ambry.Search.Query do
 
   `ts_rank_cd` over the A/B/C weights, with the `pg_trgm` `similarity` sum as
   a tiebreak and the record's own name last so the order is stable.
+
+  Ahead of all of it sit two booleans: does the record's name **start with**
+  the raw phrase, and failing that, does it **contain** it. This is the one
+  signal a `tsvector` throws away and a picker lives on — word order and
+  adjacency. Typing "murder" ranked The Thursday Murder Club above Murder by
+  Other Means, because that book's series repeats its title and a second
+  weight-B hit outscores a single weight-A one; and typing "murder by"
+  changed nothing at all, because `by` is a stop word and leaves the query
+  entirely.
+
+  They read the *raw* phrase rather than the parsed one on purpose. That
+  makes them the only place a stop word still counts and the only place the
+  order of the words survives. They cannot widen a result set — they run over
+  rows the query already matched — so they only ever decide which of them a
+  picker shows first.
 
   Deliberately *not* length-normalized. Normalization was tried, because it
   looks like the way to keep "Kramer" above "Michael Kramer" for "kra" — but
@@ -87,6 +110,34 @@ defmodule Ambry.Search.Query do
 
   defp joiner!(joiner) when joiner in [:all, :any], do: to_string(joiner)
 
+  @doc """
+  The ids of `type` matching `phrase`, best first, resolving `:narrowing`.
+
+  `build/2` cannot express `:narrowing` — it is two queries, and which one
+  answers depends on whether the first found anything — so it lives here,
+  where a caller has already accepted that it is fetching rows.
+  """
+  def ranked_ids(phrase, limit, opts) do
+    case Keyword.get(opts, :joiner, :narrowing) do
+      :narrowing ->
+        case fetch_ids(phrase, limit, Keyword.put(opts, :joiner, :all)) do
+          [] -> fetch_ids(phrase, limit, Keyword.put(opts, :joiner, :any))
+          ids -> ids
+        end
+
+      _joiner ->
+        fetch_ids(phrase, limit, opts)
+    end
+  end
+
+  defp fetch_ids(phrase, limit, opts) do
+    phrase
+    |> build(opts)
+    |> limit(^limit)
+    |> select([record], fragment("(?).id", record.reference))
+    |> Repo.all()
+  end
+
   defp scope_to_types(query, nil), do: query
 
   defp scope_to_types(query, types) do
@@ -120,6 +171,18 @@ defmodule Ambry.Search.Query do
           ^partial
         ),
       order_by: [
+        desc:
+          fragment(
+            "starts_with(unaccent(lower(?)), unaccent(lower(?)))",
+            record.primary,
+            ^phrase
+          ),
+        desc:
+          fragment(
+            "strpos(unaccent(lower(?)), unaccent(lower(?))) > 0",
+            record.primary,
+            ^phrase
+          ),
         desc:
           fragment(
             "ts_rank_cd(?, ambry_tsquery(?, ?, ?))",
@@ -175,9 +238,10 @@ defmodule Ambry.Search.Query do
   ranking and nothing else — the whole answer is which three rows go at the
   top.
 
-  So the defaults here are the picker's: `:any`, because a term that misses
-  should not empty the box, and `partial: true`, because somebody typing has
-  not finished the word yet.
+  So the defaults here are the picker's: `:narrowing`, so that another word
+  removes rows rather than adding them and a term that misses still cannot
+  empty the box, and `partial: true`, because somebody typing has not
+  finished the word yet.
 
   `queryable` is whatever the caller wants back — a schema, or one carrying
   its own preloads — matched on `id`. The index's order is reapplied after
@@ -188,16 +252,11 @@ defmodule Ambry.Search.Query do
 
     build_opts =
       build_opts
-      |> Keyword.put_new(:joiner, :any)
+      |> Keyword.put_new(:joiner, :narrowing)
       |> Keyword.put_new(:partial, true)
       |> Keyword.put(:types, [type])
 
-    ranked_ids =
-      phrase
-      |> build(build_opts)
-      |> limit(^limit)
-      |> select([record], fragment("(?).id", record.reference))
-      |> Repo.all()
+    ranked_ids = ranked_ids(phrase, limit, build_opts)
 
     rows =
       queryable

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ambry.MixProject do
   def project do
     [
       app: :ambry,
-      version: "2.4.1",
+      version: "2.4.2",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:boundary, :phoenix_live_view] ++ Mix.compilers(),

--- a/priv/repo/functions/ambry_tsquery_v3.sql
+++ b/priv/repo/functions/ambry_tsquery_v3.sql
@@ -1,0 +1,98 @@
+(phrase text, joiner text, partial boolean) RETURNS tsquery AS $$
+-- One tsquery, asked of both analyses of the text — `ambry_english`, which
+-- stems and drops stop words, and `ambry_simple`, which does neither. Each is
+-- wrong alone for a catalogue of proper nouns:
+--
+--   typed        target                english   simple
+--   kings        King Rat              yes       no      (stemming earns its keep)
+--   memories     Children of Memory    yes       no
+--   don          Don Quixote           NO        yes     ("don" is in english.stop)
+--   will         Will Wight            NO        yes
+--
+-- So the record is indexed under both and the query is asked under both,
+-- OR'd. The OR is between whole branches, not between terms: `:all` means
+-- every term matched *under one analysis*, never a mix of the two.
+--
+-- Returns NULL when neither analysis finds a lexeme — an empty box, or
+-- nothing but punctuation. A caller shows the first page for the first and
+-- nothing for the second, which are different questions.
+--
+-- Two things v2 got wrong, both found by an operator who could not find his
+-- own books (2026-08-19):
+--
+-- 1. A stop word is not a search term. `ambry_simple` keeps stop words so
+--    that somebody named Don is findable, but that only ever meant "when the
+--    phrase is *nothing but* stop words". Carried alongside real terms under
+--    `:any` they OR in most of the library ("the end of all things" reached
+--    239 of 419 books) and, worse, `ts_rank_cd` counts them as evidence.
+--    So: a word is a search term iff the english analyzer keeps it, and the
+--    whole phrase falls back to the literal words only when none survive —
+--    which is, and always was, the only case the simple branch's stop words
+--    were there to serve.
+--
+-- 2. The prefix belongs to what was typed, not to its stem. v2 stemmed and
+--    then appended `:*`, so "mars" became `'mar':*` and prefix-matched
+--    Martha, Marlon, Markson, Marin, Martin, Marsters, Marissa, Maryam.
+--    The unstemmed branch already carries the prefix property correctly, so
+--    the stemmed branch does not get `:*` at all.
+DECLARE
+  words     text[];
+  terms     text[];
+  stems     text[];
+  w         text;
+  stem      text;
+  op        text;
+  english   text;
+  simple    text;
+BEGIN
+  SELECT array_agg(lexeme ORDER BY positions[1])
+    INTO words
+    FROM unnest(to_tsvector('ambry_simple', phrase));
+
+  IF words IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  terms := '{}';
+  stems := '{}';
+
+  FOREACH w IN ARRAY words LOOP
+    stem := NULL;
+    SELECT lexeme INTO stem FROM unnest(to_tsvector('ambry_english', w)) LIMIT 1;
+    IF stem IS NOT NULL THEN
+      terms := terms || w;
+      stems := stems || stem;
+    END IF;
+  END LOOP;
+
+  -- Nothing but stop words: then they are the search. "Don", "Will".
+  IF array_length(terms, 1) IS NULL THEN
+    terms := words;
+    stems := '{}';
+  END IF;
+
+  op := CASE WHEN joiner = 'any' THEN ' | ' ELSE ' & ' END;
+
+  -- The unstemmed branch, last term opened to a prefix when asked.
+  SELECT array_to_string(array_agg(
+           CASE WHEN partial AND i = array_length(terms, 1)
+                THEN quote_literal(terms[i]) || ':*'
+                ELSE quote_literal(terms[i])
+           END ORDER BY i), op)
+    INTO simple
+    FROM generate_subscripts(terms, 1) AS i;
+
+  -- The stemmed branch. No prefix: a stem is not a prefix of what was typed.
+  SELECT array_to_string(array_agg(quote_literal(stems[i]) ORDER BY i), op)
+    INTO english
+    FROM generate_subscripts(stems, 1) AS i;
+
+  IF english IS NULL OR english = '' THEN
+    RETURN simple::tsquery;
+  ELSIF simple IS NULL OR simple = '' THEN
+    RETURN english::tsquery;
+  ELSE
+    RETURN english::tsquery || simple::tsquery;
+  END IF;
+END
+$$ LANGUAGE 'plpgsql' IMMUTABLE;

--- a/priv/repo/migrations/20260819190557_query_the_index_the_way_people_type.exs
+++ b/priv/repo/migrations/20260819190557_query_the_index_the_way_people_type.exs
@@ -1,0 +1,30 @@
+defmodule Ambry.Repo.Migrations.QueryTheIndexTheWayPeopleType do
+  @moduledoc """
+  Two query-side corrections, both found by searching the real library.
+
+  A stop word carried alongside real terms is not a search term — under
+  `:any` it OR'd in most of the library, and `ts_rank_cd` counted it as
+  evidence, so "the end of all things" reached 239 of 419 books and ranked
+  Order of the Phoenix third. It stays a search term only when the phrase is
+  nothing but stop words, which is the case it was added for.
+
+  And the prefix belongs to what was typed, not to its stem: v2 stemmed and
+  then appended `:*`, so "mars" became `'mar':*` and matched Martha, Marlon,
+  Markson, Marin, Martin, Marsters, Marissa and Maryam.
+
+  Query-side only. `ambry_tsquery` appears in no index expression and in no
+  stored vector, so nothing needs rebuilding and this is safe to run against
+  an instance already serving traffic.
+  """
+
+  use Ecto.Migration
+  use Familiar
+
+  def up do
+    replace_function("ambry_tsquery", version: 3, revert: 2)
+  end
+
+  def down do
+    replace_function("ambry_tsquery", version: 2)
+  end
+end

--- a/test/ambry/search/picker_test.exs
+++ b/test/ambry/search/picker_test.exs
@@ -131,6 +131,47 @@ defmodule Ambry.Search.PickerTest do
     end
   end
 
+  describe "the recording picker ranks" do
+    setup do
+      # Two books whose recordings sort the wrong way round alphabetically:
+      # the match is "Zeta", and "Alpha" only shares the author.
+      person = insert(:person, name: "Ada Rivers")
+      author = insert(:author, name: "Ada Rivers", person: person)
+
+      for title <- ["Alpha of the Fold", "Zeta Protocol"] do
+        book = insert(:book, title: title, book_authors: [%{author_id: author.id}])
+        insert(:media, book: book)
+      end
+
+      :ok
+    end
+
+    test "best first, not alphabetically first" do
+      # This asked `Query.ids/3`, which drops the ORDER BY for the admin
+      # lists, then sorted by book title and took the first N — so the ten
+      # shown were the alphabetically-first ten of the candidates, and the
+      # best match was routinely not among them.
+      assert ["Zeta Protocol" | _rest] = labels(Media.search_media("zeta", 10))
+    end
+
+    test "and the limit cuts from the bottom of the ranking" do
+      assert ["Zeta Protocol"] = labels(Media.search_media("zeta protocol", 1))
+    end
+
+    test "the recordings of one book stay together, in part order" do
+      book = insert(:book, title: "Kaiju Preservation Society")
+      group = insert(:recording_group, book: book, parts_total: 2)
+
+      insert(:media, book: book, part_number: 2, recording_group_id: group.id)
+      insert(:media, book: book, part_number: 1, recording_group_id: group.id)
+
+      assert [
+               "Kaiju Preservation Society (Part 1 of 2)",
+               "Kaiju Preservation Society (Part 2 of 2)"
+             ] = labels(Media.search_media("kaiju", 10))
+    end
+  end
+
   describe "an empty box" do
     test "shows the first page rather than nothing" do
       refute Books.search_series("", 10) == []
@@ -141,4 +182,6 @@ defmodule Ambry.Search.PickerTest do
       refute Media.search_media("", 10) == []
     end
   end
+
+  defp labels(options), do: Enum.map(options, & &1.label)
 end

--- a/test/ambry/search/query_test.exs
+++ b/test/ambry/search/query_test.exs
@@ -143,6 +143,110 @@ defmodule Ambry.Search.QueryTest do
     end
   end
 
+  describe "joiner: :narrowing" do
+    # The picker's policy over the other two, and the answer to the
+    # complaint that started all of this: another word is typed in order to
+    # *remove* rows, and under `:any` it only ever added them.
+    # `:narrowing` is two queries and a rule about which one answers, so it
+    # is not something `build/2` can return — these go through the picker,
+    # which is the only thing that wants it.
+    test "another term narrows while the narrowed set is non-empty" do
+      wide = picked("sanderson")
+      narrow = picked("sanderson mistborn")
+
+      assert "The Way of Kings" in wide
+      assert "Mistborn: The Final Empire" in wide
+      assert narrow == ["Mistborn: The Final Empire"]
+    end
+
+    test "and widens rather than emptying when nothing matches everything" do
+      # `:all` cannot answer this — no record holds "unabridged" — so the
+      # box falls back instead of going blank.
+      assert hits("sanderson kings unabridged", joiner: :all) == []
+      assert ["The Way of Kings" | _also_by_sanderson] = picked("sanderson kings unabridged")
+    end
+
+    test "which build/2 cannot express, and says so" do
+      assert_raise FunctionClauseError, fn ->
+        Query.build("sanderson", joiner: :narrowing)
+      end
+    end
+  end
+
+  describe "stop words" do
+    setup do
+      insert(:book, title: "The End of All Things")
+      insert(:book, title: "End of Watch")
+      insert(:book, title: "Don Quixote")
+      :ok
+    end
+
+    # This is the whole of the second reported bug: every extra common word
+    # OR'd in more of the library and dragged the ranking with it.
+    test "a stop word alongside real terms changes nothing" do
+      assert hits("end of all things") == hits("the end of all things")
+      assert top("the end of all things") == "The End of All Things"
+    end
+
+    test "but a phrase that is nothing else is still a search for them" do
+      # Somebody named Don, or Will. The only case the simple branch's stop
+      # words were ever added to serve.
+      assert top("don") == "Don Quixote"
+    end
+  end
+
+  describe "prefixes are of what was typed, not of its stem" do
+    setup do
+      insert(:person, name: "Martha Wells")
+      insert(:book, title: "Red Mars")
+      :ok
+    end
+
+    test "a stemmed term does not prefix-match unrelated words" do
+      # "mars" stems to "mar", and v2 appended `:*` after stemming — so this
+      # found Martha, Marlon, Markson, Marin, Martin, Marsters and Maryam.
+      hits = hits("mars", joiner: :any, partial: true)
+
+      assert "Red Mars" in hits
+      refute "Martha Wells" in hits
+    end
+
+    test "while the prefix property itself is untouched" do
+      assert top("mar", joiner: :any, partial: true, types: [:person]) == "Martha Wells"
+    end
+  end
+
+  describe "phrase position" do
+    setup do
+      # A series that repeats its book's title, which is how the wrong book
+      # got to the top: two hits for one fact.
+      club = insert(:series, name: "Thursday Murder Club", series_books: [])
+
+      insert(:book,
+        title: "The Thursday Murder Club",
+        series_books: [%{series_id: club.id, book_number: 1}]
+      )
+
+      insert(:book, title: "Murder by Other Means")
+      :ok
+    end
+
+    test "a name that starts with the phrase outranks one that merely contains it" do
+      assert top("murder") == "Murder by Other Means"
+    end
+
+    test "a stop word inside the phrase still narrows, though it is not a term" do
+      # "by" leaves the tsquery entirely, so this and "murder" are the same
+      # search — the phrase tiebreak is the only thing that can tell them
+      # apart, and it is the reason typing more feels like it works.
+      assert top("murder by") == "Murder by Other Means"
+    end
+
+    test "and it cannot widen a result set, only reorder one" do
+      refute "The Thursday Murder Club" in hits("murder by other means")
+    end
+  end
+
   describe "partial" do
     test "a prefix finds the name it starts" do
       refute top("sander", partial: false) == "Brandon Sanderson"
@@ -205,13 +309,17 @@ defmodule Ambry.Search.QueryTest do
     end
 
     test "and a stemmed form still is" do
-      assert top("kings") == "King Rat"
+      # Not `top/1`: "The Way of Kings" contains the word "kings" literally
+      # and King Rat only reaches it through the stemmer, so the phrase-
+      # position tiebreak — rightly — puts the literal match first. What
+      # this pins is that the stemmed one is reachable at all.
+      assert "King Rat" in hits("kings")
       assert top("memories") == "Children of Memory"
     end
 
     test "an article the operator typed does not break a title without one" do
-      # The simple branch wants "the"; the english branch drops it. One
-      # branch matching is enough, which is the point of asking both.
+      # Neither branch wants it: a stop word alongside real terms is dropped
+      # from both, so the article is simply not part of the search.
       assert top("the way of kings") == "The Way of Kings"
     end
   end
@@ -263,6 +371,12 @@ defmodule Ambry.Search.QueryTest do
     |> Query.build(opts)
     |> Ambry.Repo.all()
     |> Enum.map(& &1.primary)
+  end
+
+  # What a picker actually returns, by name — the only way to see
+  # `:narrowing`, which is a rule about two queries rather than one query.
+  defp picked(phrase) do
+    phrase |> Ambry.Books.search_books(10) |> Enum.map(& &1.label)
   end
 
   defp top(phrase, opts \\ []) do


### PR DESCRIPTION
Three defects in the picker search, all found by an operator working the inbox backlog and failing to find his own books, all measured against the real 419-book library before anything was touched. Prototyped by live-patching production, and confirmed over ~50 books before this branch existed.

## What was wrong

**The pickers threw the ranking away.** `Media.search_media/2` asked `Query.ids/3`, which drops the `ORDER BY` deliberately — it belongs to the admin list filters, where the operator has already chosen a sort — then sorted by book title and took the first ten. So `mars` showed the alphabetically-first ten of 69 candidate books, and Red Mars, ranked first, was not among them:

```
mars   ->  A Good Girl's Guide to Murder, A Killer in King's Cove,
           Across the Green Grass Fields, Adult Children of ... , Battle Ground
```

Searching for "The End of All Things" appeared to work for the single word `end` and for nothing else — `end` happened to have nine candidates, fewer than the limit, so the sort had nothing to hide.

**The prefix was applied to the stem, not to what was typed.** `ambry_tsquery` stemmed and then appended `:*`, so `mars` became `'mar':*` and matched Martha, Marlon, Markson, Marin, Martin, Marsters, Marissa and Maryam. The unstemmed branch already carries the prefix property correctly, so the stemmed branch no longer gets `:*` at all.

**Stop words were live search terms.** `ambry_simple` keeps them so somebody named Don is findable, but that only ever meant *when the phrase is nothing but stop words*. Alongside real terms under `:any` they OR'd in most of the library, and `ts_rank_cd` counted them as evidence — `the end of all things` reached 239 of 419 books and ranked Order of the Phoenix third.

## What changed

**`:narrowing`**, the picker's policy over the two joiners: ask `:all`, widen to `:any` only if nothing answers. This is the thing under all three complaints — typing another word was making the result set *bigger*, when removing rows is the entire reason anyone keeps typing. `match_books/2` is pinned to `:any` explicitly, since auto-match is a filename rather than somebody typing and wants the ranked field of candidates it scores.

**Phrase position**, two booleans ahead of every other ordering term: does the name *start with* the raw phrase, and failing that does it *contain* it. Word order and adjacency are what a `tsvector` throws away and a picker lives on. They read the raw phrase rather than the parsed one, which makes them the only place a stop word still counts — `murder by` compiles to the same tsquery as `murder`, and this is what tells them apart. Because they run over rows the query already matched, they can only reorder a result set, never widen one.

## Measured, book records, of 419

| typed | candidates before | after |
|---|---|---|
| `the end of all things` | 239 | 9 |
| `end of all things` | 91 | 9 |
| `mars` | 69 | 22 |

```
mars                    ->  Red Mars, Blue Mars, Green Mars, ...
end of all things       ->  The End of All Things
the end of all things   ->  The End of All Things      (identical, as it should be)
murder                  ->  Murder by Other Means, Murder Your Employer, ...
murder by               ->  Murder by Other Means
```

## Deploying

The migration is **query-side only**. `ambry_tsquery` appears in no index expression and in no stored vector, so nothing is rebuilt and it is safe against an instance already serving traffic. Verified up *and* down against a freshly built database, and verified idempotent against a database whose function had already been replaced by hand.

## Notes for review

- `top("kings") == "King Rat"` became `"King Rat" in hits("kings")`. "The Way of Kings" contains the word literally and King Rat reaches it only through the stemmer, so the phrase tiebreak now — rightly — puts the literal match first. The property being pinned is that the stemmed one is still reachable.
- **`The Martian` no longer matches `mars`.** It only ever did through the stem-prefix accident, and losing it is a real cost of that fix.
- **The second phrase tier ("contains") is the weaker claim.** It is ranking-only, so it does not touch the prefix-not-substring rule for *matching*, but it does mean a title containing what you typed outranks a book merely credited to someone by that name. Cheap to drop.
- **Still open:** when `:all` finds nothing, the `:any` fallback's ranking does not reward matching *more* terms — `sanderson kings` ranks title hits on "king" above the Sanderson books. A coverage-count tiebreak ahead of `ts_rank_cd` is the next lever.
- **Also still open:** a series that repeats its book's title is counted twice, at weights A and B. This branch outranks that rather than fixing it; the fix is for `Search.Index` not to repeat the title in the credits column, which needs a reindex.

## Version

`2.4.2`, a patch. What 2.4.1 shipped was a bug rather than a deliberate behaviour — the ranking was computed and sorted away, the prefix matched a stem instead of what was typed, and a stop word widened the search instead of narrowing it. `:narrowing` is included in that: it is what "another word narrows the search" always meant.

`mix check` and `mix test --warnings-as-errors` both clean (1878 tests).

https://claude.ai/code/session_01ELdksJFpbhYCNiuepi82Nx
