### PR TITLE
An answer given while a sweep was working is no longer taken back

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -422,10 +422,48 @@ defmodule Ambry.Inbox do
     end
   end
 
-  def update_item(%InboxItem{} = item, attrs) do
-    item
-    |> InboxItem.changeset(attrs)
-    |> Repo.update()
+  @doc """
+  Sets columns on an item, on the row as it is now.
+
+  Takes an id or an item, and reads the row again either way: the callers
+  here are jobs that computed `attrs` from something slow — a probe, a fan-out
+  to four metadata providers — and the copy they set out with is minutes old
+  by the time they have an answer. What they are writing does not depend on
+  what the row said in the meantime, so the fresh row is simply the right
+  thing to write onto.
+  """
+  def update_item(item_or_id, attrs)
+
+  def update_item(%InboxItem{id: id}, attrs), do: update_item(id, attrs)
+
+  def update_item(id, attrs) when is_integer(id) do
+    with_item(id, &(&1 |> InboxItem.changeset(attrs) |> write()))
+  end
+
+  # The row as committed, held for the rest of the transaction. Everything
+  # that reads an item, changes it and writes it back goes through here —
+  # `Ambry.Inbox.Lookup` and `Ambry.Inbox.Importer` take the same lock for
+  # the same reason.
+  defp with_item(id, fun) do
+    Repo.transact(fn ->
+      InboxItem
+      |> where([i], i.id == ^id)
+      |> lock("FOR UPDATE")
+      |> Repo.one!()
+      # The item callers got back before always carried its source, and
+      # plenty of them go on to resolve a path with it.
+      |> Repo.preload(:source)
+      |> fun.()
+    end)
+  end
+
+  # Every write from this module reads its row first, under that lock, so
+  # `unchanged?/1` is answerable here and a sweep that found nothing to do
+  # leaves no trace at all.
+  defp write(changeset) do
+    if InboxItem.unchanged?(changeset),
+      do: {:ok, changeset.data},
+      else: changeset |> InboxItem.versioned() |> Repo.update()
   end
 
   @doc """
@@ -463,7 +501,7 @@ defmodule Ambry.Inbox do
           rebuild_draft(item)
 
         Draft.curated?(item.draft) ->
-          update_draft(item, item.draft |> Draft.Edit.resettle(item) |> dump())
+          update_draft_with(item, &Draft.Edit.resettle/2)
 
         true ->
           rebuild_draft(item)
@@ -583,11 +621,11 @@ defmodule Ambry.Inbox do
   # stale proposal to fix on the form, not a reason to fail the import that
   # already committed.
   defp refresh_draft(%InboxItem{} = item) do
-    case update_draft(item, item.draft |> Seed.relink(item) |> dump()) do
+    case update_draft_with(item, &Seed.relink/2) do
       {:ok, _item} ->
         :ok
 
-      {:error, _changeset} ->
+      {:error, _reason} ->
         Logger.warning(fn -> "Inbox: couldn't refresh draft for item #{item.id}" end)
         :ok
     end
@@ -601,21 +639,23 @@ defmodule Ambry.Inbox do
   only ever happens when there is no draft yet — an operator's choices are
   not something a background job may overwrite.
   """
-  def prepare_draft(%InboxItem{draft: nil} = item), do: rebuild_draft(item)
-
   # An imported item's draft is the record of what was imported; nothing may
   # touch it, healing included.
   def prepare_draft(%InboxItem{status: :imported} = item), do: {:ok, item}
 
   def prepare_draft(%InboxItem{} = item) do
-    fresh =
-      item.draft
-      |> refresh_destination(item)
-      |> refresh_replacement(item)
-
-    if fresh == item.draft,
-      do: {:ok, item},
-      else: item |> InboxItem.put_draft(dump(fresh)) |> Repo.update()
+    item
+    |> update_draft_with(fn
+      nil, fresh -> Seed.build(fresh)
+      draft, fresh -> draft |> refresh_destination(fresh) |> refresh_replacement(fresh)
+    end)
+    |> case do
+      # Imported while this caller was holding the row. Healing an imported
+      # item is a no-op, not a failure — the form asks for this on mount and
+      # a read-only page is a perfectly good answer.
+      {:error, :already_imported} -> {:ok, item}
+      result -> result
+    end
   end
 
   # A decision the operator has not answered is a *default*, and a default
@@ -643,13 +683,56 @@ defmodule Ambry.Inbox do
   and editing it would be more work than starting over. Never automatic.
   """
   def rebuild_draft(%InboxItem{} = item) do
-    item
-    |> InboxItem.put_draft(item |> Seed.build() |> dump())
-    |> Repo.update()
+    update_draft_with(item, fn _discarded, fresh -> Seed.build(fresh) end)
   end
 
   @doc """
-  Saves operator edits to the staged import.
+  Applies a transformation to the draft the row actually holds.
+
+  **The way to change a draft.** Everything that changes one is a function of
+  the draft and the item — `Seed.relink/2` re-points a credit at a row that
+  now exists, `Draft.Edit.choose_field/4` records an answer, `Seed.build/1`
+  starts over — so the transformation can simply be handed the committed
+  draft instead of one the caller read earlier and may have been holding for
+  a while.
+
+  That is the whole fix for the class of bug this had: a sweep that read
+  three hundred drafts and then wrote them back one at a time was writing
+  minutes-old copies, and any answer given in between vanished without a
+  trace. Under the lock there is no in-between — the draft the function is
+  given is the draft the write lands on.
+
+  The transformation may return `nil` for "nothing to write". Note it runs
+  inside the transaction: keep it to library reads, never a provider call.
+  """
+  def update_draft_with(item_or_id, fun)
+
+  def update_draft_with(%InboxItem{id: id}, fun), do: update_draft_with(id, fun)
+
+  def update_draft_with(id, fun) when is_integer(id) do
+    with_item(id, fn
+      # An imported item's draft is the frozen record of that import.
+      %InboxItem{status: :imported} -> {:error, :already_imported}
+      item -> write_draft(item, fun.(item.draft, item))
+    end)
+  end
+
+  defp write_draft(item, nil), do: {:ok, item}
+
+  defp write_draft(item, %Draft{} = draft),
+    do: item |> InboxItem.put_draft(dump(draft)) |> write()
+
+  @doc """
+  Saves the import form's own params.
+
+  The one draft write that cannot be replayed against a newer draft, and so
+  the one that can be refused: its attrs are a rendered form, built against a
+  particular draft and meaningful only against that one. Everything else goes
+  through `update_draft_with/2`, which re-derives instead.
+
+  Returns `{:error, :stale}` when the row has moved since the form was
+  rendered. The form's answer is to reload and say so — applying the params
+  anyway is exactly the silent overwrite the version exists to stop.
 
   Every save recomputes readiness, so the queue can never claim an item is
   importable when its draft says otherwise.
@@ -659,7 +742,17 @@ defmodule Ambry.Inbox do
   def update_draft(%InboxItem{} = item, attrs) do
     item
     |> InboxItem.put_draft(attrs)
-    |> Repo.update()
+    |> InboxItem.versioned()
+    |> Repo.update(stale_error_field: :lock_version)
+    |> case do
+      {:ok, item} ->
+        {:ok, item}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if Keyword.has_key?(changeset.errors, :lock_version),
+          do: {:error, :stale},
+          else: {:error, changeset}
+    end
   end
 
   @doc """
@@ -1397,10 +1490,8 @@ defmodule Ambry.Inbox do
     end
   end
 
-  defp mark_draft_stale(%InboxItem{draft: nil}), do: :ok
-
   defp mark_draft_stale(%InboxItem{} = item) do
-    item |> InboxItem.put_draft(item.draft |> Seed.restale(item) |> dump()) |> Repo.update()
+    update_draft_with(item, &Seed.restale/2)
     :ok
   end
 

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -796,8 +796,12 @@ defmodule Ambry.Inbox.Importer do
     # row can explain itself tomorrow; succeeding is what resolves it. Left
     # in place, "Couldn't add this to the library" sat in red on rows whose
     # media was sitting right there in the library.
+    # `item` is the row `claim/1` locked, so this cannot be stale — but it
+    # still bumps the version, which is what tells a form open on this item
+    # that the thing it is editing is now in the library.
     item
     |> InboxItem.changeset(%{status: :imported, media_id: media.id, issue: nil})
+    |> InboxItem.versioned()
     |> Repo.update()
   end
 end

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -58,6 +58,10 @@ defmodule Ambry.Inbox.InboxItem do
     # leaves its own out for the same reason.
     field :search_text, :string
 
+    # Bumped by every write, and checked by every write against the value the
+    # writer read. See `versioned/1`.
+    field :lock_version, :integer, default: 1
+
     embeds_one :draft, Draft, on_replace: :update
 
     timestamps(type: :utc_datetime)
@@ -109,6 +113,50 @@ defmodule Ambry.Inbox.InboxItem do
     |> put_change(:ready, Draft.resolved?(draft))
     |> put_change(:search_text, search_text(draft))
   end
+
+  @doc """
+  The last step of every write to this table.
+
+  ## Why a version
+
+  An item is read, changed and written back from half a dozen places — the
+  form, discovery, probing, matching, the post-import sweeps — and several of
+  them run at once. All of them write the whole row, so the second to arrive
+  overwrites whatever the first decided, and nothing anywhere says so.
+  Production, 2026-08-20: the operator answered "this replaces audiobook 108"
+  and a sibling import's sweep, holding a copy of the row read seconds
+  earlier, put "a new audiobook" back. The import then refused an item whose
+  form showed nothing wrong.
+
+  So the row carries a version, every write bumps it, and every write demands
+  the version it read. A caller working from a copy that has since moved is
+  refused rather than obeyed. `Ambry.Inbox.Lookup` learned this once for
+  `matches` and closed it with a row lock; a lock each caller has to remember
+  to take is a lock the next caller forgets, which is precisely how it grew
+  back on `draft`. This is the same rule made structural.
+  """
+  def versioned(%Ecto.Changeset{} = changeset), do: optimistic_lock(changeset, :lock_version)
+
+  @doc """
+  Whether this changeset would leave the row exactly as it is.
+
+  **Only meaningful when the changeset's data is the row as read** — it
+  compares against that, not against the database — so it belongs to callers
+  that just read the row themselves, under the lock.
+
+  It exists because of a quirk that would otherwise make every version bump
+  meaningless. `Draft`'s collections are keyless `embeds_many`, so
+  `cast_embed` cannot tell an incoming element from the one already there and
+  reports every element as replaced: a draft cast back from its own dump is
+  always "changed". The post-import sweeps — which mostly find nothing to
+  relink — were therefore rewriting every draft they touched, on every
+  import. Versioned, that would bump rows nobody edited and send the
+  operator's open form stale for no reason at all.
+
+  Comparing the applied struct is what tells an edit from that noise, and it
+  is exact: equal structs mean equal jsonb.
+  """
+  def unchanged?(%Ecto.Changeset{} = changeset), do: apply_changes(changeset) == changeset.data
 
   @doc """
   What a draft is findable by, beyond the path it was found at.

--- a/lib/ambry/inbox/lookup.ex
+++ b/lib/ambry/inbox/lookup.ex
@@ -57,8 +57,17 @@ defmodule Ambry.Inbox.Lookup do
         end
       end)
 
+    hydrated = Enum.find(records, &(AutoMatch.ref(&1) == record_ref))
+
     item
-    |> update_records(level, fn _existing -> records end)
+    # By reference rather than wholesale: the list this replaced was read
+    # before the provider was asked, and a search that finished in the
+    # meantime has records in the committed one that this never saw.
+    |> update_records(level, fn existing ->
+      Enum.map(existing, fn record ->
+        if hydrated && AutoMatch.ref(record) == record_ref, do: hydrated, else: record
+      end)
+    end)
     |> update_outcomes(level, failures)
   end
 
@@ -233,28 +242,11 @@ defmodule Ambry.Inbox.Lookup do
     end
   end
 
-  # **Re-read under a lock, because two of these run at once.** The form lets
-  # the operator search for as many people as they like without waiting, and
-  # `matches` is one jsonb column holding all of them: each search merged its
-  # person into the item as it was when the button was pressed, then wrote the
-  # whole column back, so the second to finish silently threw away the first's
-  # results. The operator saw two searches fight over the page.
-  #
-  # The row this merges into is therefore the committed one rather than the
-  # caller's, and the lock makes "read, merge, write" atomic across the two
-  # requests. Same shape as `Importer.claim/1`, for the same reason.
-  defp update_person(%InboxItem{id: id}, key, name, found, outcomes) do
-    Repo.transact(fn ->
-      InboxItem
-      |> where([i], i.id == ^id)
-      |> lock("FOR UPDATE")
-      |> Repo.one!()
-      |> merge_person(key, name, found, outcomes)
-    end)
+  defp update_person(%InboxItem{} = item, key, name, found, outcomes) do
+    update_matches(item, &merge_person(&1, key, name, found, outcomes))
   end
 
-  defp merge_person(%InboxItem{} = item, key, name, found, outcomes) do
-    matches = item.matches || %{}
+  defp merge_person(matches, key, name, found, outcomes) do
     people = Map.get(matches, "people") || %{}
     held = Map.get(people, key) || %{"name" => name, "roles" => [], "local" => []}
 
@@ -274,11 +266,35 @@ defmodule Ambry.Inbox.Lookup do
       |> Map.put("local", AutoMatch.local_people(name))
       |> Map.put("providers", outcomes)
 
-    item
-    |> InboxItem.changeset(%{
-      matches: Map.put(matches, "people", Map.put(people, key, updated))
-    })
-    |> Repo.update()
+    Map.put(matches, "people", Map.put(people, key, updated))
+  end
+
+  # **Read, change and write the row as committed, because several of these
+  # run at once.** `matches` is one jsonb column holding every level's
+  # records and every person's, and the form lets the operator search for as
+  # many people as they like without waiting. Each search used to merge its
+  # results into the item as it was when the button was pressed and write the
+  # whole column back, so the second to finish silently threw away the
+  # first's and the operator watched two searches fight over the page.
+  #
+  # Under the lock there is no in-between. Same shape as
+  # `Ambry.Inbox.update_draft_with/2` and `Importer.claim/1`, for the same
+  # reason — and `versioned/1` on the way out is what tells a form holding an
+  # older copy of this row that it has one.
+  defp update_matches(%InboxItem{id: id}, fun) do
+    Repo.transact(fn ->
+      item =
+        InboxItem
+        |> where([i], i.id == ^id)
+        |> lock("FOR UPDATE")
+        |> Repo.one!()
+
+      changeset = InboxItem.changeset(item, %{matches: fun.(item.matches || %{})})
+
+      if InboxItem.unchanged?(changeset),
+        do: {:ok, item},
+        else: changeset |> InboxItem.versioned() |> Repo.update()
+    end)
   end
 
   ## plumbing
@@ -341,13 +357,11 @@ defmodule Ambry.Inbox.Lookup do
   end
 
   defp update_records(item, level, fun) do
-    matches = item.matches || %{}
-    level_map = Map.get(matches, level, %{})
-    updated = Map.put(level_map, "candidates", fun.(Map.get(level_map, "candidates", []) || []))
-
-    item
-    |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
-    |> Repo.update()
+    update_matches(item, fn matches ->
+      level_map = Map.get(matches, level, %{})
+      updated = Map.put(level_map, "candidates", fun.(Map.get(level_map, "candidates", []) || []))
+      Map.put(matches, level, updated)
+    end)
   end
 
   defp update_outcomes(item_or_result, level, outcomes, opts \\ [])
@@ -358,7 +372,12 @@ defmodule Ambry.Inbox.Lookup do
   defp update_outcomes({:error, _reason} = error, _level, _outcomes, _opts), do: error
 
   defp update_outcomes(%InboxItem{} = item, level, outcomes, opts) do
-    matches = item.matches || %{}
+    update_matches(item, fn matches ->
+      update_outcomes_in(matches, level, outcomes, opts)
+    end)
+  end
+
+  defp update_outcomes_in(matches, level, outcomes, opts) do
     level_map = Map.get(matches, level, %{})
     existing = Map.get(level_map, "providers", []) || []
 
@@ -373,11 +392,7 @@ defmodule Ambry.Inbox.Lookup do
     fresh = outcomes |> MapSet.new(& &1["id"]) |> maybe_clear(opts[:clear])
     kept = Enum.reject(existing, &MapSet.member?(fresh, &1["id"]))
 
-    updated = Map.put(level_map, "providers", kept ++ outcomes)
-
-    item
-    |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
-    |> Repo.update()
+    Map.put(matches, level, Map.put(level_map, "providers", kept ++ outcomes))
   end
 
   defp maybe_clear(ids, nil), do: ids
@@ -387,17 +402,15 @@ defmodule Ambry.Inbox.Lookup do
   defp remember_query({:error, _reason} = error, _level, _query), do: error
 
   defp remember_query(%InboxItem{} = item, level, query) do
-    matches = item.matches || %{}
+    update_matches(item, fn matches ->
+      updated =
+        matches
+        |> Map.get(level, %{})
+        |> Map.put("query", to_string(query))
+        |> Map.put("query_fields", Provider.Query.non_blank_fields(query))
 
-    updated =
-      matches
-      |> Map.get(level, %{})
-      |> Map.put("query", to_string(query))
-      |> Map.put("query_fields", Provider.Query.non_blank_fields(query))
-
-    item
-    |> InboxItem.changeset(%{matches: Map.put(matches, level, updated)})
-    |> Repo.update()
+      Map.put(matches, level, updated)
+    end)
   end
 
   defp query_from(fields), do: Provider.Query.from_fields(fields)

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -303,9 +303,26 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
     # Autosave: the form and the stored draft are never allowed to disagree,
     # so a click on any of the choice controls below can't discard typing.
+    #
+    # The one write here that can't be replayed against a newer draft — these
+    # params were rendered against a particular one — so it is the one that
+    # can come back refused. Reloading is the only honest answer: applying
+    # them anyway would overwrite whatever moved the row, unseen.
     case Inbox.update_draft(socket.assigns.item, params["draft"] || %{}) do
-      {:ok, item} -> {:noreply, load(socket, item)}
-      {:error, changeset} -> {:noreply, assign(socket, form: to_form(changeset))}
+      {:ok, item} ->
+        {:noreply, load(socket, item)}
+
+      {:error, :stale} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :error,
+           "Something else changed this item while you were typing. Reloaded — check the last thing you entered."
+         )
+         |> load(Inbox.get_item!(socket.assigns.item.id))}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
     end
   end
 
@@ -914,9 +931,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   defp resettle(socket) do
     item = socket.assigns.item
 
-    case Inbox.update_draft(item, Inbox.dump_draft(Draft.Edit.resettle(item.draft, item))) do
+    case Inbox.update_draft_with(item, &Draft.Edit.resettle/2) do
       {:ok, item} -> load(socket, item)
-      {:error, _changeset} -> socket
+      {:error, _reason} -> socket
     end
   end
 
@@ -953,12 +970,22 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   defp hydrate_if_thin(item, _level, _ref, %{"hydrated" => true}), do: {:ok, item}
   defp hydrate_if_thin(item, level, ref, _record), do: Inbox.hydrate_record(item, level, ref)
 
+  # Applied to the draft the row holds rather than the one this socket is
+  # showing. A form can sit open for a long time while background work — a
+  # sibling import's relink sweep, a rescan — moves the row under it, and an
+  # answer written from the stale copy would take the row back with it.
+  # `fun` is a transformation, so handing it the committed draft is both
+  # safe and the only version that can't lose anything.
   defp edit(socket, fun) do
-    draft = fun.(socket.assigns.item.draft)
+    case Inbox.update_draft_with(socket.assigns.item, fn draft, _item -> fun.(draft) end) do
+      {:ok, item} ->
+        load(socket, item)
 
-    case Inbox.update_draft(socket.assigns.item, Inbox.dump_draft(draft)) do
-      {:ok, item} -> load(socket, item)
-      {:error, changeset} -> assign(socket, form: to_form(changeset))
+      {:error, changeset} when is_struct(changeset, Ecto.Changeset) ->
+        assign(socket, form: to_form(changeset))
+
+      {:error, _reason} ->
+        socket
     end
   end
 

--- a/priv/repo/migrations/20260818193000_backfill_inbox_search_text.exs
+++ b/priv/repo/migrations/20260818193000_backfill_inbox_search_text.exs
@@ -10,10 +10,20 @@ defmodule Ambry.Repo.Migrations.BackfillInboxSearchText do
   Calls `InboxItem.search_text/1` rather than reaching into the draft's JSON
   from SQL, for the same reason `put_draft/2` does: the draft is a deep
   embedded structure and SQL digging through it would be a second copy of its
-  shape. That makes this migration depend on application code, which is
-  normally worth avoiding — it is safe here because the only rows it touches
-  belong to an installation whose drafts and code are the same age. A fresh
-  install has an empty queue.
+  shape.
+
+  That makes this migration depend on application code, which is normally
+  worth avoiding, so it depends on as little of it as it can: the two columns
+  it needs by name, and a schemaless update. **Selecting the struct is what
+  goes wrong.** `Repo.all(InboxItem)` names every field the schema has
+  *today*, so the next column added to `inbox_items` broke this migration for
+  every fresh install — the column does not exist yet at the point in history
+  where this runs. It failed on `lock_version` in CI, on a build whose only
+  change was adding it.
+
+  The rows it touches still belong to an installation whose drafts and code
+  are the same age; a fresh install has an empty queue and this does nothing
+  but ask.
   """
 
   use Ecto.Migration
@@ -26,15 +36,16 @@ defmodule Ambry.Repo.Migrations.BackfillInboxSearchText do
   def up do
     InboxItem
     |> where([i], not is_nil(i.draft))
+    |> select([i], {i.id, i.draft})
     |> Repo.all()
-    |> Enum.each(fn item ->
-      item
-      |> Ecto.Changeset.change(search_text: InboxItem.search_text(item.draft))
-      |> Repo.update!()
+    |> Enum.each(fn {id, draft} ->
+      "inbox_items"
+      |> where([i], i.id == ^id)
+      |> Repo.update_all(set: [search_text: InboxItem.search_text(draft)])
     end)
   end
 
   def down do
-    Repo.update_all(InboxItem, set: [search_text: nil])
+    Repo.update_all("inbox_items", set: [search_text: nil])
   end
 end

--- a/priv/repo/migrations/20260820041837_version_inbox_items.exs
+++ b/priv/repo/migrations/20260820041837_version_inbox_items.exs
@@ -1,0 +1,24 @@
+defmodule Ambry.Repo.Migrations.VersionInboxItems do
+  @moduledoc """
+  Gives an inbox item a version, so a write based on a copy of the row that
+  has since moved is refused instead of landing.
+
+  Measured in production: the operator picked the audiobook an item was
+  replacing, and a sibling import's post-commit sweep — holding a copy of the
+  same row read seconds earlier — wrote its whole draft back over the answer.
+  The import job then read a draft that said "a new audiobook", found the
+  recording decisions in play again, and refused. Nothing failed anywhere; a
+  decision simply stopped existing.
+
+  Existing rows start at 1. Nothing reads the number, so there is nothing to
+  backfill — the column only has to *change* on every write.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:inbox_items) do
+      add :lock_version, :integer, null: false, default: 1
+    end
+  end
+end

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -613,6 +613,71 @@ defmodule Ambry.InboxTest do
     end
   end
 
+  # Production, 2026-08-20: the operator answered "this replaces audiobook
+  # 108", a sibling import's post-commit sweep wrote the whole draft back
+  # from a copy of the row it had read seconds earlier, and the answer
+  # stopped existing. The import job then refused an item whose form showed
+  # nothing wrong, and no job failed anywhere.
+  describe "concurrent writes to one item" do
+    setup do
+      dir = watched_root()
+      release_folder(dir, "Contested Item", ["book.m4b"])
+      insert(:source, path: dir)
+      insert(:root, path: watched_root())
+
+      {:ok, _counts} = Inbox.discover()
+      {[item], false} = Inbox.list_items(filter: "Contested Item")
+      {:ok, item} = Inbox.probe_item(item)
+      {:ok, item} = Inbox.prepare_draft(item)
+
+      %{item: item}
+    end
+
+    test "an answer given while a sweep was working is not written back over", ctx do
+      # what the sweep read before the operator touched anything
+      sweep_holds = ctx.item
+
+      media = insert(:media, book: insert(:book))
+
+      {:ok, _answered} =
+        Inbox.update_draft_with(ctx.item, fn draft, _item ->
+          Draft.Edit.replace_recording(draft, media.id)
+        end)
+
+      {:ok, _swept} =
+        Inbox.update_draft_with(sweep_holds, fn draft, _item -> %{draft | stale: true} end)
+
+      draft = Inbox.get_item!(ctx.item.id).draft
+
+      # the sweep's own change landed...
+      assert draft.stale
+      # ...on top of the answer, rather than instead of it
+      assert %{mode: :replace, curated: true} = draft.replacement
+      assert draft.replacement.media_id == media.id
+    end
+
+    test "a sweep that finds nothing to do leaves no trace", ctx do
+      {:ok, item} = Inbox.update_draft_with(ctx.item, fn draft, _item -> draft end)
+
+      # Not merely "the draft is the same": the row must not move at all, or
+      # a form somebody has open goes stale every time an unrelated item is
+      # imported. `Draft`'s keyless collections make every re-cast look like
+      # a change, so this is the assertion that keeps that quirk contained.
+      assert item.lock_version == ctx.item.lock_version
+      assert {:ok, _saved} = Inbox.update_draft(ctx.item, Inbox.dump_draft(ctx.item.draft))
+    end
+
+    # The form's params are the one write that can't be replayed against a
+    # newer draft: they were rendered against a particular one.
+    test "form params rendered against a draft the row has moved past are refused", ctx do
+      {:ok, _moved} =
+        Inbox.update_draft_with(ctx.item, fn draft, _item -> %{draft | stale: true} end)
+
+      assert {:error, :stale} = Inbox.update_draft(ctx.item, Inbox.dump_draft(ctx.item.draft))
+      assert Inbox.get_item!(ctx.item.id).draft.stale
+    end
+  end
+
   describe "ignore_item/1 and restore_item/1" do
     test "take an item out of the queue and back, without touching files" do
       root = watched_root()


### PR DESCRIPTION
Measured on production, and the first failure in 178 legacy-upload imports.
The operator picked the audiobook item 374 was replacing, pressed the button,
and the job refused with one outstanding decision the form did not show:
"Publisher, ambiguous". Nothing failed anywhere. The Oban job completed, the
draft in the database simply said "a new audiobook" again, so the recording
half of the form was back in play and its three disagreeing publishers with
it.

Four Brandon Sanderson replacements committed in the six seconds around that
click, and each one runs `refresh_siblings/1` after it commits: read every
pending item whose draft names one of the credits just imported, relink each,
write each back. It read item 374 before the pick and wrote it after. The
whole draft column goes back, so the answer went with it.

`Ambry.Inbox.Lookup` hit exactly this once, on `matches`, and closed it with a
row lock. Nothing made that structural, so it grew back on the column that
holds decisions rather than evidence. Both halves of the fix are here.

## The transformation is applied to the row, not to a copy of it

Every draft writer is a function of the draft and the item — `Seed.relink/2`,
`Seed.build/1`, all of `Draft.Edit` — so `update_draft_with/2` re-reads under
`FOR UPDATE` and hands the function the committed draft. There is no
in-between for an answer to fall into, and no retry to get wrong. The sweeps,
healing, staleness, "start over" and every control on the import form now go
through it; `update_item/2` does the same for the plain columns, since a probe
or a four-provider fan-out is minutes old by the time it has something to
write.

`Lookup`'s three remaining unlocked writers of `matches` join the one that was
already locked, and `hydrate/3` stops replacing the record list wholesale — it
merges the hydrated record by reference, so a search that finished while the
provider was being asked is no longer discarded.

## And the row carries a version

A lock each caller has to remember to take is a lock the next caller forgets.
Every write bumps `lock_version` and demands the one it read, so a writer
working from a copy that has moved is refused rather than obeyed. One writer
cannot re-derive and so can only be refused: the import form's own params,
which were rendered against a particular draft. It reloads and says so.

The version needed one thing to be worth anything. `Draft`'s collections are
keyless `embeds_many`, so `cast_embed` cannot tell an incoming element from
the one already there and calls every element replaced: a draft cast back from
its own dump always looks changed. Every sibling import was therefore
rewriting every draft it touched — all ten Sanderson items at 00:15:06, where
relink had nothing to say about any of them. Versioned, that would send an
open form stale every time an unrelated item was imported. `unchanged?/1`
compares the applied struct, which is exact, and a sweep that finds nothing
now leaves no trace at all.

## Verification

`mix test` and `mix check` both clean. The three tests in `describe
"concurrent writes to one item"` were each confirmed to fail on main by
temporarily reverting the half they cover.

Worth a click-through before merge: pick a replacement on the import form and
confirm the button still enables and the flash reads "Replacing the files",
plus one ordinary edit-and-save, since `edit/2` now writes through a different
path.

Independent of the duplicates report; whichever merges second wants a rebase, and the
two touch different hunks of `lib/ambry/inbox.ex`.

https://claude.ai/code/session_01KTzJCsa9ERXqz1CcMzsHgt
