### PR TITLE
A page that says whether the library holds anything twice

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -67,6 +67,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.Draft.Destination
   alias Ambry.Inbox.Draft.Replacement
   alias Ambry.Inbox.Draft.Seed
+  alias Ambry.Inbox.Duplicates
   alias Ambry.Inbox.Importer
   alias Ambry.Inbox.InboxItem
   alias Ambry.Inbox.Lookup
@@ -661,6 +662,23 @@ defmodule Ambry.Inbox do
     |> InboxItem.put_draft(attrs)
     |> Repo.update()
   end
+
+  @doc """
+  Every set of library records that name the same thing.
+
+  Not an inbox report by subject — it covers records the upload flow created
+  years before this queue existed — but the definition of *the same* lives
+  here, in the rules the importer links by, and there may only be one of it.
+  See `Ambry.Inbox.Duplicates`.
+  """
+  defdelegate duplicates, to: Duplicates, as: :check
+
+  @doc """
+  How many such sets there are, and how many records were examined.
+  """
+  defdelegate duplicate_count, to: Duplicates, as: :count
+
+  defdelegate duplicates_scanned, to: Duplicates, as: :scanned
 
   @doc """
   How a provider record is referred to: its provider and that provider's id.

--- a/lib/ambry/inbox/duplicates.ex
+++ b/lib/ambry/inbox/duplicates.ex
@@ -1,0 +1,209 @@
+defmodule Ambry.Inbox.Duplicates do
+  @moduledoc """
+  What the library is holding twice.
+
+  ## Why this is a report and not a constraint
+
+  Never having duplicates is the operator's standing goal, and the database
+  cannot be asked to keep it. Two different people genuinely can share a
+  name and two different books genuinely can share a title — `Preflight`
+  reasons about exactly that when it distinguishes "Sarah J. Maas twice"
+  from "a second identity backed by somebody else" — so a unique index on
+  `people.name` would be wrong, not merely strict. The only real uniqueness
+  the library has is `recording_groups (book_id, name)`, which is why sets
+  are absent here: within a book Postgres already refuses, and across books
+  two sets of one name are two sets.
+
+  So duplication is prevented by decisions — the seeder links rather than
+  creates, `Seed.relink/2` re-points a proposal when a sibling import makes
+  its target exist, `Preflight` asks before the button. Every one of those is
+  best-effort by construction, and a goal nobody measures is a hope. This is
+  the measurement.
+
+  ## Sameness is asked the way matching asks it
+
+  Names fold through `AutoMatch.person_key/1`, titles through
+  `AutoMatch.title_key/1` and series through `AutoMatch.same_series?/2` —
+  the same functions that decide whether an import links or creates. A second
+  definition of "the same" living here is the drift that would let the report
+  and the importer disagree, and the one they'd disagree about is the row
+  that got through.
+
+  It follows that this finds records from before the inbox existed too. That
+  is the point: production's only duplicate pair was two Raymond J. Lees
+  created 25 minutes apart in 2024, by the upload flow the inbox replaced.
+
+  ## Each record says what points at it
+
+  Because the question a found pair raises is always "which one can go", and
+  it is answered by the one nothing references. Counts are per record rather
+  than per group for the same reason.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Books.Book
+  alias Ambry.Books.Series
+  alias Ambry.Inbox.AutoMatch
+  alias Ambry.People.Author
+  alias Ambry.People.Narrator
+  alias Ambry.People.Person
+  alias Ambry.Repo
+
+  @typedoc """
+  One record the library holds, and what references it.
+
+  `uses` is keyed by the word for the thing counted, because a person is
+  reached through two kinds of credit and a book through one.
+
+  An author or a narrator also carries `person_id` — the human behind the
+  identity, when exactly one is — because that is where either is edited and
+  neither has a page of its own.
+  """
+  @type entry :: %{
+          :id => integer(),
+          :name => String.t(),
+          :uses => %{atom() => non_neg_integer()},
+          optional(:person_id) => integer() | nil
+        }
+
+  @type group :: %{kind: kind(), records: [entry()]}
+
+  @type kind :: :person | :author | :narrator | :book | :series
+
+  @doc """
+  Every set of records that name the same thing, worst first within a kind.
+
+  Ordered people, authors, narrators, books, series: a duplicated person is
+  the one that splits a face and a bio in two, and a duplicated series the
+  one most likely to be two real series that merely rhyme.
+  """
+  @spec check() :: [group()]
+  def check do
+    Enum.map(groups(), fn %{kind: kind, records: records} ->
+      %{kind: kind, records: Enum.map(records, &with_uses(kind, &1))}
+    end)
+  end
+
+  @doc """
+  How many sets there are, without asking what references them.
+
+  For the overview, which reloads on a heartbeat and only needs to know
+  whether there is anything to say.
+  """
+  @spec count() :: non_neg_integer()
+  def count, do: length(groups())
+
+  @doc """
+  What was examined, so a report of nothing can say what nothing covers.
+  """
+  @spec scanned() :: %{atom() => non_neg_integer()}
+  def scanned do
+    %{
+      people: Repo.aggregate(Person, :count),
+      authors: Repo.aggregate(Author, :count),
+      narrators: Repo.aggregate(Narrator, :count),
+      books: Repo.aggregate(Book, :count),
+      series: Repo.aggregate(Series, :count)
+    }
+  end
+
+  ## finding them
+
+  defp groups do
+    by_key(:person, Person, & &1.name, &AutoMatch.person_key/1) ++
+      by_key(:author, Author, & &1.name, &AutoMatch.person_key/1) ++
+      by_key(:narrator, Narrator, & &1.name, &AutoMatch.person_key/1) ++
+      by_key(:book, Book, & &1.title, &AutoMatch.title_key/1) ++
+      series_groups()
+  end
+
+  # Whole-table reads, because these are hundreds of rows and the keys are
+  # Elixir functions: asking in SQL would mean a second spelling of each
+  # rule, which is the drift the moduledoc is about. Measured against
+  # production's 1434 records, the whole report is well under a second.
+  defp by_key(kind, schema, name, key) do
+    schema
+    |> Repo.all()
+    |> Enum.map(&%{id: &1.id, name: name.(&1)})
+    |> Enum.group_by(&key.(&1.name))
+    |> Enum.filter(fn {_key, records} -> length(records) > 1 end)
+    |> Enum.sort_by(fn {key, _records} -> key end)
+    |> Enum.map(fn {_key, records} -> %{kind: kind, records: Enum.sort_by(records, & &1.id)} end)
+  end
+
+  # `same_series?/2` is a predicate, not a key — "Kushiel's Legacy" matches
+  # both the bare name and the subtitled one without those two being equal —
+  # so the groups are built by absorption rather than by grouping on a value.
+  defp series_groups do
+    Series
+    |> Repo.all()
+    |> Enum.map(&%{id: &1.id, name: &1.name})
+    |> Enum.reduce([], &absorb/2)
+    |> Enum.filter(&(length(&1) > 1))
+    |> Enum.map(&%{kind: :series, records: Enum.sort_by(&1, fn record -> record.id end)})
+    |> Enum.sort_by(&hd(&1.records).id)
+  end
+
+  defp absorb(record, groups) do
+    {related, rest} =
+      Enum.split_with(groups, fn group ->
+        Enum.any?(group, &AutoMatch.same_series?(&1.name, record.name))
+      end)
+
+    [[record | List.flatten(related)] | rest]
+  end
+
+  ## what points at them
+
+  # One query per record, and only for records already known to collide —
+  # production has two such records in all.
+  defp with_uses(:person, record),
+    do:
+      Map.put(record, :uses, %{
+        authors: through(Person, record, :authors),
+        narrators: through(Person, record, :narrators)
+      })
+
+  defp with_uses(:author, record) do
+    record
+    |> Map.put(:uses, %{books: through(Author, record, :books)})
+    |> Map.put(:person_id, sole_person(record))
+  end
+
+  defp with_uses(:narrator, %{id: id} = record) do
+    record
+    |> Map.put(:uses, %{audiobooks: through(Narrator, record, :media)})
+    |> Map.put(:person_id, Repo.one(from n in Narrator, where: n.id == ^id, select: n.person_id))
+  end
+
+  defp with_uses(:book, record),
+    do: Map.put(record, :uses, %{audiobooks: through(Book, record, :media)})
+
+  defp with_uses(:series, record),
+    do: Map.put(record, :uses, %{books: through(Series, record, :books)})
+
+  # A pen name says who is behind it, and only when the answer is one human:
+  # a composite (two people writing as one author) has no single page to send
+  # anybody to, and neither does a bare name nobody has attached yet. The same
+  # rule `Preflight.sole_person/1` draws, for the same reason.
+  defp sole_person(%{id: id}) do
+    Author
+    |> where([a], a.id == ^id)
+    |> join(:inner, [a], p in assoc(a, :people))
+    |> select([_a, p], p.id)
+    |> Repo.all()
+    |> case do
+      [person_id] -> person_id
+      _none_or_several -> nil
+    end
+  end
+
+  defp through(schema, %{id: id}, association) do
+    schema
+    |> where([r], r.id == ^id)
+    |> join(:left, [r], related in assoc(r, ^association))
+    |> select([_r, related], count(related.id))
+    |> Repo.one()
+  end
+end

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -57,6 +57,7 @@ defmodule Ambry.Inbox.Importer do
   alias Ambry.Inbox.Draft.Replacement
   alias Ambry.Inbox.Draft.SeriesLink
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.Preflight
   alias Ambry.Library
   alias Ambry.Library.NamingTemplate
   alias Ambry.Library.Placement
@@ -90,10 +91,11 @@ defmodule Ambry.Inbox.Importer do
     # decision on one would send them to the form to fix something the form
     # can't fix.
     with {:ok, files} <- audio_files(item),
+         known = Preflight.check(item),
          {:ok, probes} <- probe_all(files),
          :ok <- resolved(item),
          {:ok, destination} <- destination(item),
-         {:ok, outcome} <- create(item, files, probes, destination) do
+         {:ok, outcome} <- create(item, files, probes, destination, known) do
       # Only now, with the records committed, is anything destroyed: a moved
       # file's source, the names a replacement moved aside, and the files the
       # recording it replaced was served from.
@@ -156,15 +158,43 @@ defmodule Ambry.Inbox.Importer do
     end
   end
 
+  # **The pre-flight again, against the library as it is at the write.**
+  #
+  # `Preflight` runs on the button, and then this import keeps going for as
+  # long as it takes to re-probe every file and copy every byte — measured on
+  # production, forty to eighty seconds, with three more imports running
+  # beside it. A sibling that committed inside that window created exactly
+  # what this one is about to create again, and nothing between the click and
+  # here would have noticed.
+  #
+  # It refuses only on findings that are **new**. The ones the operator read
+  # and accepted at the button are in both lists; a relink sweep that turned
+  # one of this draft's creates into a link while this ran can only remove
+  # them.
+  #
+  # **It is not a guarantee, and cannot be made one here.** At READ COMMITTED
+  # a peer's uncommitted rows are invisible, so two imports whose commits
+  # interleave will not see each other however carefully either one looks.
+  # This closes the minute; only serializing the identity would close the
+  # millisecond, and that would serialize the file copies of every import
+  # that shares an author. `Ambry.Inbox.Duplicates` is what says whether the
+  # remainder ever happens.
+  defp no_new_collisions(%InboxItem{} = item, known) do
+    case Preflight.check(item) -- known do
+      [] -> :ok
+      new -> {:error, {:collisions, new}}
+    end
+  end
+
   # The one branch in the whole module, and it is the smallest one there is:
   # a replacement repoints an existing recording where an ordinary import
   # creates one. Everything either side of that — the claim, the item link,
   # placement, the finish — is the same code, because it is the same import.
-  defp create(%InboxItem{draft: draft} = item, files, probes, destination) do
+  defp create(%InboxItem{draft: draft} = item, files, probes, destination, known) do
     if Replacement.replacing?(draft.replacement) do
       replace(item, files, probes, destination, draft.replacement.media_id)
     else
-      add(item, files, probes, destination)
+      add(item, files, probes, destination, known)
     end
   end
 
@@ -173,12 +203,13 @@ defmodule Ambry.Inbox.Importer do
   # fail at the commit and the worst case is a stray file in the library,
   # which the audit tooling surfaces — never a file whose source was already
   # deleted and whose record didn't survive.
-  defp add(item, files, probes, destination) do
+  defp add(item, files, probes, destination, known) do
     Repo.transact(fn ->
       # People first, and for the whole draft at once: the same human can be
       # behind two credits, and each credit creating its own left a
       # self-narrated book with two Person rows of one name.
       with {:ok, item} <- claim(item),
+           :ok <- no_new_collisions(item, known),
            {:ok, people} <- resolve_people(item.draft),
            {:ok, book} <- resolve_book(item.draft.work, people),
            {:ok, media} <- create_media(item, book, probes, people, destination),

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -98,6 +98,10 @@ defmodule AmbryWeb.Admin.Layouts do
           </.link>
 
           <p class={group_class()}>System</p>
+          <.link navigate={~p"/admin/duplicates"} class={nav_class(@active_path =~ "/admin/duplicates")}>
+            <.icon name="fa-magnifying-glass" class="h-5 w-5 text-current" />
+            <p>Duplicates</p>
+          </.link>
           <.link navigate={~p"/admin/audit"} class={nav_class(@active_path =~ "/admin/audit")}>
             <.icon name="fa-file-waveform" class="h-5 w-5 text-current" />
             <p>File Audit</p>

--- a/lib/ambry_web/live/admin/duplicates_live/index.ex
+++ b/lib/ambry_web/live/admin/duplicates_live/index.ex
@@ -1,0 +1,170 @@
+defmodule AmbryWeb.Admin.DuplicatesLive.Index do
+  @moduledoc """
+  Whether the library is holding anything twice.
+
+  ## Why it is a page and not a badge
+
+  Never having duplicates is a standing goal, and every mechanism serving it
+  — the seeder linking rather than creating, `Seed.relink/2`, the import
+  form's pre-flight — is best effort. A goal that is only ever *pursued* is
+  one you have to take on faith. This is the page that answers it, so the
+  answer can be looked at rather than believed.
+
+  Which is why an empty report is not an empty page: it says how many records
+  it examined. "Nothing found" and "nothing ran" look identical otherwise,
+  and the reassuring one is the one you need to be able to trust.
+
+  ## What it does not do
+
+  It does not merge, and it does not offer to. Two records of one name may be
+  two spellings of one person or two people who share a name, and the library
+  cannot tell them apart — `Ambry.Inbox.Preflight` won't automate that
+  judgement at the point of import, so a report that has read even less
+  context certainly may not. Each record says what points at it, because the
+  question a pair raises is which one can go, and that is answered by the one
+  nothing references.
+  """
+
+  use AmbryWeb, :admin_live_view
+
+  alias Ambry.Inbox
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(page_title: "Duplicates", header_title: "Duplicates")
+     |> load()}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("reload", _params, socket), do: {:noreply, load(socket)}
+
+  defp load(socket) do
+    assign(socket, groups: Inbox.duplicates(), scanned: Inbox.duplicates_scanned())
+  end
+
+  @doc """
+  One record in a set: what it is called, and what still points at it.
+
+  The whole row is the link where there is somewhere to go, which is the
+  overview's problem-row idiom rather than §3a's — these are not records in a
+  list, they are the members of one finding, and a 224px action rail beside
+  two lines of text would be the loudest thing on a page whose best day is
+  saying nothing.
+  """
+  attr :kind, :atom, required: true
+  attr :record, :map, required: true
+
+  def duplicate_row(assigns) do
+    assigns = assign(assigns, navigate: route(assigns.kind, assigns.record))
+
+    ~H"""
+    <.link
+      :if={@navigate}
+      navigate={@navigate}
+      class="bg-zinc-800/60 flex items-baseline justify-between gap-4 rounded-md px-3 py-2 hover:bg-zinc-800"
+      data-role="duplicate-record"
+    >
+      <span class="min-w-0 truncate text-sm text-zinc-200">{@record.name}</span>
+      <span class={["flex-none text-xs", uses_class(@record)]}>{uses(@record)}</span>
+    </.link>
+
+    <div
+      :if={!@navigate}
+      class="bg-zinc-800/60 flex items-baseline justify-between gap-4 rounded-md px-3 py-2"
+      data-role="duplicate-record"
+    >
+      <span class="min-w-0 truncate text-sm text-zinc-200">{@record.name}</span>
+      <span class={["flex-none text-xs", uses_class(@record)]}>{uses(@record)}</span>
+    </div>
+    """
+  end
+
+  # Amber is "needs attention" (§5), and between two records of one name the
+  # one nothing references is the half you can actually do something about.
+  defp uses_class(%{uses: uses}) do
+    if Enum.all?(uses, fn {_word, count} -> count == 0 end),
+      do: "text-amber-300",
+      else: "text-zinc-400"
+  end
+
+  @doc """
+  The groups of one kind, in the order the sections are laid out.
+  """
+  def of_kind(groups, kind), do: Enum.filter(groups, &(&1.kind == kind))
+
+  @doc """
+  The heading a kind's section wears, and the sentence under it.
+
+  Kept together because the two have to agree about what the section is for,
+  and split across a template they drifted the first time this was written.
+  """
+  def section(:person),
+    do: {"People", "One person, twice. Their photo, bio and credits are split between the two."}
+
+  def section(:author),
+    do: {"Authors", "One author name, twice. A book credited to each has no author in common."}
+
+  def section(:narrator),
+    do: {"Narrators", "One narrator name, twice. Neither has the other's recordings."}
+
+  def section(:book),
+    do:
+      {"Books", "One book, twice. Each holds its own audiobooks, so neither page shows them all."}
+
+  # Deliberately hedged: `same_series?/2` folds filler words, so it will pair
+  # a real "…: Audio Immersion Tunnel" companion series with its parent.
+  def section(:series),
+    do: {"Series", "These may be one series under two names, or two that merely rhyme."}
+
+  @doc """
+  What points at a record, as a line to read.
+
+  A record nothing references says so in words rather than as a zero, because
+  that is the one this page exists to help you act on.
+  """
+  def uses(%{uses: uses}) do
+    case Enum.reject(uses, fn {_word, count} -> count == 0 end) do
+      [] -> "Nothing points at this one"
+      counted -> counted |> Enum.sort() |> Enum.map_join(" · ", &counted_words/1)
+    end
+  end
+
+  defp counted_words({word, 1}), do: "1 #{word |> to_string() |> String.trim_trailing("s")}"
+  defp counted_words({word, count}), do: "#{count} #{word}"
+
+  @doc """
+  Where a record is edited.
+
+  An author and a narrator are edited on the person behind them — there is no
+  page of their own — and a narrator always has one. An author may have none
+  (a bare name nobody has attached a human to yet) or several (a composite),
+  and neither of those has a single place to go, so the row is not a link.
+  """
+  def route(:person, record), do: ~p"/admin/people/#{record.id}/edit"
+  def route(:book, record), do: ~p"/admin/books/#{record.id}/edit"
+  def route(:series, record), do: ~p"/admin/series/#{record.id}/edit"
+
+  def route(_author_or_narrator, %{person_id: id}) when is_integer(id),
+    do: ~p"/admin/people/#{id}/edit"
+
+  def route(_author_or_narrator, _no_sole_person), do: nil
+
+  @doc """
+  What the report covered, for the line under the title.
+  """
+  def scanned_words(scanned) do
+    [
+      {scanned.people, "people", "person"},
+      {scanned.authors, "authors", "author"},
+      {scanned.narrators, "narrators", "narrator"},
+      {scanned.books, "books", "book"},
+      {scanned.series, "series", "series"}
+    ]
+    |> Enum.map_join(", ", fn
+      {1, _plural, singular} -> "1 #{singular}"
+      {count, plural, _singular} -> "#{count} #{plural}"
+    end)
+  end
+end

--- a/lib/ambry_web/live/admin/duplicates_live/index.html.heex
+++ b/lib/ambry_web/live/admin/duplicates_live/index.html.heex
@@ -1,0 +1,43 @@
+<.layout title={@page_title} user={@current_user} socket={@socket}>
+  <div class="flex items-baseline gap-4">
+    <%!-- The count of what was examined, not of what was found. A report of
+        nothing and a report that never ran read identically without it, and
+        this page exists to be believed. --%>
+    <p class="text-sm text-zinc-400" data-role="scanned">
+      Checked {scanned_words(@scanned)}.
+    </p>
+    <div class="grow" />
+    <.button color={:zinc} type="button" phx-click="reload">
+      <.icon name="fa-rotate" class="mr-1.5 h-4 w-4 text-current" /> Reload
+    </.button>
+  </div>
+
+  <div :if={@groups == []} class="rounded-lg bg-zinc-900 p-4" data-role="all-clear">
+    <p class="pl-3 text-sm text-zinc-300">
+      Nothing in the library is here twice.
+    </p>
+  </div>
+
+  <div :if={@groups != []} class="space-y-14">
+    <%= for kind <- [:person, :author, :narrator, :book, :series],
+            groups = of_kind(@groups, kind),
+            groups != [] do %>
+      <% {heading, hint} = section(kind) %>
+      <section class="space-y-4" data-role={"section-#{kind}"}>
+        <h2 class="text-xl font-bold text-zinc-100">{heading}</h2>
+
+        <p class="max-w-prose text-sm text-zinc-400">{hint}</p>
+
+        <%!-- One card per set, so where one ends and the next begins is the
+            shape of the page rather than a line drawn on it. --%>
+        <div
+          :for={group <- groups}
+          class="space-y-2 rounded-lg bg-zinc-900 p-4"
+          data-role="duplicate-set"
+        >
+          <.duplicate_row :for={record <- group.records} kind={kind} record={record} />
+        </div>
+      </section>
+    <% end %>
+  </div>
+</.layout>

--- a/lib/ambry_web/live/admin/home_live/index.ex
+++ b/lib/ambry_web/live/admin/home_live/index.ex
@@ -135,7 +135,12 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
   defp slow_load(socket) do
     assign(socket,
       providers: Inbox.provider_health(),
-      unreachable: Library.unreachable_locations()
+      unreachable: Library.unreachable_locations(),
+      # Reads every person, author, narrator, book and series and folds each
+      # name the way matching does — 1434 records on production. Cheap, but
+      # not on every job signal, and the answer doesn't change between one
+      # import and the next.
+      duplicates: Inbox.duplicate_count()
     )
   end
 
@@ -196,6 +201,12 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
         # a list that disagrees with the number that was clicked is its own
         # small betrayal.
         navigate: ~p"/admin/inbox?problem=issue&status=pending"
+      },
+      %{
+        words: "Records the library holds twice",
+        count: assigns.duplicates,
+        tone: :amber,
+        navigate: ~p"/admin/duplicates"
       },
       %{
         words: "Ready to publish, held by the switch",

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -212,6 +212,8 @@ defmodule AmbryWeb.Router do
       live "/users/:user_id/playthroughs/:playthrough_id", PlaybackDebugLive.Index
       live "/users/:user_id/devices", UserDevicesLive.Index
 
+      live "/duplicates", DuplicatesLive.Index
+
       live "/audit", AuditLive.Index, :index
 
       live "/metadata-providers", MetadataLive.Providers

--- a/test/ambry/inbox/duplicates_test.exs
+++ b/test/ambry/inbox/duplicates_test.exs
@@ -1,0 +1,76 @@
+defmodule Ambry.Inbox.DuplicatesTest do
+  use Ambry.DataCase
+
+  alias Ambry.Inbox.Duplicates
+
+  describe "check/0" do
+    test "a library with nothing in it twice reports nothing" do
+      insert(:person, name: "Brandon Sanderson")
+      insert(:person, name: "Becky Chambers")
+      insert(:book, title: "Evershore")
+      insert(:series, name: "Skyward Flight")
+
+      assert Duplicates.check() == []
+      assert Duplicates.count() == 0
+    end
+
+    # The pair production actually had, spelled the way the two spellings
+    # that most often produce one arrive: an accent from one provider and
+    # none from another.
+    test "finds two people of one name, and says what points at each" do
+      kept = insert(:person, name: "Patricia Rodríguez")
+      spare = insert(:person, name: "Patricia Rodriguez")
+      insert(:narrator, name: "Patricia Rodríguez", person: kept)
+
+      assert [group] = for(g <- Duplicates.check(), g.kind == :person, do: g)
+      assert [first, second] = group.records
+
+      assert first.id == kept.id
+      assert first.uses == %{authors: 0, narrators: 1}
+
+      assert second.id == spare.id
+      assert second.uses == %{authors: 0, narrators: 0}
+    end
+
+    test "a leading article does not make a different book" do
+      one = insert(:book, title: "The Princess Bride")
+      two = insert(:book, title: "Princess Bride")
+      insert(:media, book: one)
+
+      assert [group] = for(g <- Duplicates.check(), g.kind == :book, do: g)
+      assert Enum.map(group.records, & &1.id) == Enum.sort([one.id, two.id])
+      assert [%{uses: %{audiobooks: 1}}, %{uses: %{audiobooks: 0}}] = group.records
+    end
+
+    # `same_series?/2` is a predicate rather than a key, so this is the case
+    # that would fall through a plain group-by: neither name is a prefix or a
+    # normalisation of the other, they simply mean the same shelf.
+    test "a filler word does not make a different series" do
+      saga = insert(:series, name: "The Mistborn Saga")
+      trilogy = insert(:series, name: "Mistborn Trilogy")
+
+      assert [group] = for(g <- Duplicates.check(), g.kind == :series, do: g)
+      assert Enum.map(group.records, & &1.id) == Enum.sort([saga.id, trilogy.id])
+    end
+
+    test "three spellings of one name are one set, not three pairs" do
+      for name <- ["J.K. Rowling", "J. K. Rowling", "JK Rowling"] do
+        insert(:narrator, name: name, person: insert(:person, name: name))
+      end
+
+      assert [group] = for(g <- Duplicates.check(), g.kind == :narrator, do: g)
+      assert length(group.records) == 3
+    end
+  end
+
+  describe "scanned/0" do
+    # A report of nothing has to be able to say what nothing covers, or it
+    # reads the same as a report that never ran.
+    test "counts what the check looked at" do
+      insert(:person, name: "Becky Chambers")
+      insert(:book, title: "A Psalm for the Wild-Built")
+
+      assert %{people: 1, books: 1, authors: 0, narrators: 0, series: 0} = Duplicates.scanned()
+    end
+  end
+end

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -8,6 +8,7 @@ defmodule Ambry.Inbox.ImporterTest do
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.GroupLink
   alias Ambry.Inbox.InboxItem
+  alias Ambry.Inbox.Preflight
   alias Ambry.Media
   alias Ambry.Media.Media.Chapter
   alias Ambry.Media.MediaTrack
@@ -423,6 +424,63 @@ defmodule Ambry.Inbox.ImporterTest do
       assert [credit] = second.draft.recording.narrators
       assert credit.curated
       assert credit.mode == :create
+    end
+  end
+
+  # The pre-flight runs on the button and this import then takes forty to
+  # eighty seconds to re-probe and copy, with three more running beside it. A
+  # sibling that commits inside that window created what this one is about to
+  # create, and nothing between the click and the write would have noticed.
+  describe "a collision that appears while the import is running" do
+    @finding %{
+      kind: :book,
+      section: :work,
+      label: "Book: The Way of Kings",
+      certain?: true,
+      matches: []
+    }
+
+    test "refuses the import, and nothing is created" do
+      item = tagged_item()
+      patch(Preflight, :check, answering([[], [@finding]]))
+
+      assert {:error, {:collisions, [@finding]}} = Inbox.import_item(item)
+
+      assert Repo.aggregate(Book, :count) == 0
+      assert Inbox.get_item!(item.id).status == :pending
+      assert Inbox.get_item!(item.id).issue =~ "may already be in the library"
+    end
+
+    # The other half, and the one that makes the guard usable: a collision the
+    # operator read at the button and accepted is in *both* readings, so it is
+    # not new and may not stop them a second time.
+    test "one the operator already accepted is not refused again" do
+      item = tagged_item()
+      patch(Preflight, :check, fn _item -> [@finding] end)
+
+      assert {:ok, _media} = Inbox.import_item(item)
+    end
+
+    # A relink sweep can turn one of this draft's creates into a link while
+    # the import runs, which only ever removes findings.
+    test "one that disappears while the import runs is not a refusal" do
+      item = tagged_item()
+      patch(Preflight, :check, answering([[@finding], []]))
+
+      assert {:ok, _media} = Inbox.import_item(item)
+    end
+
+    # One reading per call, in order, so a test can say what the library did
+    # between the button and the write.
+    defp answering(readings) do
+      {:ok, calls} = Agent.start_link(fn -> readings end)
+
+      fn _item ->
+        Agent.get_and_update(calls, fn
+          [last] -> {last, [last]}
+          [next | rest] -> {next, rest}
+        end)
+      end
     end
   end
 

--- a/test/ambry_web/live/admin/duplicates_live/index_test.exs
+++ b/test/ambry_web/live/admin/duplicates_live/index_test.exs
@@ -1,0 +1,78 @@
+defmodule AmbryWeb.Admin.DuplicatesLive.IndexTest do
+  use AmbryWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_admin_user
+
+  describe "Index" do
+    # The reassuring answer is the one that has to be trustworthy, so an
+    # empty report says what it looked at. Without the count, "nothing found"
+    # and "nothing ran" render identically.
+    test "a clean library says so, and says what it checked", %{conn: conn} do
+      insert(:person, name: "Becky Chambers")
+      insert(:book, title: "A Psalm for the Wild-Built")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+
+      assert has_element?(view, "[data-role='all-clear']", "Nothing in the library is here twice")
+      assert has_element?(view, "[data-role='scanned']", "1 person")
+      assert has_element?(view, "[data-role='scanned']", "1 book")
+    end
+
+    test "a duplicated person is one set of two records", %{conn: conn} do
+      kept = insert(:person, name: "Patricia Rodríguez")
+      insert(:person, name: "Patricia Rodriguez")
+      insert(:narrator, name: "Patricia Rodríguez", person: kept)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+
+      refute has_element?(view, "[data-role='all-clear']")
+      assert has_element?(view, "[data-role='section-person']", "People")
+
+      # One card, two rows in it.
+      assert view |> element("[data-role='section-person']") |> render() =~ "duplicate-set"
+      assert view |> render() |> count_of("data-role=\"duplicate-record\"") == 2
+    end
+
+    # The whole point of the counts: between two records of one name, the one
+    # nothing references is the one you can act on.
+    test "says which half nothing points at", %{conn: conn} do
+      kept = insert(:person, name: "Patricia Rodríguez")
+      insert(:person, name: "Patricia Rodriguez")
+      insert(:narrator, name: "Patricia Rodríguez", person: kept)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+
+      assert has_element?(view, "[data-role='duplicate-record']", "1 narrator")
+      assert has_element?(view, "[data-role='duplicate-record']", "Nothing points at this one")
+    end
+
+    test "each record links to where it is edited", %{conn: conn} do
+      one = insert(:book, title: "The Princess Bride")
+      two = insert(:book, title: "Princess Bride")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+
+      assert has_element?(view, ~s|a[href="/admin/books/#{one.id}/edit"]|)
+      assert has_element?(view, ~s|a[href="/admin/books/#{two.id}/edit"]|)
+    end
+
+    # The report is a snapshot of a library that keeps moving, so it has to be
+    # re-askable without a page load.
+    test "reload picks up a duplicate created since the page opened", %{conn: conn} do
+      insert(:book, title: "The Princess Bride")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+      assert has_element?(view, "[data-role='all-clear']")
+
+      insert(:book, title: "Princess Bride")
+      render_click(view, "reload")
+
+      refute has_element?(view, "[data-role='all-clear']")
+      assert has_element?(view, "[data-role='section-book']", "Books")
+    end
+  end
+
+  defp count_of(html, needle), do: html |> String.split(needle) |> length() |> Kernel.-(1)
+end


### PR DESCRIPTION
Never having duplicates is a standing goal, and every mechanism serving it is
best effort: the seeder links rather than creates, `Seed.relink/2` re-points a
proposal once a sibling import makes its target exist, `Preflight` asks before
the button. A goal that is only ever pursued is one you have to take on faith.

## The report

`Ambry.Inbox.Duplicates` folds names through `AutoMatch.person_key/1`, titles
through `title_key/1` and series through `same_series?/2` — the same functions
that decide whether an import links or creates. A second definition of "the
same" is the drift that would let the report and the importer disagree, and
the row they disagreed about is the one that got through. Each record says
what still points at it, since the question a pair raises is which one can go
and it is answered by the one nothing references.

Sets are absent on purpose: `recording_groups (book_id, name)` is unique, so
within a book Postgres already refuses and across books two sets of one name
are two sets. Nothing else can carry a constraint. Two people genuinely can
share a name and two books genuinely can share a title — `Preflight` reasons
about exactly that when it tells "Sarah J. Maas twice" from "a second identity
backed by somebody else" — so `people.name` cannot be unique, and this can
only ever be a report.

An empty report is not an empty page. It says how many records it examined,
because "nothing found" and "nothing ran" render identically otherwise and the
reassuring one is the one that has to be trustworthy. It does not merge and
does not offer to; the judgement it would need is the one `Preflight` already
declines to automate with more context than this has.

`/admin/duplicates`, under System in the nav. The overview gets a Problems row
only when the count is non-zero, per its own rule about green zeroes; the page
is where you go to see the zero.

## And the pre-flight runs again at the door of the write

`Preflight` runs on the button, and the import then spends forty to eighty
seconds re-probing and copying with three more imports beside it. A sibling
that commits inside that window created exactly what this one is about to
create, and nothing between the click and the write noticed. It refuses only
findings that are **new**: the ones the operator read and accepted are in both
readings, and a relink sweep that turns a create into a link while the import
runs only ever removes them. The refusal lands on the row as an issue and the
queue keeps moving, like every other one.

It is not a guarantee and cannot be made one here. At READ COMMITTED a peer's
uncommitted rows are invisible, so two imports whose commits interleave will
not see each other however carefully either looks. This closes the minute;
closing the millisecond would mean serializing the file copies of every import
that shares an author, which is why the report exists instead.

## Measured against production before it was written

444 people, 138 authors, 325 narrators, 419 books, 108 series, and one pair —
two Raymond J. Lees created 25 minutes apart in 2024 by the upload flow the
inbox replaced (since deleted). **The inbox has created none in 178 imports.**
The series grouping needs transitive absorption rather than a group-by, since
`same_series?/2` is a predicate; run against the real 108 series it produces
exactly two pairs and does not over-merge.

`mix test` and `mix check` both clean. The refusal test was confirmed to fail
without the guard.

## Two things worth knowing

The nav icon is a compromise. The vendored FA set is 69 icons with no `clone`
or `copy`, and `layer-group` and `binoculars` are taken by Sets and Overview,
so it uses `magnifying-glass`.

The two series pairs the report finds on production ("Dungeon Crawler Carl" /
"…: Audio Immersion Tunnel", "The Mistborn Saga" / "The Mistborn Trilogy") may
be legitimate. `same_series?/2` folds filler words and subtitle heads, so it
will pair a real companion series with its parent, which is why that section's
hint hedges. An ignore list is the obvious follow-up if they become noise; it
is left out because a report with a dismiss button on day one is a report that
can be emptied without fixing anything.

Independent of the inbox lost-update fix; whichever merges second wants a rebase, and the
two touch different hunks of `lib/ambry/inbox.ex`.

https://claude.ai/code/session_01KTzJCsa9ERXqz1CcMzsHgt
