### PR TITLE
Two escape hatches for a wrongly grouped release

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,6 +33,7 @@ import { ListScrollResetHook } from "./hooks/list-scroll-reset"
 import { MainTainAttrsHook } from "./hooks/maintain-attrs"
 import { PasteImageHook } from "./hooks/paste-image"
 import { ReadMoreHook } from "./hooks/read-more"
+import { ReorderRowsHook } from "./hooks/reorder-rows"
 import { ScrollIntoViewHook } from "./hooks/scroll-into-view"
 import { ScrollMatchHook } from "./hooks/scroll-match"
 import { SearchBoxHook } from "./hooks/search-box"
@@ -58,6 +59,7 @@ let liveSocket = new LiveSocket("/live", Socket, {
     "scroll-match": ScrollMatchHook,
     "paste-image": PasteImageHook,
     "sticky-footer": StickyFooterHook,
+    "reorder-rows": ReorderRowsHook,
     "auto-dismiss": AutoDismissHook,
   },
 })

--- a/assets/js/hooks/reorder-rows.js
+++ b/assets/js/hooks/reorder-rows.js
@@ -1,0 +1,65 @@
+// Moving one row of an ordered has_many up or down, the way LiveView's
+// `inputs_for` docs move rows: the client edits the form's own inputs and
+// dispatches a change, and the server does nothing but cast the params it is
+// given.
+//
+// Two hidden inputs per row carry everything:
+//
+//   <input name="book[book_authors_sort][]" value="0">      which slot goes here
+//   <input name="book[book_authors][0][position]" value="0"> what to write down
+//
+// The sort list is read in DOM order, so swapping two of its *values* swaps
+// the rows. The positions swap with them, and that half is not optional: a
+// `has_many` is not order-tracked by Ecto (`Ecto.Association.Has` has no
+// `:ordered` field, while `Ecto.Embedded` does), so a reorder that changes no
+// field at all leaves every child changeset empty and the whole association
+// is skipped — buttons that visibly work and save nothing.
+//
+// A row removed with the ✕ is not rendered, so it posts nothing and is not
+// here to be moved; Ecto's own `sort -- drop` reconciles the two whenever
+// they do arrive together. That is the whole reason this lives here rather
+// than in an event handler rewriting params behind the cast: the delete and
+// the move were two mechanisms indexing one list, and a move after a delete
+// used to redirect the delete onto a different row.
+export const ReorderRowsHook = {
+  mounted() {
+    this.el.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-move]")
+
+      if (button && !button.disabled && this.el.contains(button)) {
+        this.move(button)
+      }
+    })
+  },
+
+  move(button) {
+    const field = button.dataset.moveField
+    const from = parseInt(button.dataset.moveIndex, 10)
+    const to = from + (button.dataset.move === "up" ? -1 : 1)
+
+    const slots = Array.from(this.el.querySelectorAll(`input[name$="[${field}_sort][]"]`))
+    const fromSlot = slots[from]
+    const toSlot = slots[to]
+
+    // The ends of the list wear disabled buttons; a stale page can still get
+    // here, and there is nothing past the end to swap with.
+    if (!fromSlot || !toSlot || to < 0) return
+
+    const prefix = fromSlot.name.replace(`[${field}_sort][]`, "")
+    const position = (key) => this.el.querySelector(`input[name="${prefix}[${field}][${key}][position]"]`)
+
+    const fromPosition = position(fromSlot.value)
+    const toPosition = position(toSlot.value)
+
+    swapValues(fromSlot, toSlot)
+    if (fromPosition && toPosition) swapValues(fromPosition, toPosition)
+
+    button.dispatchEvent(new Event("change", { bubbles: true }))
+  },
+}
+
+function swapValues(a, b) {
+  const value = a.value
+  a.value = b.value
+  b.value = value
+}

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -247,9 +247,19 @@ defmodule Ambry.Inbox do
     end)
   end
 
-  def get_item!(id), do: Repo.get!(InboxItem, id)
+  @doc """
+  One item, carrying the source its `path` and `files` are relative to.
 
-  def fetch_item(id), do: Repo.fetch(InboxItem, id)
+  Preloaded here rather than by each caller: every one of them either
+  resolves a path or renders where the item came from, and an item without
+  its source is a struct whose two most-used columns can't be read. The write
+  path has said this for as long as it has taken a row lock (`with_item/2`).
+  """
+  def get_item!(id), do: InboxItem |> Repo.get!(id) |> Repo.preload(:source)
+
+  def fetch_item(id) do
+    with {:ok, item} <- Repo.fetch(InboxItem, id), do: {:ok, Repo.preload(item, :source)}
+  end
 
   @no_counts %{created: 0, updated: 0, skipped: 0, unreachable: 0}
 

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -352,7 +352,7 @@ defmodule Ambry.Inbox do
     item = Repo.preload(item, :source)
 
     attrs =
-      case item.files do
+      case InboxItem.included(item) do
         [] -> %{issue: "no audio files found"}
         _files -> probe_recording(InboxItem.disk_files(item))
       end
@@ -1125,6 +1125,11 @@ defmodule Ambry.Inbox do
   def describe_error(:not_divisible),
     do: "These files are all in one folder, so splitting by folder would change nothing."
 
+  def describe_error(:last_file),
+    do: "This is the only file left in the audiobook. Ignore the whole item instead."
+
+  def describe_error(:not_held), do: "This item doesn't hold that file any more."
+
   # The invariant, phrased for a human. It names the count rather than the
   # decisions because the form lists them properly — this is the flash you get
   # if you somehow reached import from the queue.
@@ -1247,6 +1252,61 @@ defmodule Ambry.Inbox do
     case split_groups(item, by) do
       [_one] -> {:error, :not_divisible}
       groups -> regroup([item], groups)
+    end
+  end
+
+  @doc """
+  Takes one file out of an item's audiobook, or puts it back.
+
+  A release can ship the same part twice — Oathbringer's second part carries
+  `STORMLIGHT0302P06.mp3` and `STORMLIGHT0302P06_CD.mp3`, the same forty
+  minutes at two bitrates — and nothing but a listener can tell. Splitting
+  doesn't help (the rest is one audiobook) and neither does ignoring (that
+  takes the whole item out), so this is the grain in between.
+
+  **The file is not let go of.** It stays in `files`, which is what
+  discovery reads to decide who owns what; an item that shortened its list
+  instead would be handed the file back as an inbox item of its own on the
+  next scan, and every scan after that. It is listed and struck through
+  rather than hidden for the same reason a split is visible: the operator
+  decided something, and a form that quietly showed six of seven files would
+  be lying about what it holds.
+
+  The recording changes, so the item is read again — its duration, size and
+  chapter marks are all measured across the files. That is the same path a
+  file appearing on disk takes: an untouched draft is rebuilt around the new
+  reading, and a curated one is left alone and says it is out of date.
+
+  Refused on an imported item (its files are the record of what was
+  imported), for a file the item doesn't hold, and for the last one standing:
+  an audiobook with no audio in it is not a decision, it's an empty item.
+  """
+  def exclude_file(%InboxItem{} = item, file), do: set_included(item, file, false)
+
+  def include_file(%InboxItem{} = item, file), do: set_included(item, file, true)
+
+  defp set_included(%InboxItem{status: :imported}, _file, _included?),
+    do: {:error, :already_imported}
+
+  defp set_included(%InboxItem{} = item, file, included?) do
+    cond do
+      file not in item.files -> {:error, :not_held}
+      not included? and InboxItem.included(item) == [file] -> {:error, :last_file}
+      true -> reread(item, excluded_after(item, file, included?))
+    end
+  end
+
+  defp excluded_after(%InboxItem{excluded_files: excluded}, file, true), do: excluded -- [file]
+
+  defp excluded_after(%InboxItem{excluded_files: excluded}, file, false),
+    do: Enum.uniq(excluded ++ [file])
+
+  defp reread(%InboxItem{} = item, excluded) do
+    with {:ok, item} <- update_item(item, %{excluded_files: excluded}) do
+      # The draft describes a recording that just changed length.
+      mark_draft_stale(item)
+      {:ok, _job} = probe_item_async(item)
+      {:ok, item}
     end
   end
 
@@ -1740,8 +1800,11 @@ defmodule Ambry.Inbox do
     items = InboxItem |> Repo.all() |> Repo.preload(:source)
 
     %{
+      # Every file the item holds, not just the recording's: a file the
+      # operator excluded is still owned, and a ledger that forgot it would
+      # hand it an item of its own on the next scan.
       by_file:
-        for(item <- items, file <- InboxItem.disk_files(item), into: %{}, do: {file, item}),
+        for(item <- items, file <- InboxItem.owned_disk_files(item), into: %{}, do: {file, item}),
       by_path: Map.new(items, &{InboxItem.disk_path(&1), &1})
     }
   end

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -44,14 +44,17 @@ defmodule Ambry.Inbox do
     * create items from files nothing owns,
     * give an unowned file to the item that owns the folder above it,
     * drop a file that is gone from its owner (which marks that item's draft
-      stale, since the draft describes files that moved under it).
+      stale, since the draft describes files that moved under it), where
+      "gone" means no candidate in the whole walk claimed it.
 
   It may never move a file from one item to another, and it never touches an
-  imported item at all. That is what makes a split durable without a marker:
-  once the operator says five folders are five releases, the files are owned,
-  and re-walking the folder that holds them has nothing to say. It is a
-  property of the construction rather than a rule the code has to remember —
-  `record_candidate/3` groups by owner before it looks at anything else.
+  imported item at all. That is what makes a split *and* a combine durable
+  without a marker: once the operator says five folders are five releases, or
+  that three are one, the files are owned, and re-walking the folder that
+  holds them has nothing to say. It is a property of the construction rather
+  than a rule the code has to remember — `record_candidate/4` groups by owner
+  before it looks at anything else, and settles what each owner holds only
+  once the walk is over.
   """
 
   use Boundary,
@@ -306,10 +309,14 @@ defmodule Ambry.Inbox do
     if File.dir?(source.path) do
       ledger = ledger()
 
-      results =
+      # Two passes, because an owner can span several candidates and only the
+      # whole walk knows what it still holds — see `record_candidate/4`.
+      {creations, claims} =
         source.path
         |> candidates()
-        |> Enum.flat_map(&List.wrap(record_candidate(&1, ledger, source)))
+        |> Enum.map_reduce(%{}, &record_candidate(&1, &2, ledger, source))
+
+      results = List.flatten(creations) ++ Enum.map(claims, &refresh_claim/1)
 
       {:ok,
        %{
@@ -1229,20 +1236,166 @@ defmodule Ambry.Inbox do
   def split_item(%InboxItem{} = item, by) do
     case split_groups(item, by) do
       [_one] -> {:error, :not_divisible}
-      groups -> replace_with_children(item, groups)
+      groups -> regroup([item], groups)
     end
   end
 
-  defp replace_with_children(%InboxItem{} = item, groups) do
+  @doc """
+  The other items this one would be combined with, and the folder they'd
+  become — or nil when there is nothing to offer.
+
+  The offer is *the folder that holds this item*, and everything the queue
+  still has waiting under it. That is the shape the mistake comes in: a
+  release whose parts sit in subfolders the walk couldn't read as parts, so
+  it handed back one item per subfolder.
+
+  Nothing is offered for an item at the top of its source. Every item there
+  shares the source root, and "combine with the other 283 things you
+  downloaded" is not a question worth asking.
+  """
+  def combine_group(%InboxItem{status: :pending} = item) do
+    with folder when not is_nil(folder) <- parent_folder(item),
+         [_one, _two | _rest] = items <- items_under(folder, item.source_id),
+         target when not is_nil(target) <- common_folder(items) do
+      %{folder: target, items: items}
+    else
+      _nothing_to_offer -> nil
+    end
+  end
+
+  def combine_group(%InboxItem{}), do: nil
+
+  @doc """
+  Combines this item with the rest of its folder (`combine_group/1`) into one.
+  """
+  def combine_item(%InboxItem{} = item) do
+    case combine_group(item) do
+      nil -> {:error, :nothing_to_combine}
+      %{items: items} -> combine_items(items)
+    end
+  end
+
+  @doc """
+  Merges several items into a single one for the folder that holds them.
+
+  The opposite mistake to a split, and it comes from the same place. The walk
+  decides where one release ends by what a folder holds, and a folder whose
+  subfolders don't *say* they are parts reads as a container of releases —
+  deliberately, because "Gwendy's Button Box 2" is its own book far more
+  often than it is disc two of something. When it isn't, the queue has three
+  items that are one audiobook and no way to say so: import would create
+  three audiobooks, and splitting further only makes it worse.
+
+  So the operator says these are one, and they become one item at the folder
+  they share, holding every file in the order a single candidate for that
+  folder would have found them (`audio_files/1`'s order, so a rescan agrees).
+  The drafts of the parts are not merged into it. Each described a different
+  audiobook — its own title, its own chapters, its own matches — and half of
+  three wrong answers is not an answer; the combined item is probed and
+  matched fresh, as one recording.
+
+  Refused when any of them is imported (the item is the record of what was
+  imported), below two items, when they don't all come from one source, and
+  when the folder they share is the source root itself: an item there would
+  own every file that ever lands in the watched folder.
+  """
+  def combine_items(items)
+
+  def combine_items(items) when length(items) < 2, do: {:error, :not_multiple}
+
+  def combine_items([%InboxItem{} | _rest] = items) do
+    cond do
+      Enum.any?(items, &(&1.status == :imported)) -> {:error, :already_imported}
+      not one_source?(items) -> {:error, :different_sources}
+      folder = common_folder(items) -> combine_under(folder, items)
+      true -> {:error, :no_shared_folder}
+    end
+  end
+
+  defp one_source?(items), do: items |> Enum.map(& &1.source_id) |> Enum.uniq() |> length() == 1
+
+  defp combine_under(folder, items) do
+    if occupied?(folder, items) do
+      {:error, :path_taken}
+    else
+      files = items |> Enum.flat_map(& &1.files) |> Enum.sort(NaturalOrder)
+
+      with {:ok, [combined]} <- regroup(items, [{folder, files}]), do: {:ok, combined}
+    end
+  end
+
+  # An item at the path the combined one would take, that isn't one of the
+  # items being replaced. `path` is unique across the whole table, so this
+  # asks the same question the constraint would, early enough to refuse with
+  # a reason rather than a constraint error.
+  defp occupied?(folder, items) do
+    ids = Enum.map(items, & &1.id)
+
+    InboxItem
+    |> where([i], i.path == ^folder and i.id not in ^ids)
+    |> Repo.exists?()
+  end
+
+  # The items still waiting under a folder, including one sitting at the
+  # folder itself. `starts_with` rather than a LIKE: release folders are full
+  # of `%` and `_`, and a pattern would read them as wildcards.
+  defp items_under(folder, source_id) do
+    InboxItem
+    |> where([i], i.source_id == ^source_id and i.status == :pending)
+    |> where([i], i.path == ^folder or fragment("starts_with(?, ?)", i.path, ^(folder <> "/")))
+    |> order_by([i], i.path)
+    |> Repo.all()
+    |> Repo.preload(:source)
+  end
+
+  defp parent_folder(%InboxItem{path: path}) do
+    case Path.dirname(path) do
+      "." -> nil
+      folder -> folder
+    end
+  end
+
+  # The deepest folder holding all of them, or nil when that is the source
+  # root. Read off the paths rather than their parents, so that an item
+  # sitting *at* the folder counts as being in it: two or more distinct paths
+  # can only share their common folder as a prefix, and a path that is an
+  # ancestor of another is that folder.
+  defp common_folder(items) do
+    items
+    |> Enum.map(&Path.split(&1.path))
+    |> Enum.reduce(&common_prefix/2)
+    |> case do
+      [] -> nil
+      segments -> Path.join(segments)
+    end
+  end
+
+  defp common_prefix(a, b) do
+    a |> Enum.zip(b) |> Enum.take_while(fn {x, y} -> x == y end) |> Enum.map(&elem(&1, 0))
+  end
+
+  # One grouping replaced by another: the items that were wrong go, the items
+  # that are right arrive, and each of the new ones is read from scratch.
+  # Both directions are the same move, which is why they share this.
+  defp regroup(items, groups) do
     Repo.transact(fn ->
-      with {:ok, _parent} <- Repo.delete(item),
-           {:ok, children} <- insert_children(item, groups) do
+      with :ok <- delete_items(items),
+           {:ok, children} <- insert_children(hd(items), groups) do
         # In the transaction on purpose: a job for a child that didn't get
         # created must not exist either.
         Enum.each(children, fn child -> {:ok, _job} = probe_item_async(child) end)
         {:ok, children}
       end
     end)
+  end
+
+  defp delete_items(items) do
+    ids = Enum.map(items, & &1.id)
+    {deleted, _returning} = InboxItem |> where([i], i.id in ^ids) |> Repo.delete_all()
+
+    # Someone else got there first, and the grouping was decided about items
+    # that are no longer what the queue holds.
+    if deleted == length(ids), do: :ok, else: {:error, :stale}
   end
 
   @doc """
@@ -1436,14 +1589,36 @@ defmodule Ambry.Inbox do
   # release is the work. The provenance is still read, one step further on:
   # it pre-fills the import form's replace decision (`Ambry.Media.imported_from/1`),
   # demoted from a filter to a suggestion the operator confirms.
-  defp record_candidate({path, files}, ledger, source) do
-    files
-    |> Enum.group_by(&owner_of(&1, ledger))
-    |> Enum.flat_map(fn
-      {nil, orphans} -> List.wrap(adopt(path, files, orphans, source))
-      {%InboxItem{} = item, theirs} -> [refresh_owner(item, theirs)]
-    end)
+  #
+  # **What an owner still holds is answered by the whole walk, not by one
+  # candidate**, which is what makes a *combined* item durable. The walk has
+  # no idea that three subfolders are one release — that is precisely the
+  # judgement the operator made — so it offers them as three candidates, and
+  # refreshing the item from each in turn would leave it holding whichever
+  # ran last. So a candidate only ever *claims* files for their owner here,
+  # and the claims are settled once the source has been walked: an item's new
+  # file list is everything claimed for it, and a file is gone only when
+  # nothing anywhere claimed it.
+  defp record_candidate({path, files}, claims, ledger, source) do
+    by_owner = Enum.group_by(files, &owner_of(&1, ledger))
+    orphans = Map.get(by_owner, nil, [])
+
+    creations = if orphans == [], do: [], else: List.wrap(adopt(path, files, orphans, source))
+
+    claims =
+      by_owner
+      |> Map.delete(nil)
+      |> Enum.reduce(claims, fn {%InboxItem{} = item, theirs}, claims ->
+        # Appended in walk order, which is the order a single candidate for
+        # the whole folder would have produced: `audio_files/1` sorts the
+        # subtree, and the walk visits its folders in that same order.
+        Map.update(claims, item.id, {item, theirs}, fn {item, held} -> {item, held ++ theirs} end)
+      end)
+
+    {creations, claims}
   end
+
+  defp refresh_claim({_id, {item, files}}), do: refresh_owner(item, files)
 
   # A file's owner, in the order that decides it: the item that already lists
   # it, then the nearest item *above* it — which is how a file that appears

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -850,7 +850,7 @@ defmodule Ambry.Inbox.AutoMatch do
   # operator's filesystem layout and says nothing about this release.
   defp raw_text(%InboxItem{} = item) do
     [Path.basename(item.path || "")]
-    |> Enum.concat(Enum.map(item.files || [], &Path.basename/1))
+    |> Enum.concat(Enum.map(InboxItem.included(item), &Path.basename/1))
     |> Enum.concat(tag_text(item.tags))
     |> Enum.join(" ")
   end

--- a/lib/ambry/inbox/draft/seed.ex
+++ b/lib/ambry/inbox/draft/seed.ex
@@ -278,9 +278,10 @@ defmodule Ambry.Inbox.Draft.Seed do
   end
 
   # Cheap and sufficient: what a draft was built against is the set of files
-  # and their probe. Neither a rename nor a replacement can slip past it.
+  # *in the recording* and their probe. Neither a rename, nor a replacement,
+  # nor the operator taking one file out of the audiobook can slip past it.
   defp evidence(%InboxItem{} = item) do
-    :erlang.phash2({item.files, item.probe}) |> Integer.to_string()
+    :erlang.phash2({InboxItem.included(item), item.probe}) |> Integer.to_string()
   end
 
   ## replacement
@@ -1054,7 +1055,7 @@ defmodule Ambry.Inbox.Draft.Seed do
   # the value straight to the extractor.
   defp cover_field(sources, tags, item) do
     embedded =
-      if tags["has_cover_art"] && item.files != [] do
+      if tags["has_cover_art"] && InboxItem.included(item) != [] do
         %Candidate{
           value: item |> Repo.preload(:source) |> InboxItem.disk_files() |> List.first(),
           source: "embedded",

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -13,6 +13,22 @@ defmodule Ambry.Inbox.InboxItem do
   `disk_path/1` and `disk_files/1`, never by joining the columns against
   anything directly.
 
+  ## Two questions about one list
+
+  `files` is everything under this item, and `excluded_files` says which of
+  them the operator took out of the audiobook — a release that ships the same
+  part twice, which no rule can spot and only a listener would notice.
+
+  They are separate columns because they answer to different things.
+  **`files` is the ownership ledger discovery reads**: a file it doesn't
+  claim belongs to nobody, so the next hourly scan makes it an inbox item of
+  its own, and shortening the list to exclude a file would mean it came back
+  every hour, forever. So the item keeps holding it and says it isn't in the
+  recording.
+
+  Which one a caller wants is not a detail: `owned_disk_files/1` for who
+  holds what, `disk_files/1` for what a listener will hear.
+
   Every item has a source. There is no other way in, which is what makes
   the relative form an invariant rather than a convention.
   """
@@ -39,7 +55,11 @@ defmodule Ambry.Inbox.InboxItem do
     belongs_to :source, Source
 
     field :path, :string
+
+    # Everything under this item, and which of it isn't part of the
+    # recording. See the moduledoc: two questions, two lists.
     field :files, {:array, :string}, default: []
+    field :excluded_files, {:array, :string}, default: []
     field :status, Ecto.Enum, values: @statuses, default: :pending
     field :probe, :map
     field :tags, :map
@@ -75,6 +95,7 @@ defmodule Ambry.Inbox.InboxItem do
     |> cast(attrs, [
       :path,
       :files,
+      :excluded_files,
       :status,
       :probe,
       :tags,
@@ -217,9 +238,34 @@ defmodule Ambry.Inbox.InboxItem do
   def disk_path(%__MODULE__{path: path} = item), do: resolve!(item, path)
 
   @doc """
-  The item's files as absolute disk paths, in discovery order.
+  The recording's files, as absolute disk paths, in discovery order.
+
+  What a listener will hear, which is what everything downstream of curation
+  means by "the files": the probe measures these, the draft is seeded from
+  them, and import places these and writes them as tracks. Use
+  `owned_disk_files/1` for the other question — see the moduledoc.
   """
-  def disk_files(%__MODULE__{files: files} = item), do: Enum.map(files, &resolve!(item, &1))
+  def disk_files(%__MODULE__{} = item), do: Enum.map(included(item), &resolve!(item, &1))
+
+  @doc """
+  Every file this item holds, excluded ones included, as absolute disk paths.
+
+  Ownership, not playback. Discovery reads this: a file the queue no longer
+  claims belongs to nobody, and the next scan hands it an inbox item of its
+  own. Excluding a file must therefore never let go of it.
+  """
+  def owned_disk_files(%__MODULE__{files: files} = item), do: Enum.map(files, &resolve!(item, &1))
+
+  @doc """
+  The stored form of the recording's files: everything held, less what the
+  operator took out.
+  """
+  def included(%__MODULE__{files: files, excluded_files: excluded}), do: files -- excluded
+
+  @doc """
+  Whether this file is held by the item but not part of the recording.
+  """
+  def excluded?(%__MODULE__{excluded_files: excluded}, file), do: file in excluded
 
   # Raising is deliberate: these paths get probed and placed, and a path that
   # can't resolve must never quietly become a relative one.

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -1240,11 +1240,19 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
-  defp common_dir([]), do: ""
+  @doc """
+  The directory every one of these files shares.
 
-  defp common_dir(files) do
+  Public because a caller sometimes needs to know what this card is about to
+  say: the inbox form prints the item's path above it and drops that line
+  when the list is going to state the same thing (`stated_by_files?/1`). Two
+  answers to "where is this" would have to agree, so there is one.
+  """
+  def common_dir([]), do: ""
+
+  def common_dir(files) do
     files
-    |> Enum.map(&Path.split(Path.dirname(&1)))
+    |> Enum.map(&folder_segments/1)
     |> Enum.reduce(fn segments, acc ->
       acc
       |> Enum.zip(segments)
@@ -1254,6 +1262,16 @@ defmodule AmbryWeb.Admin.Components do
     |> case do
       [] -> ""
       segments -> Path.join(segments)
+    end
+  end
+
+  # A file with no directory above it has no directory *line*: `Path.dirname`
+  # answers "." for a path that is just a name, and the card was printing
+  # "./" over the loose files at the top of a watched folder.
+  defp folder_segments(file) do
+    case Path.dirname(file) do
+      "." -> []
+      dir -> Path.split(dir)
     end
   end
 

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -1204,6 +1204,29 @@ defmodule AmbryWeb.Admin.Components do
     """
   end
 
+  attr :source, :any, required: true, doc: "the `Ambry.Library.Source` an item was found in"
+  attr :class, :any, default: nil
+
+  @doc """
+  Which watched folder an inbox item came from.
+
+  One tint for every source: they are told apart by name, and colouring them
+  apart would invent a taxonomy the model doesn't have. What import will *do*
+  with the files is deliberately not here — that is a per-import decision,
+  stated in full on the item's own destination card, and no item reaches the
+  library without passing through it.
+
+  Two surfaces ask this, so there is one answer: the queue row, and the
+  import form, where it was missing.
+  """
+  def source_tag(assigns) do
+    ~H"""
+    <span class={["bg-blue-400/15 rounded-sm px-1 py-0.5 text-xs text-blue-300", @class]}>
+      {@source.name}
+    </span>
+    """
+  end
+
   attr :files, :list, required: true
   attr :label, :string, default: nil, doc: "the card names itself — rendered inside, on the rail"
   attr :class, :any, default: nil

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -1229,6 +1229,15 @@ defmodule AmbryWeb.Admin.Components do
 
   attr :files, :list, required: true
   attr :label, :string, default: nil, doc: "the card names itself — rendered inside, on the rail"
+
+  attr :excluded, :list,
+    default: [],
+    doc: "files that are listed but not part of the thing: struck through, and counted"
+
+  attr :toggle, :string,
+    default: nil,
+    doc: "phx-click event taking a file in or out; without it the list is a fact display"
+
   attr :class, :any, default: nil
 
   @doc """
@@ -1241,21 +1250,66 @@ defmodule AmbryWeb.Admin.Components do
   Long lists scroll *inside* the card — the label and common-directory line
   stay pinned, and the scrollbar sits in its own gutter (`pr-2`), the same
   anatomy as the chapter editor's rows.
+
+  ## Taking one file out
+
+  Given `toggle`, each row grows the list-row remove (§6's ✕, for something
+  undoable), and an excluded file **stays in the list** — struck through,
+  named as out, with the way back beside it. Hiding it would make the card
+  disagree with the folder it is describing, and the operator could not
+  change their mind.
+
+  The count line appears only when something is out. A card that said "7
+  files · 0 excluded" on every item in the queue would be paying for the rare
+  case on all of them.
   """
   def file_list(assigns) do
     assigns = assign(assigns, :common, common_dir(assigns.files))
 
     ~H"""
     <div :if={@files != []} class={["space-y-1 rounded-lg bg-zinc-900 p-4", @class]}>
-      <.label :if={@label} class="pl-3">{@label}</.label>
+      <div class="flex items-baseline justify-between gap-3 pl-3">
+        <.label :if={@label}>{@label}</.label>
+        <p :if={@excluded != []} class="flex-none text-xs text-zinc-400" data-role="excluded-count">
+          {length(@files) - length(@excluded)} of {length(@files)} in this audiobook
+        </p>
+      </div>
       <%!-- The directory every file shares, printed once so the names below
           are names. On the rail, like the label above it and the rows below
           it — a card has two left edges, never three (§3). --%>
       <p :if={@common != ""} class="font-mono truncate pl-3 text-xs text-zinc-500">{@common}/</p>
       <div class="max-h-64 overflow-y-auto pr-2">
         <ul class="space-y-0.5 pt-1">
-          <li :for={file <- @files} class="font-mono truncate pl-3 text-xs text-zinc-400">
-            {file_label(file, @common)}
+          <%!-- The row lights up as a whole, because the control is at the
+              far edge of a wide card and the name is at the near one: with
+              nothing joining them, lining up the ✕ with the file it belongs
+              to is a measuring exercise. Only when there is something to
+              click — a fact list has no reason to react to a cursor. --%>
+          <li
+            :for={file <- @files}
+            class={["group flex items-baseline gap-2 rounded-sm py-0.5 pl-3 text-xs", @toggle && "hover:bg-white/5"]}
+            data-role={file in @excluded && "excluded-file"}
+          >
+            <span class={[
+              "font-mono min-w-0 truncate",
+              if(file in @excluded, do: "text-zinc-500 line-through", else: "text-zinc-400")
+            ]}>
+              {file_label(file, @common)}
+            </span>
+
+            <span :if={file in @excluded} class="flex-none text-zinc-500">not in this audiobook</span>
+
+            <button
+              :if={@toggle}
+              type="button"
+              phx-click={@toggle}
+              phx-value-file={file}
+              class="ml-auto flex-none rounded-sm px-1 text-zinc-500 hover:bg-white/10 hover:text-zinc-100 group-hover:text-zinc-300"
+              title={if file in @excluded, do: "Put this file back", else: "Not part of this audiobook"}
+              aria-label={if file in @excluded, do: "Put this file back", else: "Not part of this audiobook"}
+            >
+              <.icon name={if file in @excluded, do: "fa-rotate-left", else: "fa-xmark"} class="h-3 w-3 text-current" />
+            </button>
           </li>
         </ul>
       </div>

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -1021,6 +1021,13 @@ defmodule AmbryWeb.Admin.Components do
 
   The button at each end of the list is rendered disabled rather than hidden,
   so the controls don't shift horizontally as rows move past them.
+
+  **These send no event.** They are read by the `reorder-rows` hook on the
+  form, which swaps two hidden inputs and dispatches a change — the same
+  arrangement `inputs_for/1` documents for adding and removing rows, where the
+  client edits the form and the server only casts what it is posted. A form
+  holding one of these therefore needs `phx-hook="reorder-rows"`; the count
+  comes from `AmbryWeb.Admin.Reordering.row_count/2`.
   """
   attr :field, :atom, required: true, doc: "the association field being reordered"
   attr :index, :integer, required: true
@@ -1038,10 +1045,9 @@ defmodule AmbryWeb.Admin.Components do
     <div class={["flex h-10 flex-none flex-col justify-center", @class]} data-role="move-buttons">
       <button
         type="button"
-        phx-click="move"
-        phx-value-field={@field}
-        phx-value-index={@index}
-        phx-value-direction="up"
+        data-move="up"
+        data-move-field={@field}
+        data-move-index={@index}
         disabled={@index == 0}
         title="Move up"
         data-role="move-up"
@@ -1054,10 +1060,9 @@ defmodule AmbryWeb.Admin.Components do
       </button>
       <button
         type="button"
-        phx-click="move"
-        phx-value-field={@field}
-        phx-value-index={@index}
-        phx-value-direction="down"
+        data-move="down"
+        data-move-field={@field}
+        data-move-index={@index}
         disabled={@index == @count - 1}
         title="Move down"
         data-role="move-down"

--- a/lib/ambry_web/components/admin/curation.ex
+++ b/lib/ambry_web/components/admin/curation.ex
@@ -210,6 +210,10 @@ defmodule AmbryWeb.Admin.Curation do
   attr :proposals, :list, required: true
   attr :event, :string, default: "accept-proposal"
 
+  attr :adds_rows, :boolean,
+    default: false,
+    doc: "these chips append a row to a list rather than set a field's value"
+
   attr :revert, :map,
     default: nil,
     doc: ~s(`%{display:, image:}` for the saved value — rendered only while the field differs)
@@ -221,6 +225,11 @@ defmodule AmbryWeb.Admin.Curation do
   Chip anatomy is identical to the import form's: only the chosen chip's
   source tag fills lime, everyone else's is bare muted uppercase; one line
   or a list, never a partial wrap.
+
+  `adds_rows` says these chips credit a person or join a series rather than
+  fill a field, which changes what a *chosen* one means: not "the field holds
+  this" but "the record already has it", and a click has nothing to do except
+  add it twice (`proposal_chip/1`).
   """
   def proposal_row(assigns) do
     assigns = assign(assigns, :images?, Enum.any?(assigns.proposals, & &1[:image]))
@@ -237,6 +246,7 @@ defmodule AmbryWeb.Admin.Curation do
         <.proposal_chip
           :for={proposal <- @proposals}
           chosen={proposal.chosen}
+          inert={@adds_rows}
           event={@event}
           values={%{field: @field, key: proposal.key}}
         >

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -1748,6 +1748,11 @@ defmodule AmbryWeb.Admin.Decisions do
 
   attr :chosen, :boolean, required: true
   attr :event, :string, required: true
+
+  attr :inert, :boolean,
+    default: false,
+    doc: "when chosen, this chip is a statement rather than an offer — see below"
+
   attr :values, :map, default: %{}
   attr :title, :string, default: nil
   attr :shape, :string, default: "text"
@@ -1761,7 +1766,37 @@ defmodule AmbryWeb.Admin.Decisions do
   person's photos, a person's bios — because they are the same interaction and
   were being hand-written each time, which is how one of them ended up with no
   way to tell which chip was chosen.
+
+  **`inert` is for a chip that adds a row.** Clicking a chosen one appended
+  the author it was already reporting, so an author ticked green could be
+  added to the book a second time, and a third. There is nothing a click
+  could mean there, so it renders as a plain span with the same costume and
+  no click, and becomes an offer again the moment it stops being true — edit
+  the field, or remove the row.
+
+  Chosen chips elsewhere stay live on purpose. On the import form, clicking
+  the one already in use is how a decision gets confirmed: the value doesn't
+  change, the rail goes green, and the operator has said they looked.
   """
+  def proposal_chip(%{chosen: true, inert: true} = assigns) do
+    ~H"""
+    <span
+      title={@title}
+      class={[
+        "bg-brand-dark/15 ring-brand-dark/50 max-w-full rounded-md text-left text-xs ring-2 ring-inset",
+        @shape == "circle" && "rounded-full p-0.5",
+        @shape != "circle" && "inline-flex items-center gap-1.5 px-2 py-1"
+      ]}
+    >
+      <%!-- The chosen chip is the single most important state on the form, and
+            a 1px border-hue change was nearly invisible — so it says so three
+            ways: border, tint, and a check. --%>
+      <.icon :if={@shape != "circle"} name="fa-check" class="text-brand-dark h-3 w-3 flex-none" />
+      {render_slot(@inner_block)}
+    </span>
+    """
+  end
+
   def proposal_chip(assigns) do
     ~H"""
     <button

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -301,10 +301,16 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   # stale page or two chips whose different names resolve to one author —
   # "J.R.R. Tolkien" and "John Ronald Reuel Tolkien" naming the same row. The
   # rendering rule is what the operator sees; this is what makes it true.
+  #
+  # `get_field/2` and not `get_assoc/2`: a row removed with the ✕ is still in
+  # the association, marked for replacement, and counting it as credited made
+  # the chip refuse to put back the author it had just let go of — the same
+  # trap `Reordering.row_count/2` exists for. This is the applied list, which
+  # is the list on screen.
   defp already_credited?(socket, assoc, key, id) do
     socket.assigns.form.source
-    |> Changeset.get_assoc(assoc)
-    |> Enum.any?(fn row -> Changeset.get_field(row, key) == id end)
+    |> Changeset.get_field(assoc)
+    |> Enum.any?(&(Map.get(&1, key) == id))
   end
 
   # The author identity a proposed credit names: an existing author of that

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -120,13 +120,6 @@ defmodule AmbryWeb.Admin.BookLive.Form do
     end
   end
 
-  def handle_event("move", params, socket) do
-    changeset = socket.assigns.form.source
-    book_params = Reordering.move(changeset, socket.assigns.form.params, params)
-
-    {:noreply, assign_form(socket, Books.change_book(socket.assigns.book, book_params))}
-  end
-
   # ── the evidence panel ─────────────────────────────────────────────────
 
   def handle_event("research", params, socket) do

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -253,13 +253,21 @@ defmodule AmbryWeb.Admin.BookLive.Form do
   defp accept_entity(socket, :authors, proposal) do
     author_id = resolve_author(proposal.params["name"], proposal.source)
 
-    socket
-    |> append_row(:book_authors, %{"author_id" => to_string(author_id)}, ~w(author_id))
-    |> assign(
-      provenance_hints:
-        ProvenanceHints.for_list(socket.assigns.provenance_hints, "book_authors", proposal.source)
-    )
-    |> refresh_chips()
+    if already_credited?(socket, :book_authors, :author_id, author_id) do
+      socket
+    else
+      socket
+      |> append_row(:book_authors, %{"author_id" => to_string(author_id)}, ~w(author_id))
+      |> assign(
+        provenance_hints:
+          ProvenanceHints.for_list(
+            socket.assigns.provenance_hints,
+            "book_authors",
+            proposal.source
+          )
+      )
+      |> refresh_chips()
+    end
   end
 
   defp accept_entity(socket, :series, proposal) do
@@ -271,13 +279,32 @@ defmodule AmbryWeb.Admin.BookLive.Form do
         (proposal.params["number"] && %{"book_number" => proposal.params["number"]}) || %{}
       )
 
-    socket
-    |> append_row(:series_books, row, ~w(series_id book_number))
-    |> assign(
-      provenance_hints:
-        ProvenanceHints.for_list(socket.assigns.provenance_hints, "series_books", proposal.source)
-    )
-    |> refresh_chips()
+    if already_credited?(socket, :series_books, :series_id, series_id) do
+      socket
+    else
+      socket
+      |> append_row(:series_books, row, ~w(series_id book_number))
+      |> assign(
+        provenance_hints:
+          ProvenanceHints.for_list(
+            socket.assigns.provenance_hints,
+            "series_books",
+            proposal.source
+          )
+      )
+      |> refresh_chips()
+    end
+  end
+
+  # Asked of the *resolved* record rather than of the chip: a chosen chip no
+  # longer offers a click (`proposal_chip/1`), so reaching here means either a
+  # stale page or two chips whose different names resolve to one author —
+  # "J.R.R. Tolkien" and "John Ronald Reuel Tolkien" naming the same row. The
+  # rendering rule is what the operator sees; this is what makes it true.
+  defp already_credited?(socket, assoc, key, id) do
+    socket.assigns.form.source
+    |> Changeset.get_assoc(assoc)
+    |> Enum.any?(fn row -> Changeset.get_field(row, key) == id end)
   end
 
   # The author identity a proposed credit names: an existing author of that
@@ -449,9 +476,9 @@ defmodule AmbryWeb.Admin.BookLive.Form do
       form: to_form(changeset),
       # the move buttons need to know where the ends of each list are, and
       # the empty states whether there is a list at all
-      book_author_count: length(Changeset.get_assoc(changeset, :book_authors)),
-      series_book_count: length(Changeset.get_assoc(changeset, :series_books)),
-      book_universe_count: length(Changeset.get_assoc(changeset, :book_universes))
+      book_author_count: Reordering.row_count(changeset, :book_authors),
+      series_book_count: Reordering.row_count(changeset, :series_books),
+      book_universe_count: Reordering.row_count(changeset, :book_universes)
     )
   end
 

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -11,7 +11,14 @@
       retrying={@retrying}
     />
 
-    <.simple_form id="book-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form
+      id="book-form"
+      for={@form}
+      phx-hook="reorder-rows"
+      phx-change="validate"
+      phx-submit="submit"
+      autocomplete="off"
+    >
       <%!-- What the book is called and when it came out — the two facts that
           identify the work, in one block. --%>
       <.field_group>

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -83,6 +83,7 @@
             id="proposals-authors"
             field="authors"
             event="accept-entity"
+            adds_rows
             proposals={@chips[:authors] || []}
           />
         </:proposals>
@@ -136,6 +137,7 @@
             id="proposals-series"
             field="series"
             event="accept-entity"
+            adds_rows
             proposals={@chips[:series] || []}
           />
         </:proposals>

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -1180,6 +1180,40 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   def job_label(:incomplete), do: {"Never finished matching", :yellow}
   def job_label(_settled), do: nil
 
+  @doc """
+  Whether the file list below already states where this item is.
+
+  The header prints the item's path and the list prints the directory its
+  files share, and on most items those are the same string two cards apart:
+  a release folder holds its own files, and a loose file is its own path with
+  the folder above it on the list's first line. The header drops the line
+  rather than the list, because the list is where the operator is looking
+  when they want it.
+
+  It stays when the files sit *deeper* than the item does (a release folder
+  whose audio is all in one "Disc 1"): the list then names the subfolder, and
+  which of the two this item is is exactly what a split or a combine is
+  about. It stays when there are no files at all, where the path is the only
+  thing known about the item.
+  """
+  def stated_by_files?(%InboxItem{files: []}), do: false
+
+  def stated_by_files?(%InboxItem{path: path, files: files}) do
+    case common_dir(files) do
+      ^path -> true
+      parent -> files == [path] and parent == folder_of(path)
+    end
+  end
+
+  # `Path.dirname` says "." for a name with no directory in it; `common_dir`
+  # says "" for the same thing, because it is about to print the answer.
+  defp folder_of(path) do
+    case Path.dirname(path) do
+      "." -> ""
+      dir -> dir
+    end
+  end
+
   @doc "What the item's files say they are, for the evidence header."
   def evidence(%InboxItem{probe: probe}) when is_map(probe) do
     [

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -554,6 +554,28 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
+  # One file in or out of the audiobook. The item is re-read either way, so
+  # the form goes busy and comes back with the recording's new length.
+  def handle_event("toggle-file", %{"file" => file}, socket) do
+    item = socket.assigns.item
+
+    result =
+      if InboxItem.excluded?(item, file),
+        do: Inbox.include_file(item, file),
+        else: Inbox.exclude_file(item, file)
+
+    case result do
+      {:ok, item} ->
+        {:noreply, load(socket, item)}
+
+      {:error, :last_file} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(:last_file))}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Couldn't change that file.")}
+    end
+  end
+
   def handle_event("add-credit", %{"section" => s}, socket) do
     {:noreply, edit(socket, &Draft.Edit.add_credit(&1, atom(s)))}
   end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -518,6 +518,22 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
     end
   end
 
+  # Recomputed here rather than taken from the assigns: the queue may have
+  # moved since this form was rendered, and the items being combined are the
+  # ones waiting under that folder *now*.
+  def handle_event("combine", _params, socket) do
+    case Inbox.combine_item(socket.assigns.item) do
+      {:ok, combined} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Combined into one item. Reading the files now.")
+         |> push_navigate(to: ~p"/admin/inbox/#{combined}")}
+
+      {:error, _reason} ->
+        {:noreply, put_flash(socket, :error, "Couldn't combine these items.")}
+    end
+  end
+
   def handle_event("add-credit", %{"section" => s}, socket) do
     {:noreply, edit(socket, &Draft.Edit.add_credit(&1, atom(s)))}
   end
@@ -1029,6 +1045,10 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       # split controls. Both grains exist on a GraphicAudio set; a folder of
       # three files has only the finer one.
       grains: Inbox.split_grains(item),
+      # The other half of that question, for when the walk went wrong the
+      # other way: the items waiting under the same folder as this one, which
+      # may be the parts of one audiobook.
+      combine: Inbox.combine_group(item),
       # Matching retries with a backoff measured in minutes, so an item can be
       # legitimately mid-work while the form looks like nothing was found.
       job: job,

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -62,7 +62,27 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   @impl Phoenix.LiveView
   def mount(%{"id" => id} = params, _session, socket) do
-    item = Inbox.get_item!(id)
+    case Inbox.fetch_item(id) do
+      {:ok, item} -> mount_item(item, params, socket)
+      {:error, :not_found} -> gone(params, socket)
+    end
+  end
+
+  # Regrouping replaces items rather than editing them, so the id in the
+  # address bar can outlive the item: browser Back after a split or a combine
+  # lands on one of the items that were just replaced. That is the queue
+  # working, and a 404 page said the admin was broken.
+  defp gone(params, socket) do
+    {:ok,
+     socket
+     |> put_flash(
+       :info,
+       "That item is gone. Splitting and combining replace items with new ones."
+     )
+     |> push_navigate(to: return_to(params))}
+  end
+
+  defp mount_item(item, params, socket) do
     {:ok, item} = Inbox.prepare_draft(item)
 
     {:ok,

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -127,6 +127,29 @@
             </button>
           </div>
         </div>
+
+        <%!-- The same question from the other side, and the folder answers
+            it: a release whose parts sit in subfolders that don't say they
+            are parts arrives as one item per subfolder, because "Gwendy's
+            Button Box 2" is its own book far more often than it is disc two
+            of something. When it isn't, this is the way to say so. --%>
+        <div :if={@combine && !@read_only} class="space-y-2 pt-2">
+          <.label class="pl-3">Only part of one?</.label>
+
+          <div class="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              phx-click="combine"
+              data-confirm={"Combine these #{length(@combine.items)} items into one, at \"#{Path.basename(@combine.folder)}\"? They become a single inbox item, scanned fresh, and the drafts of the parts are thrown away."}
+              data-role="combine"
+              class={action_classes()}
+            >
+              Combine {length(@combine.items)} items into one
+            </button>
+
+            <p class="font-mono min-w-0 truncate text-xs text-zinc-400">{@combine.folder}</p>
+          </div>
+        </div>
       </section>
 
       <%!-- Once imported, the draft is the record of what was imported — the

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -17,54 +17,61 @@
     />
 
     <div class="-mb-4 max-w-4xl space-y-14" inert={busy?(assigns)}>
-      <%!-- the evidence: what was found, before anybody interpreted it --%>
-      <section class="space-y-1 rounded-lg bg-zinc-900 p-4">
-        <div class="flex items-start justify-between gap-4">
-          <div class="min-w-0 pl-3">
-            <p class="truncate font-bold">{@page_title}</p>
-            <p class="font-mono truncate text-xs text-zinc-400">{@item.path}</p>
-            <p class="text-sm text-zinc-400">{evidence(@item)}</p>
+      <%!-- the evidence: what was found, before anybody interpreted it. The
+            files themselves are part of it and sit in this section too — what
+            the tags say and which files said it are one question, and they
+            were three screens apart. --%>
+      <section class="space-y-2">
+        <div class="space-y-1 rounded-lg bg-zinc-900 p-4">
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0 pl-3">
+              <p class="truncate font-bold">{@page_title}</p>
+              <p class="font-mono truncate text-xs text-zinc-400">{@item.path}</p>
+              <p class="text-sm text-zinc-400">{evidence(@item)}</p>
 
-            <%!-- "Still working" and "found nothing" look identical in a form
+              <%!-- "Still working" and "found nothing" look identical in a form
                 full of empty fields, and matching now backs off for minutes
                 rather than giving up on the first rate limit. --%>
-            <.badge
-              :if={job_label(@job)}
-              color={elem(job_label(@job), 1)}
-              class="mt-1 text-xs"
-              data-role="job-status"
-            >
-              {elem(job_label(@job), 0)}
-            </.badge>
+              <.badge
+                :if={job_label(@job)}
+                color={elem(job_label(@job), 1)}
+                class="mt-1 text-xs"
+                data-role="job-status"
+              >
+                {elem(job_label(@job), 0)}
+              </.badge>
+            </div>
+
+            <div class="flex-none text-right">
+              <p class="text-sm">
+                <span class="font-bold">{@progress.resolved}</span> of {@progress.total} settled
+              </p>
+              <.button
+                :if={!@read_only}
+                type="button"
+                color={:zinc}
+                class="mt-2"
+                phx-click="rebuild"
+                data-confirm="Throw away every choice made here and rebuild from the files and providers?"
+              >
+                Start over
+              </.button>
+            </div>
           </div>
 
-          <div class="flex-none text-right">
-            <p class="text-sm">
-              <span class="font-bold">{@progress.resolved}</span> of {@progress.total} settled
-            </p>
-            <.button
-              :if={!@read_only}
-              type="button"
-              color={:zinc}
-              class="mt-2"
-              phx-click="rebuild"
-              data-confirm="Throw away every choice made here and rebuild from the files and providers?"
-            >
-              Start over
-            </.button>
-          </div>
-        </div>
-
-        <%!-- Tags are the primary source (98% of real releases carry a usable
+          <%!-- Tags are the primary source (98% of real releases carry a usable
             one) and the form used to show none of them, so a match that went
-            somewhere strange had no visible cause. --%>
-        <.disclosure
-          :if={tag_rows(@item) != [] or hint_rows(@item) != []}
-          summary="What the files say"
-          class="text-sm text-zinc-400"
-          container_class="pt-2"
-        >
-          <div class="grid grid-cols-1 gap-4 pt-2 pl-3 sm:grid-cols-2">
+            somewhere strange had no visible cause. Read, never folded: this
+            is the evidence the whole form is an interpretation of, and it was
+            behind a click on every item.
+
+            The two column headings are the naming here. A "File tags" label
+            over them would be a third heading in four lines saying what
+            "Embedded tags" already says. --%>
+          <div
+            :if={tag_rows(@item) != [] or hint_rows(@item) != []}
+            class="grid grid-cols-1 gap-4 pt-2 pl-3 sm:grid-cols-2"
+          >
             <div :if={tag_rows(@item) != []} data-role="tags">
               <p class="text-xs font-bold text-zinc-300">Embedded tags</p>
               <p :for={{label, value} <- tag_rows(@item)} class="text-xs text-zinc-400">
@@ -77,79 +84,80 @@
               <p :for={{label, value} <- hint_rows(@item)} class="text-xs text-zinc-400">
                 <span class="text-zinc-400">{label}:</span> {value}
               </p>
-              <p class="pt-1 text-xs text-zinc-400">
-                Taken from the tags first and the release name second.
-              </p>
             </div>
           </div>
-        </.disclosure>
 
-        <p :if={@item.issue} class="flex items-baseline gap-1.5 pt-2 pl-3 text-sm text-red-400">
-          <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
-          {@item.issue}
-        </p>
+          <p :if={@item.issue} class="flex items-baseline gap-1.5 pt-2 pl-3 text-sm text-red-400">
+            <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
+            {@item.issue}
+          </p>
 
-        <%!-- These files are one recording unless the operator says
+          <%!-- These files are one recording unless the operator says
             otherwise — a folder of forty mp3s is one book in forty pieces far
             more often than it is forty books. Splitting is the escape hatch
             for when it genuinely isn't: each split item becomes its own
             import, to link to its own book or take a part number. --%>
-        <%!-- Two grains, because the grouping can be wrong at two levels: a
+          <%!-- Two grains, because the grouping can be wrong at two levels: a
             folder of "1 of 5" subfolders is one release in parts, and a
             GraphicAudio set of the same shape is five recordings. The
             question labels them both rather than riding on the first. --%>
-        <div :if={@grains != %{} and !@read_only} class="space-y-2 pt-2">
-          <.label class="pl-3">Not one audiobook?</.label>
+          <div :if={@grains != %{} and !@read_only} class="space-y-2 pt-2">
+            <.label class="pl-3">Not one audiobook?</.label>
 
-          <div class="flex flex-wrap items-center gap-2">
-            <button
-              :if={@grains[:folder]}
-              type="button"
-              phx-click="split"
-              phx-value-by="folder"
-              data-confirm={"Split into #{@grains[:folder]} items, one per folder? Each becomes its own inbox item and is scanned fresh."}
-              data-role="split-folder"
-              class={action_classes()}
-            >
-              Split into {@grains[:folder]} folders
-            </button>
+            <div class="flex flex-wrap items-center gap-2">
+              <button
+                :if={@grains[:folder]}
+                type="button"
+                phx-click="split"
+                phx-value-by="folder"
+                data-confirm={"Split into #{@grains[:folder]} items, one per folder? Each becomes its own inbox item and is scanned fresh."}
+                data-role="split-folder"
+                class={action_classes()}
+              >
+                Split into {@grains[:folder]} folders
+              </button>
 
-            <button
-              :if={@grains[:file]}
-              type="button"
-              phx-click="split"
-              phx-value-by="file"
-              data-confirm={"Split into #{@grains[:file]} items, one per file? Each becomes its own inbox item and is scanned fresh."}
-              data-role="split"
-              class={action_classes()}
-            >
-              Split into {@grains[:file]} files
-            </button>
+              <button
+                :if={@grains[:file]}
+                type="button"
+                phx-click="split"
+                phx-value-by="file"
+                data-confirm={"Split into #{@grains[:file]} items, one per file? Each becomes its own inbox item and is scanned fresh."}
+                data-role="split"
+                class={action_classes()}
+              >
+                Split into {@grains[:file]} files
+              </button>
+            </div>
           </div>
-        </div>
 
-        <%!-- The same question from the other side, and the folder answers
+          <%!-- The same question from the other side, and the folder answers
             it: a release whose parts sit in subfolders that don't say they
             are parts arrives as one item per subfolder, because "Gwendy's
             Button Box 2" is its own book far more often than it is disc two
             of something. When it isn't, this is the way to say so. --%>
-        <div :if={@combine && !@read_only} class="space-y-2 pt-2">
-          <.label class="pl-3">Only part of one?</.label>
+          <div :if={@combine && !@read_only} class="space-y-2 pt-2">
+            <.label class="pl-3">Only part of one?</.label>
 
-          <div class="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              phx-click="combine"
-              data-confirm={"Combine these #{length(@combine.items)} items into one, at \"#{Path.basename(@combine.folder)}\"? They become a single inbox item, scanned fresh, and the drafts of the parts are thrown away."}
-              data-role="combine"
-              class={action_classes()}
-            >
-              Combine {length(@combine.items)} items into one
-            </button>
+            <div class="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                phx-click="combine"
+                data-confirm={"Combine these #{length(@combine.items)} items into one, at \"#{Path.basename(@combine.folder)}\"? They become a single inbox item, scanned fresh, and the drafts of the parts are thrown away."}
+                data-role="combine"
+                class={action_classes()}
+              >
+                Combine {length(@combine.items)} items into one
+              </button>
 
-            <p class="font-mono min-w-0 truncate text-xs text-zinc-400">{@combine.folder}</p>
+              <p class="font-mono min-w-0 truncate text-xs text-zinc-400">{@combine.folder}</p>
+            </div>
           </div>
         </div>
+
+        <%!-- A sibling card, never nested inside the one above: a card in a
+            card is what eats the elevation ladder (§1). --%>
+        <.file_list files={@item.files} label="Files" />
       </section>
 
       <%!-- Once imported, the draft is the record of what was imported — the
@@ -875,11 +883,11 @@
         <% end %>
       </section>
 
-      <%!-- ==================== FILES & DESTINATION ==================== --%>
+      <%!-- ==================== DESTINATION ==================== --%>
+      <%!-- The files themselves are read at the top of the form, with the
+          tags that describe them; what is left here is where they go. --%>
       <section id="destination" class="space-y-2" inert={@read_only}>
-        <h2 class="text-xl font-bold text-zinc-100">
-          Files &amp; destination
-        </h2>
+        <h2 class="text-xl font-bold text-zinc-100">Destination</h2>
 
         <%!-- Any input may feed any output, so the root and the policy are
             chosen here rather than fixed on the watched folder. With one root
@@ -936,8 +944,6 @@
           <.icon name="fa-triangle-exclamation" class="h-3.5 w-3.5 flex-none translate-y-0.5 text-current" />
           {@destination.blocker}
         </p>
-
-        <.file_list files={@item.files} label="Files" class="mt-2" />
       </section>
 
       <%!-- ==================== THE BUTTON ==================== --%>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -25,7 +25,14 @@
         <div class="space-y-1 rounded-lg bg-zinc-900 p-4">
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0 pl-3">
-              <p class="truncate font-bold">{@page_title}</p>
+              <%!-- Which watched folder this was found in, in the queue row's
+                  own tag. The row has carried it since the queue could hold
+                  more than one source; the form, which is where an item's
+                  paths are actually read, had lost it. --%>
+              <div class="flex min-w-0 items-baseline gap-2">
+                <p class="truncate font-bold">{@page_title}</p>
+                <.source_tag source={@item.source} class="flex-none" />
+              </div>
               <%!-- Dropped when the file list below is about to print the
                   same string: a release folder and its own files, or a loose
                   file under the folder the list names first. --%>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -173,7 +173,12 @@
 
         <%!-- A sibling card, never nested inside the one above: a card in a
             card is what eats the elevation ladder (§1). --%>
-        <.file_list files={@item.files} label="Files" />
+        <.file_list
+          files={@item.files}
+          label="Files"
+          excluded={@item.excluded_files}
+          toggle={!@read_only && "toggle-file"}
+        />
       </section>
 
       <%!-- Once imported, the draft is the record of what was imported — the

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -26,7 +26,16 @@
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0 pl-3">
               <p class="truncate font-bold">{@page_title}</p>
-              <p class="font-mono truncate text-xs text-zinc-400">{@item.path}</p>
+              <%!-- Dropped when the file list below is about to print the
+                  same string: a release folder and its own files, or a loose
+                  file under the folder the list names first. --%>
+              <p
+                :if={!stated_by_files?(@item)}
+                class="font-mono truncate text-xs text-zinc-400"
+                data-role="item-path"
+              >
+                {@item.path}
+              </p>
               <p class="text-sm text-zinc-400">{evidence(@item)}</p>
 
               <%!-- "Still working" and "found nothing" look identical in a form

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -19,7 +19,6 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   alias Ambry.Inbox.Draft.Replacement
   alias Ambry.Inbox.Draft.Tier
   alias Ambry.Inbox.InboxItem
-  alias Ambry.Library.Source
 
   @statuses [:pending, :ignored, :imported]
 
@@ -386,14 +385,6 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp rail_class(%{status: :pending}), do: "border-l-4 border-amber-400"
   defp rail_class(%{status: :imported}), do: "border-brand-dark/40 border-l-4"
   defp rail_class(_item), do: "border-l-4 border-zinc-700"
-
-  # Which watched folder this came from. What import will *do* with it is
-  # not here on purpose: that is a per-import decision now, it is stated in
-  # full on the item's own destination card, and there is no way to import
-  # without passing through it.
-  defp source_label(%Source{name: name}), do: name
-
-  defp source_color(%Source{}), do: "bg-blue-400/15 text-blue-300"
 
   @doc """
   The candidate's name — usually the release name, and the most recognizable

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -268,9 +268,7 @@
             <div class="grid-cols-[5rem_minmax(0,1fr)] grid items-baseline gap-x-2">
               <span class="text-xs text-zinc-400">source</span>
               <p class="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-zinc-400">
-                <span class={["mr-1 rounded-sm px-1 py-0.5", source_color(item.source)]}>
-                  {source_label(item.source)}
-                </span>
+                <.source_tag source={item.source} class="mr-1" />
                 <span class="font-mono">{item.path}</span>
               </p>
             </div>

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -626,7 +626,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     assign(socket,
       form: to_form(changeset),
       # the move buttons need to know where the ends of the list are
-      media_narrator_count: length(Changeset.get_assoc(changeset, :media_narrators))
+      media_narrator_count: Reordering.row_count(changeset, :media_narrators)
     )
   end
 

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -201,13 +201,6 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     end
   end
 
-  def handle_event("move", params, socket) do
-    changeset = socket.assigns.form.source
-    media_params = Reordering.move(changeset, socket.assigns.form.params, params)
-
-    {:noreply, assign_form(socket, Media.change_media(socket.assigns.media, media_params))}
-  end
-
   # ── the part set ───────────────────────────────────────────────────────
 
   def handle_event("add-group-row", _params, socket) do

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -11,7 +11,14 @@
       retrying={@retrying}
     />
 
-    <.simple_form id="media-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
+    <.simple_form
+      id="media-form"
+      for={@form}
+      phx-hook="reorder-rows"
+      phx-change="validate"
+      phx-submit="submit"
+      autocomplete="off"
+    >
       <.form_section id="recording">
         <.field_group>
           <.input

--- a/lib/ambry_web/live/admin/reordering.ex
+++ b/lib/ambry_web/live/admin/reordering.ex
@@ -52,8 +52,37 @@ defmodule AmbryWeb.Admin.Reordering do
 
   def move(%Ecto.Changeset{}, params, _params), do: params
 
+  @doc """
+  How many rows of an ordered list the form is actually rendering.
+
+  Not `length(get_assoc(changeset, assoc))`, which is the trap this exists to
+  close: a row removed with the ✕ is still *in* the association, marked for
+  replacement, and `inputs_for` skips it while a plain count does not. So the
+  form believed there was one more row than the operator could see — the last
+  visible row kept its "move down" arrow, pointing at a row that wasn't there,
+  and a single remaining row still wore arrows at all.
+
+  Every call site asks the same question ("how many rows are on screen") for
+  three purposes: whether to offer the arrows, what the last index is, and
+  whether to say the list is empty.
+  """
+  def row_count(%Ecto.Changeset{} = changeset, association) do
+    changeset
+    |> get_assoc(association)
+    |> Enum.count(&rendered?/1)
+  end
+
+  # A child marked for replacement or deletion is gone from the form; the
+  # struct form of a row (an unchanged association) is always rendered.
+  defp rendered?(%Ecto.Changeset{action: action}), do: action not in [:replace, :delete]
+  defp rendered?(_struct), do: true
+
   defp swap(changeset, params, association, field, from, to) do
-    entries = entries(changeset, params, field, get_assoc(changeset, association))
+    {params, entries} =
+      changeset
+      |> entries(params, field, get_assoc(changeset, association))
+      |> settle_drops(params, field)
+
     keys = entries |> Map.keys() |> Enum.sort_by(&String.to_integer/1)
 
     with from_key when not is_nil(from_key) <- Enum.at(keys, from),
@@ -86,6 +115,60 @@ defmodule AmbryWeb.Admin.Reordering do
     |> Enum.reduce(entries, fn {key, index}, entries ->
       Map.update!(entries, key, &Map.put(&1, "position", to_string(index)))
     end)
+  end
+
+  # **A removed row is really removed before anything is moved.**
+  #
+  # A `_drop` param names a *slot*, and a move swaps what is *in* two slots,
+  # so the two indexed the same list by different things: delete the second
+  # author and move the first one down, and the drop then landed on the row
+  # that had just moved into slot two. The deleted author came back and the
+  # kept one was destroyed, on save, silently. The middle of a list was worse
+  # — a move across a dropped slot swapped a live row into it.
+  #
+  # Dropping an entry from the params says exactly what the drop param says:
+  # `cast_assoc` deletes an existing child that the incoming list no longer
+  # mentions, which is the mechanism `drop_param` is built on. So the removal
+  # is applied here and the drop param retired, and everything after this
+  # point sees the list the operator is looking at.
+  defp settle_drops(entries, params, field) do
+    case dropped(params, field) do
+      [] ->
+        {params, entries}
+
+      dropped ->
+        entries = Map.drop(entries, dropped)
+
+        params =
+          params
+          |> Map.put(field, entries)
+          |> Map.delete(field <> "_drop")
+          |> prune_sort(field, dropped)
+
+        {params, entries}
+    end
+  end
+
+  # The slot has to leave the sort param too, or the removal invents a row.
+  # `_sort` is what tells `cast_assoc` how many entries there are: left naming
+  # a slot the entries no longer have, it builds an **empty child** for it —
+  # a book author with no author — and the form then carried a blank row that
+  # failed to save, or saved a null. That was the crash behind "the arrow on
+  # the row above the deleted one".
+  defp prune_sort(params, field, dropped) do
+    case Map.get(params, field <> "_sort") do
+      sort when is_list(sort) -> Map.put(params, field <> "_sort", sort -- dropped)
+      _no_sort -> params
+    end
+  end
+
+  # The empty string is the hidden input every drop list carries so that
+  # removing the last row still posts the parameter; it names no slot.
+  defp dropped(params, field) do
+    params
+    |> Map.get(field <> "_drop", [])
+    |> List.wrap()
+    |> Enum.reject(&(&1 == ""))
   end
 
   # What the form last submitted, or — before it has submitted anything — the

--- a/lib/ambry_web/live/admin/reordering.ex
+++ b/lib/ambry_web/live/admin/reordering.ex
@@ -1,56 +1,47 @@
 defmodule AmbryWeb.Admin.Reordering do
   @moduledoc """
-  Moving an entry of an ordered `has_many` up or down in an admin form.
+  Ordered `has_many` rows in an admin form: what the client does, and the one
+  thing the server has to know about it.
 
   Deliberately not drag-and-drop. Ordering a book's two authors is a
-  once-in-a-while act on a list that is almost always two or three long, and
-  a pair of buttons needs no JavaScript, works on a phone, and can be tested
-  without a browser.
+  once-in-a-while act on a list that is almost always two or three long, and a
+  pair of buttons needs no JavaScript beyond a swap, works on a phone, and
+  leaves the ordering itself in the params where it can be read.
 
-  ## Why this works on params rather than the changeset
+  ## The move is a change event, like every other edit
 
-  The obvious implementation — reorder the changeset's assoc list — does not
-  work, and the reason is worth writing down.
+  `inputs_for/1` documents adding and removing rows as buttons that carry a
+  name and a value and dispatch a change: **the client edits the form, the
+  server casts what it is posted.** Reordering is not in those docs, but it
+  belongs to the same arrangement, and the `reorder-rows` hook implements it —
+  it swaps two rows' hidden `_sort` values (which is the order) and their
+  `position` values, then dispatches the change. Nothing here handles a move.
 
-  `cast_assoc`'s `:sort_param` really does order the incoming params (see
-  `Ecto.Changeset.cast_params/4`), but `cast_relation` then throws the result
-  away unless something actually changed: a pure reorder leaves every child
-  changeset empty, `Relation.cast` returns `:ignore`, and the association ends
-  up with no change at all. Reordering alone is invisible to Ecto.
+  It was an event once, and the handler rewrote the form's params: reorder the
+  entries, renumber them, write the sort list back. That is a second mechanism
+  indexing the same list as `_drop`, which names a *slot* — so deleting the
+  second author and then moving the first one down landed the delete on the
+  row that had just moved into that slot. The author who was deleted came
+  back and the author who was kept was destroyed, silently, on save. Ecto
+  reconciles the two itself (`cast_params/4` begins `sort -- drop`), and it
+  can only do that when both arrive in one cast, from the form, unedited.
 
-  So the order has to be carried by a real field. Each row renders a hidden
-  `position` input holding its rendered index; moving a row swaps two entries
-  in the params, which swaps both their render order *and* their positions.
-  Now the children genuinely differ, the cast keeps them in the new order, and
-  `Ambry.Ecto.Positions` renumbers them 0..n on the way to the database.
+  ## Why a row carries a position at all
+
+  `cast_assoc`'s `:sort_param` really does order the incoming params, but
+  order alone does not survive the round trip: `Ecto.Association.Has` has no
+  `:ordered` field (`Ecto.Embedded` does), so a reorder that changes no field
+  leaves every child changeset empty, `Relation.cast` returns `:ignore`, and
+  the association ends up with no change at all — buttons that visibly work
+  and save nothing.
+
+  So the order is carried by a real field. Each row renders a hidden
+  `position` holding its rendered index, and swapping two of them is what
+  makes the children genuinely differ; `Ambry.Ecto.Positions` renumbers them
+  0..n on the way to the database.
   """
 
   import Ecto.Changeset
-
-  @doc """
-  Applies a `move` event's params to the form's params.
-
-  Returns the updated params map, ready to rebuild a changeset with. Anything
-  unrecognised returns the params untouched rather than raising: these values
-  come off the wire, and the field name is only ever resolved against the
-  schema's own associations, so a crafted event can't reach an arbitrary atom
-  or an unrelated field.
-  """
-  def move(%Ecto.Changeset{} = changeset, params, %{
-        "field" => field,
-        "index" => index,
-        "direction" => direction
-      }) do
-    with {:ok, association} <- association(changeset, field),
-         {index, ""} <- Integer.parse(index),
-         {:ok, offset} <- offset(direction) do
-      swap(changeset, params, association, field, index, index + offset)
-    else
-      _unrecognized -> params
-    end
-  end
-
-  def move(%Ecto.Changeset{}, params, _params), do: params
 
   @doc """
   How many rows of an ordered list the form is actually rendering.
@@ -76,126 +67,4 @@ defmodule AmbryWeb.Admin.Reordering do
   # struct form of a row (an unchanged association) is always rendered.
   defp rendered?(%Ecto.Changeset{action: action}), do: action not in [:replace, :delete]
   defp rendered?(_struct), do: true
-
-  defp swap(changeset, params, association, field, from, to) do
-    {params, entries} =
-      changeset
-      |> entries(params, field, get_assoc(changeset, association))
-      |> settle_drops(params, field)
-
-    keys = entries |> Map.keys() |> Enum.sort_by(&String.to_integer/1)
-
-    with from_key when not is_nil(from_key) <- Enum.at(keys, from),
-         to_key when not is_nil(to_key) <- Enum.at(keys, to),
-         true <- to >= 0 do
-      entries =
-        entries
-        |> Map.put(from_key, Map.fetch!(entries, to_key))
-        |> Map.put(to_key, Map.fetch!(entries, from_key))
-        |> renumber(keys)
-
-      params
-      |> Map.put(field, entries)
-      |> Map.put(field <> "_sort", keys)
-    else
-      _out_of_range -> params
-    end
-  end
-
-  # The position belongs to the slot, not to the row that's sitting in it.
-  #
-  # Letting it travel with the row is the subtle way to build buttons that do
-  # nothing: every row would submit the position it already had, no child
-  # changeset would differ, and `cast_relation` would discard the whole
-  # association as unchanged — visibly reordered on screen, unchanged in the
-  # database.
-  defp renumber(entries, keys) do
-    keys
-    |> Enum.with_index()
-    |> Enum.reduce(entries, fn {key, index}, entries ->
-      Map.update!(entries, key, &Map.put(&1, "position", to_string(index)))
-    end)
-  end
-
-  # **A removed row is really removed before anything is moved.**
-  #
-  # A `_drop` param names a *slot*, and a move swaps what is *in* two slots,
-  # so the two indexed the same list by different things: delete the second
-  # author and move the first one down, and the drop then landed on the row
-  # that had just moved into slot two. The deleted author came back and the
-  # kept one was destroyed, on save, silently. The middle of a list was worse
-  # — a move across a dropped slot swapped a live row into it.
-  #
-  # Dropping an entry from the params says exactly what the drop param says:
-  # `cast_assoc` deletes an existing child that the incoming list no longer
-  # mentions, which is the mechanism `drop_param` is built on. So the removal
-  # is applied here and the drop param retired, and everything after this
-  # point sees the list the operator is looking at.
-  defp settle_drops(entries, params, field) do
-    case dropped(params, field) do
-      [] ->
-        {params, entries}
-
-      dropped ->
-        entries = Map.drop(entries, dropped)
-
-        params =
-          params
-          |> Map.put(field, entries)
-          |> Map.delete(field <> "_drop")
-          |> prune_sort(field, dropped)
-
-        {params, entries}
-    end
-  end
-
-  # The slot has to leave the sort param too, or the removal invents a row.
-  # `_sort` is what tells `cast_assoc` how many entries there are: left naming
-  # a slot the entries no longer have, it builds an **empty child** for it —
-  # a book author with no author — and the form then carried a blank row that
-  # failed to save, or saved a null. That was the crash behind "the arrow on
-  # the row above the deleted one".
-  defp prune_sort(params, field, dropped) do
-    case Map.get(params, field <> "_sort") do
-      sort when is_list(sort) -> Map.put(params, field <> "_sort", sort -- dropped)
-      _no_sort -> params
-    end
-  end
-
-  # The empty string is the hidden input every drop list carries so that
-  # removing the last row still posts the parameter; it names no slot.
-  defp dropped(params, field) do
-    params
-    |> Map.get(field <> "_drop", [])
-    |> List.wrap()
-    |> Enum.reject(&(&1 == ""))
-  end
-
-  # What the form last submitted, or — before it has submitted anything — the
-  # minimum that describes each existing row. Partial params are safe here:
-  # `cast_assoc` only casts the keys it's given, so an untouched field keeps
-  # its stored value.
-  defp entries(_changeset, params, field, _assoc) when is_map_key(params, field) do
-    Map.fetch!(params, field)
-  end
-
-  defp entries(_changeset, _params, _field, assoc) do
-    assoc
-    |> Enum.with_index()
-    |> Map.new(fn {entry, index} ->
-      {key(index), %{"id" => to_string(get_field(entry, :id)), "position" => to_string(index)}}
-    end)
-  end
-
-  defp association(%Ecto.Changeset{data: %schema{}}, field) do
-    Enum.find_value(schema.__schema__(:associations), :error, fn association ->
-      if Atom.to_string(association) == field, do: {:ok, association}
-    end)
-  end
-
-  defp offset("up"), do: {:ok, -1}
-  defp offset("down"), do: {:ok, 1}
-  defp offset(_other), do: :error
-
-  defp key(index), do: to_string(index)
 end

--- a/priv/repo/migrations/20260820183956_inbox_item_excluded_files.exs
+++ b/priv/repo/migrations/20260820183956_inbox_item_excluded_files.exs
@@ -1,0 +1,16 @@
+defmodule Ambry.Repo.Migrations.InboxItemExcludedFiles do
+  use Ecto.Migration
+
+  # Which of the files an item holds are not part of the recording.
+  #
+  # A second column rather than a shorter `files`, because those are two
+  # different questions and only one of them is discovery's. `files` is the
+  # ownership ledger: a file missing from it belongs to nobody, and the next
+  # scan makes it an inbox item of its own, every hour. So the file stays
+  # owned and this says it isn't in the audiobook.
+  def change do
+    alter table(:inbox_items) do
+      add :excluded_files, {:array, :string}, null: false, default: []
+    end
+  end
+end

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -55,6 +55,34 @@ defmodule Ambry.Inbox.ImporterTest do
       assert Decimal.compare(media.duration, 0) == :gt
     end
 
+    # A release that ships the same part twice: the operator takes one file
+    # out on the form, and what reaches the library is the audiobook they
+    # said it was — no track for it, and nothing placed for it either.
+    test "an excluded file is neither a track nor placed" do
+      item = tagged_item(files: ["P05.m4b", "P06.m4b", "P06_CD.m4b"], settle: false)
+      {:ok, item} = Inbox.exclude_file(item, "#{item.path}/P06_CD.m4b")
+      {:ok, item} = Inbox.probe_item(item)
+      item = settle(item)
+
+      assert {:ok, media} = Inbox.import_item(item)
+
+      media = Media.get_media!(media.id)
+      assert length(media.media_tracks) == 2
+
+      placed =
+        Enum.map(media.media_tracks, fn track ->
+          {:ok, path} = MediaTrack.disk_path(track)
+          Path.basename(path)
+        end)
+
+      # numbered as two, not "001, 003": the third file is not part of this
+      assert Enum.sort(placed) == ["The Way of Kings - 001.m4b", "The Way of Kings - 002.m4b"]
+
+      # and the file itself is untouched where it was found
+      [_p05, _p06, excluded] = item |> Repo.preload(:source) |> InboxItem.owned_disk_files()
+      assert File.exists?(excluded)
+    end
+
     test "a symlink import never touches the originals" do
       item = tagged_item(policy: :symlink)
       [file] = item |> Repo.preload(:source) |> InboxItem.disk_files()
@@ -737,7 +765,10 @@ defmodule Ambry.Inbox.ImporterTest do
         )
 
       names ->
-        Enum.each(names, &File.cp!(valid_audio(:mp3), Path.join(release, &1)))
+        # The same tagged fixture under each name: a multi-file release is
+        # one book in pieces, and its pieces carry the book's tags.
+        fixture = tagged_fixture(Keyword.get(opts, :dated, true), Keyword.get(opts, :narrator))
+        Enum.each(names, &File.cp!(fixture, Path.join(release, &1)))
     end
 
     # One root for the whole test — a second one would make every

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -932,6 +932,166 @@ defmodule Ambry.InboxTest do
     end
   end
 
+  # The grouping heuristic's other known failure, and the mirror of a split:
+  # a release whose parts sit in subfolders that don't say they are parts
+  # ("Gwendy's Button Box 2" is a book, not a disc) arrives as one item per
+  # subfolder. Combining is the operator's correction, and like a split it
+  # has to survive the hourly rescan or it silently un-happens.
+  describe "combine_items/1" do
+    test "makes one item of a release the walk shattered into subfolders" do
+      root = watched_root()
+      book = shattered_release(root)
+
+      assert {:ok, %{created: 3}} = discover(root)
+      {items, false} = Inbox.list_items()
+
+      assert {:ok, combined} = Inbox.combine_items(items)
+
+      assert InboxItem.disk_path(combined) == book
+      assert {[only], false} = Inbox.list_items()
+      assert only.id == combined.id
+
+      # read from scratch: each part's probe, tags and matches described a
+      # different audiobook
+      assert_enqueued(worker: Ambry.Inbox.RunProbe, args: %{inbox_item_id: combined.id})
+      for item <- items, do: refute(Repo.get(InboxItem, item.id))
+    end
+
+    # The files are one book's timeline now, so their order is playing order,
+    # and it has to be the order a single candidate for that folder would
+    # have found them in.
+    test "holds every file, in the order a scan of the folder would give" do
+      root = watched_root()
+      book = shattered_release(root)
+      {:ok, _counts} = discover(root)
+      {items, false} = Inbox.list_items()
+
+      assert {:ok, combined} = Inbox.combine_items(items)
+
+      assert InboxItem.disk_files(combined) == [
+               Path.join(book, "Gwendy's Button Box 1/Track01.mp3"),
+               Path.join(book, "Gwendy's Button Box 1/Track02.mp3"),
+               Path.join(book, "Gwendy's Button Box 2/Track01.mp3"),
+               Path.join(book, "Gwendy's Button Box 2/Track02.mp3"),
+               Path.join(book, "Gwendy's Button Box 3/Track01.mp3")
+             ]
+    end
+
+    # The walk cannot see what the operator saw, so it still offers those
+    # three subfolders as three candidates every hour. Ownership is what
+    # answers them, and it is only answerable once the whole walk is in:
+    # refreshing the item from each candidate in turn left it holding
+    # whichever ran last.
+    test "a rescan respects the combine instead of shattering the folder again" do
+      root = watched_root()
+      shattered_release(root)
+      {:ok, _counts} = discover(root)
+      {items, false} = Inbox.list_items()
+      {:ok, combined} = Inbox.combine_items(items)
+
+      assert {:ok, %{created: 0, updated: 0}} = discover(root)
+
+      assert {[item], false} = Inbox.list_items()
+      assert item.files == combined.files
+      refute Inbox.get_item!(item.id).draft
+    end
+
+    test "a file that appears in a combined folder joins it" do
+      root = watched_root()
+      book = shattered_release(root)
+      {:ok, _counts} = discover(root)
+      {items, false} = Inbox.list_items()
+      {:ok, combined} = Inbox.combine_items(items)
+
+      copy_audio(Path.join(book, "Gwendy's Button Box 3"), "Track02.mp3")
+
+      assert {:ok, %{created: 0, updated: 1}} = discover(root)
+
+      assert {[item], false} = Inbox.list_items()
+      assert length(item.files) == length(combined.files) + 1
+    end
+
+    test "refuses an imported item, a lone item, and two sources" do
+      source = insert(:source)
+      one = raw_item(%{path: "Set/One", files: ["Set/One/a.mp3"], source_id: source.id})
+
+      imported =
+        raw_item(%{
+          path: "Set/Two",
+          files: ["Set/Two/a.mp3"],
+          status: :imported,
+          source_id: source.id
+        })
+
+      assert {:error, :already_imported} = Inbox.combine_items([one, imported])
+      assert {:error, :not_multiple} = Inbox.combine_items([one])
+
+      elsewhere = raw_item(%{path: "Set/Three", files: ["Set/Three/a.mp3"]})
+      assert {:error, :different_sources} = Inbox.combine_items([one, elsewhere])
+    end
+
+    # An item at the top of a source shares only the watched folder itself,
+    # and an item there would own every file that ever lands in it.
+    test "refuses items that share nothing but the source root" do
+      source = insert(:source)
+      one = raw_item(%{path: "One.m4b", files: ["One.m4b"], source_id: source.id})
+      two = raw_item(%{path: "Two/a.mp3", files: ["Two/a.mp3"], source_id: source.id})
+
+      assert {:error, :no_shared_folder} = Inbox.combine_items([one, two])
+    end
+
+    test "refuses when something else already holds the folder" do
+      source = insert(:source)
+      one = raw_item(%{path: "Set/One", files: ["Set/One/a.mp3"], source_id: source.id})
+      two = raw_item(%{path: "Set/Two", files: ["Set/Two/a.mp3"], source_id: source.id})
+      _squatter = raw_item(%{path: "Set", files: [], source_id: source.id, status: :ignored})
+
+      assert {:error, :path_taken} = Inbox.combine_items([one, two])
+    end
+  end
+
+  describe "combine_group/1" do
+    test "offers the rest of the folder, and nothing at the top of a source" do
+      root = watched_root()
+      shattered_release(root)
+      loose = copy_audio(root, "Gwendy's Final Task.m4b")
+      {:ok, _counts} = discover(root)
+
+      {items, false} = Inbox.list_items()
+      by_path = Map.new(items, &{InboxItem.disk_path(&1), &1})
+
+      assert %{items: offered, folder: folder} =
+               Inbox.combine_group(
+                 by_path[Path.join(root, "Gwendy's Button Box/Gwendy's Button Box 1")]
+               )
+
+      assert length(offered) == 3
+      assert folder == "Gwendy's Button Box"
+
+      # a loose file at the top shares only the watched folder with them
+      assert Inbox.combine_group(by_path[loose]) == nil
+    end
+
+    test "offers nothing once the folder holds one waiting item" do
+      root = watched_root()
+      release_folder(Path.join(root, "Set"), "Only", ["a.mp3"])
+      {:ok, _counts} = discover(root)
+
+      {[item], false} = Inbox.list_items()
+      assert Inbox.combine_group(item) == nil
+    end
+
+    test "an imported item is not up for regrouping" do
+      root = watched_root()
+      shattered_release(root)
+      {:ok, _counts} = discover(root)
+      {[item | _rest], false} = Inbox.list_items()
+      {:ok, item} = Inbox.update_item(item, %{status: :imported})
+
+      assert Inbox.combine_group(item) == nil
+    end
+  end
+
   describe "queue_summary/0" do
     test "splits pending into ready, waiting on a decision, and never asked" do
       ready_item(%{path: "ready"})
@@ -1080,6 +1240,22 @@ defmodule Ambry.InboxTest do
     root = Ambry.Paths.source_media_disk_path("watched-#{Ecto.UUID.generate()}")
     File.mkdir_p!(root)
     root
+  end
+
+  # The operator's real case: three subfolders that are one audiobook, named
+  # so that nothing but a human could tell them from three books.
+  defp shattered_release(root) do
+    book = Path.join(root, "Gwendy's Button Box")
+
+    for {part, files} <- [
+          {"1", ["Track01.mp3", "Track02.mp3"]},
+          {"2", ["Track01.mp3", "Track02.mp3"]},
+          {"3", ["Track01.mp3"]}
+        ] do
+      release_folder(book, "Gwendy's Button Box #{part}", files)
+    end
+
+    book
   end
 
   defp release_folder(root, name, filenames) do

--- a/test/ambry/inbox_test.exs
+++ b/test/ambry/inbox_test.exs
@@ -1050,6 +1050,115 @@ defmodule Ambry.InboxTest do
     end
   end
 
+  # A release that ships the same part twice — Oathbringer's second part
+  # carries STORMLIGHT0302P06.mp3 and STORMLIGHT0302P06_CD.mp3, the same forty
+  # minutes at two bitrates. Splitting doesn't help and ignoring takes the
+  # whole item out, so one file goes and the rest stay.
+  describe "exclude_file/2" do
+    test "takes a file out of the recording without letting go of it" do
+      root = watched_root()
+      release = release_folder(root, "Oathbringer", ["P05.mp3", "P06.mp3", "P06_CD.mp3"])
+      {:ok, _counts} = discover(root)
+      {[item], false} = Inbox.list_items()
+
+      assert {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.mp3")
+
+      # still held — that is what stops the next scan adopting it
+      assert length(item.files) == 3
+      assert item.excluded_files == ["Oathbringer/P06_CD.mp3"]
+
+      assert InboxItem.disk_files(item) == [
+               Path.join(release, "P05.mp3"),
+               Path.join(release, "P06.mp3")
+             ]
+
+      assert length(InboxItem.owned_disk_files(item)) == 3
+
+      # the recording changed length, so it is read again
+      assert_enqueued(worker: Ambry.Inbox.RunProbe, args: %{inbox_item_id: item.id})
+    end
+
+    # The whole reason the file stays in `files`. A shorter list would leave
+    # it owned by nobody, and discovery hands an unowned file in a
+    # partly-owned folder an item of its own — every hour, forever.
+    test "a rescan does not offer an excluded file as an item of its own" do
+      root = watched_root()
+      release_folder(root, "Oathbringer", ["P05.mp3", "P06.mp3", "P06_CD.mp3"])
+      {:ok, _counts} = discover(root)
+      {[item], false} = Inbox.list_items()
+      {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.mp3")
+
+      assert {:ok, %{created: 0, updated: 0}} = discover(root)
+
+      assert {[unchanged], false} = Inbox.list_items()
+      assert unchanged.id == item.id
+      assert unchanged.excluded_files == item.excluded_files
+    end
+
+    test "probing measures the recording, not everything held" do
+      root = watched_root()
+      release_folder(root, "Oathbringer", ["P05.mp3", "P06.mp3", "P06_CD.mp3"])
+      {:ok, _counts} = discover(root)
+      {[item], false} = Inbox.list_items()
+      {:ok, whole} = Inbox.probe_item(item)
+
+      {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.mp3")
+      {:ok, part} = Inbox.probe_item(item)
+
+      assert part.probe["files"] == 2
+      assert whole.probe["files"] == 3
+
+      assert Decimal.lt?(
+               Decimal.new(part.probe["duration"]),
+               Decimal.new(whole.probe["duration"])
+             )
+    end
+
+    test "putting it back restores the recording" do
+      root = watched_root()
+      release_folder(root, "Oathbringer", ["P05.mp3", "P06_CD.mp3"])
+      {:ok, _counts} = discover(root)
+      {[item], false} = Inbox.list_items()
+
+      {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.mp3")
+      assert {:ok, item} = Inbox.include_file(item, "Oathbringer/P06_CD.mp3")
+
+      assert item.excluded_files == []
+      assert length(InboxItem.disk_files(item)) == 2
+    end
+
+    test "refuses the last file, a file it doesn't hold, and an imported item" do
+      root = watched_root()
+      release_folder(root, "Oathbringer", ["P05.mp3", "P06_CD.mp3"])
+      {:ok, _counts} = discover(root)
+      {[item], false} = Inbox.list_items()
+
+      assert {:error, :not_held} = Inbox.exclude_file(item, "Oathbringer/nope.mp3")
+
+      {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.mp3")
+      assert {:error, :last_file} = Inbox.exclude_file(item, "Oathbringer/P05.mp3")
+
+      {:ok, imported} = Inbox.update_item(item, %{status: :imported})
+      assert {:error, :already_imported} = Inbox.exclude_file(imported, "Oathbringer/P05.mp3")
+    end
+
+    # An excluded file is a decision about the recording, so a draft built
+    # before it says so.
+    test "a curated draft is told the recording changed" do
+      root = watched_root()
+      release_folder(root, "Oathbringer", ["P05.mp3", "P06.mp3", "P06_CD.mp3"])
+      {:ok, _counts} = discover(root)
+      {[item], false} = Inbox.list_items()
+      {:ok, item} = Inbox.probe_item(item)
+      {:ok, item} = Inbox.prepare_draft(item)
+      refute item.draft.stale
+
+      {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.mp3")
+
+      assert Inbox.get_item!(item.id).draft.stale
+    end
+  end
+
   describe "combine_group/1" do
     test "offers the rest of the folder, and nothing at the top of a source" do
       root = watched_root()

--- a/test/ambry_web/live/admin/book_live/evidence_test.exs
+++ b/test/ambry_web/live/admin/book_live/evidence_test.exs
@@ -231,6 +231,54 @@ defmodule AmbryWeb.Admin.BookLive.EvidenceTest do
     assert html =~ ~s(value="1")
   end
 
+  # The chip is green and ticked because the book already has that author.
+  # Clicking it again credited them a second time, and a third, which is how
+  # the same bug got the narrator chips removed from the audiobook form.
+  test "an author the book already has is not offered again", %{conn: conn} do
+    patch_search()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/new")
+    search(view, %{"title" => "Dungeon Crawler Carl"})
+    tick_first_record(view)
+
+    html = view |> element(~s{#proposals-authors button}) |> render_click()
+    assert html =~ "Matt Dinniman"
+
+    # nothing left to click: the chip reports what the record holds
+    refute has_element?(view, ~s{#proposals-authors button})
+    assert has_element?(view, ~s{#proposals-authors span}, "Matt Dinniman")
+
+    # and the event itself is idempotent, for a page that still shows the old chip
+    render_click(view, "accept-entity", %{"field" => "authors", "key" => "Matt Dinniman"})
+
+    assert [%{name: "Matt Dinniman"}] = Ambry.Repo.all(Ambry.People.Person)
+    assert view |> render() |> author_row_count() == 1
+  end
+
+  test "a series the book is already in is not offered again", %{conn: conn} do
+    patch_search()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/new")
+    search(view, %{"title" => "Dungeon Crawler Carl"})
+    tick_first_record(view)
+
+    view |> element(~s{#proposals-series button}) |> render_click()
+    refute has_element?(view, ~s{#proposals-series button})
+
+    render_click(view, "accept-entity", %{"field" => "series", "key" => "Dungeon Crawler Carl"})
+
+    assert [%{name: "Dungeon Crawler Carl"}] = Ambry.Repo.all(Ambry.Books.Series)
+    assert view |> render() |> series_row_count() == 1
+  end
+
+  defp author_row_count(html) do
+    html |> Floki.parse_document!() |> Floki.find("[name$='[author_id]']") |> length()
+  end
+
+  defp series_row_count(html) do
+    html |> Floki.parse_document!() |> Floki.find("[name$='[series_id]']") |> length()
+  end
+
   test "the record that filled fields at import is recognized: pre-ticked, and says what it gave",
        %{conn: conn} do
     book =

--- a/test/ambry_web/live/admin/book_live/evidence_test.exs
+++ b/test/ambry_web/live/admin/book_live/evidence_test.exs
@@ -255,6 +255,46 @@ defmodule AmbryWeb.Admin.BookLive.EvidenceTest do
     assert view |> render() |> author_row_count() == 1
   end
 
+  # Removing the row is what makes the chip an offer again, so it has to be an
+  # offer that works: the ✕ leaves the row in the association marked for
+  # replacement, and reading that list made the chip refuse to re-add the
+  # author it had just removed.
+  test "an author removed with the ✕ can be credited again from the chip", %{conn: conn} do
+    patch_search()
+
+    # A *saved* author, which is the whole difference: removing a row that
+    # exists in the database leaves it in the association marked for
+    # replacement, where an unsaved one simply disappears.
+    person = insert(:person, name: "Matt Dinniman")
+    author = insert(:author, name: "Matt Dinniman", person: person)
+    book = insert(:book, title: "Dungeon Crawler Carl", book_authors: [])
+    {:ok, book} = credit_author(book, author)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+    search(view, %{"title" => "Dungeon Crawler Carl"})
+    tick_first_record(view)
+
+    # the book already has them, so the chip is a statement
+    refute has_element?(view, ~s{#proposals-authors button})
+
+    html =
+      view |> form("#book-form") |> render_change(%{"book" => %{"book_authors_drop" => ["0"]}})
+
+    assert author_row_count(html) == 0
+    # green is gone: the book no longer has them
+    assert has_element?(view, ~s{#proposals-authors button})
+
+    html = view |> element(~s{#proposals-authors button}) |> render_click()
+    assert author_row_count(html) == 1
+    refute has_element?(view, ~s{#proposals-authors button})
+  end
+
+  defp credit_author(book, author) do
+    Ambry.Books.update_book(book, %{
+      "book_authors" => %{"0" => %{"author_id" => to_string(author.id), "position" => "0"}}
+    })
+  end
+
   test "a series the book is already in is not offered again", %{conn: conn} do
     patch_search()
 

--- a/test/ambry_web/live/admin/book_live/reorder_test.exs
+++ b/test/ambry_web/live/admin/book_live/reorder_test.exs
@@ -124,6 +124,73 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
     end
   end
 
+  # Removing a row and reordering the rest are two mechanisms indexing one
+  # list, and they disagreed: `_drop` names a *slot*, a move swaps what is
+  # *in* two slots, so a move after a delete redirected the delete onto
+  # whichever row had just arrived in that slot. Saving then destroyed a row
+  # the operator kept and restored the one they removed, silently.
+  describe "removing a row, then reordering" do
+    test "the delete still lands on the row that was deleted", %{conn: conn} do
+      %{book: book, authors: [first, second]} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      drop(view, "book_authors", "1")
+      # a stale page can still send this; the form no longer offers it
+      render_click(view, "move", %{
+        "field" => "book_authors",
+        "index" => "0",
+        "direction" => "down"
+      })
+
+      view |> form("#book-form") |> render_submit()
+
+      assert author_order(book) == [first.id]
+      refute second.id in author_order(book)
+    end
+
+    test "a row removed from the middle takes its neighbours' order with it", %{conn: conn} do
+      %{book: book, authors: [first, _second, third]} = book_with_three_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      drop(view, "book_authors", "1")
+      view |> element("[data-role='move-down']:not([disabled])") |> render_click()
+      view |> form("#book-form") |> render_submit()
+
+      # second is gone because second was removed, and the two that stayed
+      # swapped places because that is what was clicked
+      assert author_order(book) == [third.id, first.id]
+    end
+
+    # One row left is nothing to order, and the row above a deleted last row
+    # had a live "move down" pointing at a row that was no longer rendered.
+    test "the arrows follow what is on screen, not what is in the changeset", %{conn: conn} do
+      %{book: book} = book_with_two_authors()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+      assert has_element?(view, "[data-role='move-buttons']")
+
+      html = drop(view, "book_authors", "1")
+      document = Floki.parse_document!(html)
+
+      assert Floki.find(document, "[name$='[author_id]']") |> length() == 1
+      assert Floki.find(document, "[data-role='move-buttons']") == []
+    end
+  end
+
+  defp drop(view, field, index) do
+    view |> form("#book-form") |> render_change(%{"book" => %{(field <> "_drop") => [index]}})
+  end
+
+  defp book_with_three_authors do
+    book = insert(:book)
+    authors = for _ <- 1..3, do: insert(:author)
+    {:ok, book} = put_authors(book, Enum.map(authors, & &1.id))
+
+    %{book: book, authors: authors}
+  end
+
   defp book_with_two_authors do
     book = insert(:book)
     first = insert(:author)

--- a/test/ambry_web/live/admin/book_live/reorder_test.exs
+++ b/test/ambry_web/live/admin/book_live/reorder_test.exs
@@ -3,10 +3,17 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
   Reordering a book's authors and series through the actual form.
 
   The unit tests cover the changeset; this covers the part that historically
-  went wrong — that clicking a button in the rendered form actually reaches
-  the database. A reorder that changes no field is invisible to `cast_assoc`,
-  so it is entirely possible for the buttons to look like they work, the list
-  to visibly move, and nothing at all to be saved.
+  went wrong — that a move made in the rendered form actually reaches the
+  database. A reorder that changes no field is invisible to `cast_assoc`, so
+  it is entirely possible for the buttons to look like they work, the list to
+  visibly move, and nothing at all to be saved.
+
+  The arrows send no event now: the `reorder-rows` hook swaps two rows'
+  hidden inputs and dispatches a change, the way `inputs_for/1` documents
+  adding and removing rows. So `move/4` here posts exactly what that hook
+  posts, read off the rendered form. **What no test here can cover is the
+  hook itself** — there is no JavaScript test setup in this project — so this
+  is the server's half of the contract, stated in the browser's own terms.
   """
   use AmbryWeb.ConnCase, async: true
 
@@ -23,7 +30,7 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
 
-      view |> element("[data-role='move-down']:not([disabled])") |> render_click()
+      move(view, "book_authors", 0, :down)
       view |> form("#book-form") |> render_submit()
 
       assert author_order(book) == [second.id, first.id]
@@ -34,7 +41,7 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
 
-      view |> element("[data-role='move-up']:not([disabled])") |> render_click()
+      move(view, "book_authors", 1, :up)
       view |> form("#book-form") |> render_submit()
 
       assert author_order(book) == [second.id, first.id]
@@ -46,7 +53,7 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
       {:ok, view, html} = live(conn, ~p"/admin/books/#{book}/edit")
       assert rendered_author_ids(html) == [first.id, second.id]
 
-      html = view |> element("[data-role='move-down']:not([disabled])") |> render_click()
+      html = move(view, "book_authors", 0, :down)
       assert rendered_author_ids(html) == [second.id, first.id]
     end
 
@@ -62,51 +69,27 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
       assert [_down_disabled] = Floki.find(document, "[data-role='move-down'][disabled]")
     end
 
-    test "an out-of-range move is ignored rather than crashing", %{conn: conn} do
+    # The arrows at the ends of the list are disabled, and the hook refuses a
+    # swap with nothing on the other side, so a move past the end never
+    # reaches the server as anything at all. What the server sees is a sort
+    # list, and a sort list naming a slot that isn't there is Ecto's business:
+    # it builds an empty child for it. That is a form the operator cannot
+    # save, not a crash, and it is why the hook checks.
+    test "a sort list naming a slot that isn't there does not crash the form", %{conn: conn} do
       %{book: book, authors: [first, second]} = book_with_two_authors()
 
       {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
 
-      render_click(view, "move", %{
-        "field" => "book_authors",
-        "index" => "9",
-        "direction" => "down"
-      })
+      html =
+        view
+        |> form("#book-form")
+        |> render_change(%{"book" => %{"book_authors_sort" => ["0", "1", "7"]}})
 
-      view |> form("#book-form") |> render_submit()
-      assert author_order(book) == [first.id, second.id]
-    end
-
-    # Moving up from the top computes index -1, and `Enum.at(list, -1)` is the
-    # *last* element — so a careless implementation swaps the first row with
-    # the last instead of doing nothing.
-    test "moving up from the top does not wrap around to the bottom", %{conn: conn} do
-      %{book: book, authors: [first, second]} = book_with_two_authors()
-
-      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
-
-      render_click(view, "move", %{
-        "field" => "book_authors",
-        "index" => "0",
-        "direction" => "up"
-      })
-
-      view |> form("#book-form") |> render_submit()
-      assert author_order(book) == [first.id, second.id]
-    end
-
-    # The field name comes off the wire, so it's resolved against the schema's
-    # own associations and nothing else.
-    test "a move naming an unknown field is ignored", %{conn: conn} do
-      %{book: book, authors: [first, second]} = book_with_two_authors()
-
-      {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
-
-      render_click(view, "move", %{
-        "field" => "not_an_association",
-        "index" => "0",
-        "direction" => "down"
-      })
+      # Ecto's own answer, worth writing down: `cast_params/4` pops a missing
+      # slot as `%{}`, so a sort list can conjure a blank row. The form shows
+      # it and refuses to save it; nothing crashes and nothing is lost.
+      assert html |> Floki.parse_document!() |> Floki.find("[name$='[author_id]']") |> length() ==
+               3
 
       view |> form("#book-form") |> render_submit()
       assert author_order(book) == [first.id, second.id]
@@ -136,13 +119,7 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
       {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
 
       drop(view, "book_authors", "1")
-      # a stale page can still send this; the form no longer offers it
-      render_click(view, "move", %{
-        "field" => "book_authors",
-        "index" => "0",
-        "direction" => "down"
-      })
-
+      # nothing is left to move, and the row that stayed is the one that stays
       view |> form("#book-form") |> render_submit()
 
       assert author_order(book) == [first.id]
@@ -155,7 +132,7 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
       {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
 
       drop(view, "book_authors", "1")
-      view |> element("[data-role='move-down']:not([disabled])") |> render_click()
+      move(view, "book_authors", 0, :down)
       view |> form("#book-form") |> render_submit()
 
       # second is gone because second was removed, and the two that stayed
@@ -177,6 +154,49 @@ defmodule AmbryWeb.Admin.BookLive.ReorderTest do
       assert Floki.find(document, "[name$='[author_id]']") |> length() == 1
       assert Floki.find(document, "[data-role='move-buttons']") == []
     end
+  end
+
+  # What the `reorder-rows` hook posts: the two rows' `_sort` values swapped,
+  # which is the order, and their `position` values with them, which is what
+  # makes the children differ at all. Read off the rendered form, so a test
+  # moves a row the way the browser does rather than by inventing params.
+  defp move(view, field, from, direction) do
+    to = if direction == :up, do: from - 1, else: from + 1
+    document = view |> render() |> Floki.parse_document!()
+
+    keys = slot_keys(document, field)
+    {from_key, to_key} = {Enum.at(keys, from), Enum.at(keys, to)}
+    positions = positions(document, field, keys)
+
+    view
+    |> form("#book-form")
+    |> render_change(%{
+      "book" => %{
+        (field <> "_sort") =>
+          keys |> List.replace_at(from, to_key) |> List.replace_at(to, from_key),
+        field => %{
+          from_key => %{"position" => positions[to_key]},
+          to_key => %{"position" => positions[from_key]}
+        }
+      }
+    })
+  end
+
+  defp slot_keys(document, field) do
+    document
+    |> Floki.find("input[name='book[#{field}_sort][]']")
+    |> Enum.flat_map(&Floki.attribute(&1, "value"))
+  end
+
+  defp positions(document, field, keys) do
+    Map.new(keys, fn key ->
+      [value] =
+        document
+        |> Floki.find("input[name='book[#{field}][#{key}][position]']")
+        |> Floki.attribute("value")
+
+      {key, value}
+    end)
   end
 
   defp drop(view, field, index) do

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -2360,6 +2360,74 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  # A release that ships the same part twice, which nothing but a listener
+  # can spot: the file list is where it is seen, so it is where it is fixed.
+  describe "taking one file out of the audiobook" do
+    setup %{conn: conn} do
+      root = watched_root()
+      release = Path.join(root, "Oathbringer")
+      File.mkdir_p!(release)
+
+      for name <- ["P05.m4b", "P06.m4b", "P06_CD.m4b"] do
+        File.cp!(tagged_fixture(true, false, nil), Path.join(release, name))
+      end
+
+      {:ok, _counts} = discover(root)
+      {[item], _more} = Inbox.list_items(filter: "Oathbringer")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      %{conn: conn, item: item}
+    end
+
+    test "the ✕ on a row takes it out, and the row says so", %{conn: conn, item: item} do
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # nothing is out, so nothing is counted
+      refute has_element?(view, "[data-role='excluded-count']")
+      refute html =~ "not in this audiobook"
+
+      view
+      |> element("button[phx-value-file='Oathbringer/P06_CD.m4b']")
+      |> render_click()
+
+      assert Inbox.get_item!(item.id).excluded_files == ["Oathbringer/P06_CD.m4b"]
+
+      html = render(view)
+      assert html =~ "2 of 3 in this audiobook"
+      assert html =~ "not in this audiobook"
+
+      # still listed, because the folder still holds it
+      assert html =~ "P06_CD.m4b"
+    end
+
+    test "and the same control puts it back", %{conn: conn, item: item} do
+      {:ok, item} = Inbox.exclude_file(item, "Oathbringer/P06_CD.m4b")
+      # the re-read that excluding queues has finished; without this the form
+      # is busy and refuses every event, which is the point of the overlay
+      Repo.delete_all(Oban.Job)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+      assert has_element?(view, "[data-role='excluded-file']")
+
+      view
+      |> element("button[phx-value-file='Oathbringer/P06_CD.m4b']")
+      |> render_click()
+
+      assert Inbox.get_item!(item.id).excluded_files == []
+      refute has_element?(view, "[data-role='excluded-file']")
+    end
+
+    test "an imported item's files are read-only", %{conn: conn, item: item} do
+      {:ok, item} = Inbox.prepare_draft(item)
+      {:ok, item} = Inbox.update_item(item, %{status: :imported})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "button[phx-value-file]")
+    end
+  end
+
   describe "combining items that are one audiobook" do
     # The operator's real case, and the mirror of the split above: three
     # subfolders holding one audiobook, named so that nothing but a human

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -2300,6 +2300,16 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       refute html =~ "./"
     end
 
+    # The queue row has carried the watched folder since the queue could hold
+    # more than one; the form is where the paths are actually read.
+    test "the source it was found in is on the form, in the row's own tag", %{conn: conn} do
+      item = Inbox.get_item!(probed_item().id)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ item.source.name
+    end
+
     test "the path stays when the files sit deeper than the item", %{conn: conn} do
       root = watched_root()
       disc = Path.join(root, "Some Release/Disc 1")

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -1493,13 +1493,16 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert has_element?(view, "form#research-work input[name='title']")
     end
 
-    test "the file's own tags are visible", %{conn: conn} do
+    # Not behind a disclosure: this is the evidence every decision below it
+    # is an interpretation of.
+    test "the file's own tags are visible without opening anything", %{conn: conn} do
       item = probed_item()
 
-      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
 
-      assert html =~ "What the files say"
+      assert html =~ "Embedded tags"
       assert html =~ "Michael Kramer"
+      refute has_element?(view, "details [data-role='tags']")
     end
   end
 

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -2268,6 +2268,28 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "an item that is gone" do
+    # A split or a combine replaces items rather than editing them, so the id
+    # in the address bar outlives the item and browser Back walks straight
+    # into it. The queue is where that goes, with the list the operator was
+    # on kept.
+    test "lands back in the queue rather than on a 404", %{conn: conn} do
+      item = probed_item()
+      id = item.id
+      Repo.delete!(item)
+
+      assert {:error, {kind, %{to: to, flash: flash}}} = live(conn, ~p"/admin/inbox/#{id}")
+      assert kind in [:redirect, :live_redirect]
+      assert to == ~p"/admin/inbox"
+      assert flash["info"] =~ "gone"
+
+      assert {:error, {_kind, %{to: to}}} =
+               live(conn, ~p"/admin/inbox/#{id}?#{[status: "ignored", page: "2"]}")
+
+      assert to == ~p"/admin/inbox?#{[page: "2", status: "ignored"]}"
+    end
+  end
+
   describe "combining items that are one audiobook" do
     # The operator's real case, and the mirror of the split above: three
     # subfolders holding one audiobook, named so that nothing but a human

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -2265,6 +2265,58 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  describe "combining items that are one audiobook" do
+    # The operator's real case, and the mirror of the split above: three
+    # subfolders holding one audiobook, named so that nothing but a human
+    # could tell them from three books. The walk offers three items; the
+    # correction has to be reachable from any one of them.
+    test "the combine button makes one item of the folder", %{conn: conn} do
+      root = watched_root()
+      book = Path.join(root, "Gwendy's Button Box by Stephen King & Richard Chizmar")
+
+      for part <- 1..3, track <- 1..2 do
+        dir = Path.join(book, "Gwendy's Button Box #{part}")
+        File.mkdir_p!(dir)
+        File.cp!(tagged_fixture(true, false, nil), Path.join(dir, "Track0#{track}.mp3"))
+      end
+
+      {:ok, _counts} = discover(root)
+      {items, _more} = Inbox.list_items(filter: "Gwendy")
+      assert length(items) == 3
+
+      item = Enum.find(items, &(InboxItem.name(&1) == "Gwendy's Button Box 1"))
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Only part of one?"
+      assert html =~ "Combine 3 items into one"
+
+      view |> element("button[data-role='combine']") |> render_click()
+      {path, _flash} = assert_redirect(view)
+
+      {[combined], _more} = Inbox.list_items(filter: "Gwendy")
+      assert path == ~p"/admin/inbox/#{combined}"
+      assert InboxItem.name(combined) == "Gwendy's Button Box by Stephen King & Richard Chizmar"
+      assert length(combined.files) == 6
+
+      # and the folder now holds one item, so there is nothing left to offer
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{combined}")
+      refute html =~ "Only part of one?"
+    end
+
+    # Every item at the top of a watched folder shares the watched folder,
+    # and an item there would own everything that ever lands in it.
+    test "a release of its own is offered nothing", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute html =~ "Only part of one?"
+    end
+  end
+
   describe "destination" do
     test "is two pickers and no prose", %{conn: conn} do
       item = probed_item(policy: :symlink) |> settle()

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -2268,6 +2268,66 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
     end
   end
 
+  # The header used to print the item's path over a file list about to print
+  # the same string two cards below it.
+  describe "where the item is, said once" do
+    test "the path goes when the file list states it", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "[data-role='item-path']")
+      # still on the page: the list prints the folder its files share
+      assert html =~ "The Way of Kings [M4B]"
+    end
+
+    # A loose file at the top of a watched folder has no directory above it,
+    # and the list printed "./" for one until it stopped answering "." to a
+    # question about where something is.
+    test "a loose file is its own path, printed once and without a directory",
+         %{conn: conn} do
+      root = watched_root()
+      File.cp!(tagged_fixture(true, false, nil), Path.join(root, "Loose Book.m4b"))
+
+      {:ok, _counts} = discover(root)
+      {[item], _more} = Inbox.list_items(filter: "Loose Book")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      refute has_element?(view, "[data-role='item-path']")
+      refute html =~ "./"
+    end
+
+    test "the path stays when the files sit deeper than the item", %{conn: conn} do
+      root = watched_root()
+      disc = Path.join(root, "Some Release/Disc 1")
+      File.mkdir_p!(disc)
+      File.cp!(tagged_fixture(true, false, nil), Path.join(disc, "01.m4b"))
+
+      {:ok, _counts} = discover(root)
+      {[item], _more} = Inbox.list_items(filter: "Some Release")
+      {:ok, item} = Inbox.probe_item(item)
+      Repo.delete_all(Oban.Job)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      # the list names "Some Release/Disc 1"; which of the two this item is
+      # is what a split or a combine is about
+      assert has_element?(view, "[data-role='item-path']")
+    end
+
+    test "the path stays when there are no files to say it", %{conn: conn} do
+      item = probed_item()
+      {:ok, item} = Inbox.update_item(item, %{files: []})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert has_element?(view, "[data-role='item-path']")
+    end
+  end
+
   describe "an item that is gone" do
     # A split or a combine replaces items rather than editing them, so the id
     # in the address bar outlives the item and browser Back walks straight

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -483,6 +483,16 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
   # Every row the inbox does work on gets covered, for the same reason the
   # form does: a job is about to change it, and a row that looks readable but
   # is about to be rewritten invites a click that goes nowhere.
+  describe "where a row came from" do
+    test "the row names the watched folder", %{conn: conn} do
+      item = Inbox.get_item!(probed_item().id)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/inbox")
+
+      assert html =~ item.source.name
+    end
+  end
+
   describe "rows a job is working on" do
     test "a queued row is covered and inert", %{conn: conn} do
       # discovery enqueues the match job, so a fresh item has one


### PR DESCRIPTION
Two escape hatches the queue didn't have, found by working the downloads
backlog, plus what fell out of building them.

## The queue can be told it grouped wrongly, in both directions

**Combine** (`eacd4d67`). "Gwendy's Button Box by Stephen King & Richard
Chizmar" holds three subfolders of mp3s that are one audiobook, and the queue
offered it as three items. The walk is not wrong to do that — a folder whose
subfolders don't state a position in a set is a container of releases, and
`ReleaseName`'s comment names this very folder as the reason the rule is
strict — so this is the operator's correction, and split's other half. They
become one item at the folder they share, holding every file in the order a
single candidate for that folder would have found them.

The load-bearing half is in discovery. A combined item spans several walk
candidates and always will, and `refresh_known/2` treated each candidate as
the whole truth about its owner: left alone, the first rescan would have set
the item's files to folder 1's ten, then folder 2's nineteen, then folder
3's seven. A candidate now only *claims* files for their owner and the claims
are settled once the source has been walked, so "gone" means nothing in the
whole walk claimed it.

**Exclude one file** (`cd162892`). Oathbringer's second part ships the same
forty minutes twice, at two bitrates, seven seconds apart — importing it
plays the end of the part twice, and it is the only file of its kind in 353
items. Splitting makes 37 items out of one audiobook; ignoring takes the
whole audiobook out. So the file stays where it is and stops being part of
the recording.

`files` never shrinks: it is the ownership ledger discovery reads, and a file
missing from it belongs to nobody, so the duplicate would come back as its
own inbox item every hour. `excluded_files` says it isn't in the audiobook,
and the two accessors say which question they answer — `owned_disk_files/1`
for who holds what, `disk_files/1` for what a listener will hear. Placement
and `media_tracks` follow the second without knowing this feature exists.

Both were run against the production downloads mount on the dev instance: the
three Gwendy items became one, 36 files probed at 2h42m, matched as one book
with the right author pair and narrator; excluding the Oathbringer duplicate
took the recording from 149736.99s to 145442.59s, which is that file's
4294.40s to the centisecond. A full rescan of all 353 items afterwards
reported 0 created, 0 updated.

## The import form, while we were in it

- **The files are read at the top of it** (`501c17f8`) — the tags and the file
  list were one question asked at opposite ends of a long form. The tags are
  no longer folded away, either: they are the evidence every decision below
  them is an interpretation of.
- **Said once** (`3ff6f0bc`) — the header dropped its path where the file list
  is about to print the same string, which is all 353 items in the operator's
  queue. The list also stops printing "./" over a loose file.
- **The source tag** (`13b83b5d`) — the queue row has carried it since the
  queue could hold more than one source; the form, where the paths are
  actually read, had lost it.
- **A dead id lands in the queue, not on a 404** (`955207c0`) — regrouping
  replaces items, so browser Back after a split or a combine walks into an id
  that no longer exists.

## And two defects in the edit forms' lists

Found while answering "why can't the edit form fix this?" (`df690071`,
`47b3c917`):

- An entity chip reports what the record already **has**, and clicking it
  appended the row anyway, as often as it was clicked. This is the bug the
  narrator chips were removed for (17aa2234); nobody noticed the same code on
  the book form.
- `_drop` names a slot and a move swaps what is *in* two slots, so a reorder
  after a delete redirected the delete onto a different row: delete the second
  author, move the first down, save, and the author you deleted came back
  while the one you kept was destroyed. Silently.
- The arrows also believed in rows that were not on screen: a removed row is
  still in the association, marked for replacement, and a plain `length/1`
  counted it.

The reorder mechanism itself is being converted to the documented
`sort_param`/`drop_param` model next, which removes the class rather than
these three instances.

## Notes for review

- One migration, `20260820183956_inbox_item_excluded_files`, additive with a
  default.
- No release yet: prod needs one before combine and exclusion can be used on
  the backlog they were built for.

https://claude.ai/code/session_01MqS3aWUFDbtcNv193tAm1K
