### PR TITLE
The audiobook form's file evidence, and the scrim that was never covering anything

### DIFF
--- a/assets/js/hooks/image-size.js
+++ b/assets/js/hooks/image-size.js
@@ -1,29 +1,44 @@
+// The caption under an image preview: how big the image actually is.
+//
+// **Measured from `data-measure`, not from what is on screen.** A form may
+// render a derived thumbnail and zoom to the original — the audiobook form
+// does — and reading the rendered element there reports the thumbnail's size,
+// which is a fact about our own resizing rather than about the picture. When
+// the two are the same URL the browser has it cached and nothing is fetched
+// twice.
 export const ImageSizeHook = {
   mounted() {
-    const el = this.el
-    const targetId = this.el.dataset.target
-    const image = document.getElementById(targetId)
+    this.preview = document.getElementById(this.el.dataset.target)
+    this.measure()
 
-    const updateSize = () => {
-      const size = `${image.naturalWidth}×${image.naturalHeight}`
-      this.el.innerText = size
-    }
-
-    if (image.complete) {
-      updateSize()
-    } else {
-      image.addEventListener("load", (event) => {
-        updateSize()
-      })
-    }
-
-    observer = new MutationObserver((changes) => {
-      changes.forEach((change) => {
-        if (change.attributeName.includes("src")) {
-          updateSize()
-        }
-      })
+    // The src changes as chips are picked, and the caption has to follow.
+    this.observer = new MutationObserver((changes) => {
+      if (changes.some((change) => change.attributeName === "src")) this.measure()
     })
-    observer.observe(image, { attributes: true })
+
+    if (this.preview) this.observer.observe(this.preview, { attributes: true })
+  },
+
+  destroyed() {
+    if (this.observer) this.observer.disconnect()
+  },
+
+  measure() {
+    const src = this.el.dataset.measure || (this.preview && this.preview.src)
+
+    if (!src) return
+
+    const probe = new Image()
+
+    probe.addEventListener("load", () => {
+      this.el.innerText = `${probe.naturalWidth}×${probe.naturalHeight}`
+    })
+
+    // A URL that won't load says nothing rather than the last image's size.
+    probe.addEventListener("error", () => {
+      this.el.innerText = ""
+    })
+
+    probe.src = src
   },
 }

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -1150,7 +1150,10 @@ defmodule Ambry.Media do
       id: group.id,
       label: group.name,
       image: first_member_thumbnail(group),
-      detail: parts_progress(group)
+      detail: parts_progress(group),
+      # A member's form states the set's total rather than asking for it, so
+      # the option has to carry the number and not only the words.
+      parts_total: group.parts_total
     }
   end
 

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -507,7 +507,11 @@ defmodule Ambry.Media do
       {:error, :not_found}
 
   """
-  def fetch_media(id), do: Repo.fetch(Media, id)
+  # With its tracks: an imported recording keeps its files there, so a media
+  # fetched without them is one you cannot ask what it is made of — and
+  # `Ambry.Media.Scanner.audio_files/1` used to answer that question from the
+  # empty transcode columns rather than refusing it.
+  def fetch_media(id), do: Media |> preload(:media_tracks) |> Repo.fetch(id)
 
   @doc """
   Fetches a single direct-play track.

--- a/lib/ambry/media/scanner.ex
+++ b/lib/ambry/media/scanner.ex
@@ -88,6 +88,13 @@ defmodule Ambry.Media.Scanner do
   The tracks are asked first, since an imported recording has no transcode
   sources at all.
   """
+  # **Pass a media with its tracks loaded.** An unloaded association is
+  # neither `[_ | _]` nor `[]`, so it falls through to the transcode sources
+  # below and answers as if the recording had no tracks — which, for an
+  # imported one, is every file it has. That is not detectable here: a media
+  # built with no tracks at all looks exactly the same. So the invariant lives
+  # at the two ways in, `get_media!/1` and `fetch_media/1`, which both preload
+  # them.
   def audio_files(%Media{media_tracks: [_ | _] = tracks}) do
     {:ok, tracks |> Enum.sort_by(& &1.index) |> Enum.map(&MediaTrack.disk_path!/1)}
   end

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -86,8 +86,8 @@ defmodule AmbryWeb.Admin.Components do
   #   30   the sticky page footers — `sticky_slab_classes/0`
   #   35   a typeahead's popup: clear of the sticky footer it may open over,
   #        under the scrims that mean the form is not yours right now
-  #   40   a page-wide busy scrim (the import form's), which has to cover the
-  #        Save button or it is only advisory
+  #   40   a page-wide busy scrim (`busy_overlay/1` at `scope={:form}`), which
+  #        has to cover the Save button or it is only advisory
   #   50   this header, and the public one
   #   60   the drawer's scrim
   #   70   the side nav drawer
@@ -743,6 +743,12 @@ defmodule AmbryWeb.Admin.Components do
 
   attr :busy, :boolean, required: true
   attr :label, :string, required: true
+
+  attr :scope, :atom,
+    default: :card,
+    values: [:card, :form],
+    doc: "how much it covers, which decides both its layer and where its label sits"
+
   attr :rest, :global
 
   @doc """
@@ -762,18 +768,40 @@ defmodule AmbryWeb.Admin.Components do
   covering them; `inert` on the content beside it is what actually stops
   keyboard focus, and the LiveView refuses the events anyway — the overlay is
   the explanation, not the enforcement.
+
+  ## Two scopes, because a form is not a card
+
+  `:card` covers one block and sits at 20. `:form` covers a whole form and
+  sits at **40, above the sticky footer** — a scrim that leaves Save clickable
+  is only advisory, which is what the layer ladder above has always said and
+  what this component could not actually do: it took the classes through
+  `:global`, which rendered a *second* `class` attribute that the browser
+  discards. Every page-wide scrim in the admin was a card scrim at 20 with its
+  label centred somewhere down a form nobody could see.
+
+  So the shape is named rather than passed in. A `:form` scrim keeps its label
+  in a `sticky top-0 h-screen` child: one viewport tall, pinned to the top of
+  the view, centring its contents — so the message sits in the middle of the
+  screen and follows the scroll, instead of in the middle of a form that may
+  be three screens long.
   """
   def busy_overlay(assigns) do
     ~H"""
     <div
       :if={@busy}
-      class="bg-zinc-950/70 backdrop-blur-[1px] absolute inset-0 z-20 flex items-center justify-center gap-2 rounded-lg"
+      class={[
+        "bg-zinc-950/70 backdrop-blur-[1px] absolute inset-0 rounded-lg",
+        @scope == :card && "z-20 flex items-center justify-center gap-2",
+        @scope == :form && "z-40"
+      ]}
       data-role="busy-overlay"
       aria-live="polite"
       {@rest}
     >
-      <.icon name="fa-rotate" class="h-4 w-4 animate-spin text-zinc-300" />
-      <span class="text-sm font-semibold text-zinc-200">{@label}</span>
+      <div class={@scope == :form && "sticky top-0 flex h-screen items-center justify-center gap-2"}>
+        <.icon name="fa-rotate" class="h-4 w-4 animate-spin text-zinc-300" />
+        <span class="text-sm font-semibold text-zinc-200">{@label}</span>
+      </div>
     </div>
     """
   end

--- a/lib/ambry_web/components/admin/curation.ex
+++ b/lib/ambry_web/components/admin/curation.ex
@@ -40,8 +40,11 @@ defmodule AmbryWeb.Admin.Curation do
   attr :evidence, Evidence, required: true
   attr :level, :string, required: true, doc: ~s("work" or "recording" — routes the fan-out)
   attr :title, :string, required: true
-  attr :hint, :string, default: nil
   attr :retrying, :any, default: nil
+
+  attr :scan_files, :boolean,
+    default: false,
+    doc: "the recording level: its files have something to say, and asking them is not a search"
 
   @doc """
   The evidence panel: one search, fanned out to every capable provider, its
@@ -49,33 +52,42 @@ defmodule AmbryWeb.Admin.Curation do
 
   Sits **outside** the record's own `<form>` (the search is a form of its
   own), above it — evidence first, then the decisions it feeds, the order
-  the import form established. It starts **folded**: an edit form is
-  visited for reasons that mostly aren't curation, and a paragraph of
-  tick-these-records instructions above a form with no records was noise.
-  The hint appears with the records it explains.
+  the import form established. It starts **folded**: an edit form is visited
+  for reasons that mostly aren't curation.
+
+  ## Reading the files is not searching for the book
+
+  At the recording level the button did two things: it read the recording's
+  own files, and it asked every provider about the book. One takes
+  milliseconds and always has something to say; the other takes seconds and
+  often doesn't. An operator working down the back catalogue asking "would
+  the embedded cover be an improvement?" had to pay for a provider fan-out to
+  find out. So there are two buttons, and the panel says both things in its
+  title.
+
+  ## Nothing is editable while it runs
+
+  A search used to leave the whole form live and say so only by relabelling
+  its own button — the last surface in the admin still doing that. The scrim
+  is the caller's, over the whole form, because that is the size of what a
+  fan-out changes: chips appear under every field it can fill. The import
+  form has done this since matching could hold an item.
   """
   def evidence_panel(assigns) do
     ~H"""
-    <%!-- `open` is pinned server-side once a search runs: LiveView patches
-        strip a client-toggled open attribute (any results arriving would
-        slam the panel shut), and a panel with records in it should stay
-        open anyway. --%>
+    <%!-- `open` is pinned server-side once anything has been asked: LiveView
+        patches strip a client-toggled open attribute (any results arriving
+        would slam the panel shut), and a panel you have used should stay open
+        anyway. The tags belong in that list even though they put nothing in
+        the panel — a fold that closes itself the moment you press a button
+        inside it reads as the button having gone wrong. --%>
     <.disclosure
       class="pl-3 text-sm font-semibold text-zinc-200"
       container_class="space-y-2"
       data-role="evidence-panel"
-      open={@evidence.running? or @evidence.searched?}
+      open={@evidence.running? or @evidence.searched? or @evidence.tags != nil}
     >
-      <:summary_slot>
-        {@title}
-        <span :if={@evidence.searched?} class="font-normal text-zinc-400">
-          · {length(@evidence.records)} records, {MapSet.size(@evidence.used)} ticked
-        </span>
-      </:summary_slot>
-
-      <p :if={@hint && @evidence.records != []} class="max-w-prose pt-1 pl-3 text-sm text-zinc-400">
-        {@hint}
-      </p>
+      <:summary_slot>{@title}</:summary_slot>
 
       <%!-- The query, then who answered, then what they said — the import
           form's grammar, because a card of search results is a search form
@@ -87,7 +99,8 @@ defmodule AmbryWeb.Admin.Curation do
           level={@level}
           fields={@evidence.fields}
           running={@evidence.running?}
-          label={(@evidence.searched? && "Search again") || "Search"}
+          scan_files={@scan_files}
+          label={search_words(@evidence, @scan_files)}
         />
 
         <%!-- A person is searched by name — the research form's
@@ -99,7 +112,6 @@ defmodule AmbryWeb.Admin.Curation do
           event="research"
           name={@evidence.fields["name"]}
           running={@evidence.running?}
-          label={(@evidence.searched? && "Search again") || "Search"}
         />
 
         <.provider_outcomes_row
@@ -131,6 +143,12 @@ defmodule AmbryWeb.Admin.Curation do
     </.disclosure>
     """
   end
+
+  # "Search again" presumed a search; a panel that also reads files has two
+  # verbs to name and the button that does both should say so.
+  defp search_words(_evidence, true), do: "Read files & search"
+  defp search_words(%Evidence{searched?: true}, _scan), do: "Search again"
+  defp search_words(_evidence, _scan), do: "Search"
 
   attr :field, FormField, required: true
   attr :label, :string, required: true

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -501,6 +501,10 @@ defmodule AmbryWeb.Admin.Decisions do
     default: "Search again",
     doc: ~s(the edit forms' fresh panel says "Search" — nothing was searched yet)
 
+  attr :scan_files, :boolean,
+    default: false,
+    doc: "offer the files on their own — see `AmbryWeb.Admin.Curation.evidence_panel/1`"
+
   @doc """
   An editable version of the search that produced these records.
 
@@ -554,6 +558,20 @@ defmodule AmbryWeb.Admin.Decisions do
           short next to every input it touches. --%>
       <.button color={:zinc} type="submit" disabled={@running}>
         {if @running, do: "Searching…", else: @label}
+      </.button>
+
+      <%!-- Milliseconds, and it always has something to say. Its own control
+            because pairing it with a provider fan-out made "would the
+            embedded cover be better than this one?" cost a round trip to
+            every database that has ever heard of the book. --%>
+      <.button
+        :if={@scan_files}
+        color={:zinc}
+        type="button"
+        phx-click="scan-files"
+        disabled={@running}
+      >
+        Read files only
       </.button>
     </form>
     """

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -2386,22 +2386,30 @@ defmodule AmbryWeb.Admin.Decisions do
           phx-change="link-group"
           class="min-w-48 flex max-w-md flex-grow items-start gap-2"
         >
-          <%!-- The box has to be stated here, unlike every other control on
-              this row. `@tailwindcss/forms` gives `input`, `select` and
-              `textarea` their padding and border, and `input_classes/1`
-              leans on that; a drop-down's trigger is a `button`, which the
-              plugin never touches, so it collapsed to exactly the height of
-              its own text. These are the plugin's own numbers, so it sits
-              level with the number boxes beside it. --%>
-          <.live_component
-            :if={@link.candidates != []}
-            module={EntityDropdown}
-            id="group-dropdown"
-            name="recording_group_id"
-            options={group_options(@link)}
-            value={group_choice(@link)}
-            class={input_classes("w-full border px-3 py-2")}
-          />
+          <%!-- **`flex-1 min-w-0`, not `w-full`.** Two `w-full` children of a
+              flex row shrink in proportion to their *content*, so naming a
+              set for a book that already has one crushed the drop-down to
+              "N…" beside a name box three times its width. Basis-zero splits
+              the column evenly however long the words in it are, which is
+              what the audiobook form's row does. --%>
+          <div :if={@link.candidates != []} class="min-w-0 flex-1">
+            <%!-- The box has to be stated here, unlike every other control on
+                this row. `@tailwindcss/forms` gives `input`, `select` and
+                `textarea` their padding and border, and `input_classes/1`
+                leans on that; a drop-down's trigger is a `button`, which the
+                plugin never touches, so it collapsed to exactly the height of
+                its own text. These are the plugin's own numbers, so it sits
+                level with the number boxes beside it. --%>
+            <.live_component
+              module={EntityDropdown}
+              id="group-dropdown"
+              name="recording_group_id"
+              options={group_options(@link)}
+              value={group_choice(@link)}
+              class={input_classes("w-full border px-3 py-2")}
+            />
+          </div>
+
           <input
             :if={@link.mode == :create}
             type="text"
@@ -2409,7 +2417,7 @@ defmodule AmbryWeb.Admin.Decisions do
             value={@link.name}
             placeholder="set name"
             phx-debounce="500"
-            class={input_classes("w-full")}
+            class={input_classes("w-full min-w-0 flex-1")}
             data-role="group-name"
           />
         </form>

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -2422,6 +2422,9 @@ defmodule AmbryWeb.Admin.Decisions do
           />
         </form>
 
+        <%!-- `w-20` on both boxes, not `w-16`: "total" clipped to "tota" in
+              the narrower one, and two adjacent number boxes of different
+              widths to fit one placeholder reads as an accident. --%>
         <form id="group-part" phx-change="set-group-part" class="flex-none">
           <input
             type="number"
@@ -2429,7 +2432,7 @@ defmodule AmbryWeb.Admin.Decisions do
             name="part_number"
             value={@link.part_number}
             placeholder="no."
-            class={input_classes("w-16")}
+            class={input_classes("w-20")}
             data-role="part-number"
           />
         </form>
@@ -2445,7 +2448,7 @@ defmodule AmbryWeb.Admin.Decisions do
             name="parts_total"
             value={@link.parts_total}
             placeholder="total"
-            class={input_classes("w-16")}
+            class={input_classes("w-20")}
             data-role="parts-total"
           />
         </form>

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -1012,11 +1012,17 @@ defmodule AmbryWeb.CoreComponents do
         >
           <.icon name="fa-magnifying-glass" class="h-3 w-3 text-zinc-100" />
         </span>
+        <%!-- Measured from `full`, not from what is on screen: the forms
+            render a derived thumbnail and zoom to the original, and a caption
+            under a 512px preview saying "512×512" answers a question nobody
+            asked. What the operator wants to know is how big the image they
+            imported is. --%>
         <p
           id={"#{@id}-size"}
           class="text-center text-xs text-zinc-700"
           phx-hook="image-size"
           data-target={"#{@id}-preview"}
+          data-measure={@full}
           phx-update="ignore"
         />
       </div>

--- a/lib/ambry_web/controllers/admin/embedded_cover_controller.ex
+++ b/lib/ambry_web/controllers/admin/embedded_cover_controller.ex
@@ -32,9 +32,14 @@ defmodule AmbryWeb.Admin.EmbeddedCoverController do
   # The same question asked of a recording that already exists: an edit form
   # offering the file's own art has to show it for the same reason the import
   # form does.
+  #
+  # **Through the scanner, which asks the tracks first.** `Media.files/2`
+  # reads `source_files`, and those are transcode bookkeeping — what a
+  # transcode *consumed* — so an imported recording has none and this found
+  # nothing to extract from. The chip rendered a 404 as an image.
   def media(conn, %{"id" => id}) do
     with {:ok, media} <- Media.fetch_media(id),
-         [path | _rest] <- Media.Media.files(media, Media.Scanner.extensions()) do
+         {:ok, [path | _rest]} <- Media.Scanner.audio_files(media) do
       send_cover(conn, path)
     else
       _no_media -> send_resp(conn, 404, "Not Found")

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -1,136 +1,149 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="-mb-4 max-w-4xl space-y-7">
-    <%!-- Evidence first, then the decisions it feeds — the import form's
-        order. Its search is a form of its own, so it lives outside the
-        book's form element. --%>
-    <.evidence_panel
-      evidence={@evidence}
-      level="work"
-      title="Search providers"
-      hint="Tick every record that describes this book. Ticked records offer their values as chips under the fields below."
-      retrying={@retrying}
+  <div class="relative">
+    <%!-- A fan-out rebuilds the chips under every field it can fill, so a form
+        with one running is not the operator's to edit yet — and it says so
+        over the whole thing, the way the import form does while matching
+        holds an item. `sticky top-0 h-screen` keeps the scrim one viewport
+        tall and the label in view however far down the form the click was;
+        `z-40` clears the sticky footer with the Save in it, and stays under
+        the header. --%>
+    <.busy_overlay
+      busy={@evidence.running?}
+      label="Asking the databases…"
+      class="sticky top-0 z-40 h-screen"
     />
 
-    <.simple_form
-      id="book-form"
-      for={@form}
-      phx-hook="reorder-rows"
-      phx-change="validate"
-      phx-submit="submit"
-      autocomplete="off"
-    >
-      <%!-- What the book is called and when it came out — the two facts that
+    <div class="-mb-4 max-w-4xl space-y-7" inert={@evidence.running?}>
+      <%!-- Evidence first, then the decisions it feeds — the import form's
+        order. Its search is a form of its own, so it lives outside the
+        book's form element. --%>
+      <.evidence_panel
+        evidence={@evidence}
+        level="work"
+        title="Search providers"
+        retrying={@retrying}
+      />
+
+      <.simple_form
+        id="book-form"
+        for={@form}
+        phx-hook="reorder-rows"
+        phx-change="validate"
+        phx-submit="submit"
+        autocomplete="off"
+      >
+        <%!-- What the book is called and when it came out — the two facts that
           identify the work, in one block. --%>
-      <.field_group>
-        <.curated_input
-          field={@form[:title]}
-          label="Title"
-          class="max-w-xl"
-          record={@book}
-          hints={@provenance_hints}
-          proposals={@chips[:title] || []}
-          revert={@reverts[:title]}
-        />
-
-        <div class="space-y-1">
-          <.curated_date
-            date_field={@form[:published]}
-            format_field={@form[:published_format]}
-            label="First published"
+        <.field_group>
+          <.curated_input
+            field={@form[:title]}
+            label="Title"
+            class="max-w-xl"
             record={@book}
             hints={@provenance_hints}
-            proposals={@chips[:published] || []}
-            revert={@reverts[:published]}
+            proposals={@chips[:title] || []}
+            revert={@reverts[:title]}
           />
-          <span class="block pl-3 text-sm text-zinc-400">
-            {preview_date_format(@form)}
-          </span>
-        </div>
-      </.field_group>
 
-      <.list_cluster label="Authors">
-        <:flag>
-          <.provenance_flag
-            :if={@book_author_count > 0}
-            record={@book}
-            field={:book_authors}
-            hints={@provenance_hints}
-          />
-        </:flag>
-        <p :if={@book_author_count == 0} class="pl-3 text-sm text-zinc-400">No authors.</p>
-        <.inputs_for :let={book_author_form} field={@form[:book_authors]}>
-          <.sort_input field={@form[:book_authors_sort]} index={book_author_form.index} />
-          <.position_input field={book_author_form[:position]} index={book_author_form.index} />
+          <div class="space-y-1">
+            <.curated_date
+              date_field={@form[:published]}
+              format_field={@form[:published_format]}
+              label="First published"
+              record={@book}
+              hints={@provenance_hints}
+              proposals={@chips[:published] || []}
+              revert={@reverts[:published]}
+            />
+            <span class="block pl-3 text-sm text-zinc-400">
+              {preview_date_format(@form)}
+            </span>
+          </div>
+        </.field_group>
 
-          <%!-- Controls trail the input: a leading column pushed every input
+        <.list_cluster label="Authors">
+          <:flag>
+            <.provenance_flag
+              :if={@book_author_count > 0}
+              record={@book}
+              field={:book_authors}
+              hints={@provenance_hints}
+            />
+          </:flag>
+          <p :if={@book_author_count == 0} class="pl-3 text-sm text-zinc-400">No authors.</p>
+          <.inputs_for :let={book_author_form} field={@form[:book_authors]}>
+            <.sort_input field={@form[:book_authors_sort]} index={book_author_form.index} />
+            <.position_input field={book_author_form[:position]} index={book_author_form.index} />
+
+            <%!-- Controls trail the input: a leading column pushed every input
               off the box edge whenever a list crossed one row (§3, two left
               edges). Order matches the import form's cards — reorder first,
               remove last — so the destructive control is at the end of the
               row rather than in the middle of it. --%>
-          <div class="flex items-start gap-2">
-            <%!-- Create mode: a book may credit an author the library has
+            <div class="flex items-start gap-2">
+              <%!-- Create mode: a book may credit an author the library has
                 never heard of, and typing their name is how you say so. The
                 name posts beside the id and becomes a person when the form
                 is saved. --%>
-            <.input
-              field={book_author_form[:author_id]}
-              type="autocomplete"
-              search={&People.search_authors/2}
-              fetch={&People.author_option/1}
-              create_name={"#{book_author_form.name}[author][name]"}
-              create_value={staged_name(book_author_form, :author)}
-              create_flag_name={"#{book_author_form.name}[author][create]"}
-              create_flag_value={NewPerson.chosen(book_author_form, :author)}
-              container_class="grow"
-            />
-            <%!-- Who this credit means, and a way down to their card. --%>
-            <.inputs_for
-              :let={author_form}
-              :if={NewPerson.carded?(book_author_form, :author, [:author, :author_people])}
-              field={book_author_form[:author]}
-              skip_hidden
-              skip_persistent_id
-            >
+              <.input
+                field={book_author_form[:author_id]}
+                type="autocomplete"
+                search={&People.search_authors/2}
+                fetch={&People.author_option/1}
+                create_name={"#{book_author_form.name}[author][name]"}
+                create_value={staged_name(book_author_form, :author)}
+                create_flag_name={"#{book_author_form.name}[author][create]"}
+                create_flag_value={NewPerson.chosen(book_author_form, :author)}
+                container_class="grow"
+              />
+              <%!-- Who this credit means, and a way down to their card. --%>
               <.inputs_for
-                :let={author_person_form}
-                field={author_form[:author_people]}
+                :let={author_form}
+                :if={NewPerson.carded?(book_author_form, :author, [:author, :author_people])}
+                field={book_author_form[:author]}
                 skip_hidden
                 skip_persistent_id
               >
-                <.new_person_pill
-                  row={author_person_form}
-                  key={"#{NewPerson.key(book_author_form)}-#{author_person_form.index}"}
-                />
+                <.inputs_for
+                  :let={author_person_form}
+                  field={author_form[:author_people]}
+                  skip_hidden
+                  skip_persistent_id
+                >
+                  <.new_person_pill
+                    row={author_person_form}
+                    key={"#{NewPerson.key(book_author_form)}-#{author_person_form.index}"}
+                  />
+                </.inputs_for>
               </.inputs_for>
-            </.inputs_for>
 
-            <.move_buttons
-              :if={@book_author_count > 1}
-              field={:book_authors}
-              index={book_author_form.index}
-              count={@book_author_count}
+              <.move_buttons
+                :if={@book_author_count > 1}
+                field={:book_authors}
+                index={book_author_form.index}
+                count={@book_author_count}
+              />
+              <.delete_button field={@form[:book_authors_drop]} index={book_author_form.index} />
+            </div>
+          </.inputs_for>
+
+          <:proposals>
+            <.proposal_row
+              id="proposals-authors"
+              field="authors"
+              event="accept-entity"
+              adds_rows
+              proposals={@chips[:authors] || []}
             />
-            <.delete_button field={@form[:book_authors_drop]} index={book_author_form.index} />
-          </div>
-        </.inputs_for>
+          </:proposals>
 
-        <:proposals>
-          <.proposal_row
-            id="proposals-authors"
-            field="authors"
-            event="accept-entity"
-            adds_rows
-            proposals={@chips[:authors] || []}
-          />
-        </:proposals>
+          <:add>
+            <.add_button field={@form[:book_authors_sort]}>Add author</.add_button>
+            <.delete_input field={@form[:book_authors_drop]} />
+          </:add>
+        </.list_cluster>
 
-        <:add>
-          <.add_button field={@form[:book_authors_sort]}>Add author</.add_button>
-          <.delete_input field={@form[:book_authors_drop]} />
-        </:add>
-      </.list_cluster>
-
-      <%!-- The humans these credits are about to invent, in the import form's
+        <%!-- The humans these credits are about to invent, in the import form's
           own section — under the credits that name them, because that is
           where they came from, and separate from them, because "what is this
           person called, and what do they look like" is a different question
@@ -142,142 +155,143 @@
           the nested chain, which exists exactly where a row reaches a person
           nobody has made yet — never for a credit pointing at an author the
           library already has. --%>
-      <.form_section
-        :if={NewPerson.any?(@form.source, :book_authors, :author, [:author, :author_people])}
-        id="new-people"
-        title="New people"
-      >
-        <.inputs_for
-          :let={book_author_form}
-          field={@form[:book_authors]}
-          skip_hidden
-          skip_persistent_id
+        <.form_section
+          :if={NewPerson.any?(@form.source, :book_authors, :author, [:author, :author_people])}
+          id="new-people"
+          title="New people"
         >
           <.inputs_for
-            :let={author_form}
-            :if={NewPerson.carded?(book_author_form, :author, [:author, :author_people])}
-            field={book_author_form[:author]}
+            :let={book_author_form}
+            field={@form[:book_authors]}
+            skip_hidden
+            skip_persistent_id
           >
-            <%!-- A bracket, never a filled block: wrapping cards in a card is
+            <.inputs_for
+              :let={author_form}
+              :if={NewPerson.carded?(book_author_form, :author, [:author, :author_people])}
+              field={book_author_form[:author]}
+            >
+              <%!-- A bracket, never a filled block: wrapping cards in a card is
               what eats the elevation ladder. One author credit can stand for
               several humans, and the label names the credit they share — the
               inbox's own People section, verbatim. --%>
-            <div
-              :if={NewPerson.people_count(book_author_form) > 1}
-              class="space-y-3 border-l-2 border-zinc-700 pl-4"
-              data-role="pen-name-group"
-            >
-              <p class="text-xs text-zinc-400">
-                {NewPerson.people_count(book_author_form)} people behind this name
-              </p>
+              <div
+                :if={NewPerson.people_count(book_author_form) > 1}
+                class="space-y-3 border-l-2 border-zinc-700 pl-4"
+                data-role="pen-name-group"
+              >
+                <p class="text-xs text-zinc-400">
+                  {NewPerson.people_count(book_author_form)} people behind this name
+                </p>
+                <.author_person_cards
+                  book_author_form={book_author_form}
+                  author_form={author_form}
+                  new_people={@new_people}
+                />
+              </div>
+
               <.author_person_cards
+                :if={NewPerson.people_count(book_author_form) == 1}
                 book_author_form={book_author_form}
                 author_form={author_form}
                 new_people={@new_people}
               />
-            </div>
 
-            <.author_person_cards
-              :if={NewPerson.people_count(book_author_form) == 1}
-              book_author_form={book_author_form}
-              author_form={author_form}
-              new_people={@new_people}
-            />
-
-            <.delete_input field={author_form[:author_people_drop]} />
+              <.delete_input field={author_form[:author_people_drop]} />
+            </.inputs_for>
           </.inputs_for>
-        </.inputs_for>
-      </.form_section>
+        </.form_section>
 
-      <.list_cluster label="Series">
-        <:flag>
-          <.provenance_flag
-            :if={@series_book_count > 0}
-            record={@book}
-            field={:series_books}
-            hints={@provenance_hints}
-          />
-        </:flag>
-        <p :if={@series_book_count == 0} class="pl-3 text-sm text-zinc-400">Not in a series.</p>
-        <.inputs_for :let={series_book_form} field={@form[:series_books]}>
-          <.sort_input field={@form[:series_books_sort]} index={series_book_form.index} />
-          <.position_input field={series_book_form[:position]} index={series_book_form.index} />
-
-          <div class="flex items-start gap-2">
-            <.input
-              field={series_book_form[:book_number]}
-              placeholder="no."
-              container_class="w-14 flex-none"
-              show_errors={false}
-            />
-            <.input
-              field={series_book_form[:series_id]}
-              type="autocomplete"
-              search={&Books.search_series/2}
-              fetch={&Books.series_option/1}
-              create_name={"#{series_book_form.name}[series][name]"}
-              create_value={staged_name(series_book_form, :series)}
-              container_class="grow"
-            />
-            <.move_buttons
-              :if={@series_book_count > 1}
+        <.list_cluster label="Series">
+          <:flag>
+            <.provenance_flag
+              :if={@series_book_count > 0}
+              record={@book}
               field={:series_books}
-              index={series_book_form.index}
-              count={@series_book_count}
+              hints={@provenance_hints}
             />
-            <.delete_button field={@form[:series_books_drop]} index={series_book_form.index} />
-          </div>
-        </.inputs_for>
+          </:flag>
+          <p :if={@series_book_count == 0} class="pl-3 text-sm text-zinc-400">Not in a series.</p>
+          <.inputs_for :let={series_book_form} field={@form[:series_books]}>
+            <.sort_input field={@form[:series_books_sort]} index={series_book_form.index} />
+            <.position_input field={series_book_form[:position]} index={series_book_form.index} />
 
-        <:proposals>
-          <.proposal_row
-            id="proposals-series"
-            field="series"
-            event="accept-entity"
-            adds_rows
-            proposals={@chips[:series] || []}
-          />
-        </:proposals>
+            <div class="flex items-start gap-2">
+              <.input
+                field={series_book_form[:book_number]}
+                placeholder="no."
+                container_class="w-14 flex-none"
+                show_errors={false}
+              />
+              <.input
+                field={series_book_form[:series_id]}
+                type="autocomplete"
+                search={&Books.search_series/2}
+                fetch={&Books.series_option/1}
+                create_name={"#{series_book_form.name}[series][name]"}
+                create_value={staged_name(series_book_form, :series)}
+                container_class="grow"
+              />
+              <.move_buttons
+                :if={@series_book_count > 1}
+                field={:series_books}
+                index={series_book_form.index}
+                count={@series_book_count}
+              />
+              <.delete_button field={@form[:series_books_drop]} index={series_book_form.index} />
+            </div>
+          </.inputs_for>
 
-        <:add>
-          <.add_button field={@form[:series_books_sort]}>Add series</.add_button>
-          <.delete_input field={@form[:series_books_drop]} />
-        </:add>
-      </.list_cluster>
-
-      <.list_cluster label="Universes">
-        <p :if={@book_universe_count == 0} class="pl-3 text-sm text-zinc-400">
-          Not in a universe.
-        </p>
-        <.inputs_for :let={book_universe_form} field={@form[:book_universes]}>
-          <.sort_input field={@form[:book_universes_sort]} index={book_universe_form.index} />
-
-          <div class="flex items-start gap-2">
-            <.input
-              field={book_universe_form[:universe_id]}
-              type="autocomplete"
-              search={&Books.search_universes/2}
-              fetch={&Books.universe_option/1}
-              create_name={"#{book_universe_form.name}[universe][name]"}
-              create_value={staged_name(book_universe_form, :universe)}
-              container_class="grow"
+          <:proposals>
+            <.proposal_row
+              id="proposals-series"
+              field="series"
+              event="accept-entity"
+              adds_rows
+              proposals={@chips[:series] || []}
             />
-            <.delete_button
-              field={@form[:book_universes_drop]}
-              index={book_universe_form.index}
-            />
-          </div>
-        </.inputs_for>
+          </:proposals>
 
-        <:add>
-          <.add_button field={@form[:book_universes_sort]}>Add universe</.add_button>
-          <.delete_input field={@form[:book_universes_drop]} />
-        </:add>
-      </.list_cluster>
+          <:add>
+            <.add_button field={@form[:series_books_sort]}>Add series</.add_button>
+            <.delete_input field={@form[:series_books_drop]} />
+          </:add>
+        </.list_cluster>
 
-      <.form_footer>
-        <.button>Save</.button>
-      </.form_footer>
-    </.simple_form>
+        <.list_cluster label="Universes">
+          <p :if={@book_universe_count == 0} class="pl-3 text-sm text-zinc-400">
+            Not in a universe.
+          </p>
+          <.inputs_for :let={book_universe_form} field={@form[:book_universes]}>
+            <.sort_input field={@form[:book_universes_sort]} index={book_universe_form.index} />
+
+            <div class="flex items-start gap-2">
+              <.input
+                field={book_universe_form[:universe_id]}
+                type="autocomplete"
+                search={&Books.search_universes/2}
+                fetch={&Books.universe_option/1}
+                create_name={"#{book_universe_form.name}[universe][name]"}
+                create_value={staged_name(book_universe_form, :universe)}
+                container_class="grow"
+              />
+              <.delete_button
+                field={@form[:book_universes_drop]}
+                index={book_universe_form.index}
+              />
+            </div>
+          </.inputs_for>
+
+          <:add>
+            <.add_button field={@form[:book_universes_sort]}>Add universe</.add_button>
+            <.delete_input field={@form[:book_universes_drop]} />
+          </:add>
+        </.list_cluster>
+
+        <.form_footer>
+          <.button>Save</.button>
+        </.form_footer>
+      </.simple_form>
+    </div>
   </div>
 </.layout>

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -1,5 +1,8 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="relative">
+  <%!-- The scrim is the form's width, not the window's: its label centres
+      over what it is covering, and a message floating in the middle of a
+      1920px viewport does not read as belonging to the form beneath it. --%>
+  <div class="relative max-w-4xl">
     <%!-- A fan-out rebuilds the chips under every field it can fill, so a form
         with one running is not the operator's to edit yet — and it says so
         over the whole thing, the way the import form does while matching

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -13,7 +13,7 @@
     <.busy_overlay
       busy={@evidence.running?}
       label="Asking the databases…"
-      class="sticky top-0 z-40 h-screen"
+      scope={:form}
     />
 
     <div class="-mb-4 max-w-4xl space-y-7" inert={@evidence.running?}>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -16,7 +16,7 @@
     <.busy_overlay
       busy={busy?(assigns)}
       label={busy_label(@job)}
-      class="sticky top-0 z-40 h-screen"
+      scope={:form}
     />
 
     <div class="-mb-4 max-w-4xl space-y-14" inert={busy?(assigns)}>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -1,5 +1,8 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="relative">
+  <%!-- The scrim is the form's width, not the window's: its label centres
+      over what it is covering, and a message floating in the middle of a
+      1920px viewport does not read as belonging to the form beneath it. --%>
+  <div class="relative max-w-4xl">
     <%!-- Matching keeps retrying until every provider has answered, and it
           rebuilds an untouched draft when one finally comes back — so a form
           with a job on it is not the operator's to edit yet, and says so

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -881,6 +881,24 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # does not mean "no set": leaving the set is the ✕, which is an event.
   defp new_set_option, do: %{id: "", label: "New set"}
 
+  # Naming one, as opposed to joining one. Read off the id the drop-down
+  # posts, which is the same thing `Ambry.Media.Media`'s cast reads to decide
+  # whether to build a set at all.
+  defp naming_a_set?(form), do: to_string(form[:recording_group_id].value || "") == ""
+
+  # How many parts the set being *joined* says it has, for the line that
+  # states it. A set being named has a box for it instead, and a set that
+  # doesn't know says nothing.
+  defp joined_set_total(%{form: form, recording_group_options: options}) do
+    if !naming_a_set?(form) do
+      id = to_string(form[:recording_group_id].value)
+
+      Enum.find_value(options, fn option ->
+        to_string(option.id) == id && option.parts_total
+      end)
+    end
+  end
+
   defp preview_date_format(form) do
     format_published(%{
       published_format: Ecto.Changeset.get_field(form.source, :published_format),

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -335,6 +335,27 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
     end
   end
 
+  # The files on their own. Reading a header is milliseconds and always has
+  # something to say; a provider fan-out is seconds and often has nothing, and
+  # pairing them made "would the embedded cover be an improvement?" cost the
+  # second to get the first.
+  #
+  # Always re-reads, unlike the once-only read a search does on the way past:
+  # a control the operator pressed on purpose that quietly did nothing the
+  # second time would be worse than the round trip it saves.
+  #
+  # No scrim. `running?` is the panel's, and it means "the databases are being
+  # asked" — a header read is not that, and blanking the form for it would
+  # cost more than it takes.
+  def handle_event("scan-files", _params, socket) do
+    media = socket.assigns.media
+
+    {:noreply,
+     socket
+     |> assign(evidence: %{socket.assigns.evidence | tags: nil})
+     |> start_async(:file_tags, fn -> Media.Scanner.tags(media) end)}
+  end
+
   def handle_event("retry-provider", %{"provider" => outcome_id}, socket) do
     query = Provider.Query.from_fields(socket.assigns.evidence.fields)
     {provider_id, kind} = Outcome.split(outcome_id)
@@ -759,9 +780,10 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # The file's own art, extracted at save the way an import extracts it. The
   # path is taken from the recording rather than from a param: what the form
   # accepted was "this recording's embedded cover", and the only honest
-  # reading of that is the recording's own files.
+  # reading of that is the recording's own files — asked of the scanner,
+  # which asks the tracks before the transcode sources.
   defp handle_embedded_image(socket, %{"image_type" => "embedded"} = media_params) do
-    with [path | _rest] <- Media.Media.files(socket.assigns.media, Media.Scanner.extensions()),
+    with {:ok, [path | _rest]} <- Media.Scanner.audio_files(socket.assigns.media),
          {:ok, web_path} <- Images.extract_embedded(path) do
       {:ok, Map.put(media_params, "image_path", web_path)}
     else

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -45,6 +45,14 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
   # Credits, which are people: accepting one of these stages a row naming the
   # human, and the save makes them (`Ambry.Ecto.EntityRef`).
+  # What the set drop-down's "New set" row posts. A sentinel rather than "",
+  # for the reason the import form gives where it does the same:
+  # `EntityOption.selected?/2` reads a blank value as nothing held, so an
+  # option with a blank id can never draw as chosen — picking it left the
+  # trigger empty. `naming_a_set/2` translates it back to the absence of an id
+  # that the cast wants.
+  @new_set "new"
+
   @entity_kinds %{"narrators" => :narrators}
   @person_events NewPerson.events()
 
@@ -466,8 +474,10 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # recording pointing at no group and holding no part number is simply not in
   # a set, and the schema cannot tell the two apart.
   defp naming_a_set(params, %{assigns: %{group_row_visible: true}}) do
-    if params["recording_group_id"] in [nil, ""] do
-      Map.put_new(params, "recording_group", %{})
+    if params["recording_group_id"] in [nil, "", @new_set] do
+      params
+      |> Map.put("recording_group_id", "")
+      |> Map.put_new("recording_group", %{})
     else
       Map.delete(params, "recording_group")
     end
@@ -879,12 +889,14 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
   # The drop-down's escape hatch, and the reason a blank id inside the set row
   # does not mean "no set": leaving the set is the ✕, which is an event.
-  defp new_set_option, do: %{id: "", label: "New set"}
+  defp new_set_option, do: %{id: @new_set, label: "New set"}
 
   # Naming one, as opposed to joining one. Read off the id the drop-down
   # posts, which is the same thing `Ambry.Media.Media`'s cast reads to decide
   # whether to build a set at all.
-  defp naming_a_set?(form), do: to_string(form[:recording_group_id].value || "") == ""
+  defp naming_a_set?(form), do: to_string(form[:recording_group_id].value || "") in ["", @new_set]
+
+  defp set_choice(form), do: (naming_a_set?(form) && @new_set) || form[:recording_group_id].value
 
   # How many parts the set being *joined* says it has, for the line that
   # states it. A set being named has a box for it instead, and a set that

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -1,309 +1,323 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="-mb-4 max-w-4xl space-y-7">
-    <%!-- Evidence first, then the decisions it feeds — the import form's
-        order. Its search is a form of its own, so it lives outside the
-        media form element. --%>
-    <.evidence_panel
-      evidence={@evidence}
-      level="recording"
-      title="Search providers"
-      hint="Tick every record of this exact reading; check the narrator first. Ticked records offer their values as chips under the fields below."
-      retrying={@retrying}
+  <div class="relative">
+    <%!-- A fan-out rebuilds the chips under every field it can fill, so a form
+        with one running is not the operator's to edit yet — and it says so
+        over the whole thing, the way the import form does while matching
+        holds an item. `sticky top-0 h-screen` keeps the scrim one viewport
+        tall and the label in view however far down the form the click was;
+        `z-40` clears the sticky footer with the Save in it, and stays under
+        the header. --%>
+    <.busy_overlay
+      busy={@evidence.running?}
+      label="Asking the databases…"
+      class="sticky top-0 z-40 h-screen"
     />
 
-    <.simple_form
-      id="media-form"
-      for={@form}
-      phx-hook="reorder-rows"
-      phx-change="validate"
-      phx-submit="submit"
-      autocomplete="off"
-    >
-      <.form_section id="recording">
-        <.field_group>
-          <.input
-            field={@form[:book_id]}
-            label="Book"
-            type="autocomplete"
-            search={&Books.search_books/2}
-            fetch={&Books.book_option/1}
-            container_class="max-w-xl"
-          />
+    <div class="-mb-4 max-w-4xl space-y-7" inert={@evidence.running?}>
+      <%!-- Evidence first, then the decisions it feeds — the import form's
+        order. Its search is a form of its own, so it lives outside the
+        media form element. --%>
+      <.evidence_panel
+        evidence={@evidence}
+        level="recording"
+        title="Read the files and search providers"
+        scan_files
+        retrying={@retrying}
+      />
 
-          <.curated_input
-            field={@form[:title]}
-            label="Title override"
-            placeholder="defaults to the book's title"
-            class="max-w-xl"
-            record={@media}
-            hints={@provenance_hints}
-            proposals={@chips[:title] || []}
-            revert={@reverts[:title]}
-          />
-        </.field_group>
+      <.simple_form
+        id="media-form"
+        for={@form}
+        phx-hook="reorder-rows"
+        phx-change="validate"
+        phx-submit="submit"
+        autocomplete="off"
+      >
+        <.form_section id="recording">
+          <.field_group>
+            <.input
+              field={@form[:book_id]}
+              label="Book"
+              type="autocomplete"
+              search={&Books.search_books/2}
+              fetch={&Books.book_option/1}
+              container_class="max-w-xl"
+            />
 
-        <.field_group>
-          <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
-            <div class="space-y-1">
-              <.curated_date
-                date_field={@form[:published]}
-                format_field={@form[:published_format]}
-                label="Published"
+            <.curated_input
+              field={@form[:title]}
+              label="Title override"
+              placeholder="defaults to the book's title"
+              class="max-w-xl"
+              record={@media}
+              hints={@provenance_hints}
+              proposals={@chips[:title] || []}
+              revert={@reverts[:title]}
+            />
+          </.field_group>
+
+          <.field_group>
+            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
+              <div class="space-y-1">
+                <.curated_date
+                  date_field={@form[:published]}
+                  format_field={@form[:published_format]}
+                  label="Published"
+                  record={@media}
+                  hints={@provenance_hints}
+                  proposals={@chips[:published] || []}
+                  revert={@reverts[:published]}
+                />
+                <span class="block pl-3 text-sm text-zinc-400">
+                  {preview_date_format(@form)}
+                </span>
+              </div>
+              <.curated_input
+                field={@form[:publisher]}
+                label="Publisher"
                 record={@media}
                 hints={@provenance_hints}
-                proposals={@chips[:published] || []}
-                revert={@reverts[:published]}
+                proposals={@chips[:publisher] || []}
+                revert={@reverts[:publisher]}
               />
-              <span class="block pl-3 text-sm text-zinc-400">
-                {preview_date_format(@form)}
-              </span>
             </div>
-            <.curated_input
-              field={@form[:publisher]}
-              label="Publisher"
-              record={@media}
-              hints={@provenance_hints}
-              proposals={@chips[:publisher] || []}
-              revert={@reverts[:publisher]}
-            />
-          </div>
 
-          <div class="flex gap-4">
-            <.input field={@form[:abridged]} label="Abridged" type="checkbox" />
-            <.input field={@form[:full_cast]} label="Full cast" type="checkbox" />
-          </div>
-        </.field_group>
+            <div class="flex gap-4">
+              <.input field={@form[:abridged]} label="Abridged" type="checkbox" />
+              <.input field={@form[:full_cast]} label="Full cast" type="checkbox" />
+            </div>
+          </.field_group>
 
-        <.field_group>
-          <div class="flex items-baseline gap-2 pl-3">
-            <.label for={@form[:description].id}>Description</.label>
-            <.provenance_flag record={@media} field={:description} hints={@provenance_hints} />
-          </div>
-          <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            <.input
-              id="description-input"
-              field={@form[:description]}
-              type="textarea"
-              phx-hook="maintain-attrs"
-              data-attrs="style"
-            />
-            <div class="relative">
-              <div
-                id="description-preview"
-                phx-hook="scroll-match"
-                data-target="description-input"
-                class="bg-zinc-800/50 absolute inset-0 hidden overflow-auto rounded-sm sm:block"
-              >
-                <.markdown content={@form[:description].value || ""} class="p-2" />
+          <.field_group>
+            <div class="flex items-baseline gap-2 pl-3">
+              <.label for={@form[:description].id}>Description</.label>
+              <.provenance_flag record={@media} field={:description} hints={@provenance_hints} />
+            </div>
+            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <.input
+                id="description-input"
+                field={@form[:description]}
+                type="textarea"
+                phx-hook="maintain-attrs"
+                data-attrs="style"
+              />
+              <div class="relative">
+                <div
+                  id="description-preview"
+                  phx-hook="scroll-match"
+                  data-target="description-input"
+                  class="bg-zinc-800/50 absolute inset-0 hidden overflow-auto rounded-sm sm:block"
+                >
+                  <.markdown content={@form[:description].value || ""} class="p-2" />
+                </div>
               </div>
             </div>
-          </div>
-          <.proposal_row
-            id="proposals-description"
-            field="description"
-            proposals={@chips[:description] || []}
-            revert={@reverts[:description]}
-          />
-        </.field_group>
-
-        <.list_cluster label="Read by">
-          <:flag>
-            <.provenance_flag
-              :if={@media_narrator_count > 0}
-              record={@media}
-              field={:media_narrators}
-              hints={@provenance_hints}
+            <.proposal_row
+              id="proposals-description"
+              field="description"
+              proposals={@chips[:description] || []}
+              revert={@reverts[:description]}
             />
-          </:flag>
-          <%!-- legal, not an error: a full-cast recording can credit nobody --%>
-          <p :if={@media_narrator_count == 0} class="pl-3 text-sm text-zinc-400">No narrators.</p>
-          <.inputs_for :let={media_narrator_form} field={@form[:media_narrators]}>
-            <.sort_input field={@form[:media_narrators_sort]} index={media_narrator_form.index} />
-            <.position_input field={media_narrator_form[:position]} index={media_narrator_form.index} />
+          </.field_group>
 
-            <%!-- Controls trail the input: a leading column pushed every input
+          <.list_cluster label="Read by">
+            <:flag>
+              <.provenance_flag
+                :if={@media_narrator_count > 0}
+                record={@media}
+                field={:media_narrators}
+                hints={@provenance_hints}
+              />
+            </:flag>
+            <%!-- legal, not an error: a full-cast recording can credit nobody --%>
+            <p :if={@media_narrator_count == 0} class="pl-3 text-sm text-zinc-400">No narrators.</p>
+            <.inputs_for :let={media_narrator_form} field={@form[:media_narrators]}>
+              <.sort_input field={@form[:media_narrators_sort]} index={media_narrator_form.index} />
+              <.position_input field={media_narrator_form[:position]} index={media_narrator_form.index} />
+
+              <%!-- Controls trail the input: a leading column pushed every input
                 off the box edge whenever a list crossed one row (§3). Order
                 matches the import form's cards — reorder first, remove last —
                 so the destructive control is at the end of the row. --%>
-            <div class="flex items-start gap-2">
-              <.input
-                field={media_narrator_form[:narrator_id]}
-                type="autocomplete"
-                search={&People.search_narrators/2}
-                fetch={&People.narrator_option/1}
-                create_name={"#{media_narrator_form.name}[narrator][name]"}
-                create_value={staged_name(media_narrator_form, :narrator)}
-                create_flag_name={"#{media_narrator_form.name}[narrator][create]"}
-                create_flag_value={NewPerson.chosen(media_narrator_form, :narrator)}
-                container_class="grow"
-              />
-              <%!-- Who this credit means, and a way down to their card. --%>
-              <.inputs_for
-                :let={narrator_form}
-                :if={NewPerson.carded?(media_narrator_form, :narrator, [:narrator])}
-                field={media_narrator_form[:narrator]}
-                skip_hidden
-                skip_persistent_id
-              >
-                <.new_person_pill row={narrator_form} key={NewPerson.key(media_narrator_form)} />
-              </.inputs_for>
+              <div class="flex items-start gap-2">
+                <.input
+                  field={media_narrator_form[:narrator_id]}
+                  type="autocomplete"
+                  search={&People.search_narrators/2}
+                  fetch={&People.narrator_option/1}
+                  create_name={"#{media_narrator_form.name}[narrator][name]"}
+                  create_value={staged_name(media_narrator_form, :narrator)}
+                  create_flag_name={"#{media_narrator_form.name}[narrator][create]"}
+                  create_flag_value={NewPerson.chosen(media_narrator_form, :narrator)}
+                  container_class="grow"
+                />
+                <%!-- Who this credit means, and a way down to their card. --%>
+                <.inputs_for
+                  :let={narrator_form}
+                  :if={NewPerson.carded?(media_narrator_form, :narrator, [:narrator])}
+                  field={media_narrator_form[:narrator]}
+                  skip_hidden
+                  skip_persistent_id
+                >
+                  <.new_person_pill row={narrator_form} key={NewPerson.key(media_narrator_form)} />
+                </.inputs_for>
 
-              <.move_buttons
-                :if={@media_narrator_count > 1}
-                field={:media_narrators}
-                index={media_narrator_form.index}
-                count={@media_narrator_count}
-              />
-              <.delete_button
-                field={@form[:media_narrators_drop]}
-                index={media_narrator_form.index}
-              />
-            </div>
-          </.inputs_for>
+                <.move_buttons
+                  :if={@media_narrator_count > 1}
+                  field={:media_narrators}
+                  index={media_narrator_form.index}
+                  count={@media_narrator_count}
+                />
+                <.delete_button
+                  field={@form[:media_narrators_drop]}
+                  index={media_narrator_form.index}
+                />
+              </div>
+            </.inputs_for>
 
-          <%!-- The narrators a ticked record names. Two readings of one book
+            <%!-- The narrators a ticked record names. Two readings of one book
               differ by nothing else, so this is the field a record most needs
               to fill; `adds_rows` is what stops a chip crediting the same
               person twice (design language §6). --%>
-          <:proposals>
-            <.proposal_row
-              id="proposals-narrators"
-              field="narrators"
-              event="accept-entity"
-              adds_rows
-              proposals={@chips[:narrators] || []}
-            />
-          </:proposals>
+            <:proposals>
+              <.proposal_row
+                id="proposals-narrators"
+                field="narrators"
+                event="accept-entity"
+                adds_rows
+                proposals={@chips[:narrators] || []}
+              />
+            </:proposals>
 
-          <:add>
-            <.add_button field={@form[:media_narrators_sort]}>Add narrator</.add_button>
-            <.delete_input field={@form[:media_narrators_drop]} />
-          </:add>
-        </.list_cluster>
+            <:add>
+              <.add_button field={@form[:media_narrators_sort]}>Add narrator</.add_button>
+              <.delete_input field={@form[:media_narrators_drop]} />
+            </:add>
+          </.list_cluster>
 
-        <%!-- The humans these credits are about to invent, in the import
+          <%!-- The humans these credits are about to invent, in the import
             form's own section — under the credits that name them, because
             that is where they came from, and separate from them, because
             "what is this person called, and what do they look like" is a
             different question from "who read this book". The book form's
             twin, one join shallower. --%>
-        <.form_section
-          :if={NewPerson.any?(@form.source, :media_narrators, :narrator, [:narrator])}
-          id="new-people"
-          title="New people"
-        >
-          <.inputs_for
-            :let={media_narrator_form}
-            field={@form[:media_narrators]}
-            skip_hidden
-            skip_persistent_id
+          <.form_section
+            :if={NewPerson.any?(@form.source, :media_narrators, :narrator, [:narrator])}
+            id="new-people"
+            title="New people"
           >
             <.inputs_for
-              :let={narrator_form}
-              :if={NewPerson.carded?(media_narrator_form, :narrator, [:narrator])}
-              field={media_narrator_form[:narrator]}
+              :let={media_narrator_form}
+              field={@form[:media_narrators]}
+              skip_hidden
+              skip_persistent_id
             >
-              <.new_person_card
-                row={narrator_form}
-                key={NewPerson.key(media_narrator_form)}
-                state={NewPerson.state(@new_people, NewPerson.key(media_narrator_form))}
-                credited={staged_name(media_narrator_form, :narrator)}
-                kind={:narrator}
-              />
+              <.inputs_for
+                :let={narrator_form}
+                :if={NewPerson.carded?(media_narrator_form, :narrator, [:narrator])}
+                field={media_narrator_form[:narrator]}
+              >
+                <.new_person_card
+                  row={narrator_form}
+                  key={NewPerson.key(media_narrator_form)}
+                  state={NewPerson.state(@new_people, NewPerson.key(media_narrator_form))}
+                  credited={staged_name(media_narrator_form, :narrator)}
+                  kind={:narrator}
+                />
+              </.inputs_for>
             </.inputs_for>
-          </.inputs_for>
-        </.form_section>
+          </.form_section>
 
-        <%!-- the mirror of the book form's series rows, singular: a recording
+          <%!-- the mirror of the book form's series rows, singular: a recording
           is in at most one group, and a group belongs to this book — the
           list follows the chosen book. Like an empty series list, an
           ungrouped recording says so and offers one add; unlike series, the
           add disappears once the (single) row is showing. The group's own
           facts — name, total, wording — are edited on its page under
           Groups. --%>
-        <div class="space-y-2">
-          <.field_group label="Part of a set">
-            <p :if={!@group_row_visible} class="pl-3 text-sm text-zinc-400">
-              Not part of a set.
-            </p>
+          <div class="space-y-2">
+            <.field_group label="Part of a set">
+              <p :if={!@group_row_visible} class="pl-3 text-sm text-zinc-400">
+                Not part of a set.
+              </p>
 
-            <%!-- The removal has to be *stated*, not merely stopped being
+              <%!-- The removal has to be *stated*, not merely stopped being
                 mentioned. Hiding the row took its two inputs out of the DOM,
                 so the submit posted neither key and `cast` changes only what
                 it is handed — the picker vanished, Save reported success, and
                 the recording came back still in its set. --%>
-            <.input :if={!@group_row_visible} type="hidden" field={@form[:recording_group_id]} />
-            <.input :if={!@group_row_visible} type="hidden" field={@form[:part_number]} />
+              <.input :if={!@group_row_visible} type="hidden" field={@form[:recording_group_id]} />
+              <.input :if={!@group_row_visible} type="hidden" field={@form[:part_number]} />
 
-            <div :if={@group_row_visible} class="flex items-start gap-2">
-              <.input field={@form[:part_number]} placeholder="no." container_class="w-14 flex-none" />
-              <%!-- A book has one set, or none, or occasionally two. That is a
+              <div :if={@group_row_visible} class="flex items-start gap-2">
+                <.input field={@form[:part_number]} placeholder="no." container_class="w-14 flex-none" />
+                <%!-- A book has one set, or none, or occasionally two. That is a
                   drop-down — and where the book has none there is nothing to
                   drop down to, so the only thing on offer is naming one. The
                   import form settled this shape: a typeahead here searched
                   for sets belonging to a book that usually has none. --%>
-              <.input
-                :if={@recording_group_options != []}
-                field={@form[:recording_group_id]}
-                type="dropdown"
-                options={@recording_group_options ++ [new_set_option()]}
-                container_class="grow"
-              />
+                <.input
+                  :if={@recording_group_options != []}
+                  field={@form[:recording_group_id]}
+                  type="dropdown"
+                  options={@recording_group_options ++ [new_set_option()]}
+                  container_class="grow"
+                />
 
-              <%!-- Naming a set this book doesn't have yet. The row belongs
+                <%!-- Naming a set this book doesn't have yet. The row belongs
                   to the recording, so the set is created by the save that
                   puts the recording in it, and the book is the recording's
                   own — never asked for, never postable. --%>
-              <.inputs_for :let={group_form} field={@form[:recording_group]}>
-                <div class="flex grow items-start gap-2">
-                  <.input field={group_form[:name]} placeholder="set name" container_class="grow" />
-                  <.input
-                    field={group_form[:parts_total]}
-                    type="number"
-                    min="1"
-                    placeholder="of"
-                    container_class="w-16 flex-none"
-                  />
-                </div>
-              </.inputs_for>
-              <%!-- Hand-rolled because taking this audiobook out of its set is
+                <.inputs_for :let={group_form} field={@form[:recording_group]}>
+                  <div class="flex grow items-start gap-2">
+                    <.input field={group_form[:name]} placeholder="set name" container_class="grow" />
+                    <.input
+                      field={group_form[:parts_total]}
+                      type="number"
+                      min="1"
+                      placeholder="of"
+                      container_class="w-16 flex-none"
+                    />
+                  </div>
+                </.inputs_for>
+                <%!-- Hand-rolled because taking this audiobook out of its set is
                   an event, not a drop input, so it has to say so. It wears
                   `.delete_button`'s box all the same — one input tall, glyph
                   centred, beside the field rather than inside it. --%>
-              <button
-                type="button"
-                phx-click="remove-group-row"
-                class="flex h-10 flex-none items-center"
-                title="Not part of a set"
-              >
-                <.icon
-                  name="fa-xmark"
-                  class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-400"
-                />
-              </button>
-            </div>
-          </.field_group>
+                <button
+                  type="button"
+                  phx-click="remove-group-row"
+                  class="flex h-10 flex-none items-center"
+                  title="Not part of a set"
+                >
+                  <.icon
+                    name="fa-xmark"
+                    class="h-4 w-4 cursor-pointer text-current transition-colors hover:text-red-400"
+                  />
+                </button>
+              </div>
+            </.field_group>
 
-          <.add_button :if={!@group_row_visible} phx-click="add-group-row">
-            This audiobook is part of a set
-          </.add_button>
-        </div>
+            <.add_button :if={!@group_row_visible} phx-click="add-group-row">
+              This audiobook is part of a set
+            </.add_button>
+          </div>
 
-        <.input type="hidden" field={@form[:image_type]} />
-        <.input type="hidden" field={@form[:image_path]} />
+          <.input type="hidden" field={@form[:image_type]} />
+          <.input type="hidden" field={@form[:image_path]} />
 
-        <%= if @form[:image_path].value && @form[:image_path].value != "" do %>
-          <.field_group>
-            <div class="flex items-baseline gap-2 pl-3">
-              <.label class="flex items-center gap-2">
-                Image <.image_delete_button field={@form[:image_path]} />
-              </.label>
-              <.provenance_flag record={@media} field={:image_path} hints={@provenance_hints} />
-            </div>
-            <%!-- One cover, on the text rail (an image is content, §3) — the
+          <%= if @form[:image_path].value && @form[:image_path].value != "" do %>
+            <.field_group>
+              <div class="flex items-baseline gap-2 pl-3">
+                <.label class="flex items-center gap-2">
+                  Image <.image_delete_button field={@form[:image_path]} />
+                </.label>
+                <.provenance_flag record={@media} field={:image_path} hints={@provenance_hints} />
+              </div>
+              <%!-- One cover, on the text rail (an image is content, §3) — the
                 five-variant parade said nothing the operator could act on.
                 Whether the derived sizes exist is one fact, so it's one line. --%>
-            <%!-- The derived size inline, the original behind the magnifier.
+              <%!-- The derived size inline, the original behind the magnifier.
                 Rendering the original was showing whatever the publisher
                 embedded, at whatever size and in whatever format they used —
                 and one Martian import put 753KB of TIFF in a file named
@@ -313,212 +327,213 @@
                 lie. `extract_embedded/1` no longer produces that file, and
                 showing the derived image means the form survives the next
                 thing a publisher embeds either way. --%>
-            <div class="pl-3">
-              <.image_with_size
-                id={"image-#{@media.id}"}
-                src={preview_src(@media, @form[:image_path].value)}
-                full={@form[:image_path].value}
-                class="w-48 rounded-sm"
+              <div class="pl-3">
+                <.image_with_size
+                  id={"image-#{@media.id}"}
+                  src={preview_src(@media, @form[:image_path].value)}
+                  full={@form[:image_path].value}
+                  class="w-48 rounded-sm"
+                />
+              </div>
+              <p class="flex items-center gap-1.5 pl-3 text-xs text-zinc-400">
+                <%= if @media.thumbnails do %>
+                  <.icon name="fa-check" class="text-brand-dark h-3 w-3" /> thumbnails generated in all
+                  five sizes
+                <% else %>
+                  <.icon name="fa-triangle-exclamation" class="h-3 w-3 text-amber-300" /> thumbnails not generated yet
+                <% end %>
+              </p>
+              <.proposal_row
+                id="proposals-image"
+                field="image"
+                proposals={@chips[:image] || []}
+                revert={@reverts[:image]}
               />
-            </div>
-            <p class="flex items-center gap-1.5 pl-3 text-xs text-zinc-400">
-              <%= if @media.thumbnails do %>
-                <.icon name="fa-check" class="text-brand-dark h-3 w-3" /> thumbnails generated in all
-                five sizes
-              <% else %>
-                <.icon name="fa-triangle-exclamation" class="h-3 w-3 text-amber-300" /> thumbnails not generated yet
-              <% end %>
-            </p>
-            <.proposal_row
-              id="proposals-image"
-              field="image"
-              proposals={@chips[:image] || []}
-              revert={@reverts[:image]}
-            />
-          </.field_group>
-        <% else %>
-          <.field_group>
-            <.tabs
-              field={@form[:image_type]}
-              options={[
-                {"Upload file", "upload"},
-                {"Import image from URL", "url_import"}
-              ]}
-            >
-              <.label class="pl-3">Image</.label>
-            </.tabs>
+            </.field_group>
+          <% else %>
+            <.field_group>
+              <.tabs
+                field={@form[:image_type]}
+                options={[
+                  {"Upload file", "upload"},
+                  {"Import image from URL", "url_import"}
+                ]}
+              >
+                <.label class="pl-3">Image</.label>
+              </.tabs>
 
-            <.file_input
-              :if={@form[:image_type].value == "upload"}
-              upload={@uploads.image}
-              on_cancel="cancel-upload"
-              image_preview_class="h-48 w-48 rounded-sm"
-            />
+              <.file_input
+                :if={@form[:image_type].value == "upload"}
+                upload={@uploads.image}
+                on_cancel="cancel-upload"
+                image_preview_class="h-48 w-48 rounded-sm"
+              />
 
-            <.image_import_input
-              :if={@form[:image_type].value == "url_import"}
-              field={@form[:image_import_url]}
-              image_preview_class="h-48 w-48 rounded-sm"
-            />
+              <.image_import_input
+                :if={@form[:image_type].value == "url_import"}
+                field={@form[:image_import_url]}
+                image_preview_class="h-48 w-48 rounded-sm"
+              />
 
-            <%!-- Neither tab is the answer here: the art is a stream inside
+              <%!-- Neither tab is the answer here: the art is a stream inside
                 the audio file, and it is taken out when the form saves. The
                 picture is the whole point of the choice, so it shows. --%>
-            <div :if={@form[:image_type].value == "embedded"} class="space-y-2 pl-3">
-              <.image_with_size
-                id={"embedded-cover-#{@media.id}"}
-                src={~p"/admin/audiobooks/#{@media}/embedded-cover"}
-                class="h-48 w-48 rounded-sm object-cover"
-              />
-              <p class="text-sm text-zinc-400">Taken from the file when you save.</p>
-            </div>
+              <div :if={@form[:image_type].value == "embedded"} class="space-y-2 pl-3">
+                <.image_with_size
+                  id={"embedded-cover-#{@media.id}"}
+                  src={~p"/admin/audiobooks/#{@media}/embedded-cover"}
+                  class="h-48 w-48 rounded-sm object-cover"
+                />
+                <p class="text-sm text-zinc-400">Taken from the file when you save.</p>
+              </div>
 
-            <.proposal_row
-              id="proposals-image"
-              field="image"
-              proposals={@chips[:image] || []}
-              revert={@reverts[:image]}
+              <.proposal_row
+                id="proposals-image"
+                field="image"
+                proposals={@chips[:image] || []}
+                revert={@reverts[:image]}
+              />
+            </.field_group>
+          <% end %>
+
+          <.field_group>
+            <.input
+              field={@form[:notes]}
+              label="Notes"
+              type="textarea"
+              phx-hook="maintain-attrs"
+              data-attrs="style"
+              class="!min-h-24"
             />
           </.field_group>
-        <% end %>
+        </.form_section>
 
-        <.field_group>
-          <.input
-            field={@form[:notes]}
-            label="Notes"
-            type="textarea"
-            phx-hook="maintain-attrs"
-            data-attrs="style"
-            class="!min-h-24"
-          />
-        </.field_group>
-      </.form_section>
-
-      <%!-- Markers are file-derived facts, titles are decisions — the 1h
+        <%!-- Markers are file-derived facts, titles are decisions — the 1h
           split, in one card. A ticked record with an ASIN grows a title
           chip; the fetched titles render into the rows as a proposed
           column, and nothing lands until Take. --%>
-      <.form_section :if={@live_action == :edit} title="Chapters" id="chapters">
-        <.marker_source_input form={@form} />
+        <.form_section :if={@live_action == :edit} title="Chapters" id="chapters">
+          <.marker_source_input form={@form} />
 
-        <.chapter_rows form={@form} pending={@chapter_import}>
-          <:flag>
-            <.provenance_flag record={@media} field={:chapters} hints={@provenance_hints} />
-          </:flag>
-          <:proposals>
-            <.chapter_title_chips
-              id="chapter-title-chips"
-              chips={title_chips(Evidence.used_records(@evidence), @chapters_applied_asin)}
-              file={@file_chapters}
-            />
-          </:proposals>
-        </.chapter_rows>
-      </.form_section>
+          <.chapter_rows form={@form} pending={@chapter_import}>
+            <:flag>
+              <.provenance_flag record={@media} field={:chapters} hints={@provenance_hints} />
+            </:flag>
+            <:proposals>
+              <.chapter_title_chips
+                id="chapter-title-chips"
+                chips={title_chips(Evidence.used_records(@evidence), @chapters_applied_asin)}
+                file={@file_chapters}
+              />
+            </:proposals>
+          </.chapter_rows>
+        </.form_section>
 
-      <%!-- What the bytes are — a different question from what the recording
+        <%!-- What the bytes are — a different question from what the recording
           IS. Nothing here is editable any more: the files arrive through the
           inbox and this says what they are. --%>
-      <.form_section title="Audio" id="audio">
-        <%!-- The files this recording is served from, which is its tracks.
+        <.form_section title="Audio" id="audio">
+          <%!-- The files this recording is served from, which is its tracks.
             A fact display, not a dropzone: nothing here accepts a file, and
             dressing it as though it might would promise what it can't
             deliver. Absent for a transcoded recording, whose audio is the
             packaged trio in the fold below. --%>
-        <.file_list files={@audio_files} label="Files" />
+          <.file_list files={@audio_files} label="Files" />
 
-        <%!-- Transcoded recordings only, and assigned nil otherwise: an
+          <%!-- Transcoded recordings only, and assigned nil otherwise: an
             imported recording has no packaged artifacts and no transcode
             sources, so there is nothing here for it to fold away. --%>
-        <.field_group :if={@file_stats}>
-          <%!-- The one fold costume (§3): summary on the rail, chevron
+          <.field_group :if={@file_stats}>
+            <%!-- The one fold costume (§3): summary on the rail, chevron
               hanging in the gutter — not a lime "show" link, which wore the
               semantic accent for a purely structural action. --%>
-          <.disclosure summary="Streaming files" class="pl-3 text-sm font-semibold text-zinc-200">
-            <div class="bg-zinc-800/60 mt-2 space-y-2 rounded-md p-3">
-              <.file_stat_row label="mp4" file={@file_stats.mp4_file} />
-              <.file_stat_row label="mpd" file={@file_stats.mpd_file} />
-              <.file_stat_row label="hls" file={@file_stats.hls_master} />
-              <.file_stat_row label="hls_0" file={@file_stats.hls_playlist} />
+            <.disclosure summary="Streaming files" class="pl-3 text-sm font-semibold text-zinc-200">
+              <div class="bg-zinc-800/60 mt-2 space-y-2 rounded-md p-3">
+                <.file_stat_row label="mp4" file={@file_stats.mp4_file} />
+                <.file_stat_row label="mpd" file={@file_stats.mpd_file} />
+                <.file_stat_row label="hls" file={@file_stats.hls_master} />
+                <.file_stat_row label="hls_0" file={@file_stats.hls_playlist} />
 
-              <.disclosure summary="Source files" container_class="pt-1">
-                <div class="space-y-2 pt-2">
-                  <%= case @file_stats.source_files do %>
-                    <% error when is_atom(error) -> %>
-                      <.file_stat_row
-                        label="source"
-                        file={%{path: @media.source_path, stat: error}}
-                        error_type={:warn}
-                      />
-                    <% source_files when is_list(source_files) -> %>
-                      <.file_stat_row
-                        :if={source_files == []}
-                        label="source"
-                        file={%{path: @media.source_path, stat: :empty}}
-                        error_type={:warn}
-                      />
-                      <.file_stat_row
-                        :for={source_file <- source_files}
-                        label="source"
-                        file={source_file}
-                        error_type={:warn}
-                      />
-                  <% end %>
-                </div>
-              </.disclosure>
-            </div>
-          </.disclosure>
-        </.field_group>
+                <.disclosure summary="Source files" container_class="pt-1">
+                  <div class="space-y-2 pt-2">
+                    <%= case @file_stats.source_files do %>
+                      <% error when is_atom(error) -> %>
+                        <.file_stat_row
+                          label="source"
+                          file={%{path: @media.source_path, stat: error}}
+                          error_type={:warn}
+                        />
+                      <% source_files when is_list(source_files) -> %>
+                        <.file_stat_row
+                          :if={source_files == []}
+                          label="source"
+                          file={%{path: @media.source_path, stat: :empty}}
+                          error_type={:warn}
+                        />
+                        <.file_stat_row
+                          :for={source_file <- source_files}
+                          label="source"
+                          file={source_file}
+                          error_type={:warn}
+                        />
+                    <% end %>
+                  </div>
+                </.disclosure>
+              </div>
+            </.disclosure>
+          </.field_group>
 
-        <%!-- The one list on this form that wasn't a card: a bare upload
+          <%!-- The one list on this form that wasn't a card: a bare upload
             control on the ground, and a card below it that existed only
             once there was something in it — so the section had no name
             until it had contents. `list_cluster`'s grammar instead (§3b),
             with the dropzone as the add. --%>
-        <.list_cluster label="Supplemental files">
-          <p
-            :if={@live_action != :edit || @form[:supplemental_files].value == []}
-            class="pl-3 text-sm text-zinc-400"
-          >
-            No supplemental files.
-          </p>
+          <.list_cluster label="Supplemental files">
+            <p
+              :if={@live_action != :edit || @form[:supplemental_files].value == []}
+              class="pl-3 text-sm text-zinc-400"
+            >
+              No supplemental files.
+            </p>
 
-          <.inputs_for
-            :let={supplemental_file_form}
-            :if={@live_action == :edit}
-            field={@form[:supplemental_files]}
-          >
-            <.sort_input field={@form[:supplemental_files_sort]} index={supplemental_file_form.index} />
-            <.input field={supplemental_file_form[:id]} type="hidden" />
+            <.inputs_for
+              :let={supplemental_file_form}
+              :if={@live_action == :edit}
+              field={@form[:supplemental_files]}
+            >
+              <.sort_input field={@form[:supplemental_files_sort]} index={supplemental_file_form.index} />
+              <.input field={supplemental_file_form[:id]} type="hidden" />
 
-            <div class="flex items-center gap-2">
-              <.label for={supplemental_file_form[:label].name} class="pl-3">Label</.label>
-              <.input field={supplemental_file_form[:label]} placeholder="Label" container_class="grow" />
-              <.label for={supplemental_file_form[:filename].name} class="pl-3">Filename</.label>
-              <.input field={supplemental_file_form[:filename]} placeholder="filename.ext" container_class="grow" />
-              <.delete_button
-                field={@form[:supplemental_files_drop]}
-                index={supplemental_file_form.index}
-              />
-            </div>
-          </.inputs_for>
+              <div class="flex items-center gap-2">
+                <.label for={supplemental_file_form[:label].name} class="pl-3">Label</.label>
+                <.input field={supplemental_file_form[:label]} placeholder="Label" container_class="grow" />
+                <.label for={supplemental_file_form[:filename].name} class="pl-3">Filename</.label>
+                <.input field={supplemental_file_form[:filename]} placeholder="filename.ext" container_class="grow" />
+                <.delete_button
+                  field={@form[:supplemental_files_drop]}
+                  index={supplemental_file_form.index}
+                />
+              </div>
+            </.inputs_for>
 
-          <.delete_input field={@form[:supplemental_files_drop]} />
+            <.delete_input field={@form[:supplemental_files_drop]} />
 
-          <%!-- Inside the card, not under it. A dropzone is not an add-button
+            <%!-- Inside the card, not under it. A dropzone is not an add-button
               — it is a control the block owns, the way the cover and the
               person photo own theirs — and this was the only file input in
               the admin standing outside the thing it belongs to. --%>
-          <.file_input
-            upload={@uploads.supplemental}
-            on_cancel="cancel-supplemental-upload"
-            image_preview_class="h-12 w-12 rounded-md object-cover"
-          />
-        </.list_cluster>
-      </.form_section>
+            <.file_input
+              upload={@uploads.supplemental}
+              on_cancel="cancel-supplemental-upload"
+              image_preview_class="h-12 w-12 rounded-md object-cover"
+            />
+          </.list_cluster>
+        </.form_section>
 
-      <.form_footer>
-        <.button>Save</.button>
-      </.form_footer>
-    </.simple_form>
+        <.form_footer>
+          <.button>Save</.button>
+        </.form_footer>
+      </.simple_form>
+    </div>
   </div>
 </.layout>

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -13,7 +13,7 @@
     <.busy_overlay
       busy={@evidence.running?}
       label="Asking the databases…"
-      class="sticky top-0 z-40 h-screen"
+      scope={:form}
     />
 
     <div class="-mb-4 max-w-4xl space-y-7" inert={@evidence.running?}>
@@ -264,32 +264,36 @@
                   drop down to, so the only thing on offer is naming one. The
                   import form settled this shape: a typeahead here searched
                   for sets belonging to a book that usually has none. --%>
-                <%!-- The value is stated rather than taken from the field:
-                  "New set" is the absence of an id, and `cast` turns the
-                  empty string it posts into nil — so the trigger matched no
-                  option and went blank on the one choice that has nothing to
-                  point at. --%>
-                <.input
-                  :if={@recording_group_options != []}
-                  field={@form[:recording_group_id]}
-                  value={(naming_a_set?(@form) && "") || @form[:recording_group_id].value}
-                  type="dropdown"
-                  options={@recording_group_options ++ [new_set_option()]}
-                  container_class="min-w-48 max-w-md grow"
-                />
-
-                <%!-- Naming a set this book doesn't have yet. The row belongs
-                  to the recording, so the set is created by the save that
-                  puts the recording in it, and the book is the recording's
-                  own — never asked for, never postable. --%>
-                <.inputs_for :let={group_form} field={@form[:recording_group]}>
+                <%!-- One box's worth of width between them, the way the
+                  import form shares it: whichever controls are showing split
+                  the same `min-w-48 max-w-md` column, rather than each
+                  claiming one and the row growing when you switch modes. --%>
+                <div class="min-w-48 flex max-w-md grow items-start gap-2">
+                  <%!-- The value is stated rather than taken from the field:
+                    naming a set is the *absence* of an id by the time it is
+                    cast, and a blank value reads as nothing held. --%>
                   <.input
-                    :if={naming_a_set?(@form)}
-                    field={group_form[:name]}
-                    placeholder="set name"
-                    container_class="min-w-48 max-w-md grow"
+                    :if={@recording_group_options != []}
+                    field={@form[:recording_group_id]}
+                    value={set_choice(@form)}
+                    type="dropdown"
+                    options={@recording_group_options ++ [new_set_option()]}
+                    container_class="w-full"
                   />
-                </.inputs_for>
+
+                  <%!-- Naming a set this book doesn't have yet. The row
+                    belongs to the recording, so the set is created by the
+                    save that puts the recording in it, and the book is the
+                    recording's own — never asked for, never postable. --%>
+                  <.inputs_for :let={group_form} field={@form[:recording_group]}>
+                    <.input
+                      :if={naming_a_set?(@form)}
+                      field={group_form[:name]}
+                      placeholder="set name"
+                      container_class="w-full"
+                    />
+                  </.inputs_for>
+                </div>
 
                 <.input field={@form[:part_number]} placeholder="no." container_class="w-16 flex-none" />
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -295,7 +295,10 @@
                   </.inputs_for>
                 </div>
 
-                <.input field={@form[:part_number]} placeholder="no." container_class="w-16 flex-none" />
+                <%!-- `w-20`, not `w-16`: "total" clipped to "tota" in the
+                  narrower box, and two adjacent number boxes of different
+                  widths to fit one placeholder reads as an accident. --%>
+                <.input field={@form[:part_number]} placeholder="no." container_class="w-20 flex-none" />
 
                 <p :if={naming_a_set?(@form)} class="text-sm text-zinc-400">of</p>
 
@@ -306,7 +309,7 @@
                     type="number"
                     min="1"
                     placeholder="total"
-                    container_class="w-16 flex-none"
+                    container_class="w-20 flex-none"
                   />
                 </.inputs_for>
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -1,5 +1,8 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="relative">
+  <%!-- The scrim is the form's width, not the window's: its label centres
+      over what it is covering, and a message floating in the middle of a
+      1920px viewport does not read as belonging to the form beneath it. --%>
+  <div class="relative max-w-4xl">
     <%!-- A fan-out rebuilds the chips under every field it can fill, so a form
         with one running is not the operator's to edit yet — and it says so
         over the whole thing, the way the import form does while matching
@@ -249,19 +252,30 @@
               <.input :if={!@group_row_visible} type="hidden" field={@form[:recording_group_id]} />
               <.input :if={!@group_row_visible} type="hidden" field={@form[:part_number]} />
 
-              <div :if={@group_row_visible} class="flex items-start gap-2">
-                <.input field={@form[:part_number]} placeholder="no." container_class="w-14 flex-none" />
+              <%!-- The import form's row, read in its order: which set, then
+                where in it — "<set> no. 1 of 3". A set's own facts are its
+                own: joining one shows its total, and only a set being named
+                here asks for one, because editing a set from a member's form
+                would edit it for every other member too. Its page under Sets
+                is where that belongs. --%>
+              <div :if={@group_row_visible} class="flex flex-wrap items-center gap-x-3 gap-y-2">
                 <%!-- A book has one set, or none, or occasionally two. That is a
                   drop-down — and where the book has none there is nothing to
                   drop down to, so the only thing on offer is naming one. The
                   import form settled this shape: a typeahead here searched
                   for sets belonging to a book that usually has none. --%>
+                <%!-- The value is stated rather than taken from the field:
+                  "New set" is the absence of an id, and `cast` turns the
+                  empty string it posts into nil — so the trigger matched no
+                  option and went blank on the one choice that has nothing to
+                  point at. --%>
                 <.input
                   :if={@recording_group_options != []}
                   field={@form[:recording_group_id]}
+                  value={(naming_a_set?(@form) && "") || @form[:recording_group_id].value}
                   type="dropdown"
                   options={@recording_group_options ++ [new_set_option()]}
-                  container_class="grow"
+                  container_class="min-w-48 max-w-md grow"
                 />
 
                 <%!-- Naming a set this book doesn't have yet. The row belongs
@@ -269,17 +283,33 @@
                   puts the recording in it, and the book is the recording's
                   own — never asked for, never postable. --%>
                 <.inputs_for :let={group_form} field={@form[:recording_group]}>
-                  <div class="flex grow items-start gap-2">
-                    <.input field={group_form[:name]} placeholder="set name" container_class="grow" />
-                    <.input
-                      field={group_form[:parts_total]}
-                      type="number"
-                      min="1"
-                      placeholder="of"
-                      container_class="w-16 flex-none"
-                    />
-                  </div>
+                  <.input
+                    :if={naming_a_set?(@form)}
+                    field={group_form[:name]}
+                    placeholder="set name"
+                    container_class="min-w-48 max-w-md grow"
+                  />
                 </.inputs_for>
+
+                <.input field={@form[:part_number]} placeholder="no." container_class="w-16 flex-none" />
+
+                <p :if={naming_a_set?(@form)} class="text-sm text-zinc-400">of</p>
+
+                <.inputs_for :let={group_form} field={@form[:recording_group]}>
+                  <.input
+                    :if={naming_a_set?(@form)}
+                    field={group_form[:parts_total]}
+                    type="number"
+                    min="1"
+                    placeholder="total"
+                    container_class="w-16 flex-none"
+                  />
+                </.inputs_for>
+
+                <%!-- Shown, not asked: the set says how many parts it has. --%>
+                <p :if={joined_set_total(assigns)} class="text-sm text-zinc-400">
+                  of {joined_set_total(assigns)}
+                </p>
                 <%!-- Hand-rolled because taking this audiobook out of its set is
                   an event, not a drop input, so it has to say so. It wears
                   `.delete_button`'s box all the same — one input tall, glyph

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -1,195 +1,214 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="-mb-4 max-w-4xl space-y-7">
-    <%!-- Evidence first, then the decisions it feeds — the import form's
-        order. Its search is a form of its own, so it lives outside the
-        person form element. --%>
-    <.evidence_panel
-      evidence={@evidence}
-      level="person"
-      title="Search providers"
-      hint="Tick every record of this person; check the name carefully first. Ticked records offer names, photos and bios below."
-      retrying={@retrying}
+  <div class="relative">
+    <%!-- A fan-out rebuilds the chips under every field it can fill, so a form
+        with one running is not the operator's to edit yet — and it says so
+        over the whole thing, the way the import form does while matching
+        holds an item. `sticky top-0 h-screen` keeps the scrim one viewport
+        tall and the label in view however far down the form the click was;
+        `z-40` clears the sticky footer with the Save in it, and stays under
+        the header. --%>
+    <.busy_overlay
+      busy={@evidence.running?}
+      label="Asking the databases…"
+      class="sticky top-0 z-40 h-screen"
     />
 
-    <.simple_form id="person-form" for={@form} phx-change="validate" phx-submit="submit" autocomplete="off">
-      <.field_group>
-        <.curated_input
-          field={@form[:name]}
-          label="Name"
-          class="max-w-md"
-          record={@person}
-          hints={@provenance_hints}
-          proposals={@chips[:name] || []}
-          revert={@reverts[:name]}
-        />
-      </.field_group>
+    <div class="-mb-4 max-w-4xl space-y-7" inert={@evidence.running?}>
+      <%!-- Evidence first, then the decisions it feeds — the import form's
+        order. Its search is a form of its own, so it lives outside the
+        person form element. --%>
+      <.evidence_panel
+        evidence={@evidence}
+        level="person"
+        title="Search providers"
+        retrying={@retrying}
+      />
 
-      <.field_group>
-        <div class="flex items-baseline gap-2 pl-3">
-          <.label for={@form[:description].id}>Description</.label>
-          <.provenance_flag record={@person} field={:description} hints={@provenance_hints} />
-        </div>
-        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          <.input
-            id="description-input"
-            field={@form[:description]}
-            type="textarea"
-            phx-hook="maintain-attrs"
-            data-attrs="style"
+      <.simple_form
+        id="person-form"
+        for={@form}
+        phx-change="validate"
+        phx-submit="submit"
+        autocomplete="off"
+      >
+        <.field_group>
+          <.curated_input
+            field={@form[:name]}
+            label="Name"
+            class="max-w-md"
+            record={@person}
+            hints={@provenance_hints}
+            proposals={@chips[:name] || []}
+            revert={@reverts[:name]}
           />
-          <div class="relative">
-            <div
-              id="description-preview"
-              phx-hook="scroll-match"
-              data-target="description-input"
-              class="bg-zinc-800/50 absolute inset-0 hidden overflow-auto rounded-sm sm:block"
-            >
-              <.markdown content={@form[:description].value || ""} class="p-2" />
+        </.field_group>
+
+        <.field_group>
+          <div class="flex items-baseline gap-2 pl-3">
+            <.label for={@form[:description].id}>Description</.label>
+            <.provenance_flag record={@person} field={:description} hints={@provenance_hints} />
+          </div>
+          <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <.input
+              id="description-input"
+              field={@form[:description]}
+              type="textarea"
+              phx-hook="maintain-attrs"
+              data-attrs="style"
+            />
+            <div class="relative">
+              <div
+                id="description-preview"
+                phx-hook="scroll-match"
+                data-target="description-input"
+                class="bg-zinc-800/50 absolute inset-0 hidden overflow-auto rounded-sm sm:block"
+              >
+                <.markdown content={@form[:description].value || ""} class="p-2" />
+              </div>
             </div>
           </div>
-        </div>
-        <.proposal_row
-          id="proposals-description"
-          field="description"
-          proposals={@chips[:description] || []}
-          revert={@reverts[:description]}
-        />
-      </.field_group>
+          <.proposal_row
+            id="proposals-description"
+            field="description"
+            proposals={@chips[:description] || []}
+            revert={@reverts[:description]}
+          />
+        </.field_group>
 
-      <%!-- Author and Narrator are credit NAMES, not roles, and the form used
+        <%!-- Author and Narrator are credit NAMES, not roles, and the form used
           to say so out loud: two lists to populate, where having just typed
           "Stephen King" you were asked to add an author and the answer was
           "Stephen King". Two questions instead, answered by a tick, with the
           name stated rather than typed. "Both" is two ticks, not a case. --%>
-      <.field_group label="Credited as">
-        <%!-- Unticking can be refused — `delete_orphaned_authors/2` names the
+        <.field_group label="Credited as">
+          <%!-- Unticking can be refused — `delete_orphaned_authors/2` names the
             book still crediting them — and with the list hidden there was
             nowhere for that to land: the save simply didn't happen and said
             nothing. --%>
-        <.field_errors field={@form[:author_people]} />
-        <.field_errors field={@form[:narrators]} />
+          <.field_errors field={@form[:author_people]} />
+          <.field_errors field={@form[:narrators]} />
 
-        <div class="space-y-4">
-          <%!-- ── writes ─────────────────────────────────────────────── --%>
-          <div class="space-y-2">
-            <%!-- The hatch rides the question it qualifies rather than
+          <div class="space-y-4">
+            <%!-- ── writes ─────────────────────────────────────────────── --%>
+            <div class="space-y-2">
+              <%!-- The hatch rides the question it qualifies rather than
                 sitting on a line of its own underneath: two ticks and two
                 hatches was four lines to ask two questions. Baseline, not
                 centre — the two texts are different sizes (§3). --%>
-            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <button
-                type="button"
-                role="checkbox"
-                aria-checked={to_string(@writes)}
-                phx-click="toggle-credit"
-                phx-value-kind="author"
-                class="flex items-center gap-2 pl-3"
-              >
-                <%!-- The tick is always in the box, hidden rather than
+              <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={to_string(@writes)}
+                  phx-click="toggle-credit"
+                  phx-value-kind="author"
+                  class="flex items-center gap-2 pl-3"
+                >
+                  <%!-- The tick is always in the box, hidden rather than
                     absent. A flex container takes its baseline from its first
                     item, and an *empty* box has no item to take one from — so
                     it synthesized one from its own bottom edge instead, three
                     pixels lower, and the link beside it stepped down every
                     time the box was unticked. --%>
-                <span class={[
-                  "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
-                  (@writes && "bg-brand-dark") || "bg-zinc-800"
-                ]}>
-                  <.icon
-                    name="fa-check"
-                    class={["h-2.5 w-2.5 text-zinc-900", !@writes && "invisible"]}
-                  />
-                </span>
-                <%!-- The label absorbs the "as": revealed, the names below it
+                  <span class={[
+                    "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
+                    (@writes && "bg-brand-dark") || "bg-zinc-800"
+                  ]}>
+                    <.icon
+                      name="fa-check"
+                      class={["h-2.5 w-2.5 text-zinc-900", !@writes && "invisible"]}
+                    />
+                  </span>
+                  <%!-- The label absorbs the "as": revealed, the names below it
                     are what it is credited as, so the line reads into them
                     rather than repeating the person's name beside the box. --%>
-                <span class="text-sm text-zinc-200">
-                  Writes books{if revealed?(assigns, :author), do: " as"}
-                </span>
-              </button>
+                  <span class="text-sm text-zinc-200">
+                    Writes books{if revealed?(assigns, :author), do: " as"}
+                  </span>
+                </button>
 
-              <%!-- Offered whether or not the box is ticked: linking a
+                <%!-- Offered whether or not the box is ticked: linking a
                   shared pen name is how a person becomes an author at all in
                   the composite case, and routing that through "tick, then
                   delete the author it made" is not a route. --%>
-              <button
-                :if={not revealed?(assigns, :author)}
-                type="button"
-                phx-click="reveal-credit"
-                phx-value-kind="author"
-                class="text-xs text-zinc-400 underline"
-              >
-                Writes under a pen name?
-              </button>
-            </div>
+                <button
+                  :if={not revealed?(assigns, :author)}
+                  type="button"
+                  phx-click="reveal-credit"
+                  phx-value-kind="author"
+                  class="text-xs text-zinc-400 underline"
+                >
+                  Writes under a pen name?
+                </button>
+              </div>
 
-            <%!-- Collapsed, the credits still ride along. A card that renders
+              <%!-- Collapsed, the credits still ride along. A card that renders
                 nothing says nothing, and "said nothing" is indistinguishable
                 from "deleted them all" by the time the params arrive — so
                 ticking the box and pressing Save created no author at all.
                 Collapsed also means every credit here is their own name
                 (a pen name or a shared one forces the card open), which is
                 why the name can simply track the box above. --%>
-            <div :if={not revealed?(assigns, :author)} class="hidden">
-              <.inputs_for :let={author_person_form} field={@form[:author_people]}>
-                <input
-                  :if={author_person_form[:id].value}
-                  type="hidden"
-                  name={author_person_form[:id].name}
-                  value={author_person_form[:id].value}
-                />
-                <.inputs_for :let={author_form} field={author_person_form[:author]}>
+              <div :if={not revealed?(assigns, :author)} class="hidden">
+                <.inputs_for :let={author_person_form} field={@form[:author_people]}>
                   <input
-                    :if={author_form[:id].value}
+                    :if={author_person_form[:id].value}
                     type="hidden"
-                    name={author_form[:id].name}
-                    value={author_form[:id].value}
+                    name={author_person_form[:id].name}
+                    value={author_person_form[:id].value}
                   />
-                  <input type="hidden" name={author_form[:name].name} value={@form[:name].value} />
-                </.inputs_for>
-              </.inputs_for>
-            </div>
-            <%!-- Revealed: the names themselves, which is the only state
-                where linking an existing author means anything specific. --%>
-            <div :if={revealed?(assigns, :author)} class="space-y-2 pl-6">
-              <.inputs_for :let={author_person_form} field={@form[:author_people]}>
-                <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
-
-                <%= if linked_author_row?(author_person_form) do %>
-                  <div class="flex items-start gap-2">
-                    <.input type="hidden" field={author_person_form[:author_id]} />
-                    <.input
-                      type="text"
-                      name={"linked-author-#{author_person_form.index}"}
-                      value={linked_author_name(author_person_form[:author_id].value)}
-                      disabled
-                      container_class="grow"
-                    />
-                    <.delete_button
-                      field={@form[:author_people_drop]}
-                      index={author_person_form.index}
-                    />
-                  </div>
-                <% else %>
                   <.inputs_for :let={author_form} field={author_person_form[:author]}>
+                    <input
+                      :if={author_form[:id].value}
+                      type="hidden"
+                      name={author_form[:id].name}
+                      value={author_form[:id].value}
+                    />
+                    <input type="hidden" name={author_form[:name].name} value={@form[:name].value} />
+                  </.inputs_for>
+                </.inputs_for>
+              </div>
+              <%!-- Revealed: the names themselves, which is the only state
+                where linking an existing author means anything specific. --%>
+              <div :if={revealed?(assigns, :author)} class="space-y-2 pl-6">
+                <.inputs_for :let={author_person_form} field={@form[:author_people]}>
+                  <.sort_input field={@form[:author_people_sort]} index={author_person_form.index} />
+
+                  <%= if linked_author_row?(author_person_form) do %>
                     <div class="flex items-start gap-2">
-                      <.input field={author_form[:name]} container_class="grow" />
+                      <.input type="hidden" field={author_person_form[:author_id]} />
+                      <.input
+                        type="text"
+                        name={"linked-author-#{author_person_form.index}"}
+                        value={linked_author_name(author_person_form[:author_id].value)}
+                        disabled
+                        container_class="grow"
+                      />
                       <.delete_button
                         field={@form[:author_people_drop]}
                         index={author_person_form.index}
                       />
                     </div>
-                    <p
-                      :if={shared_with(author_person_form, @person) != []}
-                      class="pl-3 text-xs text-zinc-500"
-                    >
-                      Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
-                    </p>
-                  </.inputs_for>
-                <% end %>
-              </.inputs_for>
+                  <% else %>
+                    <.inputs_for :let={author_form} field={author_person_form[:author]}>
+                      <div class="flex items-start gap-2">
+                        <.input field={author_form[:name]} container_class="grow" />
+                        <.delete_button
+                          field={@form[:author_people_drop]}
+                          index={author_person_form.index}
+                        />
+                      </div>
+                      <p
+                        :if={shared_with(author_person_form, @person) != []}
+                        class="pl-3 text-xs text-zinc-500"
+                      >
+                        Shared pen name with {Enum.join(shared_with(author_person_form, @person), ", ")}
+                      </p>
+                    </.inputs_for>
+                  <% end %>
+                </.inputs_for>
 
-              <%!-- Two ways to add a name, side by side and each saying which
+                <%!-- Two ways to add a name, side by side and each saying which
                   it is. The boxes above are authoritative — this form is
                   where an author's name is *decided*, so typing in one
                   renames the record and nothing about that is a guess. The
@@ -202,195 +221,196 @@
                   wore the "new" badge while quietly renaming, and the two
                   meanings fought over the same hidden inputs on every
                   keystroke. Separate controls, separate promises. --%>
-              <div class="flex flex-wrap items-end gap-x-4 gap-y-2">
-                <div class="flex items-baseline gap-x-4">
-                  <.add_button field={@form[:author_people_sort]}>Add a pen name</.add_button>
-                  <.delete_input field={@form[:author_people_drop]} />
+                <div class="flex flex-wrap items-end gap-x-4 gap-y-2">
+                  <div class="flex items-baseline gap-x-4">
+                    <.add_button field={@form[:author_people_sort]}>Add a pen name</.add_button>
+                    <.delete_input field={@form[:author_people_drop]} />
+                  </div>
+
+                  <.input
+                    field={@form[:link_author_id]}
+                    type="autocomplete"
+                    search={&People.search_authors/2}
+                    fetch={&People.author_option/1}
+                    label="Or link one that already exists"
+                    container_class="min-w-64 grow"
+                  />
                 </div>
 
-                <.input
-                  field={@form[:link_author_id]}
-                  type="autocomplete"
-                  search={&People.search_authors/2}
-                  fetch={&People.author_option/1}
-                  label="Or link one that already exists"
-                  container_class="min-w-64 grow"
-                />
-              </div>
-
-              <div class="flex flex-wrap items-baseline gap-x-4">
-                <%!-- Every way in needs a way out — but only while the data
+                <div class="flex flex-wrap items-baseline gap-x-4">
+                  <%!-- Every way in needs a way out — but only while the data
                     still agrees, or the hatch would hide what it describes. --%>
-                <button
-                  :if={not @author_diverges}
-                  type="button"
-                  phx-click="hide-credit"
-                  phx-value-kind="author"
-                  class="text-xs text-zinc-400 underline"
-                >
-                  No, they write under their own name
-                </button>
+                  <button
+                    :if={not @author_diverges}
+                    type="button"
+                    phx-click="hide-credit"
+                    phx-value-kind="author"
+                    class="text-xs text-zinc-400 underline"
+                  >
+                    No, they write under their own name
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
 
-          <%!-- ── narrates ───────────────────────────────────────────── --%>
-          <%!-- No linking hatch: a Narrator belongs to exactly one Person,
+            <%!-- ── narrates ───────────────────────────────────────────── --%>
+            <%!-- No linking hatch: a Narrator belongs to exactly one Person,
               so there is no shared-narrator case to offer. The asymmetry is
               the model's, and stating it beats faking symmetry. --%>
-          <div class="space-y-2">
-            <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <button
-                type="button"
-                role="checkbox"
-                aria-checked={to_string(@narrates)}
-                phx-click="toggle-credit"
-                phx-value-kind="narrator"
-                class="flex items-center gap-2 pl-3"
-              >
-                <span class={[
-                  "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
-                  (@narrates && "bg-brand-dark") || "bg-zinc-800"
-                ]}>
-                  <.icon
-                    name="fa-check"
-                    class={["h-2.5 w-2.5 text-zinc-900", !@narrates && "invisible"]}
-                  />
-                </span>
-                <span class="text-sm text-zinc-200">
-                  Narrates audiobooks{if revealed?(assigns, :narrator), do: " as"}
-                </span>
-              </button>
-
-              <button
-                :if={not revealed?(assigns, :narrator)}
-                type="button"
-                phx-click="reveal-credit"
-                phx-value-kind="narrator"
-                class="text-xs text-zinc-400 underline"
-              >
-                Narrates under a stage name?
-              </button>
-            </div>
-
-            <div :if={not revealed?(assigns, :narrator)} class="hidden">
-              <.inputs_for :let={narrator_form} field={@form[:narrators]}>
-                <input
-                  :if={narrator_form[:id].value}
-                  type="hidden"
-                  name={narrator_form[:id].name}
-                  value={narrator_form[:id].value}
-                />
-                <input type="hidden" name={narrator_form[:name].name} value={@form[:name].value} />
-              </.inputs_for>
-            </div>
-            <div :if={revealed?(assigns, :narrator)} class="space-y-2 pl-6">
-              <.inputs_for :let={narrator_form} field={@form[:narrators]}>
-                <.sort_input field={@form[:narrators_sort]} index={narrator_form.index} />
-
-                <div class="flex items-start gap-2">
-                  <.input field={narrator_form[:name]} container_class="grow" />
-                  <.delete_button
-                    field={@form[:narrators_drop]}
-                    index={narrator_form.index}
-                  />
-                </div>
-              </.inputs_for>
-
-              <div class="flex flex-wrap items-baseline gap-x-4">
-                <.add_button field={@form[:narrators_sort]}>Add a stage name</.add_button>
-                <.delete_input field={@form[:narrators_drop]} />
+            <div class="space-y-2">
+              <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <button
+                  type="button"
+                  role="checkbox"
+                  aria-checked={to_string(@narrates)}
+                  phx-click="toggle-credit"
+                  phx-value-kind="narrator"
+                  class="flex items-center gap-2 pl-3"
+                >
+                  <span class={[
+                    "flex h-4 w-4 flex-none items-center justify-center rounded-sm",
+                    (@narrates && "bg-brand-dark") || "bg-zinc-800"
+                  ]}>
+                    <.icon
+                      name="fa-check"
+                      class={["h-2.5 w-2.5 text-zinc-900", !@narrates && "invisible"]}
+                    />
+                  </span>
+                  <span class="text-sm text-zinc-200">
+                    Narrates audiobooks{if revealed?(assigns, :narrator), do: " as"}
+                  </span>
+                </button>
 
                 <button
-                  :if={not @narrator_diverges}
+                  :if={not revealed?(assigns, :narrator)}
                   type="button"
-                  phx-click="hide-credit"
+                  phx-click="reveal-credit"
                   phx-value-kind="narrator"
                   class="text-xs text-zinc-400 underline"
                 >
-                  No, they narrate under their own name
+                  Narrates under a stage name?
                 </button>
+              </div>
+
+              <div :if={not revealed?(assigns, :narrator)} class="hidden">
+                <.inputs_for :let={narrator_form} field={@form[:narrators]}>
+                  <input
+                    :if={narrator_form[:id].value}
+                    type="hidden"
+                    name={narrator_form[:id].name}
+                    value={narrator_form[:id].value}
+                  />
+                  <input type="hidden" name={narrator_form[:name].name} value={@form[:name].value} />
+                </.inputs_for>
+              </div>
+              <div :if={revealed?(assigns, :narrator)} class="space-y-2 pl-6">
+                <.inputs_for :let={narrator_form} field={@form[:narrators]}>
+                  <.sort_input field={@form[:narrators_sort]} index={narrator_form.index} />
+
+                  <div class="flex items-start gap-2">
+                    <.input field={narrator_form[:name]} container_class="grow" />
+                    <.delete_button
+                      field={@form[:narrators_drop]}
+                      index={narrator_form.index}
+                    />
+                  </div>
+                </.inputs_for>
+
+                <div class="flex flex-wrap items-baseline gap-x-4">
+                  <.add_button field={@form[:narrators_sort]}>Add a stage name</.add_button>
+                  <.delete_input field={@form[:narrators_drop]} />
+
+                  <button
+                    :if={not @narrator_diverges}
+                    type="button"
+                    phx-click="hide-credit"
+                    phx-value-kind="narrator"
+                    class="text-xs text-zinc-400 underline"
+                  >
+                    No, they narrate under their own name
+                  </button>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </.field_group>
+        </.field_group>
 
-      <.input type="hidden" field={@form[:image_type]} />
-      <.input type="hidden" field={@form[:image_path]} />
+        <.input type="hidden" field={@form[:image_type]} />
+        <.input type="hidden" field={@form[:image_path]} />
 
-      <%= if @form[:image_path].value && @form[:image_path].value != "" do %>
-        <.field_group>
-          <div class="flex items-baseline gap-2 pl-3">
-            <.label class="flex items-center gap-2">
-              Image <.image_delete_button field={@form[:image_path]} />
-            </.label>
-            <.provenance_flag record={@person} field={:image_path} hints={@provenance_hints} />
-          </div>
-          <%!-- One photo, on the text rail (an image is content, §3) — the
+        <%= if @form[:image_path].value && @form[:image_path].value != "" do %>
+          <.field_group>
+            <div class="flex items-baseline gap-2 pl-3">
+              <.label class="flex items-center gap-2">
+                Image <.image_delete_button field={@form[:image_path]} />
+              </.label>
+              <.provenance_flag record={@person} field={:image_path} hints={@provenance_hints} />
+            </div>
+            <%!-- One photo, on the text rail (an image is content, §3) — the
               five-variant parade said nothing the operator could act on. --%>
-          <div class="pl-3">
-            <.image_with_size
-              id={"image-#{@person.id}"}
-              src={@form[:image_path].value}
-              class="h-40 w-40 rounded-full object-cover object-top"
+            <div class="pl-3">
+              <.image_with_size
+                id={"image-#{@person.id}"}
+                src={@form[:image_path].value}
+                class="h-40 w-40 rounded-full object-cover object-top"
+              />
+            </div>
+            <p class="flex items-center gap-1.5 pl-3 text-xs text-zinc-400">
+              <%= if @person.thumbnails do %>
+                <.icon name="fa-check" class="text-brand-dark h-3 w-3" /> thumbnails generated in all five sizes
+              <% else %>
+                <.icon name="fa-triangle-exclamation" class="h-3 w-3 text-amber-300" /> thumbnails not generated yet
+              <% end %>
+            </p>
+            <.proposal_row
+              id="proposals-image"
+              field="image"
+              proposals={@chips[:image] || []}
+              revert={@reverts[:image]}
             />
-          </div>
-          <p class="flex items-center gap-1.5 pl-3 text-xs text-zinc-400">
-            <%= if @person.thumbnails do %>
-              <.icon name="fa-check" class="text-brand-dark h-3 w-3" /> thumbnails generated in all five sizes
-            <% else %>
-              <.icon name="fa-triangle-exclamation" class="h-3 w-3 text-amber-300" /> thumbnails not generated yet
-            <% end %>
-          </p>
-          <.proposal_row
-            id="proposals-image"
-            field="image"
-            proposals={@chips[:image] || []}
-            revert={@reverts[:image]}
-          />
-        </.field_group>
-      <% else %>
-        <.field_group>
-          <div class="flex items-baseline gap-2">
-            <.tabs
-              field={@form[:image_type]}
-              options={[
-                {"Upload file", "upload"},
-                {"Import image from URL", "url_import"}
-              ]}
-            >
-              <.label class="pl-3">Image</.label>
-            </.tabs>
-            <.provenance_flag record={@person} field={:image_path} hints={@provenance_hints} />
-          </div>
+          </.field_group>
+        <% else %>
+          <.field_group>
+            <div class="flex items-baseline gap-2">
+              <.tabs
+                field={@form[:image_type]}
+                options={[
+                  {"Upload file", "upload"},
+                  {"Import image from URL", "url_import"}
+                ]}
+              >
+                <.label class="pl-3">Image</.label>
+              </.tabs>
+              <.provenance_flag record={@person} field={:image_path} hints={@provenance_hints} />
+            </div>
 
-          <.file_input
-            :if={@form[:image_type].value == "upload"}
-            upload={@uploads.image}
-            on_cancel="cancel-upload"
-            paste_upload
-            image_preview_class="h-40 w-40 rounded-full object-cover object-top"
-          />
+            <.file_input
+              :if={@form[:image_type].value == "upload"}
+              upload={@uploads.image}
+              on_cancel="cancel-upload"
+              paste_upload
+              image_preview_class="h-40 w-40 rounded-full object-cover object-top"
+            />
 
-          <.image_import_input
-            :if={@form[:image_type].value == "url_import"}
-            field={@form[:image_import_url]}
-            image_preview_class="h-40 w-40 rounded-full object-cover object-top"
-          />
+            <.image_import_input
+              :if={@form[:image_type].value == "url_import"}
+              field={@form[:image_import_url]}
+              image_preview_class="h-40 w-40 rounded-full object-cover object-top"
+            />
 
-          <.proposal_row
-            id="proposals-image"
-            field="image"
-            proposals={@chips[:image] || []}
-            revert={@reverts[:image]}
-          />
-        </.field_group>
-      <% end %>
+            <.proposal_row
+              id="proposals-image"
+              field="image"
+              proposals={@chips[:image] || []}
+              revert={@reverts[:image]}
+            />
+          </.field_group>
+        <% end %>
 
-      <.form_footer>
-        <.button>Save</.button>
-      </.form_footer>
-    </.simple_form>
+        <.form_footer>
+          <.button>Save</.button>
+        </.form_footer>
+      </.simple_form>
+    </div>
   </div>
 </.layout>

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -1,5 +1,8 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="relative">
+  <%!-- The scrim is the form's width, not the window's: its label centres
+      over what it is covering, and a message floating in the middle of a
+      1920px viewport does not read as belonging to the form beneath it. --%>
+  <div class="relative max-w-4xl">
     <%!-- A fan-out rebuilds the chips under every field it can fill, so a form
         with one running is not the operator's to edit yet — and it says so
         over the whole thing, the way the import form does while matching

--- a/lib/ambry_web/live/admin/person_live/form.html.heex
+++ b/lib/ambry_web/live/admin/person_live/form.html.heex
@@ -13,7 +13,7 @@
     <.busy_overlay
       busy={@evidence.running?}
       label="Asking the databases…"
-      class="sticky top-0 z-40 h-screen"
+      scope={:form}
     />
 
     <div class="-mb-4 max-w-4xl space-y-7" inert={@evidence.running?}>

--- a/test/ambry_web/live/admin/media_live/evidence_test.exs
+++ b/test/ambry_web/live/admin/media_live/evidence_test.exs
@@ -101,6 +101,91 @@ defmodule AmbryWeb.Admin.MediaLive.EvidenceTest do
     end
   end
 
+  # One button was two operations: reading the recording's own files takes
+  # milliseconds and always has something to say, while asking every provider
+  # takes seconds and often has nothing. Working down the back catalogue
+  # asking "would the embedded cover be an improvement?" paid for the second
+  # to get the first.
+  # The last surface in the admin still saying "busy" by relabelling its own
+  # button while leaving everything editable.
+  test "a search covers the panel and freezes the form", %{conn: conn} do
+    media = martian()
+    test = self()
+
+    # The recording level asks twice — Audible directly, then the work-level
+    # databases for their editions — so only the first call is held open.
+    patch(Ambry.Metadata.Search, :books, fn _query, opts ->
+      if Keyword.fetch!(opts, :level) == :recording do
+        send(test, {:searching, self()})
+        receive do: (:go -> {[], []})
+      else
+        {[], []}
+      end
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    view
+    |> form("#research-recording", %{"title" => "The Martian", "author" => "Andy Weir"})
+    |> render_submit()
+
+    assert_receive {:searching, searcher}
+
+    html = render(view)
+    assert html =~ ~s{data-role="busy-overlay"}
+    assert html =~ "Asking the databases…"
+
+    # over the whole form, the way the import form does while matching holds
+    # an item — a fan-out rebuilds the chips under every field it can fill
+    assert [_frozen] =
+             html
+             |> Floki.parse_document!()
+             |> Floki.find(~s{[inert] form#media-form})
+
+    send(searcher, :go)
+    render_async(view, 2000)
+  end
+
+  describe "reading the files without searching" do
+    test "offers the file's chips, and asks no provider", %{conn: conn} do
+      media = tagged_media(cover_art: true)
+
+      patch(Ambry.Metadata.Search, :books, fn _query, _opts ->
+        flunk("a files-only read must not ask the providers")
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+      render_click(view, "scan-files", %{})
+      html = render_async(view)
+
+      assert html =~ "the file&#39;s tags"
+    end
+
+    # Pressed on purpose, so it re-reads: a control that quietly does nothing
+    # the second time is worse than the round trip it saves.
+    test "reads again when pressed again", %{conn: conn} do
+      media = tagged_media(cover_art: true)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+      render_click(view, "scan-files", %{})
+      render_async(view)
+
+      render_click(view, "scan-files", %{})
+      assert render_async(view) =~ "the file&#39;s tags"
+    end
+
+    # The other two panels have no files to read.
+    test "is not offered where there are no files", %{conn: conn} do
+      book = insert(:book)
+
+      {:ok, _view, html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+      refute html =~ "Read files only"
+    end
+  end
+
   describe "accepting a cover proposal" do
     # The chip marked itself chosen and wrote a provenance hint, and then the
     # save posted nothing: the URL input that carries the choice is only
@@ -193,7 +278,7 @@ defmodule AmbryWeb.Admin.MediaLive.EvidenceTest do
       html = search(view, %{"title" => "The Martian", "author" => "Andy Weir"})
 
       # the provider's record, and only the provider's
-      assert html =~ "1 records, 0 ticked"
+      assert [_one] = html |> Floki.parse_document!() |> Floki.find(~s{[data-role="record"]})
       refute has_element?(view, ~s{[data-role="record"]}, "the file's tags")
     end
 
@@ -336,6 +421,39 @@ defmodule AmbryWeb.Admin.MediaLive.EvidenceTest do
       assert ["image/" <> _type] = Plug.Conn.get_resp_header(conn, "content-type")
     end
 
+    # The fixture above is a *transcoded* recording, which is the only shape
+    # that ever had `source_files` — so the preview looked fine in tests and
+    # was a broken image for every recording the inbox imported, which is all
+    # of them now. `Media.files/2` reads the transcode columns; the tracks are
+    # where an imported recording's files are, and `Scanner.audio_files/1`
+    # asks them first.
+    test "preview it for an imported recording, whose files are its tracks",
+         %{conn: conn} do
+      media = imported_media(cover_art: true)
+
+      assert media.source_files == []
+      assert media.media_tracks != []
+
+      conn = get(conn, ~p"/admin/audiobooks/#{media}/embedded-cover")
+
+      assert conn.status == 200
+      assert ["image/" <> _type] = Plug.Conn.get_resp_header(conn, "content-type")
+    end
+
+    # The preview was the visible half. Accepting the chip read the same empty
+    # list and refused the save with "Failed to import image".
+    test "accepting it on an imported recording saves the art", %{conn: conn} do
+      media = imported_media(cover_art: true)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+      view
+      |> form("#media-form")
+      |> render_submit(%{"media" => %{"image_type" => "embedded", "image_path" => ""}})
+
+      assert %{image_path: "/uploads/images/" <> _rest} = Media.get_media!(media.id)
+    end
+
     # A recording whose files are gone says nothing about itself, and the
     # search still has to answer.
     test "are skipped when the file can't be read", %{conn: conn} do
@@ -346,7 +464,7 @@ defmodule AmbryWeb.Admin.MediaLive.EvidenceTest do
       html = search(view, %{"title" => "The Martian", "author" => "Andy Weir"})
 
       refute html =~ "the file&#39;s tags"
-      assert html =~ "1 records, 0 ticked"
+      assert [_one] = html |> Floki.parse_document!() |> Floki.find(~s{[data-role="record"]})
     end
   end
 
@@ -416,6 +534,26 @@ defmodule AmbryWeb.Admin.MediaLive.EvidenceTest do
   end
 
   # A real file carrying real tags, in the recording's own source folder.
+  # An imported recording's shape: tracks, and neither transcode column.
+  # `Ambry.Factory.with_probed_tracks/3` makes exactly this, except that it
+  # copies a plain sample and these need one with art inside it.
+  defp imported_media(opts) do
+    media = tagged_media(opts)
+    paths = Enum.map(media.source_files, &Ambry.Paths.web_to_disk/1)
+
+    {:ok, probes} = Media.Scanner.probe_all(paths)
+
+    tracks =
+      probes
+      |> Media.Scanner.track_attrs()
+      |> Enum.map(&%{&1 | path: Ambry.Paths.disk_to_web(&1.path)})
+
+    {:ok, media} =
+      Media.update_media(media, %{media_tracks: tracks, source_path: nil, source_files: []})
+
+    Media.get_media!(media.id)
+  end
+
   defp tagged_media(opts \\ []) do
     media = insert(:media, book: build(:book))
     folder = Media.Media.source_path(media)

--- a/test/ambry_web/live/admin/media_live/set_picker_test.exs
+++ b/test/ambry_web/live/admin/media_live/set_picker_test.exs
@@ -181,6 +181,36 @@ defmodule AmbryWeb.Admin.MediaLive.SetPickerTest do
                "Season One"
     end
 
+    # A set's own facts are its own: joining one states its total, and only a
+    # set being named here asks for one — editing a set from a member's form
+    # would edit it for every other member too. The import form's row, and
+    # its reasons.
+    test "joining a set states its total and asks for neither it nor a name", %{conn: conn} do
+      book = insert(:book)
+      group = insert(:recording_group, book: book, name: "Graphic Audio", parts_total: 3)
+      media = insert(:media, book: book, recording_group: group, part_number: 1)
+
+      {:ok, view, html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+      assert html =~ "of 3"
+      refute has_element?(view, ~s{input[name="media[recording_group][name]"]})
+      refute has_element?(view, ~s{input[name="media[recording_group][parts_total]"]})
+      assert has_element?(view, ~s{input[name="media[part_number]"]})
+    end
+
+    test "naming one asks for both", %{conn: conn} do
+      book = insert(:book)
+      insert(:recording_group, book: book, name: "Graphic Audio", parts_total: 3)
+      media = insert(:media, book: book)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+      view |> element("button[phx-click='add-group-row']") |> render_click()
+
+      assert has_element?(view, ~s{input[name="media[recording_group][name]"]})
+      assert has_element?(view, ~s{input[name="media[recording_group][parts_total]"]})
+    end
+
     # Choosing an existing set from the drop-down is still a link, and the
     # name box has no business posting a second set beside it.
     test "picking an existing set creates nothing", %{conn: conn} do


### PR DESCRIPTION
A walk-through of the audiobook form before cutting a release, and what it
turned up. Five commits, each its own thing.

## The embedded-cover chip was a broken image

And accepting it would have failed, which is the half that hadn't been hit
yet. Both the preview controller and `handle_embedded_image/2` asked
`Media.files/2` where a recording's files are — and that reads
`source_path`/`source_files`, which are **transcode bookkeeping**: what a
transcode *consumed*. An imported recording has none; its files are its
tracks. Both go through `Scanner.audio_files/1` now, which asks the tracks
first.

`Media.fetch_media/1` did not preload `:media_tracks`, which is why fixing
the caller wasn't enough — an unloaded association is neither `[_ | _]` nor
`[]`, so it fell through to the transcode clause and answered from the empty
column. I tried making `audio_files/1` raise on not-loaded to stop this
recurring, and backed it out: a media legitimately built with no tracks looks
identical, and a test says so. The invariant lives at the two ways in.

**Why it hid.** The existing test asserts a 200 — against a *transcoded*
fixture, the only shape that ever had `source_files`. It passed while the
feature was broken for every recording the inbox has ever made. The new tests
use an import's shape.

I swept the rest of `source_path`/`source_files` while I was in there. The
other twelve uses are all deliberately about the transcode era and most
already say so: the audit query explicitly excludes recordings with tracks,
the deletion path asks tracks first, `recorded_files/1` unions all three eras
on purpose. Two things I found and left alone are noted in the commit.

## Reading a recording's files is not searching for its book

One button did both. Reading the files takes milliseconds and always has
something to say; asking every provider takes seconds and often has nothing —
so working down the back catalogue asking "would the embedded cover be an
improvement on this one?" paid for the second to get the first. Two buttons,
and the panel's title says both.

The files-only read always re-reads, unlike the once-only read a search does
on the way past: a control pressed on purpose that quietly does nothing the
second time is worse than the round trip it saves. It gets no scrim — a
header read is not "the databases are being asked".

Also by request: the "Tick every record…" paragraph is gone from all three
panels, and so is the fold's "N records, M ticked" tail.

## The page-wide scrim was a card scrim all along

`busy_overlay/1` had no `class` attr, so the `sticky top-0 z-40 h-screen`
every page-wide caller passed went through `:global` and rendered a **second**
`class` attribute, which the browser discards. Every one of them — the import
form's included — has been a card scrim at `z-20`: under the sticky footer,
so **Save stayed clickable and the scrim was only advisory**, and with its
label centred in a form that can be three screens long.

The layer ladder has described the right answer since it was written ("40, a
page-wide busy scrim, which has to cover the Save button or it is only
advisory"); it just could not be reached from outside. So the shape is named
rather than passed in: `scope={:card}` or `scope={:form}`, and a `:form`
scrim keeps its label in a `sticky top-0 h-screen` child so it sits in the
middle of the *screen* and follows the scroll.

A search now freezes the whole form — the last surface in the admin still
saying "busy" by relabelling its own button.

## "Part of a set" had diverged from the import form

It asked for a set's name and total even when the set already exists. A set's
facts belong to the set: editing them from one member's form edits them for
every other member, which is why the import form states the total and asks
only when you are naming one. Same row now, in the same order — which set,
then where in it.

"New set" could never draw as chosen, for the reason the import form gives at
the line I should have read: `EntityOption.selected?/2` treats a blank value
as nothing held, which is why it uses a `"new"` sentinel. The edit form does
too, translated back to the absence of an id where the cast wants it.

And the improvement went back the other way: two `w-full` children of a flex
row shrink in proportion to their *content*, so on a book that already has a
set the **import form's** drop-down was crushed to "N…" beside a name box
three times its width. `flex-1 min-w-0` on both.

## Two small ones

The scrim is the form's width, not the window's, so its label centres over
what it covers. And the image caption measured the wrong image: the audiobook
form renders a derived thumbnail and zooms to the original, so a caption
under a 512px preview read "512×512" — a fact about our own resizing, not
about the picture. It measures what the magnifier opens.

## Checks

1982 tests, `mix check` clean. Driven on the dev server throughout: the
embedded chip on an imported recording, the files-only read, the scrim over a
real fan-out, and both set rows side by side (import 405 against audiobook
15).

https://claude.ai/code/session_01MqS3aWUFDbtcNv193tAm1K
