### PR TITLE
What using the person card in anger turned up

### DIFF
--- a/assets/js/hooks/combobox-nav.js
+++ b/assets/js/hooks/combobox-nav.js
@@ -1,13 +1,20 @@
 // Keyboard support for the entity-resolver combobox: arrows move the active
-// option, Enter picks it, Escape closes. The options are LiveView-rendered
-// `[role=option]` elements with phx-click, so "pick" is just a click.
+// option, Enter picks it, Escape and Tab close. The options are
+// LiveView-rendered `[role=option]` elements with phx-click, so "pick" is
+// just a click.
+//
+// Tab is here because closing is what tells the surrounding form this
+// control moved (`EntityResolver.moved/1`) — a mouse leaves the box by
+// clicking away, which `phx-click-away` catches, and a keyboard leaves it by
+// tabbing, which nothing did.
 export const ComboboxNavHook = {
   mounted() {
     this.input = this.el.querySelector("[role=combobox]")
 
     this.onKeydown = (event) => {
       const options = Array.from(this.el.querySelectorAll("[role=option]"))
-      if (options.length === 0 && event.key !== "Escape") return
+      const closers = ["Escape", "Tab"]
+      if (options.length === 0 && !closers.includes(event.key)) return
 
       switch (event.key) {
         case "ArrowDown":
@@ -30,7 +37,9 @@ export const ComboboxNavHook = {
           }
           break
         }
-        case "Escape": {
+        // Not prevented: Tab still moves focus, it just says so on the way.
+        case "Escape":
+        case "Tab": {
           this.pushEventTo(this.el, "close", {})
           break
         }

--- a/assets/js/hooks/maintain-attrs.js
+++ b/assets/js/hooks/maintain-attrs.js
@@ -8,6 +8,11 @@ export const MainTainAttrsHook = {
   },
 
   updated() {
-    this.prevAttrs.forEach(([name, val]) => this.el.setAttribute(name, val))
+    // Guarded because `updated` without a preceding `beforeUpdate` is
+    // reachable — a patch that moves this element rather than updating it in
+    // place mounts the hook and then updates it — and an exception thrown
+    // here takes down the rest of the patch's hook callbacks with it. Losing
+    // a resized textarea's height is a smaller loss than that.
+    ;(this.prevAttrs || []).forEach(([name, val]) => this.el.setAttribute(name, val))
   },
 }

--- a/assets/js/hooks/set-input.js
+++ b/assets/js/hooks/set-input.js
@@ -25,16 +25,30 @@ export const SetInputHook = {
 
   set(chip) {
     const form = this.el.closest("form")
+    if (!form) return
+
+    // `data-set-blank` is a JSON array of names to empty, for a control whose
+    // answer is "none of these" and therefore touches more than one field.
+    // One control, one answer, however many inputs carry it.
+    const blanks = chip.dataset.setBlank ? JSON.parse(chip.dataset.setBlank) : []
+    const pairs = chip.dataset.setInput
+      ? [[chip.dataset.setInput, chip.dataset.setValue || ""]]
+      : blanks.map((name) => [name, ""])
+
     // Names carry brackets, which need no escaping inside a quoted attribute
     // selector — and CSS.escape, which is for identifiers, would break them.
-    const input = form && form.querySelector(`[name="${chip.dataset.setInput}"]`)
+    const written = pairs
+      .map(([name, value]) => {
+        const input = form.querySelector(`[name="${name}"]`)
+        if (input) input.value = value
+        return input
+      })
+      .filter(Boolean)
 
-    if (!input) return
-
-    input.value = chip.dataset.setValue || ""
-
-    // `input`, not `change`: a textarea's phx-change fires on input, and a
-    // hidden input has no native event of its own to borrow.
-    input.dispatchEvent(new Event("input", { bubbles: true }))
+    // One dispatch however many were written: `phx-change` serializes the
+    // whole form, so a second is a second identical round trip. `input`, not
+    // `change`: a textarea's phx-change fires on input, and a hidden input has
+    // no native event of its own to borrow.
+    written[written.length - 1]?.dispatchEvent(new Event("input", { bubbles: true }))
   },
 }

--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -822,6 +822,18 @@ one mechanism for "ask the databases", not a modal per provider:
   shows where the lists diverge, which is what to fix) but is never
   poured.
 
+- **A control tells the form when it is left, not while it is being typed
+  in.** Typing a name and meaning it post the same string, so anything
+  downstream of a per-keystroke `change` reacts on the first letter — hardest
+  of all while the operator is searching for a record that already exists.
+  The picker moves its hidden inputs under the typing, so a save posts
+  whatever the box says, and raises the change on pick, create or blur, which
+  is where a native input raises it. What this replaced answered the same
+  question with a second hidden input carrying "the operator clicked Create",
+  and everything that staged a credit *without* the picker had to remember to
+  set it: a provider chip credited a new narrator and their card never
+  appeared. **A surface should read the state, not a flag beside it.**
+
 - **A credit that names somebody new gets that person's card — literally the
   inbox's card.** A picker may name a record the library has never heard of,
   so an edit form can invent a `Person`, and a person made of a name and
@@ -834,12 +846,18 @@ one mechanism for "ask the databases", not a modal per provider:
   same record list.
 
   It lives in a **section of its own** under the credits that name them — the
-  inbox's `#people` anatomy, a heading on the ground with cards below — never
-  inside the credits card, which would be a card inside a card. It renders
-  **only where the nested chain reaches a person nobody has made yet**, which
-  is never true of a credit pointing at somebody who exists, and the credit
-  rows are walked a second time (`skip_hidden`, `skip_persistent_id`) because
-  the pickers above already post those.
+  inbox's `#people` anatomy down to the heading, a heading on the ground with
+  cards below — never inside the credits card, which would be a card inside a
+  card. It renders **only where the nested chain reaches a person nobody has
+  made yet**, which is never true of a credit pointing at somebody who
+  exists, and the credit rows are walked a second time (`skip_hidden`,
+  `skip_persistent_id`) because the pickers above already post those.
+
+  It is called **People** on both surfaces, not "New people" on one of them:
+  a card can link somebody the library already holds, so the section is not
+  only about the ones being made (operator, 2026-08-21). A heading that
+  narrows what its section contains is a difference to justify, and this one
+  could not be.
 
   The card hangs off the **join row** that holds the person — `author_people`
   for a pen name, `media_narrators[i][narrator]` for a stage name — not off
@@ -847,6 +865,26 @@ one mechanism for "ask the databases", not a modal per provider:
   answered. It is what lets the card offer the people the library already has
   by that name and link one, and what lets a pen name carry more than one
   human (James S.A. Corey) the way the inbox always could.
+
+  **A ticked record about this human answers what nobody has answered.** An
+  import takes the best record's face and biography and leaves the rest one
+  click away; a credit on an edit form was only ever *offered* them, so the
+  operator who ticked a record and saved got a person with a name and nothing
+  else — the asymmetry again, one level down. Records that spell the same
+  name arrive ticked (person search is recall-first, so the rest are listed
+  and left alone) and the best of them fills the boxes nobody has filled.
+  **Absent is unanswered; present-and-empty is an answer** — the card's
+  controls are inputs, so "no photo" and a cleared biography post as `""` and
+  are left exactly as they are.
+
+  **A card rendered more than once keys its ids by the card, not by its
+  address.** An import form's people are a grid — this credit, this human
+  behind it — so the address is unique there; on an edit form every card is
+  the first person behind the first credit of the only section, and four
+  hook-bearing elements per card collided. LiveView finds elements by id
+  when it patches, so the operator saw a bio box vanish when an unrelated
+  part of the form changed. Anything repeated takes its ids from whatever is
+  actually one per copy.
 
   One thing genuinely differs, and `input_prefix` is where it is said: the
   import form saves on change and has no form of its own, so each of the
@@ -856,6 +894,17 @@ one mechanism for "ask the databases", not a modal per provider:
   on the client (`assets/js/hooks/set-input.js`) instead of raising events,
   and the state rail goes — nothing here is part-way through a decision tree.
   Everything else is the same markup.
+
+- **A section whose work repeats gets one control for all of it.** Ten
+  credits accepted from a record is ten new-person cards, each with a Search
+  of its own, and finding out about them was ten clicks in ten places
+  (operator, 2026-08-21). So the section heading carries "Search all *n*" —
+  chained `JS.push/3`, because pressing them all *is* the feature and each
+  card's handler already knows what to do with one. It counts what it would
+  ask about and disappears when that is nothing, because a control that might
+  do nothing should say so before it is pressed. Same control on the import
+  form, where matching has usually asked already, so the same rule shows it
+  only where the operator has added credits by hand.
 
 Structural lists (authors, narrators, series) carry **list-level
 provenance** — one entry per list, worn as the same "from …" flag on the

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -815,6 +815,15 @@ defmodule Ambry.Inbox do
   defdelegate record_ref(record), to: AutoMatch, as: :ref
 
   @doc """
+  Whether two spellings mean one human, as one comparable key.
+
+  Matching's own rule, so the edit forms decide "is this record about the
+  person I asked about" exactly the way an import decides it — initials,
+  punctuation and accents all fold.
+  """
+  defdelegate person_key(name), to: AutoMatch
+
+  @doc """
   Scoring hints from a library record's own fields — what lets the edit
   forms rank provider records exactly the way matching ranks them against
   an item's tags. (The scoring itself is `score_records/3`; its true home

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -1359,8 +1359,11 @@ defmodule Ambry.Inbox.AutoMatch do
     outcomes
     |> Enum.group_by(& &1["id"])
     |> Enum.map(fn {_id, [first | _rest] = group} ->
-      answered = Enum.reject(group, &Outcome.failed?/1)
-      count = Enum.sum_by(answered, &(&1["count"] || 0))
+      # Every outcome's own count, partial ones included: a failure that
+      # reached nothing carries a zero, so summing the group is the same
+      # answer for those and the right one for an answer that came back
+      # half-full.
+      count = Enum.sum_by(group, &(&1["count"] || 0))
 
       case Enum.find(group, &Outcome.failed?/1) do
         nil -> %{first | "status" => "ok", "count" => count}
@@ -1958,6 +1961,19 @@ defmodule Ambry.Inbox.AutoMatch do
           books |> Enum.take(@candidate_limit) |> Enum.map(&provider_candidate(&1, entry, hints))
 
         {candidates, Outcome.ok(entry, length(candidates))}
+
+      # What did answer is matched on; what didn't is what sends `RunMatch`
+      # round again. A region that was rate-limited during a scan of hundreds
+      # of items must not read as a region the book isn't sold in.
+      {:partial, books, reason} ->
+        candidates =
+          books |> Enum.take(@candidate_limit) |> Enum.map(&provider_candidate(&1, entry, hints))
+
+        Logger.warning(fn ->
+          "Auto-match: #{entry.id} partial for #{inspect(to_string(query))}: #{inspect(reason)}"
+        end)
+
+        {candidates, Outcome.partial(entry, length(candidates), reason)}
 
       {:error, reason} ->
         Logger.warning(fn ->

--- a/lib/ambry/metadata/cache.ex
+++ b/lib/ambry/metadata/cache.ex
@@ -71,6 +71,14 @@ defmodule Ambry.Metadata.Cache do
         store!(key, value)
         {:ok, value}
 
+      # Never stored: a partial answer is part of an outage, and caching it
+      # would keep serving the half that answered for the whole TTL. Passed
+      # through rather than dropped, because the half that did answer is
+      # worth having now — the caller records the miss and can ask again.
+      {:partial, value, reason} ->
+        Logger.warning("metadata fetch partial for #{key}: #{inspect(reason)}")
+        {:partial, value, reason}
+
       {:error, reason} when not is_nil(stale_entry) ->
         Logger.warning("metadata fetch failed for #{key}, serving stale: #{inspect(reason)}")
         {:ok, decode(stale_entry)}

--- a/lib/ambry/metadata/outcome.ex
+++ b/lib/ambry/metadata/outcome.ex
@@ -74,6 +74,32 @@ defmodule Ambry.Metadata.Outcome do
     }
   end
 
+  @doc """
+  A provider answered with part of what was asked of it.
+
+  Some of what it was asked reached it and some did not — Audible's regional
+  catalogs are the case this exists for: one marketplace rate-limited while
+  the others answered used to be indistinguishable from a marketplace with
+  nothing in it, which is the one distinction the setting exists to make.
+
+  **Recorded as a failure, and deliberately.** Everything that reads these —
+  `Ambry.Inbox.unreached_providers/1`, the retry chip, `failed?/1` — asks one
+  question of them: is there something here that a retry could still get? For
+  a partial answer there is, so it says `failed` and carries the count of
+  what did come back, and the chip words itself off `partial`. A third status
+  would have meant teaching every reader a third answer to a question that
+  only has two.
+  """
+  def partial(entry, count, reason, kind \\ :search) do
+    entry
+    |> failed(reason, kind)
+    |> Map.merge(%{"count" => count, "partial" => true})
+  end
+
+  @doc "True if this outcome is a partial answer rather than nothing at all."
+  def partial?(%{"partial" => true}), do: true
+  def partial?(_outcome), do: false
+
   # A provider that cannot be asked, as opposed to one that couldn't be
   # reached: it doesn't implement this kind of call, it is switched off, or it
   # has no credentials. No request was made, so there is nothing to report and

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -311,8 +311,12 @@ defmodule Ambry.Metadata.Provider do
   """
   @callback config_notices(config()) :: [notice()]
 
+  # `{:partial, …}` is for a provider that is more than one source behind one
+  # name — Audible's regional catalogs — where some of them answered and some
+  # did not. The results are usable and incomplete, and a provider that says
+  # only the first half turns an unreachable region into an empty one.
   @callback search_books(query :: String.t() | Query.t(), config()) ::
-              {:ok, [Book.t()]} | {:error, term}
+              {:ok, [Book.t()]} | {:partial, [Book.t()], term} | {:error, term}
   @callback book_details(id :: String.t(), config()) :: {:ok, Book.t()} | {:error, term}
   @callback search_authors(query :: String.t(), config()) :: {:ok, [Author.t()]} | {:error, term}
   @callback author_details(id :: String.t(), config()) :: {:ok, Author.t()} | {:error, term}

--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -35,8 +35,7 @@ defmodule Ambry.Metadata.Providers.Audible do
         default: "english",
         help:
           "Only show search results in this language (Audible's language names, e.g. " <>
-            ~s{"english", "german"). Set to "any" to disable filtering. } <>
-            "Clear the cache after changing so old results don't linger."
+            ~s{"english", "german"). Set to "any" to disable filtering.}
       },
       %Provider.ConfigField{
         key: :marketplaces,
@@ -47,8 +46,9 @@ defmodule Ambry.Metadata.Providers.Audible do
           "Which regional Audible catalogs to search, comma-separated — " <>
             "us, uk, ca, au, de, fr, es, it, in, jp. Editions are regional, so a UK-only " <>
             "recording is invisible to the US catalog. Results are merged, and the same " <>
-            "recording appearing in several catalogs is collapsed. Each extra marketplace " <>
-            "is another request per lookup, and a first inbox scan is hundreds of lookups."
+            "recording appearing in several catalogs is collapsed — most books are sold in " <>
+            "every region, so widening often changes nothing. Each extra marketplace is " <>
+            "another request per lookup, and a first inbox scan is hundreds of lookups."
       }
     ]
   end
@@ -97,6 +97,10 @@ defmodule Ambry.Metadata.Providers.Audible do
     case Audible.search_books(params, opts) do
       {:ok, []} -> widen(rest, config)
       {:ok, products} -> {:ok, Enum.map(products, &product_to_book/1)}
+      # Some catalogs answered and some did not. The answer is usable and
+      # incomplete, and saying only the first half is what let a region that
+      # was rate-limited read as a region with nothing in it.
+      {:partial, products, reason} -> {:partial, Enum.map(products, &product_to_book/1), reason}
       # A failure is not an empty result — widening past it would hide an
       # outage behind a vaguer query that happens to succeed.
       {:error, reason} -> {:error, reason}

--- a/lib/ambry/metadata/registry.ex
+++ b/lib/ambry/metadata/registry.ex
@@ -9,6 +9,7 @@ defmodule Ambry.Metadata.Registry do
   rreading-glasses against the public instance.
   """
 
+  alias Ambry.Metadata.Cache
   alias Ambry.Metadata.Provider
   alias Ambry.Metadata.ProviderConfig
   alias Ambry.Metadata.Providers.Audible
@@ -89,10 +90,38 @@ defmodule Ambry.Metadata.Registry do
   def update(provider_id, attrs) do
     with {:ok, entry} <- fetch(provider_id) do
       row = Repo.get(ProviderConfig, provider_id) || %ProviderConfig{}
+      changes = changes(entry, row, attrs, provider_id)
 
       row
-      |> ProviderConfig.changeset(changes(entry, row, attrs, provider_id))
+      |> ProviderConfig.changeset(changes)
       |> Repo.insert_or_update()
+      |> tap(fn
+        {:ok, _saved} -> forget_stale_answers(provider_id, row, changes)
+        _failed -> :ok
+      end)
+    end
+  end
+
+  # **A cached answer was given under the old settings.** The cache keys on
+  # the provider and the question and nothing else, so changing what a
+  # provider is *asked* — which languages count, which regional catalogs to
+  # search — left every question already asked answering the old way for the
+  # rest of its TTL, a week for searches. The operator changed Audible from
+  # `us` to `us, uk`, searched a book they had searched before, and got the
+  # US catalog's answer back (2026-08-21).
+  #
+  # Emptied on a config change rather than keyed on the config: a key that
+  # carries the settings never *forgets* the old answers, it just stops
+  # finding them, and the rows sit in Postgres until their TTL expires.
+  # Enabling, disabling and reordering leave it alone — none of them changes
+  # what a question means.
+  defp forget_stale_answers(provider_id, row, changes) do
+    case Map.fetch(changes, :config) do
+      {:ok, config} when config != %{} ->
+        if config != (row.config || %{}), do: Cache.clear_provider(provider_id)
+
+      _unchanged ->
+        :ok
     end
   end
 

--- a/lib/ambry/metadata/search.ex
+++ b/lib/ambry/metadata/search.ex
@@ -60,6 +60,12 @@ defmodule Ambry.Metadata.Search do
       {:ok, books} ->
         {books, ok_outcome(entry, length(books))}
 
+      # Usable and incomplete: the books are shown, and the chip says part of
+      # this provider was not reached and offers the retry.
+      {:partial, books, reason} ->
+        Logger.warning(fn -> "Metadata search: #{entry.id} partial: #{inspect(reason)}" end)
+        {books, Outcome.partial(entry, length(books), reason)}
+
       {:error, reason} ->
         Logger.warning(fn -> "Metadata search: #{entry.id} failed: #{inspect(reason)}" end)
         {[], failed_outcome(entry, reason)}

--- a/lib/ambry_scraping/audible/products.ex
+++ b/lib/ambry_scraping/audible/products.ex
@@ -47,6 +47,10 @@ defmodule AmbryScraping.Audible.Products do
     * `:marketplaces` — which regional catalogs to search, merged. Editions
       are regional: a UK-only recording is invisible to the US catalog no
       matter how it's queried.
+
+  Answers `{:ok, products}`, `{:partial, products, unreached}` where some of
+  the marketplaces answered and some did not, or `{:error, reason}` where
+  none did.
   """
   def search(query, opts \\ [])
 
@@ -88,13 +92,36 @@ defmodule AmbryScraping.Audible.Products do
   # One reachable marketplace is a usable answer; all of them failing is not.
   defp parse_all({[], [{_marketplace, reason} | _rest]}, _language), do: {:error, reason}
 
-  defp parse_all({products, _errors}, language) do
-    {:ok,
-     products
-     |> Enum.uniq_by(&dedupe_key/1)
-     |> Enum.map(&parse_product/1)
-     |> filter_language(language)}
+  defp parse_all({products, errors}, language) do
+    parsed =
+      products
+      |> Enum.uniq_by(&dedupe_key/1)
+      |> Enum.map(&parse_product/1)
+      |> filter_language(language)
+
+    # **A catalog that could not be reached is not a catalog with nothing in
+    # it.** This used to answer `{:ok, …}` whenever *any* marketplace came
+    # back, so a rate-limited or geo-blocked region was indistinguishable
+    # from a region where the book genuinely doesn't exist — which is the
+    # one distinction the whole setting exists to make. The results are
+    # usable and they are incomplete, and the caller is told both.
+    case errors do
+      [] -> {:ok, parsed}
+      _some -> {:partial, parsed, unreached(errors)}
+    end
   end
+
+  # Named by region, because that is the unit the operator configured and
+  # the unit they can do something about.
+  defp unreached(errors) do
+    errors
+    |> Enum.reverse()
+    |> Enum.map_join(", ", fn {marketplace, reason} -> "#{marketplace}: #{why(reason)}" end)
+  end
+
+  defp why(%{status: status}), do: "HTTP #{status}"
+  defp why(%{__exception__: true} = error), do: Exception.message(error)
+  defp why(reason), do: reason |> inspect() |> String.slice(0, 60)
 
   # NOT by ASIN: the same recording carries a *different* ASIN in each
   # regional catalog, so an ASIN key silently lets every merged marketplace

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -1396,6 +1396,9 @@ defmodule AmbryWeb.Admin.Components do
   attr :class, :any, default: nil
   slot :inner_block, required: true
 
+  slot :action,
+    doc: "a control for the section as a whole, on the heading's line at its right edge"
+
   @doc """
   A named run of field groups, for a form long enough to need finding your
   way around — the import form's anatomy, which is where this came from.
@@ -1413,7 +1416,13 @@ defmodule AmbryWeb.Admin.Components do
   def form_section(assigns) do
     ~H"""
     <section id={@id} class={["space-y-7", @class]}>
-      <h2 :if={@title} class="text-xl font-bold text-zinc-100">{@title}</h2>
+      <%!-- The heading stays on the ground with nothing under it; a control
+          for the whole section sits at the other end of its line, which is
+          where the list clusters put theirs. --%>
+      <div :if={@title || @action != []} class="flex items-baseline justify-between gap-4">
+        <h2 :if={@title} class="text-xl font-bold text-zinc-100">{@title}</h2>
+        <div :if={@action != []} class="flex-none">{render_slot(@action)}</div>
+      </div>
       {render_slot(@inner_block)}
     </section>
     """

--- a/lib/ambry_web/components/admin/decisions.ex
+++ b/lib/ambry_web/components/admin/decisions.ex
@@ -87,7 +87,7 @@ defmodule AmbryWeb.Admin.Decisions do
         >
           {outcome["name"]}: {if @retrying == outcome["id"],
             do: "asking again…",
-            else: "couldn't be reached, retry"}
+            else: unreached_words(outcome)}
         </button>
 
         <span
@@ -96,11 +96,27 @@ defmodule AmbryWeb.Admin.Decisions do
           title={outcome["reason"]}
           class="bg-red-400/10 rounded-sm px-2 py-0.5 text-xs text-red-300"
         >
-          {outcome["name"]}: couldn't be reached
+          {outcome["name"]}: {unreached_words(outcome, retry: false)}
         </span>
       </div>
     </div>
     """
+  end
+
+  # **A provider that answered by halves says so.** Audible's regional
+  # catalogs are one provider making several requests, and one region being
+  # rate-limited is not the same event as the provider being down — the
+  # records on screen came from the regions that answered, and "couldn't be
+  # reached" over the top of them reads as a lie. The count is what came
+  # back; the tooltip names the region and why.
+  defp unreached_words(outcome, opts \\ [])
+
+  defp unreached_words(%{"partial" => true, "count" => count}, opts) do
+    "#{count}, some not reached" <> if(opts[:retry] == false, do: "", else: ", retry")
+  end
+
+  defp unreached_words(_outcome, opts) do
+    "couldn't be reached" <> if(opts[:retry] == false, do: "", else: ", retry")
   end
 
   # Where a candidate stops being an alternative and starts being noise. Sits
@@ -1113,6 +1129,13 @@ defmodule AmbryWeb.Admin.Decisions do
     default: nil,
     doc: "the name these records were searched for; falls back to the person's own"
 
+  attr :at, :string,
+    default: nil,
+    doc:
+      "what this card's DOM ids are built from. Defaults to the credit's address, which is " <>
+        "unique where a card is one of a draft's; a surface that renders cards outside that " <>
+        "grid has to say. See `person_curation/1`."
+
   attr :input_prefix, :string,
     default: nil,
     doc:
@@ -1358,6 +1381,7 @@ defmodule AmbryWeb.Admin.Decisions do
 
         <.person_curation
           person={@person}
+          at={@at}
           input_prefix={@input_prefix}
           section={@group.section}
           index={@group.index}
@@ -1636,6 +1660,8 @@ defmodule AmbryWeb.Admin.Decisions do
     default: nil,
     doc: "the name these records were searched for; falls back to the person's own"
 
+  attr :at, :string, default: nil, doc: "see below — overrides where these ids are keyed"
+
   attr :input_prefix, :string,
     default: nil,
     doc: "see `person_card/1` — set where the card sits inside a form that is not its own"
@@ -1687,11 +1713,23 @@ defmodule AmbryWeb.Admin.Decisions do
   def person_curation(assigns) do
     assigns =
       assign(assigns,
-        # One person can be rendered in two places — an author who reads their
-        # own book — so DOM ids are keyed by WHERE this is, not by who it is.
-        # The person key travels in the form's hidden field, where it belongs:
-        # the edit targets the human, the id targets the element.
-        at: "#{assigns.section}-#{assigns.index}-#{assigns.person_index}",
+        # **These ids have to be unique in the document, and the address is
+        # only unique where a card is one of a draft's.** An import form's
+        # people are a grid — this credit, this human behind it — and one
+        # person can be rendered in two places, an author who reads their own
+        # book, so keying by WHERE this is rather than by who it is is what
+        # tells those two apart. An edit form has no such grid: every card is
+        # the first person behind the first credit of the only section, so
+        # every card on it claimed `recording-0-0` and four hook-bearing
+        # elements per card collided. LiveView's own words for that are
+        # "duplicate IDs will cause undefined behavior at runtime, as DOM
+        # patching will not be able to target the correct elements", and what
+        # the operator saw was a bio box that vanished when an unrelated part
+        # of the form patched (2026-08-21). So a caller with a better answer
+        # gives it; the person key travels in the form's hidden field either
+        # way, because the edit targets the human and the id targets the
+        # element.
+        at: assigns.at || "#{assigns.section}-#{assigns.index}-#{assigns.person_index}",
         image: Field.value(assigns.person.image),
         description: Field.value(assigns.person.description),
         photos: assigns.person.image.candidates,
@@ -1771,15 +1809,24 @@ defmodule AmbryWeb.Admin.Decisions do
             doubted — it found humans of roughly this name and believed none
             of them — stays outstanding until somebody says so, and this is
             what says so. It costs nothing but the photo and the biography:
-            a name is all it takes to create a person. --%>
-      <div
-        :if={@records != [] and is_nil(@input_prefix)}
-        class="flex flex-wrap items-center gap-2 pt-1"
-      >
+            a name is all it takes to create a person.
+
+            **On both surfaces.** It was the import form's alone, on the
+            reasoning that an edit form has no outstanding decision to
+            settle — and left the records running straight into the
+            biography with nothing between them, which is how the operator
+            found it (2026-08-21). The reasoning was wrong anyway: records
+            about this name arrive ticked here, so "none of these is my
+            narrator" is a thing that needs saying, and it is one click
+            against unticking every row and clearing two fields by hand.
+            Where the card is inside a form the fields are inputs, so the
+            button empties them the way the chips fill them. --%>
+      <div :if={@records != []} class="flex flex-wrap items-center gap-2 pt-1">
         <button
           type="button"
           phx-click="uncatalogued-person"
           phx-value-key={@person.key}
+          data-set-blank={@input_prefix && blank_targets(@input_prefix)}
           data-role="none-of-these"
           class={[
             "px-[11px] rounded-md border py-1 text-xs",
@@ -1793,7 +1840,14 @@ defmodule AmbryWeb.Admin.Decisions do
         </button>
       </div>
 
-      <div :if={@photos != []} class="grid-cols-[4rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3">
+      <%!-- Shown while there is a face OR faces to choose from, and not only
+            the second: a photo whose record has since been unticked leaves a
+            chosen face with no strip under it, and the strip is where the
+            way out of it lives. --%>
+      <div
+        :if={@photos != [] or @image}
+        class="grid-cols-[4rem_minmax(0,1fr)] grid items-start gap-x-2 pl-3"
+      >
         <.microlabel class="pt-1">Photos</.microlabel>
 
         <div class="flex flex-wrap items-center gap-2">
@@ -1813,6 +1867,26 @@ defmodule AmbryWeb.Admin.Decisions do
             />
           </.proposal_chip>
 
+          <%!-- **No face is one of the faces.** This was a text button after
+              the strip, shown only once a photo was chosen, and it read as a
+              caption rather than an option — the operator whose best-match
+              photo came back wrong found no way to take it off (2026-08-21).
+              A person with no picture is a perfectly good answer, so it is
+              one of the things you pick between, in the strip, wearing the
+              same ring when it is the one in force. --%>
+          <.proposal_chip
+            chosen={is_nil(@image)}
+            shape="circle"
+            event="waive-person-field"
+            values={%{"key" => @person.key, "field" => "image"}}
+            writes={writes(@input_prefix, "[image_import_url]", "")}
+            title="no photo"
+          >
+            <span class="flex h-16 w-16 items-center justify-center rounded-full border border-dashed border-zinc-600 text-xs text-zinc-400">
+              none
+            </span>
+          </.proposal_chip>
+
           <%!-- A dozen headshots is normal and would push the rest of the credit
               off the screen; the point is that alternatives EXIST, not that
               they're all on show. --%>
@@ -1824,19 +1898,6 @@ defmodule AmbryWeb.Admin.Decisions do
             class="text-xs text-zinc-400 underline"
           >
             {if @expanded, do: "show fewer", else: "show all #{length(@photos)} photos"}
-          </button>
-
-          <button
-            :if={@image}
-            type="button"
-            phx-click={!@input_prefix && "waive-person-field"}
-            phx-value-key={@person.key}
-            phx-value-field="image"
-            data-set-input={@input_prefix && @input_prefix <> "[image_import_url]"}
-            data-set-value={@input_prefix && ""}
-            class="self-center rounded-sm border border-dashed border-zinc-600 px-2 py-1 text-xs text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
-          >
-            no photo
           </button>
         </div>
       </div>
@@ -1940,6 +2001,11 @@ defmodule AmbryWeb.Admin.Decisions do
   # a decision the server holds.
   defp writes(nil, _suffix, _value), do: nil
   defp writes(prefix, suffix, value), do: %{input: prefix <> suffix, value: value}
+
+  # Everything "none of these" takes back, which is everything a record ever
+  # gave this person: the face and the biography. The name is theirs.
+  defp blank_targets(prefix),
+    do: Jason.encode!([prefix <> "[image_import_url]", prefix <> "[description]"])
 
   defp photo_preview, do: @photo_preview
 

--- a/lib/ambry_web/components/core_components.ex
+++ b/lib/ambry_web/components/core_components.ex
@@ -455,16 +455,6 @@ defmodule AmbryWeb.CoreComponents do
     default: nil,
     doc: "autocomplete: what that box starts with, for a name staged by something else"
 
-  attr :create_flag_name, :string,
-    default: nil,
-    doc:
-      "autocomplete: an input name that records whether the operator chose \"Create …\", as " <>
-        "opposed to having typed something nothing matches yet"
-
-  attr :create_flag_value, :string,
-    default: nil,
-    doc: "autocomplete: that flag's stored value, so the choice survives a re-render"
-
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
   attr :class, :string, default: nil, doc: "class overrides"
   attr :container_class, :string, default: nil, doc: "extra classes for the container div"
@@ -572,8 +562,6 @@ defmodule AmbryWeb.CoreComponents do
         name={@name}
         text_name={@create_name}
         initial_text={@create_value}
-        create_flag_name={@create_flag_name}
-        initial_created={@create_flag_value == "true"}
         search={@search}
         fetch={@fetch}
         value={@value}

--- a/lib/ambry_web/components/entity_resolver.ex
+++ b/lib/ambry_web/components/entity_resolver.ex
@@ -13,6 +13,13 @@ defmodule AmbryWeb.Components.EntityResolver do
   name under `text_name`), and the parent form's `phx-change` fires when they
   move. Parent LiveViews keep their existing handlers and param shapes.
 
+  **The form is told on blur, not per keystroke.** The hidden inputs follow
+  the typing, so a save posts whatever the box currently says; what waits for
+  the box to be left is the *announcement* — picking, creating, or looking
+  away. That is when a native input fires `change`, and it is the difference
+  between "I mean a record you don't have" and "I am still typing". See
+  `moved/1`.
+
   **The form is told by this component, not by watching the DOM.** Every
   interaction here is handled server-side, so the hidden inputs hold the new
   answer only after the patch lands; `moved/1` pushes `entity-resolver:moved`
@@ -120,18 +127,6 @@ defmodule AmbryWeb.Components.EntityResolver do
         id={"#{@id}-text"}
         name={@text_name}
         value={@text}
-      />
-      <%!-- Whether the operator *said* they meant a new record, as opposed to
-          having typed something nothing matches yet. Both post the same name,
-          because what's typed is the new record's name either way — but only
-          one of them is a decision, and a surface that reacts to the typing
-          reacts on the first letter. --%>
-      <input
-        :if={@create_flag_name}
-        type="hidden"
-        id={"#{@id}-created"}
-        name={@create_flag_name}
-        value={to_string(@created?)}
       />
       <input
         type="text"
@@ -248,11 +243,6 @@ defmodule AmbryWeb.Components.EntityResolver do
      |> assign_new(:text, fn -> assigns[:initial_text] || "" end)
      |> assign_new(:value, fn -> nil end)
      |> then(&assign(&1, :value, held_id(&1.assigns.value)))
-     |> assign_new(:create_flag_name, fn -> nil end)
-     # Sticky, on purpose: the operator goes on editing the name after
-     # choosing Create, and every keystroke is a `filter`. Only picking
-     # something that exists takes the choice back.
-     |> assign_new(:created?, fn -> assigns[:initial_created] || false end)
      |> assign_new(:placeholder, fn -> nil end)
      |> assign_new(:class, fn -> nil end)}
   end
@@ -262,60 +252,62 @@ defmodule AmbryWeb.Components.EntityResolver do
     {:noreply, assign(socket, open: true)}
   end
 
-  # **Looking away is the decision.** A name that has been typed and left
-  # alone, with nothing picked, is the operator saying they mean a new record
-  # — the same moment a native input would have fired `change`. Watching the
-  # typing instead answers on the first letter, and the "Create …" row alone
-  # is a click most people never make.
+  # **Looking away is the answer.** A name typed and left alone, with nothing
+  # picked, is the operator saying they mean a record the library doesn't
+  # have — the same moment a native input would have fired `change`, which is
+  # exactly when the form is told.
   def handle_event("close", _params, socket) do
-    typed = present?(socket.assigns[:text]) and is_nil(socket.assigns.value)
-
-    {:noreply,
-     socket
-     |> assign(open: false, query: nil, created?: socket.assigns.created? or typed)
-     |> moved()}
+    {:noreply, socket |> assign(open: false, query: nil) |> moved()}
   end
 
+  # Typing moves the box, not the form. The hidden inputs follow every
+  # keystroke so the form posts the right thing whenever it next serializes,
+  # but nothing is *announced* until the box is left — see `moved/1`.
   def handle_event("filter", %{"resolver" => params}, socket) do
     query = params[socket.assigns.id] || ""
     socket = assign(socket, query: query, open: true)
 
     # With create support on, what's typed IS the new record's name until an
-    # existing record is picked — same live behaviour the plain text input
-    # had. A pure picker only ever changes on a pick.
+    # existing record is picked. A pure picker only ever changes on a pick.
     if socket.assigns.text_name,
-      do: {:noreply, socket |> assign(value: nil, text: query) |> moved()},
+      do: {:noreply, assign(socket, value: nil, text: query)},
       else: {:noreply, socket}
   end
 
   def handle_event("pick", %{"id" => id}, socket) do
-    {:noreply, socket |> assign(value: id, created?: false, open: false, query: nil) |> moved()}
+    {:noreply, socket |> assign(value: id, open: false, query: nil) |> moved()}
   end
 
   def handle_event("create", _params, socket) do
     {:noreply,
      socket
-     |> assign(
-       value: nil,
-       created?: true,
-       text: effective_query(socket.assigns) || "",
-       open: false,
-       query: nil
-     )
+     |> assign(value: nil, text: effective_query(socket.assigns) || "", open: false, query: nil)
      |> moved()}
   end
 
   # Tells the surrounding form that this control moved, the way a native input
-  # would have.
+  # would have — which is to say on **pick, create and close, and never on a
+  # keystroke.**
   #
-  # **Only the three handlers above call it, and that is the whole point.** The
-  # hidden inputs are ordinary markup rendered from assigns, so they change
-  # for two unrelated reasons: the operator picked or typed something here, or
-  # the parent re-rendered this row around a different record entirely. The
-  # DOM cannot tell those apart — the old hook watched the value attribute
-  # mutate and fired on both, so a seeder that re-derived a credit's name had
-  # its own work reported back to it as an operator edit, and the credit was
-  # marked curated for something no human did.
+  # A keystroke is not an answer. Typing a name posts the same thing as
+  # meaning it, so a form told per keystroke has a half-typed author staged
+  # in it from the first letter — worst of all while the operator is
+  # searching for one that already exists — and every surface downstream has
+  # to guess which of the two it is looking at. What this replaced answered
+  # that guess with a second hidden input carrying a "the operator said
+  # Create" flag, which nothing that *staged* a credit knew to set: a
+  # provider chip appended a perfectly good new narrator and their card never
+  # appeared (operator, 2026-08-21). Leaving on blur is the answer, and the
+  # form hears exactly one thing.
+  #
+  # The three handlers below it call it, and nothing else does. The hidden
+  # inputs are ordinary markup rendered from assigns, so they change for two
+  # unrelated reasons: the operator moved this control, or the parent
+  # re-rendered this row around a different record entirely. The DOM cannot
+  # tell those apart — the old hook watched the value attribute mutate and
+  # fired on both, so a seeder that re-derived a credit's name had its own
+  # work reported back to it as an operator edit, and the credit was marked
+  # curated for something no human did.
   #
   # **The answer travels in the event, not just the signal to go looking for
   # it.** `push_event/3` is dispatched after the patch, so the hidden inputs

--- a/lib/ambry_web/live/admin/book_live/form.ex
+++ b/lib/ambry_web/live/admin/book_live/form.ex
@@ -404,52 +404,57 @@ defmodule AmbryWeb.Admin.BookLive.Form do
 
   defp save_book(socket, :edit, book_params) do
     opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
-    book_params = NewPerson.import_photos(book_params, "book_authors")
 
-    case Books.update_book(socket.assigns.book, book_params, opts) do
-      {:ok, book} ->
-        # the title, primary author and primary series all appear in the path
-        # of every managed recording of this book
-        {:ok, _job} = Media.organize_book_async(book.id)
+    with {:ok, book_params} <- NewPerson.import_photos(book_params, "book_authors"),
+         {:ok, book} <- Books.update_book(socket.assigns.book, book_params, opts) do
+      # the title, primary author and primary series all appear in the path
+      # of every managed recording of this book
+      {:ok, _job} = Media.organize_book_async(book.id)
 
-        {:noreply,
-         socket
-         |> put_flash(:info, "Updated #{book.title}")
-         |> push_navigate(
-           to: ReturnTo.path(~p"/admin/books", socket.assigns.list_params, book.id)
-         )}
-
+      {:noreply,
+       socket
+       |> put_flash(:info, "Updated #{book.title}")
+       |> push_navigate(to: ReturnTo.path(~p"/admin/books", socket.assigns.list_params, book.id))}
+    else
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
+
+      {:error, {:failed_photos, urls}} ->
+        {:noreply, put_flash(socket, :error, NewPerson.photos_error(urls))}
     end
   end
 
   defp save_book(socket, :new, book_params) do
     opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
-    book_params = NewPerson.import_photos(book_params, "book_authors")
 
-    case Books.create_book(book_params, opts) do
-      {:ok, book} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Created #{book.title}")
-         |> push_navigate(
-           to: ReturnTo.path(~p"/admin/books", socket.assigns.list_params, book.id)
-         )}
-
+    with {:ok, book_params} <- NewPerson.import_photos(book_params, "book_authors"),
+         {:ok, book} <- Books.create_book(book_params, opts) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Created #{book.title}")
+       |> push_navigate(to: ReturnTo.path(~p"/admin/books", socket.assigns.list_params, book.id))}
+    else
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
+
+      {:error, {:failed_photos, urls}} ->
+        {:noreply, put_flash(socket, :error, NewPerson.photos_error(urls))}
     end
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do
+    cards = NewPerson.cards(changeset, :book_authors, [:author, :author_people])
+
     assign(socket,
       form: to_form(changeset),
       # the move buttons need to know where the ends of each list are, and
       # the empty states whether there is a list at all
       book_author_count: Reordering.row_count(changeset, :book_authors),
       series_book_count: Reordering.row_count(changeset, :series_books),
-      book_universe_count: Reordering.row_count(changeset, :book_universes)
+      book_universe_count: Reordering.row_count(changeset, :book_universes),
+      # the People section's own control: the cards are rendered by
+      # `inputs_for` and a heading above them has no walk of its own
+      people_cards: cards
     )
   end
 

--- a/lib/ambry_web/live/admin/book_live/form.html.heex
+++ b/lib/ambry_web/live/admin/book_live/form.html.heex
@@ -95,14 +95,12 @@
                 fetch={&People.author_option/1}
                 create_name={"#{book_author_form.name}[author][name]"}
                 create_value={staged_name(book_author_form, :author)}
-                create_flag_name={"#{book_author_form.name}[author][create]"}
-                create_flag_value={NewPerson.chosen(book_author_form, :author)}
                 container_class="grow"
               />
               <%!-- Who this credit means, and a way down to their card. --%>
               <.inputs_for
                 :let={author_form}
-                :if={NewPerson.carded?(book_author_form, :author, [:author, :author_people])}
+                :if={NewPerson.carded?(book_author_form, [:author, :author_people])}
                 field={book_author_form[:author]}
                 skip_hidden
                 skip_persistent_id
@@ -146,12 +144,16 @@
           </:add>
         </.list_cluster>
 
-        <%!-- The humans these credits are about to invent, in the import form's
-          own section — under the credits that name them, because that is
-          where they came from, and separate from them, because "what is this
-          person called, and what do they look like" is a different question
-          from "who wrote this book". A card inside a card also eats the
-          elevation ladder (§1).
+        <%!-- The humans these credits are about, in the import form's own
+          section and under its own name — under the credits that name them,
+          because that is where they came from, and separate from them,
+          because "what is this person called, and what do they look like" is
+          a different question from "who wrote this book". A card inside a
+          card also eats the elevation ladder (§1).
+
+          "People", not "New people": a card can link somebody the library
+          already holds, so the section is not only about the ones being
+          made (operator, 2026-08-21).
 
           The rows are walked a second time with their hidden inputs skipped:
           the credit rows above already post those. What renders only here is
@@ -159,10 +161,22 @@
           nobody has made yet — never for a credit pointing at an author the
           library already has. --%>
         <.form_section
-          :if={NewPerson.any?(@form.source, :book_authors, :author, [:author, :author_people])}
-          id="new-people"
-          title="New people"
+          :if={NewPerson.any?(@form.source, :book_authors, [:author, :author_people])}
+          id="people"
+          title="People"
         >
+          <%!-- The audiobook form's twin: several authors accepted from a
+            record is several cards, each with a Search of its own, and this
+            presses them all. --%>
+          <:action :if={NewPerson.searchable(@people_cards, @new_people) > 1}>
+            <.button
+              color={:zinc}
+              type="button"
+              phx-click={NewPerson.search_all(@people_cards, @new_people)}
+            >
+              Search all {NewPerson.searchable(@people_cards, @new_people)}
+            </.button>
+          </:action>
           <.inputs_for
             :let={book_author_form}
             field={@form[:book_authors]}
@@ -171,7 +185,7 @@
           >
             <.inputs_for
               :let={author_form}
-              :if={NewPerson.carded?(book_author_form, :author, [:author, :author_people])}
+              :if={NewPerson.carded?(book_author_form, [:author, :author_people])}
               field={book_author_form[:author]}
             >
               <%!-- A bracket, never a filled block: wrapping cards in a card is

--- a/lib/ambry_web/live/admin/evidence.ex
+++ b/lib/ambry_web/live/admin/evidence.ex
@@ -22,6 +22,7 @@ defmodule AmbryWeb.Admin.Evidence do
   # nothing to offer and no row worth rendering.
   import AmbryWeb.Admin.Decisions, only: [source_words: 1]
 
+  alias Ambry.Inbox
   alias Ambry.Media.Scanner.Tags
 
   @tags_fields ~w(title authors narrators published publisher description series asin
@@ -93,12 +94,29 @@ defmodule AmbryWeb.Admin.Evidence do
   @doc """
   Folds a person fan-out's `{matches, outcomes}` into the panel —
   `Ambry.Metadata.Search.people/2` shape, flat matches across providers.
+
+  `about: name` ticks the arrivals that are **about that human** — person
+  search is recall-first, so a search for one narrator returns everybody who
+  shares a name token with them, and only the ones spelling the same name are
+  evidence about this person. This is what an import does: `Draft.Seed` uses
+  every name-matching candidate as a source without being asked, which is why
+  an imported person arrives with a face and a biography and one credited on
+  an edit form arrived empty (operator, 2026-08-21).
   """
-  def absorb_people(%__MODULE__{} = evidence, {matches, outcomes}) do
-    absorb_records(evidence, Enum.map(matches, &person_record/1), outcomes)
+  def absorb_people(%__MODULE__{} = evidence, {matches, outcomes}, opts \\ []) do
+    absorb_records(evidence, Enum.map(matches, &person_record/1), outcomes, about(opts[:about]))
   end
 
-  defp absorb_records(evidence, fresh, outcomes) do
+  # Matching's own rule for "one human, two spellings" — initials,
+  # punctuation and accents fold (`Ambry.Inbox.person_key/1`).
+  defp about(nil), do: fn _record -> false end
+
+  defp about(name) do
+    key = Inbox.person_key(name)
+    fn record -> is_binary(record["name"]) and Inbox.person_key(record["name"]) == key end
+  end
+
+  defp absorb_records(evidence, fresh, outcomes, about \\ fn _record -> false end) do
     held = MapSet.new(evidence.records, &ref/1)
     added = Enum.reject(fresh, &MapSet.member?(held, ref(&1)))
 
@@ -106,11 +124,14 @@ defmodule AmbryWeb.Admin.Evidence do
     kept = Enum.reject(evidence.outcomes, &MapSet.member?(fresh_ids, &1["id"]))
 
     # A record this record's own provenance points back at arrives ticked —
-    # it filled fields here once, so it counts until somebody says otherwise.
+    # it filled fields here once, so it counts until somebody says otherwise
+    # — and so does one that is plainly about the human being asked about.
     # Only NEWLY arrived records auto-tick: re-searching must never re-tick
     # what the operator unticked.
     recognized =
-      for record <- added, Map.has_key?(evidence.known, ref(record)), do: ref(record)
+      for record <- added,
+          Map.has_key?(evidence.known, ref(record)) or about.(record),
+          do: ref(record)
 
     %{
       evidence
@@ -216,6 +237,11 @@ defmodule AmbryWeb.Admin.Evidence do
 
     %{evidence | used: used}
   end
+
+  @doc """
+  Unticks everything — the panel's answer to "none of these describes them".
+  """
+  def use_none(%__MODULE__{} = evidence), do: %{evidence | used: MapSet.new()}
 
   @doc "Whether a record is ticked."
   def used?(%__MODULE__{} = evidence, record), do: MapSet.member?(evidence.used, ref(record))

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -54,6 +54,7 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   alias Ambry.Library.Placement
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
+  alias AmbryWeb.Admin.NewPerson
   alias AmbryWeb.Admin.ReturnTo
   alias AmbryWeb.Components.EntityResolver
   alias Phoenix.LiveView.AsyncResult
@@ -287,6 +288,35 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
 
   @doc "What each person provider said when asked about them."
   def person_outcomes(item, key), do: get_in(item.matches, ["people", key, "providers"]) || []
+
+  @doc """
+  Searches for every person nobody has asked about — the edit forms'
+  control, sharing their implementation.
+  """
+  def search_all_people(item, searching) do
+    item |> unsearched_people(searching) |> NewPerson.search_all(%{})
+  end
+
+  @doc """
+  The people on this draft nobody has asked the databases about, as
+  `{key, name}` — what the People section's "Search all" presses.
+
+  Matching asks about everyone an item arrives with, so this is normally
+  empty and the control is absent; it fills up when the operator *adds*
+  credits, which is the same state an edit form is in the whole time
+  (`AmbryWeb.Admin.NewPerson.search_all/2`).
+  """
+  def unsearched_people(item, searching) do
+    for group <- Draft.people_groups(item.draft),
+        person <- group.people,
+        person.mode == :create,
+        person_records(item, person.key) == [],
+        not Map.has_key?(searching, person.key),
+        name = Field.value(person.name),
+        name not in [nil, ""] do
+      {person.key, name}
+    end
+  end
 
   @doc """
   The people the library already has by this human's name.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -813,7 +813,22 @@
         class="space-y-7"
         inert={@read_only}
       >
-        <h2 class="text-xl font-bold text-zinc-100">People</h2>
+        <%!-- The edit forms' control, on the surface it came from: matching
+            asks about everyone an item arrives with, so this is normally
+            absent and appears where the operator has *added* credits. --%>
+        <div class="flex items-baseline justify-between gap-4">
+          <h2 class="text-xl font-bold text-zinc-100">People</h2>
+
+          <.button
+            :if={length(unsearched_people(@item, @searching_people)) > 1}
+            color={:zinc}
+            type="button"
+            phx-click={search_all_people(@item, @searching_people)}
+            class="flex-none"
+          >
+            Search all {length(unsearched_people(@item, @searching_people))}
+          </.button>
+        </div>
 
         <div :for={group <- Draft.people_groups(@item.draft)} class="space-y-3">
           <%!-- A bracket, never a filled block: wrapping cards in a card is

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -813,33 +813,39 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
 
   defp save_media(socket, :edit, media_params) do
     opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]
-    media_params = NewPerson.import_photos(media_params, "media_narrators")
 
-    case Media.update_media(socket.assigns.media, media_params, opts) do
-      {:ok, media} ->
-        # a title override or a changed date moves the folder
-        {:ok, _job} = Media.organize_async(media)
+    with {:ok, media_params} <- NewPerson.import_photos(media_params, "media_narrators"),
+         {:ok, media} <- Media.update_media(socket.assigns.media, media_params, opts) do
+      # a title override or a changed date moves the folder
+      {:ok, _job} = Media.organize_async(media)
 
-        {:noreply,
-         socket
-         |> put_flash(:info, "Updated audiobook for #{media.book.title}")
-         |> push_navigate(
-           to: ReturnTo.path(~p"/admin/audiobooks", socket.assigns.list_params, media.id)
-         )}
-
+      {:noreply,
+       socket
+       |> put_flash(:info, "Updated audiobook for #{media.book.title}")
+       |> push_navigate(
+         to: ReturnTo.path(~p"/admin/audiobooks", socket.assigns.list_params, media.id)
+       )}
+    else
       {:error, %Changeset{} = changeset} ->
         {:noreply, assign_form(socket, changeset)}
+
+      {:error, {:failed_photos, urls}} ->
+        {:noreply, put_flash(socket, :error, NewPerson.photos_error(urls))}
     end
   end
 
   defp assign_form(socket, %Changeset{} = changeset) do
     # generated chapter titles are positions and follow their rows
     changeset = renumber_generated(changeset)
+    cards = NewPerson.cards(changeset, :media_narrators, [:narrator])
 
     assign(socket,
       form: to_form(changeset),
       # the move buttons need to know where the ends of the list are
-      media_narrator_count: Reordering.row_count(changeset, :media_narrators)
+      media_narrator_count: Reordering.row_count(changeset, :media_narrators),
+      # the People section's own control: the cards are rendered by
+      # `inputs_for` and a heading above them has no walk of its own
+      people_cards: cards
     )
   end
 

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -150,14 +150,12 @@
                   fetch={&People.narrator_option/1}
                   create_name={"#{media_narrator_form.name}[narrator][name]"}
                   create_value={staged_name(media_narrator_form, :narrator)}
-                  create_flag_name={"#{media_narrator_form.name}[narrator][create]"}
-                  create_flag_value={NewPerson.chosen(media_narrator_form, :narrator)}
                   container_class="grow"
                 />
                 <%!-- Who this credit means, and a way down to their card. --%>
                 <.inputs_for
                   :let={narrator_form}
-                  :if={NewPerson.carded?(media_narrator_form, :narrator, [:narrator])}
+                  :if={NewPerson.carded?(media_narrator_form, [:narrator])}
                   field={media_narrator_form[:narrator]}
                   skip_hidden
                   skip_persistent_id
@@ -198,17 +196,30 @@
             </:add>
           </.list_cluster>
 
-          <%!-- The humans these credits are about to invent, in the import
-            form's own section — under the credits that name them, because
-            that is where they came from, and separate from them, because
-            "what is this person called, and what do they look like" is a
-            different question from "who read this book". The book form's
-            twin, one join shallower. --%>
+          <%!-- The humans these credits are about, in the import form's own
+            section and under its own name — under the credits that name
+            them, because that is where they came from, and separate from
+            them, because "what is this person called, and what do they look
+            like" is a different question from "who read this book". The book
+            form's twin, one join shallower. --%>
           <.form_section
-            :if={NewPerson.any?(@form.source, :media_narrators, :narrator, [:narrator])}
-            id="new-people"
-            title="New people"
+            :if={NewPerson.any?(@form.source, :media_narrators, [:narrator])}
+            id="people"
+            title="People"
           >
+            <%!-- Ten narrators accepted from a record is ten cards, each with
+              a Search of its own; this presses them all. It counts what it
+              would ask about, because a control that might do nothing should
+              say so before it is pressed. --%>
+            <:action :if={NewPerson.searchable(@people_cards, @new_people) > 1}>
+              <.button
+                color={:zinc}
+                type="button"
+                phx-click={NewPerson.search_all(@people_cards, @new_people)}
+              >
+                Search all {NewPerson.searchable(@people_cards, @new_people)}
+              </.button>
+            </:action>
             <.inputs_for
               :let={media_narrator_form}
               field={@form[:media_narrators]}
@@ -217,7 +228,7 @@
             >
               <.inputs_for
                 :let={narrator_form}
-                :if={NewPerson.carded?(media_narrator_form, :narrator, [:narrator])}
+                :if={NewPerson.carded?(media_narrator_form, [:narrator])}
                 field={media_narrator_form[:narrator]}
               >
                 <.new_person_card

--- a/lib/ambry_web/live/admin/new_person.ex
+++ b/lib/ambry_web/live/admin/new_person.ex
@@ -55,11 +55,13 @@ defmodule AmbryWeb.Admin.NewPerson do
   alias Ambry.People
   alias AmbryWeb.Admin.Evidence
   alias AmbryWeb.Admin.UploadHelpers
+  alias Phoenix.LiveView.JS
 
   defstruct evidence: %Evidence{},
             searching?: false,
             expanded?: false,
             own_name?: false,
+            curated?: false,
             query: nil
 
   @type t :: %__MODULE__{}
@@ -84,23 +86,6 @@ defmodule AmbryWeb.Admin.NewPerson do
   """
   def creating(row_form, path), do: nested(row_form.source, path)
 
-  @doc """
-  Whether the operator *said* they meant a new record, rather than having
-  typed something nothing matches yet.
-
-  Both post the same name — what is typed is the new record's name either way
-  — so a card that watched the typing appeared on the first letter, and did
-  so hardest when what the operator was actually doing was searching for an
-  existing author. Only one of the two is a decision, and the picker's
-  "Create …" row is where it is made (`AmbryWeb.Components.EntityResolver`).
-  """
-  def chosen(row_form, assoc) do
-    case Ecto.Changeset.get_change(row_form.source, assoc) do
-      %Ecto.Changeset{params: %{"create" => flag}} -> flag
-      _nothing -> nil
-    end
-  end
-
   @doc "How many humans a credit's pen name stands for."
   def people_count(row_form) do
     case Ecto.Changeset.get_change(row_form.source, :author) do
@@ -109,9 +94,33 @@ defmodule AmbryWeb.Admin.NewPerson do
     end
   end
 
-  @doc "Whether this row has a person to show a card for."
-  def carded?(row_form, assoc, path),
-    do: chosen(row_form, assoc) == "true" and creating(row_form, path) != nil
+  @doc """
+  Whether this row has a person to show a card for.
+
+  **The row brings a person of its own.** Three things have to be true and
+  this one sentence is all three: the credit names something the library
+  doesn't have (a row pointing at an author it *does* casts nothing —
+  `Ambry.Ecto.EntityRef`), the name is a decision rather than half a word
+  being typed (the picker only tells the form once the box is left), and the
+  human behind it is somebody to make rather than somebody to reuse — a join
+  that already says which person it means carries no nested person at all
+  (`Ambry.People.AuthorPerson.credited_changeset/3`).
+
+  Asked of the params rather than of the changes, which is what keeps the
+  card up when the operator links a library person **from** it: the pick sets
+  `person_id`, the nested person stops being cast, and a card reading changes
+  would vanish at the moment of the pick and take the way back with it. The
+  inputs are still on the page and still post, so the params still say the
+  card is there.
+
+  This used to want a separate "the operator clicked Create" flag, because
+  the picker announced every keystroke. Everything that staged a credit
+  *without* the picker then had to remember to set it, and the provider chips
+  didn't — an accepted narrator got no card at all (operator, 2026-08-21).
+  """
+  def carded?(row_form, path) do
+    match?(%Ecto.Changeset{params: %{"person" => _person}}, creating(row_form, path))
+  end
 
   defp nested(changeset, path) do
     Enum.reduce_while(path, changeset, fn step, changeset ->
@@ -129,10 +138,92 @@ defmodule AmbryWeb.Admin.NewPerson do
   What decides whether the section exists at all: a heading over nothing is
   worse than no heading.
   """
-  def any?(changeset, assoc, nested_assoc, path) do
+  def any?(changeset, assoc, path) do
     changeset
     |> Ecto.Changeset.get_change(assoc, [])
-    |> Enum.any?(&carded?(%{source: &1}, nested_assoc, path))
+    |> Enum.any?(&carded?(%{source: &1}, path))
+  end
+
+  @doc """
+  Every card this credit list renders, as `{key, the name it credits}`.
+
+  What "Search all" needs and nothing else has: the cards are rendered by
+  `inputs_for` inside the form, and a control *above* them has no walk of its
+  own. Same walk `any?/3` makes, carrying the two things a search takes.
+
+  The key mirrors what the templates build — suffixed by the person's index
+  where the join is a list, because a pen name can stand for several humans
+  and each has a card. The list is the last step of `path` in both forms.
+  """
+  def cards(changeset, assoc, path) do
+    changeset
+    |> Ecto.Changeset.get_change(assoc, [])
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {row, index} -> row_cards(row, index, path) end)
+  end
+
+  defp row_cards(row, index, [identity | _rest] = path) do
+    row_form = %{source: row, params: row.params}
+
+    if carded?(row_form, path) do
+      key = row.params["_persistent_id"] || to_string(index)
+
+      name =
+        Ecto.Changeset.get_change(row, identity)
+        |> then(&(&1 && Ecto.Changeset.get_field(&1, :name)))
+
+      case joined(row, path) do
+        {:list, count} -> for at <- 0..(count - 1)//1, do: {"#{key}-#{at}", name}
+        :one -> [{key, name}]
+      end
+    else
+      []
+    end
+  end
+
+  # Whether the card hangs off one join or off a list of them — a stage name
+  # is one human by design, a pen name may be several.
+  defp joined(changeset, path) do
+    Enum.reduce_while(path, :one, fn step, _shape ->
+      case Ecto.Changeset.get_change(changeset, step) do
+        %Ecto.Changeset{} = nested -> {:cont, {:one, nested}}
+        [_ | _] = nested -> {:cont, {:list, nested}}
+        _nothing -> {:halt, :one}
+      end
+    end)
+    |> case do
+      {:list, rows} -> {:list, length(rows)}
+      _one -> :one
+    end
+  end
+
+  @doc """
+  Searches for every card that has not been searched for yet.
+
+  Ten chips clicked is ten new people, and finding out about them was ten
+  more clicks in ten different places (operator, 2026-08-21). Chained
+  `JS.push/3` rather than a new event: pressing them all IS the feature, and
+  each card's own handler already knows what to do with one.
+
+  Cards that have already been asked about are left out — a re-search is a
+  per-card decision, and the button is about the ones nobody has asked about.
+  """
+  def search_all(cards, new_people) do
+    cards
+    |> Enum.reject(fn {key, name} -> blank?(name) or searched?(new_people, key) end)
+    |> Enum.reduce(%JS{}, fn {key, name}, js ->
+      JS.push(js, "research-person", value: %{"key" => key, "name" => name})
+    end)
+  end
+
+  @doc "How many cards `search_all/2` would ask about."
+  def searchable(cards, new_people) do
+    Enum.count(cards, fn {key, name} -> not (blank?(name) or searched?(new_people, key)) end)
+  end
+
+  defp searched?(new_people, key) do
+    state = state(new_people, key)
+    state.searching? or state.evidence.searched?
   end
 
   @doc """
@@ -205,6 +296,7 @@ defmodule AmbryWeb.Admin.NewPerson do
       person={@person}
       group={@group}
       person_index={@person_index}
+      at={"card-" <> @key}
       input_prefix={@row.name <> "[person]"}
       link_input={@row.name <> "[person_id]"}
       list_sort_name={@list_sort_name}
@@ -252,8 +344,10 @@ defmodule AmbryWeb.Admin.NewPerson do
   defp decision(row, key, state) do
     staged = row.params["person"] || %{}
     linked = presence(to_string(row[:person_id].value || ""))
-    photo = presence(staged["image_import_url"])
-    description = staged["description"]
+    photos = candidates(state, :image, "image_import_url")
+    bios = candidates(state, :description, "description")
+    photo = presence(answered(staged, "image_import_url", photos))
+    description = answered(staged, "description", bios)
 
     %PersonDecision{
       key: key,
@@ -261,11 +355,44 @@ defmodule AmbryWeb.Admin.NewPerson do
       person_id: linked,
       own_name: state.own_name?,
       name: %Field{value: staged["name"] || row.params["name"]},
-      image: field(photo, candidates(state, :image, "image_import_url")),
-      description: field(description, candidates(state, :description, "description")),
-      sources: Enum.map(Evidence.used_records(state.evidence), &SourceRef.of/1)
+      image: field(photo, photos),
+      description: field(description, bios),
+      sources: Enum.map(Evidence.used_records(state.evidence), &SourceRef.of/1),
+      # What lights "None of these", which is the card's reading of "they
+      # touched the evidence and left nothing ticked" — the same reading the
+      # import form makes. Records arrive ticked here, so an untouched card
+      # with nothing used has simply found nobody, and must not claim to have
+      # been answered.
+      evidence_curated: state.curated?
     }
   end
+
+  # **A question nobody has answered is answered by the best record.**
+  #
+  # A ticked record only ever *offered* a face and a biography here, so
+  # finishing a person meant clicking two more chips per human — and the
+  # operator who ticked the record and saved got a person with a name and
+  # nothing else, which is the exact asymmetry `EDIT_PARITY_PLAN.md` was
+  # opened to close. An import takes the best record's answer for both and
+  # leaves the rest one click away (`Draft.Seed.scalar/2`, `alternatives:
+  # true`); so does this.
+  #
+  # **Absent is unanswered; present-and-empty is an answer.** The card's
+  # controls are inputs, so once one has rendered every later post carries
+  # it — which means "no photo" and a cleared biography arrive as `""` and
+  # are left exactly as they are. Only a person nobody has posted anything
+  # about yet has no key at all, and that is the one this fills.
+  defp answered(staged, key, candidates) do
+    case Map.fetch(staged, key) do
+      {:ok, value} -> value
+      :error -> best(candidates)
+    end
+  end
+
+  # Evidence orders proposals by the score of the record that made them, so
+  # the first is the best record's answer.
+  defp best([%Candidate{value: value} | _rest]), do: value
+  defp best(_none), do: nil
 
   defp field(value, candidates) do
     chosen = Enum.find(candidates, &(present(&1.value) == present(value)))
@@ -339,7 +466,7 @@ defmodule AmbryWeb.Admin.NewPerson do
     <.credit_people
       id={"credit-people-#{@key}"}
       faces={@faces}
-      section_href="#new-people"
+      section_href="#people"
       class="h-10 items-center"
     />
     """
@@ -365,7 +492,7 @@ defmodule AmbryWeb.Admin.NewPerson do
   Every event a card raises, so a form can forward them in one clause.
   """
   def events, do: ~w(research-person person-query toggle-person-source toggle-photos separate-name
-         use-credited-name)
+         use-credited-name uncatalogued-person)
 
   @doc """
   Handles one card event. The form that renders the card owns nothing but the
@@ -391,7 +518,21 @@ defmodule AmbryWeb.Admin.NewPerson do
     state = state(socket.assigns.new_people, key)
 
     {:noreply,
-     put_state(socket, key, %{state | evidence: Evidence.toggle(state.evidence, source, id)})}
+     put_state(socket, key, %{
+       state
+       | curated?: true,
+         evidence: Evidence.toggle(state.evidence, source, id)
+     })}
+  end
+
+  # The photo and the biography are inputs, and the button blanks them on the
+  # client the way the chips fill them (`assets/js/hooks/set-input.js`); what
+  # is left for the server is the evidence itself.
+  def handle_event("uncatalogued-person", %{"key" => key}, socket) do
+    state = state(socket.assigns.new_people, key)
+
+    {:noreply,
+     put_state(socket, key, %{state | curated?: true, evidence: Evidence.use_none(state.evidence)})}
   end
 
   # What the box holds, which stops following the credited name the moment
@@ -424,6 +565,11 @@ defmodule AmbryWeb.Admin.NewPerson do
   @doc """
   Absorbs one card's search results. Records are added, never replaced, so a
   re-search cannot un-tick what the operator chose.
+
+  The ones actually **about** the name searched for arrive ticked, and the
+  best of them answers the photo and biography the operator hasn't answered
+  — see `Evidence.absorb_people/3` and `answered/3`. Person search is
+  recall-first, so the rest are listed and left alone.
   """
   def handle_async({:person_search, key}, {:ok, result}, socket) do
     state = state(socket.assigns.new_people, key)
@@ -432,7 +578,7 @@ defmodule AmbryWeb.Admin.NewPerson do
      put_state(socket, key, %{
        state
        | searching?: false,
-         evidence: Evidence.absorb_people(state.evidence, result)
+         evidence: Evidence.absorb_people(state.evidence, result, about: state.query)
      })}
   end
 
@@ -462,33 +608,63 @@ defmodule AmbryWeb.Admin.NewPerson do
   The walk is blind to the shape below the association on purpose: an author
   reaches their person through `author_people` and a narrator reaches theirs
   directly, and neither route is worth spelling out twice.
+
+  **A download that fails stops the save.** It used to drop the URL and carry
+  on, so a form that saved perfectly well created a person with no face and
+  said nothing about it — indistinguishable, from the operator's side, from a
+  photo that was never chosen. The recording's own cover has always flashed
+  in that case; so does a person's now, naming the ones that failed.
   """
   def import_photos(params, assoc) when is_map(params) do
     case Map.get(params, assoc) do
-      rows when is_map(rows) or is_list(rows) -> Map.put(params, assoc, walk(rows))
-      _nothing -> params
+      rows when is_map(rows) or is_list(rows) ->
+        case walk(rows, []) do
+          {walked, []} -> {:ok, Map.put(params, assoc, walked)}
+          {_walked, failed} -> {:error, {:failed_photos, Enum.reverse(failed)}}
+        end
+
+      _nothing ->
+        {:ok, params}
     end
   end
 
-  defp walk(value) when is_map(value) do
-    value
-    |> Map.new(fn {key, nested} -> {key, walk(nested)} end)
-    |> download()
+  @doc """
+  What to tell the operator when a chosen photo could not be fetched.
+  """
+  def photos_error([_one]),
+    do: "Couldn't download the photo chosen for a new person. Choose another, or clear it."
+
+  def photos_error(urls),
+    do:
+      "Couldn't download #{length(urls)} of the photos chosen for new people. " <>
+        "Choose others, or clear them."
+
+  defp walk(value, failed) when is_map(value) do
+    {pairs, failed} =
+      Enum.map_reduce(value, failed, fn {key, nested}, failed ->
+        {walked, failed} = walk(nested, failed)
+        {{key, walked}, failed}
+      end)
+
+    pairs |> Map.new() |> download(failed)
   end
 
-  defp walk(value) when is_list(value), do: Enum.map(value, &walk/1)
-  defp walk(value), do: value
+  defp walk(value, failed) when is_list(value), do: Enum.map_reduce(value, failed, &walk/2)
+  defp walk(value, failed), do: {value, failed}
 
-  defp download(%{"image_import_url" => url} = row) when is_binary(url) do
+  defp download(%{"image_import_url" => url} = row, failed) when is_binary(url) do
     if blank?(url) do
-      Map.delete(row, "image_import_url")
+      {Map.delete(row, "image_import_url"), failed}
     else
       case UploadHelpers.handle_image_import(url) do
-        {:ok, path} -> row |> Map.put("image_path", path) |> Map.delete("image_import_url")
-        _failed -> Map.delete(row, "image_import_url")
+        {:ok, path} ->
+          {row |> Map.put("image_path", path) |> Map.delete("image_import_url"), failed}
+
+        _failed ->
+          {Map.delete(row, "image_import_url"), [url | failed]}
       end
     end
   end
 
-  defp download(row), do: Map.delete(row, "image_import_url")
+  defp download(row, failed), do: {Map.delete(row, "image_import_url"), failed}
 end

--- a/test/ambry/metadata/cache_test.exs
+++ b/test/ambry/metadata/cache_test.exs
@@ -15,6 +15,27 @@ defmodule Ambry.Metadata.CacheTest do
     assert {:ok, :value} = Cache.fetch("test:op:arg", fn -> {:ok, :value} end)
   end
 
+  # A partial answer is part of an outage: caching it would keep serving the
+  # half that answered for the whole TTL, which is the miss it exists to
+  # report. Passed through, because the half that answered is worth having.
+  @tag :capture_log
+  test "does not cache partial answers" do
+    assert {:partial, [:some], "uk: HTTP 429"} =
+             Cache.fetch("test:op:arg", fn -> {:partial, [:some], "uk: HTTP 429"} end)
+
+    assert {:ok, :value} = Cache.fetch("test:op:arg", fn -> {:ok, :value} end)
+  end
+
+  # And it beats a stale one: it is this question's answer, now, from the
+  # sources that could be reached.
+  @tag :capture_log
+  test "a partial answer is preferred to a stale entry" do
+    assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
+
+    assert {:partial, [:some], _reason} =
+             Cache.fetch("test:op:arg", fn -> {:partial, [:some], "uk: HTTP 429"} end, ttl: -1)
+  end
+
   test "expired entries are re-fetched" do
     assert {:ok, :old} = Cache.fetch("test:op:arg", fn -> {:ok, :old} end)
     assert {:ok, :new} = Cache.fetch("test:op:arg", fn -> {:ok, :new} end, ttl: -1)

--- a/test/ambry/metadata/registry_test.exs
+++ b/test/ambry/metadata/registry_test.exs
@@ -1,6 +1,7 @@
 defmodule Ambry.Metadata.RegistryTest do
   use Ambry.DataCase
 
+  alias Ambry.Metadata.Cache
   alias Ambry.Metadata.Registry
 
   test "all/0 returns every known provider enabled by default, in priority order" do
@@ -69,6 +70,43 @@ defmodule Ambry.Metadata.RegistryTest do
     {:ok, entry} = Registry.fetch("rreading_glasses")
 
     assert entry.config == %{base_url: "https://api.bookinfo.pro"}
+  end
+
+  # The cache keys on the provider and the question and nothing else, so a
+  # question already asked kept answering the old way for the rest of its TTL
+  # — a week for searches. The operator widened Audible from `us` to
+  # `us, uk`, searched a book they had searched before, and got the US
+  # catalog's answer back (2026-08-21).
+  test "changing what a provider is asked forgets what it answered before" do
+    Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:stale]} end)
+    assert {:ok, [:stale]} = Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:fresh]} end)
+
+    {:ok, _row} = Registry.update("audible", %{config: %{"marketplaces" => "us, uk"}})
+
+    assert {:ok, [:fresh]} = Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:fresh]} end)
+  end
+
+  # Neither changes what a question means, and emptying a provider's cache
+  # for a reorder would cost a round of lookups for nothing.
+  test "enabling, disabling and reordering keep what a provider answered" do
+    Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:stale]} end)
+
+    {:ok, _row} = Registry.update("audible", %{enabled: false})
+    {:ok, _row} = Registry.update("audible", %{enabled: true, priority: 9})
+
+    assert {:ok, [:stale]} = Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:fresh]} end)
+  end
+
+  # Writing the same setting again is not a change, and the operator who
+  # opens the settings and presses Save should not pay for a fresh round of
+  # provider calls.
+  test "saving a config unchanged keeps what a provider answered" do
+    {:ok, _row} = Registry.update("audible", %{config: %{"marketplaces" => "us, uk"}})
+    Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:stale]} end)
+
+    {:ok, _row} = Registry.update("audible", %{config: %{"marketplaces" => "us, uk"}})
+
+    assert {:ok, [:stale]} = Cache.fetch("audible:search_books:q:x", fn -> {:ok, [:fresh]} end)
   end
 
   test "fetch/1 returns an error for unknown providers" do

--- a/test/ambry/metadata/search_test.exs
+++ b/test/ambry/metadata/search_test.exs
@@ -38,4 +38,32 @@ defmodule Ambry.Metadata.SearchTest do
       assert %{"id" => "audnexus", "status" => "failed"} = outcome
     end
   end
+
+  describe "books/2" do
+    # A provider that is several sources behind one name — Audible's regional
+    # catalogs — can answer by halves, and the answer is usable and
+    # incomplete. Reported as a failure *carrying a count*, because everything
+    # that reads outcomes asks one question of them: is there something a
+    # retry could still get?
+    @tag :capture_log
+    test "a provider that answered by halves keeps its records and its retry" do
+      patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+        {:partial, [%Provider.Book{provider: "audible", id: "US1", title: "A Book"}],
+         "uk: HTTP 429"}
+      end)
+
+      {found, outcomes} =
+        Search.books(%Provider.Query{title: "A Book"}, level: :recording, refresh: true)
+
+      assert [{_entry, [%{id: "US1"}]}] = Enum.filter(found, fn {e, _b} -> e.id == "audible" end)
+
+      assert %{"status" => "failed", "count" => 1, "partial" => true, "reason" => reason} =
+               Enum.find(outcomes, &(&1["id"] == "audible"))
+
+      assert reason =~ "uk"
+
+      # which is what sends the matching job round again for the rest
+      assert Ambry.Metadata.Outcome.failed?(Enum.find(outcomes, &(&1["id"] == "audible")))
+    end
+  end
 end

--- a/test/ambry_scraping/audible_test.exs
+++ b/test/ambry_scraping/audible_test.exs
@@ -68,4 +68,95 @@ defmodule AmbryScraping.AudibleTest do
       assert {:ok, []} = Audible.search_books("Jaws", language: "german")
     end
   end
+
+  # Audible's catalog is regional and an edition existing in one marketplace
+  # says nothing about the others, so the operator can ask for several. None
+  # of this was covered when it was written.
+  describe "marketplaces" do
+    defp product(attrs) do
+      Map.merge(
+        %{
+          "asin" => "B000",
+          "title" => "A Book",
+          "language" => "english",
+          "release_date" => "2020-01-01",
+          "narrators" => [%{"name" => "A Reader"}]
+        },
+        attrs
+      )
+    end
+
+    defp answering(by_marketplace) do
+      patch(Client, :get, fn _path, _params, opts ->
+        case Map.fetch(by_marketplace, Keyword.fetch!(opts, :marketplace)) do
+          {:ok, products} when is_list(products) ->
+            {:ok, %{status: 200, body: %{"products" => products}}}
+
+          {:ok, failure} ->
+            failure
+
+          :error ->
+            {:ok, %{status: 200, body: %{"products" => []}}}
+        end
+      end)
+    end
+
+    test "merges what each regional catalog answered" do
+      answering(%{
+        "us" => [product(%{"asin" => "US1", "title" => "A Book"})],
+        "uk" => [product(%{"asin" => "UK1", "title" => "Another Book"})]
+      })
+
+      assert {:ok, books} = Audible.search_books("q", marketplaces: ["us", "uk"])
+      assert Enum.map(books, & &1.title) == ["A Book", "Another Book"]
+    end
+
+    # The same recording carries a different ASIN in every regional catalog,
+    # which is why the key isn't the ASIN.
+    test "one recording in two catalogs is one result" do
+      answering(%{
+        "us" => [product(%{"asin" => "US1"})],
+        "uk" => [product(%{"asin" => "UK1"})]
+      })
+
+      assert {:ok, [only]} = Audible.search_books("q", marketplaces: ["us", "uk"])
+      # the configured order is a preference order
+      assert only.id == "US1"
+    end
+
+    # The distinction the whole setting exists to make: a catalog that could
+    # not be reached is not a catalog with nothing in it. This used to answer
+    # plain `{:ok, …}` and the miss was invisible.
+    test "a region that could not be reached is reported, with what did answer" do
+      answering(%{
+        "us" => [product(%{"asin" => "US1"})],
+        "uk" => {:ok, %{status: 429, body: %{}}}
+      })
+
+      assert {:partial, [only], unreached} = Audible.search_books("q", marketplaces: ["us", "uk"])
+      assert only.id == "US1"
+      assert unreached =~ "uk"
+      assert unreached =~ "429"
+    end
+
+    test "every region failing is a failure, not an empty catalog" do
+      answering(%{
+        "us" => {:error, :timeout},
+        "uk" => {:error, :timeout}
+      })
+
+      assert {:error, _reason} = Audible.search_books("q", marketplaces: ["us", "uk"])
+    end
+
+    test "the operator's spelling of the setting is parsed generously" do
+      assert Audible.parse_marketplaces("us, uk") == ["us", "uk"]
+      assert Audible.parse_marketplaces("US UK") == ["us", "uk"]
+      # a typo costs that one marketplace, not the search
+      assert Audible.parse_marketplaces("us, xx") == ["us"]
+      # and a setting with nothing usable in it falls back rather than
+      # silently disabling Audible
+      assert Audible.parse_marketplaces("xx") == ["us"]
+      assert Audible.parse_marketplaces(nil) == ["us"]
+    end
+  end
 end

--- a/test/ambry_web/live/admin/book_live/new_person_test.exs
+++ b/test/ambry_web/live/admin/book_live/new_person_test.exs
@@ -54,7 +54,7 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
       "book" => %{
         "book_authors_sort" => ["new"],
         "book_authors" => %{
-          "new" => %{"author_id" => "", "author" => %{"name" => name, "create" => "true"}}
+          "new" => %{"author_id" => "", "author" => %{"name" => name}}
         }
       }
     })
@@ -63,25 +63,38 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
   # Typing a name and *deciding* to create one post the same name — what is
   # typed is the new record's name either way — so a card that watched the
   # typing appeared on the first letter, and did so hardest when what the
-  # operator was doing was searching for an author who already exists.
+  # operator was doing was searching for an author who already exists. The
+  # picker is where that is settled: it moves under the typing and tells the
+  # form on blur, which is when a native input would have fired `change`.
   test "typing a name is not yet a decision to create one", %{conn: conn} do
     book = insert(:book, book_authors: [])
     {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
 
+    view
+    |> form("#book-form")
+    |> render_change(%{
+      "book" => %{"book_authors_sort" => ["new"], "book_authors" => %{"new" => %{}}}
+    })
+
+    picker = "book_book_authors_0_author_id"
+
     html =
       view
-      |> form("#book-form")
-      |> render_change(%{
-        "book" => %{
-          "book_authors_sort" => ["new"],
-          "book_authors" => %{
-            "new" => %{"author_id" => "", "author" => %{"name" => "M", "create" => "false"}}
-          }
-        }
-      })
+      |> element("##{picker}-input")
+      |> render_change(%{"resolver" => %{picker => "Matt Dinn"}})
 
     refute html =~ ~s{data-role="person-card"}
-    refute html =~ "New people"
+    refute html =~ "People"
+
+    # nothing was announced to the form, which is what kept the card away:
+    # the hidden inputs moved under the typing, and a save would post the
+    # name, but no `change` was raised for anything to react to
+    refute_push_event(view, "entity-resolver:moved", %{})
+
+    # looking away is the moment it becomes one
+    view |> with_target("##{picker}") |> render_click("close", %{})
+
+    assert_push_event(view, "entity-resolver:moved", %{text: "Matt Dinn", value: ""})
   end
 
   # The card is titled by the CREDIT — "Foo, a pen name of Bar" only reads
@@ -106,7 +119,6 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
               "author_id" => "",
               "author" => %{
                 "name" => "Robert Galbraith",
-                "create" => "true",
                 "author_people" => %{"0" => %{"person" => %{"name" => "J.K. Rowling"}}}
               }
             }
@@ -140,10 +152,10 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
 
     # A section of its own, under the credits that name them — the import
     # form's anatomy. It used to be a card inside the Authors card.
-    assert has_element?(view, ~s{#new-people [data-role="person-card"]})
+    assert has_element?(view, ~s{#people [data-role="person-card"]})
 
-    assert Floki.find(Floki.parse_document!(html), ~s{#new-people h2}) |> Floki.text() ==
-             "New people"
+    assert Floki.find(Floki.parse_document!(html), ~s{#people h2}) |> Floki.text() ==
+             "People"
   end
 
   # The complaint this card was rebuilt on: it is the import form's card, not
@@ -212,12 +224,7 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
 
     name_an_author(view, "Matt Dinniman")
     render_click(view, "research-person", %{"key" => "0-0", "name" => "Matt Dinniman"})
-    render_async(view)
-
-    html =
-      view
-      |> element(~s{[data-role="person-card"] [data-role="record"] input[type="checkbox"]})
-      |> render_click()
+    html = render_async(view)
 
     doc = Floki.parse_document!(html)
     targets = doc |> Floki.find("[data-set-input]") |> Floki.attribute("data-set-input")
@@ -290,6 +297,79 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
       })
 
     refute html =~ ~s{data-role="person-card"}
+  end
+
+  # Every card on an edit form is the first person behind the first credit of
+  # the only section, so keying their DOM ids by that address gave every card
+  # on the page the same ones, and LiveView's patcher — which finds elements
+  # by id — moved a bio box out of one card into another (operator,
+  # 2026-08-21). A pen name standing for two humans is the same collision one
+  # credit down.
+  test "two new people share no DOM ids", %{conn: conn} do
+    book = insert(:book, book_authors: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/books/#{book}/edit")
+
+    html =
+      view
+      |> form("#book-form")
+      |> render_change(%{
+        "book" => %{
+          "book_authors_sort" => ["a", "b"],
+          "book_authors" => %{
+            "a" => %{"author_id" => "", "author" => %{"name" => "Matt Dinniman"}},
+            "b" => %{"author_id" => "", "author" => %{"name" => "Andy Weir"}}
+          }
+        }
+      })
+
+    assert [_one, _two] = Floki.find(Floki.parse_document!(html), ~s{[data-role="person-card"]})
+
+    duplicates =
+      ~r/ id="([^"]+)"/
+      |> Regex.scan(html)
+      |> Enum.map(&Enum.at(&1, 1))
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_id, count} -> count > 1 end)
+
+    assert duplicates == []
+  end
+
+  # The other call site of the same save: a book being created, where a
+  # photo that cannot be fetched must stop the save rather than quietly
+  # producing an author with no face.
+  test "a photo that cannot be downloaded stops a create and says so", %{conn: conn} do
+    patch(AmbryWeb.Admin.UploadHelpers, :handle_image_import, fn
+      @photo -> {:error, :failed_to_download_image}
+      _no_url -> {:ok, :no_image_url}
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/books/new")
+
+    html =
+      view
+      |> form("#book-form")
+      |> render_submit(%{
+        "book" => %{
+          "title" => "Dungeon Crawler Carl",
+          "published" => "2020-07-22",
+          "published_format" => "full",
+          "book_authors_sort" => ["new"],
+          "book_authors" => %{
+            "new" => %{
+              "author_id" => "",
+              "author" => %{
+                "name" => "Matt Dinniman",
+                "author_people" => %{
+                  "0" => %{"person" => %{"image_import_url" => @photo}}
+                }
+              }
+            }
+          }
+        }
+      })
+
+    assert html =~ "Couldn&#39;t download the photo chosen for a new person"
+    assert Repo.all(Person) == []
   end
 
   # A pen name for a person the library already has reaches an existing
@@ -392,7 +472,6 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
               "author_id" => "",
               "author" => %{
                 "name" => "James S.A. Corey",
-                "create" => "true",
                 "author_people_sort" => ["0"],
                 "author_people" => %{"0" => %{"person_id" => to_string(person.id)}}
               }
@@ -432,7 +511,6 @@ defmodule AmbryWeb.Admin.BookLive.NewPersonTest do
             "author_id" => "",
             "author" => %{
               "name" => "James S.A. Corey",
-              "create" => "true",
               "author_people_sort" => ["0", "1"],
               "author_people" => %{
                 "0" => %{"person" => %{"name" => "Daniel Abraham"}},

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -587,6 +587,20 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       assert Floki.text(card) =~ "Credited as author and narrator"
     end
 
+    # The edit forms' control, on the surface it came from — one press for
+    # every person nobody has asked the databases about. Matching asks about
+    # everyone an item arrives with, so it is normally absent; a fixture
+    # whose providers were never configured is the state a credit added by
+    # hand leaves behind.
+    test "offers one search for the people nobody has asked about", %{conn: conn} do
+      item = probed_item(narrator: "Michael Kramer")
+
+      {:ok, view, html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert html =~ "Search all"
+      assert has_element?(view, "#people button", "Search all")
+    end
+
     # A person exists because a credit names them, so the list is derived and
     # deliberately has no add of its own (design language §5).
     test "has no add of its own", %{conn: conn} do

--- a/test/ambry_web/live/admin/media_live/new_person_test.exs
+++ b/test/ambry_web/live/admin/media_live/new_person_test.exs
@@ -50,7 +50,7 @@ defmodule AmbryWeb.Admin.MediaLive.NewPersonTest do
       "media" => %{
         "media_narrators_sort" => ["new"],
         "media_narrators" => %{
-          "new" => %{"narrator_id" => "", "narrator" => %{"name" => name, "create" => "true"}}
+          "new" => %{"narrator_id" => "", "narrator" => %{"name" => name}}
         }
       }
     })
@@ -70,7 +70,7 @@ defmodule AmbryWeb.Admin.MediaLive.NewPersonTest do
     assert html =~ "This is a stage name"
 
     # a section of its own, under the credits that name them
-    assert has_element?(view, ~s{#new-people [data-role="person-card"]})
+    assert has_element?(view, ~s{#people [data-role="person-card"]})
   end
 
   test "a credit that points at a narrator the library has gets no card", %{conn: conn} do
@@ -98,8 +98,11 @@ defmodule AmbryWeb.Admin.MediaLive.NewPersonTest do
     refute html =~ ~s{data-role="person-card"}
   end
 
-  test "ticking a record offers a photo and a bio that write the person's inputs",
-       %{conn: conn} do
+  # An import takes the best record's face and biography and leaves the rest
+  # one click away (`Draft.Seed.scalar/2`); a credit on an edit form was only
+  # ever *offered* them, so the operator who ticked a record and saved got a
+  # person with a name and nothing else. Same three questions, same answers.
+  test "a record about this human arrives ticked and answers both fields", %{conn: conn} do
     patch_providers()
     media = insert(:media, book: build(:book), media_narrators: [])
 
@@ -107,17 +110,417 @@ defmodule AmbryWeb.Admin.MediaLive.NewPersonTest do
     name_a_narrator(view, "Michael Kramer")
 
     render_click(view, "research-person", %{"key" => "0", "name" => "Michael Kramer"})
+    html = render_async(view)
+
+    assert has_element?(
+             view,
+             ~s{[data-role="person-card"] [data-role="record"] input[type="checkbox"][checked]}
+           )
+
+    assert bio_input(html) == "Michael Kramer has narrated over two hundred books."
+    assert photo_input(html) == @photo
+    assert Repo.all(Person) == []
+  end
+
+  # Recall-first: person search offers everybody sharing a name token, and a
+  # record about somebody else is listed, not used.
+  test "a record about somebody else is listed and left alone", %{conn: conn} do
+    patch(Ambry.Metadata.Providers, :search_authors, fn
+      "rreading_glasses", _query, _opts ->
+        {:ok,
+         [
+           %Provider.Author{
+             provider: "rreading_glasses",
+             id: "999",
+             name: "Michael Crichton",
+             description: "Wrote Jurassic Park.",
+             image_url: @photo
+           }
+         ]}
+
+      _other_provider, _query, _opts ->
+        {:ok, []}
+    end)
+
+    patch(Ambry.Metadata.Providers, :author_details, fn _provider, _id, _opts ->
+      {:error, :not_found}
+    end)
+
+    media = insert(:media, book: build(:book), media_narrators: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+    name_a_narrator(view, "Michael Kramer")
+
+    render_click(view, "research-person", %{"key" => "0", "name" => "Michael Kramer"})
+    html = render_async(view)
+
+    assert html =~ "Michael Crichton"
+
+    refute has_element?(
+             view,
+             ~s{[data-role="person-card"] [data-role="record"] input[type="checkbox"][checked]}
+           )
+
+    assert photo_input(html) == nil
+  end
+
+  # The card's controls are inputs, so everything the form posts after one has
+  # rendered carries an answer — including the empty one that means "not this
+  # face". Only a person nobody has said anything about yet is unanswered.
+  test "an answer already given is not overwritten", %{conn: conn} do
+    patch_providers()
+    media = insert(:media, book: build(:book), media_narrators: [])
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+    name_a_narrator(view, "Michael Kramer")
+    render_click(view, "research-person", %{"key" => "0", "name" => "Michael Kramer"})
     render_async(view)
+
+    # "no photo", which posts the same shape the chip does
+    html =
+      view
+      |> form("#media-form")
+      |> render_change(%{
+        "media" => %{
+          "media_narrators" => %{
+            "0" => %{
+              "narrator_id" => "",
+              "narrator" => %{
+                "name" => "Michael Kramer",
+                "person" => %{"image_import_url" => "", "description" => ""}
+              }
+            }
+          }
+        }
+      })
+
+    assert photo_input(html) == nil
+    assert bio_input(html) == ""
+  end
+
+  # The bug the operator hit: a chip stages a credit without going anywhere
+  # near the picker, and the card it needs was gated on something only the
+  # picker set. Nothing gates it now but the row itself.
+  test "a narrator credited by a provider chip gets their card at once", %{conn: conn} do
+    patch(Ambry.Metadata.Providers, :search_books, fn _provider, _query, _opts ->
+      {:ok,
+       [
+         %Provider.Book{
+           provider: "audible",
+           id: "B0983R6VP1",
+           title: "The Martian",
+           narrators: [%Provider.Contributor{id: "9", name: "Michael Kramer", role: "narrator"}]
+         }
+       ]}
+    end)
+
+    media = insert(:media, book: build(:book, title: "The Martian"), media_narrators: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    view |> form("#research-recording", %{"title" => "The Martian"}) |> render_submit()
+    render_async(view)
+    view |> element(~s{[data-role="record"] input[type="checkbox"]}) |> render_click()
+
+    html = view |> element("#proposals-narrators button", "Michael Kramer") |> render_click()
+
+    assert html =~ ~s{data-role="person-card"}
+    assert html =~ "media[media_narrators][0][narrator][person][description]"
+    assert Repo.all(Person) == []
+  end
+
+  # Every card on an edit form is the first person behind the first credit of
+  # the only section, so keying their ids by that address gave every card the
+  # same four ids — and LiveView's patcher, which finds elements by id, moved
+  # a bio box out of one card and into another (operator, 2026-08-21). The
+  # test harness raises on a duplicate id, so rendering two is the assertion;
+  # this counts them so a failure says what it means.
+  test "two new people share no DOM ids", %{conn: conn} do
+    media = insert(:media, book: build(:book), media_narrators: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
 
     html =
       view
-      |> element(~s{[data-role="person-card"] [data-role="record"] input[type="checkbox"]})
-      |> render_click()
+      |> form("#media-form")
+      |> render_change(%{
+        "media" => %{
+          "media_narrators_sort" => ["a", "b"],
+          "media_narrators" => %{
+            "a" => %{"narrator_id" => "", "narrator" => %{"name" => "Michael Kramer"}},
+            "b" => %{"narrator_id" => "", "narrator" => %{"name" => "Kate Reading"}}
+          }
+        }
+      })
 
-    assert html =~ "has narrated over two hundred books"
-    assert html =~ "media[media_narrators][0][narrator][person][description]"
-    assert html =~ "media[media_narrators][0][narrator][person][image_import_url]"
+    assert [_one, _two] = Floki.find(Floki.parse_document!(html), ~s{[data-role="person-card"]})
+
+    duplicates =
+      ~r/ id="([^"]+)"/
+      |> Regex.scan(html)
+      |> Enum.map(&Enum.at(&1, 1))
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_id, count} -> count > 1 end)
+
+    assert duplicates == []
+  end
+
+  # A face that could not be fetched used to be dropped in silence, so a form
+  # that saved perfectly well created a person without one and said nothing —
+  # indistinguishable from a photo nobody chose.
+  test "a photo that cannot be downloaded stops the save and says so", %{conn: conn} do
+    patch(AmbryWeb.Admin.UploadHelpers, :handle_image_import, fn
+      @photo -> {:error, :failed_to_download_image}
+      _no_url -> {:ok, :no_image_url}
+    end)
+
+    media = insert(:media, book: build(:book), media_narrators: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    html =
+      view
+      |> form("#media-form")
+      |> render_submit(%{
+        "media" => %{
+          "media_narrators_sort" => ["new"],
+          "media_narrators" => %{
+            "new" => %{
+              "narrator_id" => "",
+              "narrator" => %{
+                "name" => "Michael Kramer",
+                "person" => %{"image_import_url" => @photo}
+              }
+            }
+          }
+        }
+      })
+
+    assert html =~ "Couldn&#39;t download the photo chosen for a new person"
     assert Repo.all(Person) == []
+  end
+
+  # What the card's own box holds, which is not the same question as whether
+  # the words are on the page: a record's row states its biography whether or
+  # not the person is taking it.
+  defp bio_input(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(~s{textarea[name="media[media_narrators][0][narrator][person][description]"]})
+    |> Floki.text()
+  end
+
+  # The auto-filled face is a guess, and a wrong guess needs one obvious way
+  # off. It used to be a text button after the strip that only appeared once
+  # a photo was chosen, which read as a caption; it is one of the faces now.
+  test "no face is one of the faces, and taking one off is one click", %{conn: conn} do
+    patch_providers()
+    media = insert(:media, book: build(:book), media_narrators: [])
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+    name_a_narrator(view, "Michael Kramer")
+    render_click(view, "research-person", %{"key" => "0", "name" => "Michael Kramer"})
+    html = render_async(view)
+
+    assert photo_input(html) == @photo
+
+    # the none chip writes the same input the photo chips do, with nothing
+    assert [target] =
+             html
+             |> Floki.parse_document!()
+             |> Floki.attribute(~s{button[title="no photo"]}, "data-set-input")
+
+    assert target == "media[media_narrators][0][narrator][person][image_import_url]"
+
+    html =
+      view
+      |> form("#media-form")
+      |> render_change(%{
+        "media" => %{
+          "media_narrators" => %{
+            "0" => %{
+              "narrator_id" => "",
+              "narrator" => %{
+                "name" => "Michael Kramer",
+                "person" => %{"image_import_url" => ""}
+              }
+            }
+          }
+        }
+      })
+
+    assert photo_input(html) == nil
+
+    # and the way back is still there, wearing the ring that says it is the
+    # answer in force
+    assert html
+           |> Floki.parse_document!()
+           |> Floki.attribute(~s{button[title="no photo"]}, "class")
+           |> List.first() =~ "ring-brand-dark/50"
+  end
+
+  # A face whose record has since been unticked has no strip under it, and
+  # the strip is where the way out lives.
+  test "a chosen face keeps its strip when the records go", %{conn: conn} do
+    media = insert(:media, book: build(:book), media_narrators: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    html =
+      view
+      |> form("#media-form")
+      |> render_change(%{
+        "media" => %{
+          "media_narrators_sort" => ["new"],
+          "media_narrators" => %{
+            "new" => %{
+              "narrator_id" => "",
+              "narrator" => %{
+                "name" => "Michael Kramer",
+                "person" => %{"image_import_url" => @photo}
+              }
+            }
+          }
+        }
+      })
+
+    assert photo_input(html) == @photo
+    assert has_element?(view, ~s{button[title="no photo"]})
+  end
+
+  # The import form's answer to "the databases found people and none of them
+  # is this human", which the edit forms did not have — so the records ran
+  # straight into the biography with nothing between them, and saying "wrong
+  # person" meant unticking every row and clearing two fields by hand.
+  test "None of these unticks the records and takes back what they gave", %{conn: conn} do
+    patch_providers()
+    media = insert(:media, book: build(:book), media_narrators: [])
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+    name_a_narrator(view, "Michael Kramer")
+    render_click(view, "research-person", %{"key" => "0", "name" => "Michael Kramer"})
+    html = render_async(view)
+
+    assert html =~ ~s{data-role="none-of-these"}
+
+    # it empties the person's own inputs on the client, the way the chips
+    # fill them — both of them, from the one control
+    assert [blanks] =
+             html
+             |> Floki.parse_document!()
+             |> Floki.attribute(~s{[data-role="none-of-these"]}, "data-set-blank")
+
+    assert Jason.decode!(blanks) == [
+             "media[media_narrators][0][narrator][person][image_import_url]",
+             "media[media_narrators][0][narrator][person][description]"
+           ]
+
+    html = render_click(view, "uncatalogued-person", %{"key" => "0"})
+
+    refute has_element?(
+             view,
+             ~s{[data-role="person-card"] [data-role="record"] input[type="checkbox"][checked]}
+           )
+
+    # and it reads as the answer it is, rather than as an offer
+    assert html =~ ~s{data-role="none-of-these"}
+    assert html =~ "ring-brand-dark/50"
+  end
+
+  # An untouched card that found nobody has not been answered — it just found
+  # nobody — so the button must not claim it has.
+  test "None of these is not lit before anybody presses it", %{conn: conn} do
+    patch_providers()
+    media = insert(:media, book: build(:book), media_narrators: [])
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+    name_a_narrator(view, "Michael Kramer")
+    render_click(view, "research-person", %{"key" => "0", "name" => "Michael Kramer"})
+    render_async(view)
+
+    # untick by hand: now they HAVE touched it
+    view
+    |> element(~s{[data-role="person-card"] [data-role="record"] input[type="checkbox"]})
+    |> render_click()
+
+    assert view |> element(~s{[data-role="none-of-these"]}) |> render() =~ "ring-brand-dark/50"
+  end
+
+  # Ten chips is ten cards, and finding out about them was ten clicks in ten
+  # places.
+  test "Search all asks about every card nobody has asked about", %{conn: conn} do
+    # a record for whoever is asked about, so each card gets its own answer
+    patch(Ambry.Metadata.Providers, :search_authors, fn
+      "rreading_glasses", query, _opts ->
+        {:ok,
+         [
+           %Provider.Author{
+             provider: "rreading_glasses",
+             id: "id-#{query}",
+             name: query,
+             description: "Narrates.",
+             image_url: @photo
+           }
+         ]}
+
+      _other_provider, _query, _opts ->
+        {:ok, []}
+    end)
+
+    patch(Ambry.Metadata.Providers, :author_details, fn _provider, _id, _opts ->
+      {:error, :not_found}
+    end)
+
+    media = insert(:media, book: build(:book), media_narrators: [])
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    html =
+      view
+      |> form("#media-form")
+      |> render_change(%{
+        "media" => %{
+          "media_narrators_sort" => ["a", "b"],
+          "media_narrators" => %{
+            "a" => %{"narrator_id" => "", "narrator" => %{"name" => "Michael Kramer"}},
+            "b" => %{"narrator_id" => "", "narrator" => %{"name" => "Kate Reading"}}
+          }
+        }
+      })
+
+    assert html =~ "Search all 2"
+
+    view |> element("#people button", "Search all") |> render_click()
+    render_async(view)
+
+    # one card each, both answered
+    assert [_first, _second] =
+             Floki.find(
+               Floki.parse_document!(render(view)),
+               ~s{[data-role="person-card"] [data-role="record"]}
+             )
+
+    # and it stops offering once there is nothing left to ask
+    refute render(view) =~ "Search all"
+  end
+
+  # A single card has its own Search two inches below; a second button for
+  # the same click is noise.
+  test "Search all stays away from a form with one new person", %{conn: conn} do
+    media = insert(:media, book: build(:book), media_narrators: [])
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    html = name_a_narrator(view, "Michael Kramer")
+
+    assert html =~ ~s{data-role="person-card"}
+    refute html =~ "Search all"
+  end
+
+  # The URL the save downloads, as the card is holding it — absent rather
+  # than blank when nobody has chosen one, which is HEEx omitting a nil.
+  defp photo_input(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.attribute(
+      ~s{input[name="media[media_narrators][0][narrator][person][image_import_url]"]},
+      "value"
+    )
+    |> List.first()
   end
 
   test "the biography and photo chosen on the card are the person's", %{conn: conn} do


### PR DESCRIPTION
Everything here came out of one session of the operator using 2.5.0's edit
forms on a real audiobook. Two arcs, two commits.

## The person card the edit forms were actually given

Three reported defects, and the complaint underneath all of them: **the card's
UI and UX must be identical on both surfaces, whatever the mechanism
underneath.**

**A credit staged by a provider chip got no card.** It was gated on a hidden
`create` input that only the *picker* set. Fixed at the picker: it no longer
tells the form on every keystroke, only on pick, create and close — where a
native input raises `change` — so the flag had nothing left to do and
`carded?/2` reads the state it stood in for. Asked of the row's params rather
than its changes, so linking a library person *from* the card doesn't make the
card vanish underneath the pick. `combobox-nav` closes on Tab, since
click-away only catches a mouse leaving the box.

**A bio box that disappeared and came back.** Every card on an edit form is the
first person behind the first credit of the only section, so keying DOM ids on
that address gave every card the same four, two of them hook-bearing, and
LiveView's patcher moved elements between cards. Cards outside a draft's grid
key on the card now. That is also where the `this.prevAttrs is undefined` in
the console came from — `updated` without `beforeUpdate` is what a *moved*
element produces — and `maintain-attrs` is guarded so it can't take the rest of
a patch's hooks down with it.

**No photos saved.** The server path was clean; a ticked record only ever
*offered* a face. Which is this arc's own asymmetry one level down, so records
that spell the same name arrive ticked and the best of them answers the photo
and biography nobody has answered. Absent is unanswered, present-and-empty is
an answer. A failed photo download now stops the save and flashes instead of
being dropped in silence.

And the differences that were left: **"None of these"** is on both surfaces,
**no face is one of the faces** in the photo strip (the way off a wrong
auto-filled photo), **"Search all *n*"** on the section heading of all three
forms, and the section is called **People** everywhere — a card links a person
the library already has, so "New people" narrowed it to less than it holds.

## A region that could not be reached is not a region with nothing in it

Chasing "I set Marketplaces to `us, uk` and still only got the US edition"
turned up two ways the setting could lie. (The report itself was a true answer:
Audible UK sells the same Listening Library ASIN, and the UK recording is no
longer in the catalog at all.)

- **A cached answer was given under the old settings.** The cache keys on the
  provider and the question and nothing else, so changing what a provider is
  *asked* left every question already asked answering the old way for a week.
  `Registry.update/2` empties that provider's cache when the config actually
  changes; enabling, disabling, reordering and re-saving the same values leave
  it alone.

- **A marketplace that failed was swallowed** whenever any other one answered,
  making a rate-limited region indistinguishable from a region where the book
  doesn't exist — the one distinction the setting exists to make. There is a
  `{:partial, products, unreached}` answer now, never cached, reported as a
  failure carrying a count so the retry chip and `unreached_providers/1` keep
  working unchanged: "Audible: 2, some not reached, retry".

## Checks

`mix check` clean. 2007 tests, up from 1974 — the new ones cover the chip
path, two cards on one form having no id in common, the auto-fill and its
"already answered" rule, both escape hatches, "Search all", the failed-photo
flash, and Audible's marketplaces, which had no coverage at all.

https://claude.ai/code/session_017QrZzwL117idZ8v6txLHPm
