### PR TITLE
A row is lit up once, not every time you pass through

### DIFF
--- a/assets/js/hooks/focus-row.js
+++ b/assets/js/hooks/focus-row.js
@@ -31,6 +31,13 @@ export const FocusRowHook = {
       row.scrollIntoView({ block: "center", behavior: "instant" })
       row.classList.add("row-flash")
       row.addEventListener("animationend", () => row.classList.remove("row-flash"), { once: true })
+
+      // Spent. `?focus=` is in the address bar, which means it is in the
+      // browser's history, which meant every back and forward through this
+      // entry lit the row up again. The server replaces the entry with the
+      // same list minus the param — said from here because the flash is the
+      // thing that spends it (`AmbryWeb.Admin.ReturnTo`).
+      this.pushEvent("focus-flashed", {})
     })
   },
 }

--- a/lib/ambry_web/live/admin/book_live/index.ex
+++ b/lib/ambry_web/live/admin/book_live/index.ex
@@ -44,8 +44,6 @@ defmodule AmbryWeb.Admin.BookLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
-     # The record a form just sent the operator back to, if they came from one.
-     |> assign(focus: params["focus"])
      |> maybe_update_books(params)}
   end
 

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -70,8 +70,6 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
-     # The record a form just sent the operator back to, if they came from one.
-     |> assign(focus: params["focus"])
      |> maybe_update_media(params)}
   end
 

--- a/lib/ambry_web/live/admin/person_live/index.ex
+++ b/lib/ambry_web/live/admin/person_live/index.ex
@@ -43,8 +43,6 @@ defmodule AmbryWeb.Admin.PersonLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
-     # The record a form just sent the operator back to, if they came from one.
-     |> assign(focus: params["focus"])
      |> maybe_update_people(params)}
   end
 

--- a/lib/ambry_web/live/admin/recording_group_live/index.ex
+++ b/lib/ambry_web/live/admin/recording_group_live/index.ex
@@ -41,8 +41,6 @@ defmodule AmbryWeb.Admin.RecordingGroupLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
-     # The record a form just sent the operator back to, if they came from one.
-     |> assign(focus: params["focus"])
      |> maybe_update_groups(params)}
   end
 

--- a/lib/ambry_web/live/admin/return_to.ex
+++ b/lib/ambry_web/live/admin/return_to.ex
@@ -19,7 +19,82 @@ defmodule AmbryWeb.Admin.ReturnTo do
   came from, and the browser's own back button restores a *scroll offset* —
   which is the wrong thing to remember anyway. Rename a book and its row moves;
   what the operator means by "put me back" is the record, not the pixel.
+
+  ## `focus` is spent the moment it is used
+
+  Being in the URL is what makes it survive the round trip, and being in the
+  URL is also what put it in the browser's history: every back and forward
+  through that entry lit the row up again, on a list the operator was merely
+  passing through (operator, 2026-08-21).
+
+  So the list says when it has flashed, and the entry is **replaced** with the
+  same list minus `focus` — the history that remains is the one the operator
+  would have made themselves, and there is no entry left to come back to. It
+  is `push_patch(replace: true)`, which is `history.replaceState` with
+  LiveView's own bookkeeping kept straight; doing it in the hook by hand
+  changes the URL behind LiveView's back and leaves its idea of where it is
+  disagreeing with the address bar.
+
+  **After the flash, not on arrival.** Dropping the param as soon as it is
+  read would race the render that carries it to the client, and the whole
+  point of the param is a thing that happens in the browser.
+
+  ## One hook, every admin list
+
+  Mounted on the `:admin` live session rather than added to six index modules,
+  which is what the six identical `assign(focus: params["focus"])` lines were.
+  A page with no `focus` in its params assigns nil and nothing else happens.
   """
+
+  import Phoenix.Component, only: [assign: 2]
+  import Phoenix.LiveView
+
+  @doc false
+  def on_mount(:default, _params, _session, socket) do
+    {:cont,
+     socket
+     |> attach_hook(:focus_arrives, :handle_params, &arrives/3)
+     |> attach_hook(:focus_flashed, :handle_event, &flashed/3)}
+  end
+
+  defp arrives(params, uri, socket) do
+    {:cont, assign(socket, focus: params["focus"], focus_spent: spent_path(params, uri))}
+  end
+
+  # Raised by `assets/js/hooks/focus-row.js` once the row has been found and
+  # lit up. A list that never had a focus never sends it, and a stale page
+  # that sends it anyway has nothing to replace.
+  defp flashed("focus-flashed", _params, socket) do
+    case socket.assigns[:focus_spent] do
+      nil ->
+        {:halt, socket}
+
+      path ->
+        {:halt,
+         socket
+         |> assign(focus: nil, focus_spent: nil)
+         |> push_patch(to: path, replace: true)}
+    end
+  end
+
+  defp flashed(_event, _params, socket), do: {:cont, socket}
+
+  # The same address without the part that has now been used. Built from the
+  # URI the router gave us rather than from anything the client said, so the
+  # only thing a page can ask for is its own address.
+  defp spent_path(%{"focus" => _focus}, uri) do
+    parsed = URI.parse(uri)
+
+    query =
+      (parsed.query || "")
+      |> URI.decode_query()
+      |> Map.delete("focus")
+      |> then(&(map_size(&1) > 0 && URI.encode_query(&1)))
+
+    %URI{path: parsed.path, query: query || nil} |> URI.to_string()
+  end
+
+  defp spent_path(_params, _uri), do: nil
 
   @doc """
   The list state a row link should carry.

--- a/lib/ambry_web/live/admin/series_live/index.ex
+++ b/lib/ambry_web/live/admin/series_live/index.ex
@@ -42,8 +42,6 @@ defmodule AmbryWeb.Admin.SeriesLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
-     # The record a form just sent the operator back to, if they came from one.
-     |> assign(focus: params["focus"])
      |> maybe_update_series(params)}
   end
 

--- a/lib/ambry_web/live/admin/universe_live/index.ex
+++ b/lib/ambry_web/live/admin/universe_live/index.ex
@@ -41,8 +41,6 @@ defmodule AmbryWeb.Admin.UniverseLive.Index do
     {:noreply,
      socket
      |> assign(search_form: to_form(%{"query" => params["filter"]}, as: :search))
-     # The record a form just sent the operator back to, if they came from one.
-     |> assign(focus: params["focus"])
      |> maybe_update_universes(params)}
   end
 

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -170,7 +170,8 @@ defmodule AmbryWeb.Router do
       on_mount: [
         {AmbryWeb.UserAuth, :ensure_authenticated},
         {AmbryWeb.Admin.Auth, :ensure_mounted_admin_user},
-        AmbryWeb.Admin.NavHooks
+        AmbryWeb.Admin.NavHooks,
+        AmbryWeb.Admin.ReturnTo
       ] do
       live "/", HomeLive.Index, :index
 

--- a/test/ambry_web/live/admin/book_live/index_test.exs
+++ b/test/ambry_web/live/admin/book_live/index_test.exs
@@ -276,6 +276,33 @@ defmodule AmbryWeb.Admin.BookLive.IndexTest do
       assert has_element?(view, "#row-#{book.id}")
       assert has_element?(view, "[data-focus='#{book.id}']")
     end
+
+    # Being in the URL is what carried it here and what put it in the
+    # browser's history, where every back and forward through the entry lit
+    # the row up again. The list says when it has flashed and the entry is
+    # replaced with the same list without it.
+    test "the flash spends it, and the history entry goes with it", %{conn: conn} do
+      book = insert(:book, title: "Findable")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books?filter=Findable&focus=#{book.id}")
+
+      render_hook(view, "focus-flashed", %{})
+
+      assert_patch(view, ~p"/admin/books?filter=Findable")
+      refute has_element?(view, "[data-focus='#{book.id}']")
+    end
+
+    # The list the operator merely walked to has nothing to spend, and a
+    # stale page saying otherwise must not send them anywhere.
+    test "a list nobody was sent to stays where it is", %{conn: conn} do
+      insert(:book, title: "Findable")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/books")
+
+      render_hook(view, "focus-flashed", %{})
+
+      refute_patched(view, ~p"/admin/books")
+    end
   end
 
   defp titles(view) do


### PR DESCRIPTION
Saving an edit form sends you back to the list you came from with the record
you saved scrolled to and flashed; `?focus=42` is how the list is told which
one. Being in the URL is what carries that across the round trip — and what
put it in the browser's history, so every back and forward through that entry
lit the row up again, on a list you were merely passing through.

The param is spent the moment it is used. `focus-row.js` raises
`focus-flashed` once the row has been found and lit, and the current history
entry is replaced with the same list minus `focus`:

```
/admin/books?filter=Findable&focus=42   →  flash  →  /admin/books?filter=Findable
```

Your filter, sort and page survive; only the spent part goes, and there is no
entry left to come back to.

**`push_patch(replace: true)`, not `history.replaceState` in the hook.** They
are the same call, but one keeps LiveView's navigation bookkeeping straight and
the other changes the URL behind its back.

**After the flash, not on arrival.** Dropping the param as soon as it is read
would race the render that carries it to the client, and the thing the param
exists for happens in the browser.

**One hook, not six.** An `on_mount` on the `:admin` live session attaching a
`handle_params` hook (assigns `focus`) and a `handle_event` hook (spends it),
which deleted the six identical `assign(focus: params["focus"])` lines from the
index modules. A page with no `focus` assigns nil and nothing happens; a stale
page that raises the event anyway has nothing to replace. The path is built
from the URI the router hands `handle_params`, never from anything the client
said.

`mix check` clean, 2009 tests — two new ones: the flash spends it, and a list
nobody was sent to stays where it is.

https://claude.ai/code/session_017QrZzwL117idZ8v6txLHPm
