### PR TITLE
Not every pair the report finds is a mistake

### DIFF
--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -181,6 +181,15 @@ hanging-indicator pattern, always via `<.disclosure>`. Browser-default
 summary markers are never used bare: Firefox draws them `inside`, pushing
 the text off the rail; other engines pick their own widths.
 
+**So a fold needs a container to hang that gutter in.** On the ground there
+is no padding edge for the chevron to sit on, and `<.disclosure>` makes one
+anyway: its summary lands 12px right of every heading around it, its chevron
+on the page edge, and neither agrees with the 28px rail of the cards above
+it. Three x-positions, arrived at by following the rule. **A ground-level
+fold gets a card, and its summary becomes that card's label** — the chevron
+takes the padding edge and the summary lands on the rail with everything
+else. The duplicates report's "marked intentional" fold is the case.
+
 **A long editable list scrolls inside its card; it does not fold.** The
 chapter editor is the case: dozens of rows would swallow the form, but a
 fold hides the content *and* fights the autosave patches, while

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -803,11 +803,26 @@ defmodule Ambry.Inbox do
   defdelegate duplicates, to: Duplicates, as: :check
 
   @doc """
+  The sets still asking a question and the sets already answered, in one pass.
+  """
+  defdelegate duplicates_report, to: Duplicates, as: :report
+
+  @doc """
   How many such sets there are, and how many records were examined.
   """
   defdelegate duplicate_count, to: Duplicates, as: :count
 
   defdelegate duplicates_scanned, to: Duplicates, as: :scanned
+
+  @doc """
+  Records a set of records as deliberately distinct, and puts one back.
+
+  Two series that fold to one key may be two real series; the report cannot
+  tell, and neither may it stop saying so. This is where the operator says.
+  """
+  defdelegate dismiss_duplicates(kind, record_ids), to: Duplicates, as: :dismiss
+
+  defdelegate restore_duplicates(kind, record_ids), to: Duplicates, as: :restore
 
   @doc """
   How a provider record is referred to: its provider and that provider's id.

--- a/lib/ambry/inbox/duplicate_dismissal.ex
+++ b/lib/ambry/inbox/duplicate_dismissal.ex
@@ -1,0 +1,23 @@
+defmodule Ambry.Inbox.DuplicateDismissal do
+  @moduledoc """
+  A set of records the operator has said are not each other's duplicates.
+
+  Keyed by the exact members rather than by the folded key they collided on.
+  A dismissal should silence a finding that was looked at, never one that
+  was not: a set that gains a third member is a different set, so it is a
+  finding again and has to be answered again.
+
+  Nothing cleans these up, because nothing has to. A dismissal whose members
+  no longer all exist can never match a group again, so it is inert rather
+  than wrong, and the alternative is a second delete trigger beside
+  `track_delete` earning its keep on a table with two rows in it.
+  """
+
+  use Ecto.Schema
+
+  schema "duplicate_dismissals" do
+    field :kind, Ecto.Enum, values: ~w(person author narrator book series)a
+    field :record_ids, {:array, :integer}
+    field :dismissed_at, :utc_datetime
+  end
+end

--- a/lib/ambry/inbox/duplicates.ex
+++ b/lib/ambry/inbox/duplicates.ex
@@ -38,6 +38,19 @@ defmodule Ambry.Inbox.Duplicates do
   Because the question a found pair raises is always "which one can go", and
   it is answered by the one nothing references. Counts are per record rather
   than per group for the same reason.
+
+  ## Not every pair is a mistake
+
+  Sameness being the importer's rule means some correct findings have no
+  record to remove. `same_series?/2` folds a subtitle head and filler words,
+  so it pairs a companion series with its parent and two spellings of one
+  shelf an operator keeps apart on purpose. Both are right about the fold and
+  wrong about the conclusion, and tightening the rule here to say so is the
+  drift this module exists not to have.
+
+  So the answer is a decision, recorded: `dismiss/2` settles one set and
+  `restore/2` puts it back. A dismissal names its exact members, so a set
+  that later gains one is a set nobody has looked at, and asks again.
   """
 
   import Ecto.Query
@@ -45,6 +58,7 @@ defmodule Ambry.Inbox.Duplicates do
   alias Ambry.Books.Book
   alias Ambry.Books.Series
   alias Ambry.Inbox.AutoMatch
+  alias Ambry.Inbox.DuplicateDismissal
   alias Ambry.People.Author
   alias Ambry.People.Narrator
   alias Ambry.People.Person
@@ -77,22 +91,76 @@ defmodule Ambry.Inbox.Duplicates do
   Ordered people, authors, narrators, books, series: a duplicated person is
   the one that splits a face and a bio in two, and a duplicated series the
   one most likely to be two real series that merely rhyme.
+
+  Sets marked intentional are not here; see `report/0`.
   """
   @spec check() :: [group()]
-  def check do
-    Enum.map(groups(), fn %{kind: kind, records: records} ->
-      %{kind: kind, records: Enum.map(records, &with_uses(kind, &1))}
-    end)
+  def check, do: report().found
+
+  @doc """
+  The findings, and the sets that have been answered, from one pass.
+
+  Both halves in one call because the page shows both and `groups/0` reads
+  five tables whole. Splitting them into two functions meant the page paid
+  for that twice to draw one screen.
+  """
+  @spec report() :: %{found: [group()], dismissed: [group()]}
+  def report do
+    dismissed = dismissals()
+    {settled, found} = Enum.split_with(groups(), &dismissed?(&1, dismissed))
+
+    %{
+      found: Enum.map(found, &records_with_uses/1),
+      dismissed: Enum.map(settled, &records_with_uses/1)
+    }
   end
 
   @doc """
-  How many sets there are, without asking what references them.
+  How many sets are still asking a question, without asking what references
+  them.
 
   For the overview, which reloads on a heartbeat and only needs to know
-  whether there is anything to say.
+  whether there is anything to say. A set marked intentional has been
+  answered, so it is not something to say.
   """
   @spec count() :: non_neg_integer()
-  def count, do: length(groups())
+  def count do
+    dismissed = dismissals()
+    Enum.count(groups(), &(not dismissed?(&1, dismissed)))
+  end
+
+  @doc """
+  Records this set as intentional, so the report stops asking about it.
+
+  Idempotent: the same set marked twice is one dismissal, which matters
+  because the page it is clicked from can be open in two tabs.
+  """
+  @spec dismiss(kind(), [integer()]) :: :ok
+  def dismiss(kind, record_ids) do
+    Repo.insert!(
+      %DuplicateDismissal{
+        kind: kind,
+        record_ids: Enum.sort(record_ids),
+        dismissed_at: DateTime.truncate(DateTime.utc_now(), :second)
+      },
+      on_conflict: :nothing,
+      conflict_target: [:kind, :record_ids]
+    )
+
+    :ok
+  end
+
+  @doc """
+  Puts a set back into the report.
+  """
+  @spec restore(kind(), [integer()]) :: :ok
+  def restore(kind, record_ids) do
+    ids = Enum.sort(record_ids)
+
+    Repo.delete_all(from d in DuplicateDismissal, where: d.kind == ^kind and d.record_ids == ^ids)
+
+    :ok
+  end
 
   @doc """
   What was examined, so a report of nothing can say what nothing covers.
@@ -107,6 +175,24 @@ defmodule Ambry.Inbox.Duplicates do
       series: Repo.aggregate(Series, :count)
     }
   end
+
+  ## what has been answered
+
+  # The key is the members, sorted, and not the key they folded together on.
+  # A set that gains a third member is a set nobody has looked at, and the
+  # whole point of a dismissal is that somebody looked.
+  defp dismissed?(%{kind: kind, records: records}, dismissals),
+    do: MapSet.member?(dismissals, {kind, records |> Enum.map(& &1.id) |> Enum.sort()})
+
+  defp dismissals do
+    DuplicateDismissal
+    |> select([d], {d.kind, d.record_ids})
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp records_with_uses(%{kind: kind, records: records}),
+    do: %{kind: kind, records: Enum.map(records, &with_uses(kind, &1))}
 
   ## finding them
 

--- a/lib/ambry_web/live/admin/duplicates_live/index.ex
+++ b/lib/ambry_web/live/admin/duplicates_live/index.ex
@@ -23,11 +23,34 @@ defmodule AmbryWeb.Admin.DuplicatesLive.Index do
   context certainly may not. Each record says what points at it, because the
   question a pair raises is which one can go, and that is answered by the one
   nothing references.
+
+  ## The one thing it can be told
+
+  A set can be marked intentional, because some correct findings have no
+  record to remove: the importer's rule folds a companion series into its
+  parent, and two spellings of one shelf that an operator keeps apart stay
+  found forever otherwise. That is the only action here, and it is the
+  opposite of a merge — it says these are two things, not one.
+
+  Marked sets fold rather than vanish, and the empty state says how many
+  there are. A page whose whole job is to be believed cannot let "nothing
+  found" and "nothing you have not already waved off" read identically, which
+  is the same argument that puts the scanned counts at the top.
   """
 
   use AmbryWeb, :admin_live_view
 
   alias Ambry.Inbox
+
+  # The order the sections are laid out in, and the whitelist a dismissal's
+  # `kind` param is matched against. One list, because a kind the page can
+  # draw and a kind it will accept are the same list.
+  @kinds ~w(person author narrator book series)a
+
+  @doc """
+  The kinds, in the order their sections appear.
+  """
+  def kinds, do: @kinds
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -40,9 +63,36 @@ defmodule AmbryWeb.Admin.DuplicatesLive.Index do
   @impl Phoenix.LiveView
   def handle_event("reload", _params, socket), do: {:noreply, load(socket)}
 
-  defp load(socket) do
-    assign(socket, groups: Inbox.duplicates(), scanned: Inbox.duplicates_scanned())
+  def handle_event("dismiss", %{"kind" => kind, "ids" => ids}, socket) do
+    Inbox.dismiss_duplicates(kind(kind), ids(ids))
+
+    {:noreply,
+     socket
+     |> load()
+     |> put_flash(:info, "Marked intentional. It is in the fold at the bottom of this page.")}
   end
+
+  def handle_event("restore", %{"kind" => kind, "ids" => ids}, socket) do
+    Inbox.restore_duplicates(kind(kind), ids(ids))
+
+    {:noreply, socket |> load() |> put_flash(:info, "Back in the report.")}
+  end
+
+  defp load(socket) do
+    report = Inbox.duplicates_report()
+
+    assign(socket,
+      found: report.found,
+      dismissed: report.dismissed,
+      scanned: Inbox.duplicates_scanned()
+    )
+  end
+
+  # Matched against the kinds rather than `to_existing_atom/1`: the page is
+  # admin-only, but a param is a param, and the list is five words long.
+  defp kind(value), do: Enum.find(@kinds, &(to_string(&1) == value))
+
+  defp ids(value), do: value |> String.split(",") |> Enum.map(&String.to_integer/1)
 
   @doc """
   One record in a set: what it is called, and what still points at it.
@@ -93,6 +143,29 @@ defmodule AmbryWeb.Admin.DuplicatesLive.Index do
   The groups of one kind, in the order the sections are laid out.
   """
   def of_kind(groups, kind), do: Enum.filter(groups, &(&1.kind == kind))
+
+  @doc """
+  A set's members, as the value the dismiss and undo buttons carry.
+  """
+  def ids_value(%{records: records}), do: Enum.map_join(records, ",", & &1.id)
+
+  @doc """
+  What an empty report is allowed to claim.
+
+  "Nothing here twice" stops being true the moment a set has been marked
+  intentional: those records *are* here twice and the operator has said it is
+  fine. Saying the plain thing anyway would make this page the one thing it
+  may not be, which is wrong while looking reassuring.
+  """
+  def all_clear_words([]), do: "Nothing in the library is here twice."
+
+  def all_clear_words(_dismissed), do: "Nothing here twice that you have not already answered."
+
+  @doc """
+  The fold's summary.
+  """
+  def dismissed_words([_one]), do: "1 set marked intentional"
+  def dismissed_words(dismissed), do: "#{length(dismissed)} sets marked intentional"
 
   @doc """
   The heading a kind's section wears, and the sentence under it.

--- a/lib/ambry_web/live/admin/duplicates_live/index.html.heex
+++ b/lib/ambry_web/live/admin/duplicates_live/index.html.heex
@@ -1,43 +1,99 @@
 <.layout title={@page_title} user={@current_user} socket={@socket}>
-  <div class="flex items-baseline gap-4">
-    <%!-- The count of what was examined, not of what was found. A report of
-        nothing and a report that never ran read identically without it, and
-        this page exists to be believed. --%>
-    <p class="text-sm text-zinc-400" data-role="scanned">
-      Checked {scanned_words(@scanned)}.
-    </p>
-    <div class="grow" />
-    <.button color={:zinc} type="button" phx-click="reload">
-      <.icon name="fa-rotate" class="mr-1.5 h-4 w-4 text-current" /> Reload
-    </.button>
-  </div>
+  <%!-- The page's blocks are 28px apart (§3's rhythm). Without this the
+      header row's button sat flush against the card below it. --%>
+  <div class="space-y-7">
+    <div class="flex items-baseline gap-4">
+      <%!-- The count of what was examined, not of what was found. A report of
+          nothing and a report that never ran read identically without it, and
+          this page exists to be believed. Ground level, so no rail (§3). --%>
+      <p class="text-sm text-zinc-400" data-role="scanned">
+        Checked {scanned_words(@scanned)}.
+      </p>
+      <div class="grow" />
+      <.button color={:zinc} type="button" phx-click="reload">
+        <.icon name="fa-rotate" class="mr-1.5 h-4 w-4 text-current" /> Reload
+      </.button>
+    </div>
 
-  <div :if={@groups == []} class="rounded-lg bg-zinc-900 p-4" data-role="all-clear">
-    <p class="pl-3 text-sm text-zinc-300">
-      Nothing in the library is here twice.
-    </p>
-  </div>
+    <div :if={@found == []} class="rounded-lg bg-zinc-900 p-4" data-role="all-clear">
+      <p class="pl-3 text-sm text-zinc-300">
+        {all_clear_words(@dismissed)}
+      </p>
+    </div>
 
-  <div :if={@groups != []} class="space-y-14">
-    <%= for kind <- [:person, :author, :narrator, :book, :series],
-            groups = of_kind(@groups, kind),
-            groups != [] do %>
-      <% {heading, hint} = section(kind) %>
-      <section class="space-y-4" data-role={"section-#{kind}"}>
-        <h2 class="text-xl font-bold text-zinc-100">{heading}</h2>
+    <div :if={@found != []} class="space-y-14">
+      <%= for kind <- kinds(),
+              groups = of_kind(@found, kind),
+              groups != [] do %>
+        <% {heading, hint} = section(kind) %>
+        <section class="space-y-4" data-role={"section-#{kind}"}>
+          <h2 class="text-xl font-bold text-zinc-100">{heading}</h2>
 
-        <p class="max-w-prose text-sm text-zinc-400">{hint}</p>
+          <p class="max-w-prose text-sm text-zinc-400">{hint}</p>
 
-        <%!-- One card per set, so where one ends and the next begins is the
-            shape of the page rather than a line drawn on it. --%>
-        <div
-          :for={group <- groups}
-          class="space-y-2 rounded-lg bg-zinc-900 p-4"
-          data-role="duplicate-set"
-        >
-          <.duplicate_row :for={record <- group.records} kind={kind} record={record} />
+          <%!-- One card per set, so where one ends and the next begins is the
+              shape of the page rather than a line drawn on it. --%>
+          <div
+            :for={group <- groups}
+            class="space-y-2 rounded-lg bg-zinc-900 p-4"
+            data-role="duplicate-set"
+          >
+            <.duplicate_row :for={record <- group.records} kind={kind} record={record} />
+
+            <%!-- The only action a set can carry: this page does not merge, so
+                the one thing it can be told is that there is nothing to merge. --%>
+            <div class="flex justify-end pt-1">
+              <.button
+                color={:zinc}
+                size={:sm}
+                type="button"
+                phx-click="dismiss"
+                phx-value-kind={kind}
+                phx-value-ids={ids_value(group)}
+              >
+                Not a duplicate
+              </.button>
+            </div>
+          </div>
+        </section>
+      <% end %>
+    </div>
+
+    <%!-- The fold is a card, and its summary is the card's own label: a
+        `<details>` needs a 12px gutter to hang its chevron in, and on the
+        ground there is no container whose padding can be that gutter, so it
+        manufactures a third x-position (§3). Carded, the chevron sits on the
+        padding edge and the summary lands on the same rail as every other
+        card's text.
+
+        Folded rather than filtered away, because a set nobody can see is one
+        nobody can change their mind about, and the summary is what stops
+        "nothing found" from quietly meaning "nothing you have not already
+        waved off". --%>
+    <div :if={@dismissed != []} class="rounded-lg bg-zinc-900 p-4" data-role="dismissed">
+      <.disclosure summary={dismissed_words(@dismissed)} class="text-sm text-zinc-300">
+        <div class="space-y-7 pt-3">
+          <div :for={group <- @dismissed} class="space-y-2" data-role="dismissed-set">
+            <% {heading, _hint} = section(group.kind) %>
+            <.microlabel class="block pl-3">{heading}</.microlabel>
+
+            <.duplicate_row :for={record <- group.records} kind={group.kind} record={record} />
+
+            <div class="flex justify-end pt-1">
+              <.button
+                color={:zinc}
+                size={:sm}
+                type="button"
+                phx-click="restore"
+                phx-value-kind={group.kind}
+                phx-value-ids={ids_value(group)}
+              >
+                Undo
+              </.button>
+            </div>
+          </div>
         </div>
-      </section>
-    <% end %>
+      </.disclosure>
+    </div>
   </div>
 </.layout>

--- a/priv/repo/migrations/20260821235718_duplicate_dismissals.exs
+++ b/priv/repo/migrations/20260821235718_duplicate_dismissals.exs
@@ -1,0 +1,27 @@
+defmodule Ambry.Repo.Migrations.DuplicateDismissals do
+  @moduledoc """
+  An answer to the duplicates report.
+
+  `Ambry.Inbox.Duplicates` asks sameness the way the importer asks it, which
+  is deliberate and which means it pairs a companion series with its parent
+  ("Dungeon Crawler Carl: Audio Immersion Tunnel") and two spellings of one
+  shelf the operator keeps apart on purpose ("The Mistborn Saga", "The
+  Mistborn Trilogy"). Those findings are correct. What was missing was a way
+  to answer them.
+
+  A dismissal names the exact set of records it settles, not the folded key
+  they collided on, so a set that gains a member is a finding again.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create table(:duplicate_dismissals) do
+      add :kind, :string, null: false
+      add :record_ids, {:array, :bigint}, null: false
+      add :dismissed_at, :utc_datetime, null: false
+    end
+
+    create unique_index(:duplicate_dismissals, [:kind, :record_ids])
+  end
+end

--- a/test/ambry/inbox/duplicates_test.exs
+++ b/test/ambry/inbox/duplicates_test.exs
@@ -63,6 +63,106 @@ defmodule Ambry.Inbox.DuplicatesTest do
     end
   end
 
+  describe "dismiss/2 and restore/2" do
+    # The pair production actually had this argument about: the importer folds
+    # "Saga" and "Trilogy" together, correctly, and these are still two real
+    # series the operator keeps apart.
+    defp mistborn do
+      saga = insert(:series, name: "The Mistborn Saga")
+      trilogy = insert(:series, name: "The Mistborn Trilogy")
+
+      {saga, trilogy}
+    end
+
+    test "a dismissed set stops being a finding" do
+      {saga, trilogy} = mistborn()
+
+      assert Duplicates.count() == 1
+
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+
+      assert Duplicates.check() == []
+      assert Duplicates.count() == 0
+    end
+
+    test "a dismissed set is still readable, so it can be taken back" do
+      {saga, trilogy} = mistborn()
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+
+      assert %{found: [], dismissed: [group]} = Duplicates.report()
+      assert group.kind == :series
+      assert Enum.map(group.records, & &1.id) == Enum.sort([saga.id, trilogy.id])
+
+      # It carries what points at it exactly as a finding does, because the
+      # question it answers is the same one.
+      assert [%{uses: %{books: 0}}, %{uses: %{books: 0}}] = group.records
+    end
+
+    test "restore puts it back" do
+      {saga, trilogy} = mistborn()
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+      :ok = Duplicates.restore(:series, [saga.id, trilogy.id])
+
+      assert %{found: [_group], dismissed: []} = Duplicates.report()
+      assert Duplicates.count() == 1
+    end
+
+    # The property the whole design turns on. A dismissal settles the set that
+    # was looked at, and a set that grew is not that set.
+    test "a set that gains a member is a finding again" do
+      {saga, trilogy} = mistborn()
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+      assert Duplicates.count() == 0
+
+      third = insert(:series, name: "Mistborn")
+
+      assert %{found: [group], dismissed: []} = Duplicates.report()
+
+      assert Enum.map(group.records, & &1.id) ==
+               Enum.sort([saga.id, trilogy.id, third.id])
+    end
+
+    test "the order the members are given in does not matter" do
+      {saga, trilogy} = mistborn()
+
+      :ok = Duplicates.dismiss(:series, [trilogy.id, saga.id])
+
+      assert Duplicates.count() == 0
+    end
+
+    # The page it is clicked from can be open twice.
+    test "dismissing the same set twice is one dismissal" do
+      {saga, trilogy} = mistborn()
+
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+
+      assert Duplicates.count() == 0
+      assert %{dismissed: [_one]} = Duplicates.report()
+    end
+
+    # Nothing sweeps a dismissal whose members are gone, and nothing needs to:
+    # it can never match a group again.
+    test "a dismissal outliving its members is inert, not wrong" do
+      {saga, trilogy} = mistborn()
+      :ok = Duplicates.dismiss(:series, [saga.id, trilogy.id])
+
+      Ambry.Repo.delete!(trilogy)
+
+      assert %{found: [], dismissed: []} = Duplicates.report()
+      assert Duplicates.count() == 0
+    end
+
+    test "one kind's dismissal does not settle another kind's set" do
+      one = insert(:book, title: "The Princess Bride")
+      two = insert(:book, title: "Princess Bride")
+
+      :ok = Duplicates.dismiss(:series, [one.id, two.id])
+
+      assert Duplicates.count() == 1
+    end
+  end
+
   describe "scanned/0" do
     # A report of nothing has to be able to say what nothing covers, or it
     # reads the same as a report that never ran.

--- a/test/ambry_web/live/admin/duplicates_live/index_test.exs
+++ b/test/ambry_web/live/admin/duplicates_live/index_test.exs
@@ -74,5 +74,50 @@ defmodule AmbryWeb.Admin.DuplicatesLive.IndexTest do
     end
   end
 
+  describe "marking a set intentional" do
+    setup do
+      saga = insert(:series, name: "The Mistborn Saga")
+      trilogy = insert(:series, name: "The Mistborn Trilogy")
+
+      %{ids: Enum.join(Enum.sort([saga.id, trilogy.id]), ",")}
+    end
+
+    test "the set folds away and the page says so", %{conn: conn, ids: ids} do
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+      assert has_element?(view, "[data-role='section-series']")
+
+      render_click(view, "dismiss", %{"kind" => "series", "ids" => ids})
+
+      refute has_element?(view, "[data-role='section-series']")
+      assert has_element?(view, "[data-role='dismissed']", "1 set marked intentional")
+      assert has_element?(view, "[data-role='dismissed-set']", "The Mistborn Saga")
+    end
+
+    # The page's whole job is to be believed, so the reassuring sentence has
+    # to stop short of a claim the dismissal made untrue.
+    test "the empty state does not claim more than it can", %{conn: conn, ids: ids} do
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+      render_click(view, "dismiss", %{"kind" => "series", "ids" => ids})
+
+      assert has_element?(
+               view,
+               "[data-role='all-clear']",
+               "Nothing here twice that you have not already answered"
+             )
+
+      refute view |> element("[data-role='all-clear']") |> render() =~
+               "Nothing in the library is here twice"
+    end
+
+    test "undo puts it back in the report", %{conn: conn, ids: ids} do
+      {:ok, view, _html} = live(conn, ~p"/admin/duplicates")
+      render_click(view, "dismiss", %{"kind" => "series", "ids" => ids})
+      render_click(view, "restore", %{"kind" => "series", "ids" => ids})
+
+      assert has_element?(view, "[data-role='section-series']")
+      refute has_element?(view, "[data-role='dismissed']")
+    end
+  end
+
   defp count_of(html, needle), do: html |> String.split(needle) |> length() |> Kernel.-(1)
 end


### PR DESCRIPTION
The duplicates report has two findings in production and both are correct:

```
series: Dungeon Crawler Carl (8 books)  |  Dungeon Crawler Carl: Audio Immersion Tunnel (2 books)
series: The Mistborn Saga (6 books)     |  The Mistborn Trilogy (3 books)
```

Neither has a record to remove. The report asks sameness the way the importer asks it, deliberately, and `same_series?/2` folds a subtitle head and the filler words `saga` and `trilogy`. Both pairs are right about the fold and wrong about the conclusion. Tightening the rule in `Duplicates` is the drift that module exists not to have; tightening it in `AutoMatch` would make imports start creating the duplicates this is meant to catch.

So a set can be told it is not a duplicate. It is the only action on the page, and it is the opposite of a merge: it says these are two things, not one.

## The decisions

**Keyed on the exact members, not the folded key.** A dismissal silences a finding somebody looked at, never one they have not, so a set that gains a third member is a different set and asks again. That property has its own test.

**Nothing cleans them up.** A dismissal whose members no longer all exist can never match a group again, so it is inert rather than wrong. The alternative was a second delete trigger beside `track_delete` on a table with two rows in it.

**The empty state stops short of a claim the dismissal made untrue.** "Nothing in the library is here twice" is false once a set is marked intentional, so it becomes "Nothing here twice that you have not already answered", and marked sets fold rather than vanish. Same argument as the scanned counts.

**`report/0` returns both halves from one pass**, since `groups/0` reads five tables whole. `check/0` is its `found` half, so existing callers kept working; `count/0` excludes dismissed sets, which is what takes the overview tile to zero.

## Design language

The fold is a card and its summary is that card's label. A `<details>` needs a 12px gutter for its chevron, and on the ground there is no padding edge to be that gutter, so it manufactures a third x-position by following the rule correctly. §3 said where the chevron goes and never said a fold needs a container to hang it in. It does now, with this page named as the case.

## Migration

One additive table, `duplicate_dismissals`. No backfill, nothing existing changes shape.

https://claude.ai/code/session_01T6rFUksK4tkZ4ZNS4ZvY3n