### PR TITLE
What an item is and what is in it are one card

### DIFF
--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -448,9 +448,12 @@ defmodule Ambry.Media do
   def get_media!(id),
     do:
       Media
-      |> preload([:book, :media_narrators, :media_tracks, :recording_group])
+      |> preload([:book, :media_narrators, :recording_group, media_tracks: :library_root])
       |> Repo.get!(id)
 
+  # Tracks carry the root their paths are relative to, and the form says
+  # which one that is, so the root comes along rather than being fetched
+  # per track by whoever renders them.
   @doc """
   Gets a media and the book with all its details.
   """

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -1254,8 +1254,40 @@ defmodule AmbryWeb.Admin.Components do
   """
   def source_tag(assigns) do
     ~H"""
-    <span class={["bg-blue-400/15 rounded-sm px-1 py-0.5 text-xs text-blue-300", @class]}>
-      {@source.name}
+    <.place_tag name={@source.name} class={@class} />
+    """
+  end
+
+  attr :root, :any, required: true, doc: "the `Ambry.Library.Root` the files live in"
+  attr :class, :any, default: nil
+
+  @doc """
+  Which library root a recording's files live in.
+
+  The same costume as `source_tag/1`, because it answers the same question
+  about the same list of files: where these are. A watched folder and a
+  library root are different things, but "where" is one fact and two tints
+  for it would say there are two kinds of answer.
+  """
+  def root_tag(assigns) do
+    ~H"""
+    <.place_tag name={@root.name} class={@class} />
+    """
+  end
+
+  attr :name, :string, required: true
+  attr :class, :any, default: nil
+
+  # Blue is location (§5), and there is one tint for every place: they are
+  # told apart by name, and colouring them apart would invent a taxonomy the
+  # model doesn't have.
+  defp place_tag(assigns) do
+    ~H"""
+    <span
+      class={["bg-blue-400/15 rounded-sm px-1 py-0.5 text-xs text-blue-300", @class]}
+      data-role="place"
+    >
+      {@name}
     </span>
     """
   end
@@ -1271,7 +1303,13 @@ defmodule AmbryWeb.Admin.Components do
     default: nil,
     doc: "phx-click event taking a file in or out; without it the list is a fact display"
 
+  attr :card, :boolean,
+    default: true,
+    doc: "false where the caller is already a card — a card in a card eats the ladder (§1)"
+
   attr :class, :any, default: nil
+
+  slot :tag, doc: "where these files are, beside the label — a source or a library root"
 
   @doc """
   A read-only list of files: mono, muted, the common directory printed once.
@@ -1300,9 +1338,14 @@ defmodule AmbryWeb.Admin.Components do
     assigns = assign(assigns, :common, common_dir(assigns.files))
 
     ~H"""
-    <div :if={@files != []} class={["space-y-1 rounded-lg bg-zinc-900 p-4", @class]}>
-      <div class="flex items-baseline justify-between gap-3 pl-3">
-        <.label :if={@label}>{@label}</.label>
+    <div :if={@files != []} class={["space-y-1", @card && "rounded-lg bg-zinc-900 p-4", @class]}>
+      <div class="flex items-baseline justify-between gap-3 pl-3" data-role="files-header">
+        <%!-- Label and place read as one fact, so they share the left of the
+            line and the count keeps the right. --%>
+        <div class="flex min-w-0 items-baseline gap-2">
+          <.label :if={@label}>{@label}</.label>
+          {render_slot(@tag)}
+        </div>
         <p :if={@excluded != []} class="flex-none text-xs text-zinc-400" data-role="excluded-count">
           {length(@files) - length(@excluded)} of {length(@files)} in this audiobook
         </p>

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -25,17 +25,10 @@
             the tags say and which files said it are one question, and they
             were three screens apart. --%>
       <section class="space-y-2">
-        <div class="space-y-1 rounded-lg bg-zinc-900 p-4">
+        <div class="space-y-1 rounded-lg bg-zinc-900 p-4" data-role="item-card">
           <div class="flex items-start justify-between gap-4">
             <div class="min-w-0 pl-3">
-              <%!-- Which watched folder this was found in, in the queue row's
-                  own tag. The row has carried it since the queue could hold
-                  more than one source; the form, which is where an item's
-                  paths are actually read, had lost it. --%>
-              <div class="flex min-w-0 items-baseline gap-2">
-                <p class="truncate font-bold">{@page_title}</p>
-                <.source_tag source={@item.source} class="flex-none" />
-              </div>
+              <p class="truncate font-bold">{@page_title}</p>
               <%!-- Dropped when the file list below is about to print the
                   same string: a release folder and its own files, or a loose
                   file under the folder the list names first. --%>
@@ -111,6 +104,29 @@
             {@item.issue}
           </p>
 
+          <%!-- The files are part of this card, not a card of their own: what
+            this item is and what is in it were never two subjects, and the
+            split was making the reader hold the first while looking at the
+            second. `card={false}` because a card inside a card is what eats
+            the elevation ladder (§1) — merged means merged, not nested.
+
+            They sit above the two questions below, which are both questions
+            *about this list*. Asking "not one audiobook?" before showing the
+            files asked the operator to answer from memory. --%>
+          <.file_list
+            files={@item.files}
+            label="Files"
+            card={false}
+            class="pt-2"
+            excluded={@item.excluded_files}
+            toggle={!@read_only && "toggle-file"}
+          >
+            <%!-- Which watched folder this was found in, in the queue row's
+                own tag. It belongs on the file list rather than the title: it
+                names where these paths are, and the paths are here. --%>
+            <:tag><.source_tag source={@item.source} class="flex-none" /></:tag>
+          </.file_list>
+
           <%!-- These files are one recording unless the operator says
             otherwise — a folder of forty mp3s is one book in forty pieces far
             more often than it is forty books. Splitting is the escape hatch
@@ -173,15 +189,6 @@
             </div>
           </div>
         </div>
-
-        <%!-- A sibling card, never nested inside the one above: a card in a
-            card is what eats the elevation ladder (§1). --%>
-        <.file_list
-          files={@item.files}
-          label="Files"
-          excluded={@item.excluded_files}
-          toggle={!@read_only && "toggle-file"}
-        />
       </section>
 
       <%!-- Once imported, the draft is the record of what was imported — the

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -15,6 +15,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   alias Ambry.Books
   alias Ambry.Images
   alias Ambry.Inbox
+  alias Ambry.Library.Root
   alias Ambry.Media
   alias Ambry.Media.Chapters.Merge
   alias Ambry.Metadata.Outcome
@@ -89,6 +90,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       page_title: Media.Media.display_title(media),
       media: media,
       audio_files: audio_files(media),
+      audio_root: audio_root(media),
       file_stats: legacy_file_stats(media),
       # View state, not derived per render: deriving it from the typeahead's
       # value made the row vanish mid-edit the moment the box was cleared.
@@ -105,6 +107,17 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
   # from.
   defp audio_files(%{media_tracks: tracks}),
     do: tracks |> Enum.sort_by(& &1.index) |> Enum.map(& &1.path)
+
+  # The library root those paths are relative to, and only when there is one
+  # answer to give. A track can sit outside every root (`/uploads/...`, root
+  # nil), and nothing stops two tracks naming different roots, so this states
+  # a fact rather than picking a winner: the badge is absent instead of wrong.
+  defp audio_root(%{media_tracks: tracks}) do
+    case Enum.uniq_by(tracks, & &1.library_root_id) do
+      [%{library_root: %Root{} = root}] -> root
+      _none_or_several -> nil
+    end
+  end
 
   # Only a transcoded recording has streaming files, and only it pays for
   # the `File.ls` and four `File.stat`s that describe them.

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -486,7 +486,12 @@
             dressing it as though it might would promise what it can't
             deliver. Absent for a transcoded recording, whose audio is the
             packaged trio in the fold below. --%>
-          <.file_list files={@audio_files} label="Files" />
+          <.file_list files={@audio_files} label="Files">
+            <%!-- Which library root these paths are relative to. The same
+              answer the import form's tag gives about the same list: where
+              these files are. Absent where there is no single root to name. --%>
+            <:tag :if={@audio_root}><.root_tag root={@audio_root} class="flex-none" /></:tag>
+          </.file_list>
 
           <%!-- Transcoded recordings only, and assigned nil otherwise: an
             imported recording has no packaged artifacts and no transcode

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -17,6 +17,33 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
 
   setup :register_and_log_in_admin_user
 
+  describe "the item card" do
+    # What this item is and what is in it were never two subjects, so they are
+    # one card. The containment is the assertion: a sibling card would satisfy
+    # any test that only looked for the file list somewhere on the page.
+    test "the files are in the item card, not a card of their own", %{conn: conn} do
+      item = probed_item()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert has_element?(view, "[data-role='item-card'] [data-role='files-header']")
+    end
+
+    # The tag names where these paths are, so it belongs on the list of them
+    # rather than beside the title.
+    test "the source is named on the file list", %{conn: conn} do
+      item = probed_item() |> Repo.preload(:source)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      assert has_element?(
+               view,
+               "[data-role='files-header'] [data-role='place']",
+               item.source.name
+             )
+    end
+  end
+
   describe "the invariant" do
     test "an unsettled item can't be imported", %{conn: conn} do
       item = probed_item()

--- a/test/ambry_web/live/admin/media_live/files_test.exs
+++ b/test/ambry_web/live/admin/media_live/files_test.exs
@@ -46,15 +46,38 @@ defmodule AmbryWeb.Admin.MediaLive.FilesTest do
     assert html =~ "Streaming files"
   end
 
-  # An import's shape: tracks, and neither of the transcode columns.
-  defp imported_media do
-    media = insert(:media, book: build(:book), status: :ready)
+  test "the files say which library root they are in", %{conn: conn} do
+    media = imported_media(root: insert(:root, name: "Audiobooks"))
 
-    insert(:media_track,
-      media: media,
-      index: 0,
-      path: "/uploads/source_media/#{Ecto.UUID.generate()}/The Way of Kings.m4b"
-    )
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    assert has_element?(view, "[data-role='files-header'] [data-role='place']", "Audiobooks")
+  end
+
+  # A track can sit outside every root, and a badge that named one anyway
+  # would state a fact the database does not hold.
+  test "a recording outside every root names none", %{conn: conn} do
+    media = imported_media()
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media}/edit")
+
+    assert has_element?(view, "[data-role='files-header']")
+    refute has_element?(view, "[data-role='files-header'] [data-role='place']")
+  end
+
+  # An import's shape: tracks, and neither of the transcode columns.
+  defp imported_media(opts \\ []) do
+    media = insert(:media, book: build(:book), status: :ready)
+    root = Keyword.get(opts, :root)
+
+    # `media_tracks_path_resolvable`: a path under a root is relative to it,
+    # and a path with no root is an absolute one under uploads.
+    path =
+      if root,
+        do: "Sanderson/The Way of Kings/The Way of Kings.m4b",
+        else: "/uploads/source_media/#{Ecto.UUID.generate()}/The Way of Kings.m4b"
+
+    insert(:media_track, media: media, index: 0, library_root: root, path: path)
 
     {:ok, media} =
       media.id


### PR DESCRIPTION
The import form opened with two cards where there was one subject. The second held the files, and the split made the reader hold *"this is The Way of Kings, found in Watched, tagged like so"* while looking at the list that was the evidence for it.

## The import form

**Merged, not nested.** `file_list` grows `card={false}` for a caller that is already a card, because a card inside a card is what eats the elevation ladder (§1). Everything else about the list is unchanged, including the scroll region and the ✕ that takes a file out.

**The files sit above the two questions, not below them.** "Not one audiobook?" and "Only part of one?" are both questions *about this list*, and they were being asked before it was shown — the operator was answering from memory of the queue row. This is the one part that goes beyond a literal merge; say the word and I'll put them back under.

**The source tag moves off the title and onto the list.** It names where these paths are, and the paths are here. Beside the title it was decorating a name `@page_title` already said.

## The audiobook edit form

The same badge, naming the library root the recording's files are in. `source_tag/1` and the new `root_tag/1` share one costume through `place_tag/1`: a watched folder and a library root are different things, but "where" is one fact, and two tints for it would claim there are two kinds of answer. Blue is location (§5), one tint for every place, told apart by name.

It states a fact or says nothing: a track can sit outside every root, and nothing stops two tracks naming different roots, so the badge appears only where there is a single root to name. Absent rather than wrong, with a test for each.

The root rides along on `get_media!/1`'s preload rather than being fetched per track by whoever renders them.

## Verified

`mix check` green, full suite 2024 passing. Four new tests, including the containment assertion — a sibling card would satisfy any test that only looked for the file list *somewhere* on the page.

https://claude.ai/code/session_01T6rFUksK4tkZ4ZNS4ZvY3n