### PR TITLE
An import that has been replaced stops claiming the audiobook

### DIFF
--- a/docs/admin-design-language.md
+++ b/docs/admin-design-language.md
@@ -136,6 +136,22 @@ outlives the thing it describes says so plainly rather than falling back to
 the process view, which would describe a decision whose outcome no longer
 exists.
 
+**And that its result is no longer its own.** A third state sits between
+those two: the outcome still exists, but it belongs to a later record — an
+import replaced by another import of the same audiobook. Wearing the result
+there is the worst of the three, because it is not merely stale, it is
+*someone else's*, and it keeps updating: the row would go on showing a cover,
+credits and state badges that another record is responsible for.
+
+So the row goes back to describing **itself** — the release it holds, its own
+files, the date it landed — and carries a badge for the one thing that shape
+cannot say, which is that this was imported and then superseded. This is the
+documented exception to "the status badge goes": the badge is what stops an
+import-shaped row from reading as work still to do.
+
+It does not offer the result. A way to the record that *replaced* it is the
+honest link, and the way to the audiobook is that record's to give.
+
 ## 3. Geometry
 
 **Two left edges, never three.** Every container has exactly two

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -239,6 +239,11 @@ defmodule Ambry.Inbox.Importer do
            {:ok, media} <- existing_recording(media_id),
            retired = Media.retired_files(media),
            {:ok, media} <- repoint(media, probes, destination),
+           # Before the link, not after: `inbox_items_one_live_import_per_media`
+           # is checked per statement and a partial unique index cannot be
+           # deferred, so the old claim has to be released before the new one
+           # is made rather than the two overlapping for a statement.
+           :ok <- supersede_previous(item, media),
            {:ok, _item} <- link(item, media),
            {:ok, media, placements, vacated} <-
              place(destination, media.book, media, files, retired.files),
@@ -834,5 +839,29 @@ defmodule Ambry.Inbox.Importer do
     |> InboxItem.changeset(%{status: :imported, media_id: media.id, issue: nil})
     |> InboxItem.versioned()
     |> Repo.update()
+  end
+
+  # The other half of the replacement: the item this one just took over from
+  # stops being the recording's import. Runs after `link/2`, so the row it
+  # must not touch is the one that now holds this media id.
+  #
+  # `updated_at` is deliberately left alone. It is the moment the superseded
+  # item was imported — the row's date, the imported tab's sort, and the
+  # ordering this whole feature is built on — and `Repo.update_all` not
+  # bumping it is the behaviour being relied on rather than an omission.
+  # Touching it would rewrite the history this is trying to record.
+  #
+  # Ordinarily one row. Zero when the recording came from somewhere other
+  # than the inbox, and more than one only for data that predates the
+  # backfill.
+  defp supersede_previous(%InboxItem{id: id}, %Media.Media{id: media_id}) do
+    import Ecto.Query, only: [where: 3]
+
+    InboxItem
+    |> where([i], i.media_id == ^media_id and i.id != ^id)
+    |> where([i], i.status == :imported and is_nil(i.superseded_by_id))
+    |> Repo.update_all(set: [superseded_by_id: id])
+
+    :ok
   end
 end

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -31,6 +31,22 @@ defmodule Ambry.Inbox.InboxItem do
 
   Every item has a source. There is no other way in, which is what makes
   the relative form an invariant rather than a convention.
+
+  ## An imported item can stop being the one that counts
+
+  A replacement links a second item to a recording the library already has,
+  and from then on the first item describes files that are gone: the
+  replacement deleted the library copy it produced, and if the placement was
+  a `move` its source went at import time. `superseded_by_id` is how that is
+  known, and it has to be *recorded* rather than worked out — a file can
+  arrive by hardlink, symlink, copy or move, so there is no comparison that
+  answers it for every import.
+
+  The rule it records is a fact about the write path: a replacement is the
+  only way a second item comes to name one recording, so the item that
+  linked last is the live one. A partial unique index enforces the other
+  side of it — a recording has at most one import that has not been
+  superseded.
   """
 
   use Ecto.Schema
@@ -49,6 +65,12 @@ defmodule Ambry.Inbox.InboxItem do
 
   schema "inbox_items" do
     belongs_to :media, Media
+
+    # The import that replaced this one. Set on the *old* item when a
+    # replacement links a second item to one recording, which is the only way
+    # two items come to name the same one. Nil means this item's files are
+    # what the recording is served from — see the moduledoc.
+    belongs_to :superseded_by, __MODULE__
 
     # The watched folder this was found in, and the base its `path` and
     # `files` are relative to.

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -195,7 +195,7 @@
           library records were created FROM it, so an edit here would make
           the record lie. The rail is lime because imported IS settled. --%>
       <section
-        :if={@read_only}
+        :if={@read_only and !@item.superseded_by_id}
         class="border-brand-dark/60 rounded-lg border-l-4 bg-zinc-900 p-4"
         data-role="imported-banner"
       >
@@ -204,6 +204,25 @@
           This item was imported. Everything below is the read-only record of that import.
           <.brand_link :if={@item.media_id} navigate={~p"/admin/audiobooks/#{@item.media_id}/edit"}>
             Open the audiobook
+          </.brand_link>
+        </p>
+      </section>
+
+      <%!-- A superseded import is still settled, so it keeps the lime rail:
+          nothing here needs doing and nothing here is wrong. What changed is
+          what it is the record OF. It does not offer the audiobook, because
+          the audiobook is no longer what this item produced. --%>
+      <section
+        :if={@read_only and @item.superseded_by_id}
+        class="border-brand-dark/60 rounded-lg border-l-4 bg-zinc-900 p-4"
+        data-role="superseded-banner"
+      >
+        <p class="pl-3 font-bold">Replaced by a later import</p>
+        <p class="max-w-prose pt-1 pl-3 text-sm text-zinc-400">
+          These files were imported and have since been replaced. The audiobook is served from
+          the newer import, and the files below are gone.
+          <.brand_link navigate={~p"/admin/inbox/#{@item.superseded_by_id}"}>
+            Open the import that replaced it
           </.brand_link>
         </p>
       </section>

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -71,78 +71,38 @@
           cover-and-credits shape, because it is the same thing. --%>
     <:row :let={item}>
       <%= if item.status == :imported do %>
-        <%= if audiobook = @audiobooks[item.id] do %>
+        <%= if item.superseded_by_id do %>
+          <%!-- A replaced import stops wearing the audiobook. The record is
+                still true about what it was — this release, these files, this
+                date — and false about everything the audiobook says now,
+                because the recording is served from somebody else's files and
+                has been edited since. So it goes back to describing itself,
+                with the badge for the one thing its shape can't say: this was
+                imported, and then superseded. --%>
           <.index_row
-            navigate={~p"/admin/audiobooks/#{audiobook.id}/edit"}
+            navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
             class={rail_class(item)}
           >
-            <:cover>
-              <div class={["h-16 w-16 rounded-sm", if(!audiobook.thumbnail, do: "bg-zinc-800")]}>
-                <img
-                  :if={audiobook.thumbnail}
-                  src={audiobook.thumbnail}
-                  alt=""
-                  class="h-full w-full rounded-sm"
-                />
-              </div>
-            </:cover>
+            <:headline>
+              <span class="text-zinc-400">{item_name(item)}</span>
+            </:headline>
 
-            <:headline>{media_display_title(audiobook)}</:headline>
-
-            <.credit_lines authors={audiobook.authors} narrators={audiobook.narrators} />
-
-            <%!-- No "imported" badge: the footer's date already says it, and
-                  what varies from one imported row to the next is the state
-                  of the audiobook, which is what these say. --%>
             <:badges>
-              <.badge
-                :if={audiobook.status != :ready}
-                color={library_status_color(audiobook.status)}
-                class="text-xs"
-              >
-                {audiobook.status}
-              </.badge>
-              <.badge
-                :if={audiobook.missing_since}
-                color={:red}
-                class="text-xs"
-                title={"Files couldn't be read since #{Calendar.strftime(audiobook.missing_since, "%x %X")}"}
-                data-role="audiobook-missing"
-              >
-                missing
-              </.badge>
+              <.badge color={:gray} class="text-xs" data-role="superseded">superseded</.badge>
             </:badges>
 
-            <%!-- The audiobooks list's line, verbatim: same helper, same
-                  place, same words. It was an inline middle-dot line here and
-                  a footer column there, which is two answers to one question. --%>
-            <p
-              :if={record_meta(audiobook) != ""}
-              class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
-            >
-              {record_meta(audiobook)}
+            <p class="text-sm text-zinc-400">
+              Replaced by a later import. The audiobook is served from that one now.
             </p>
 
-            <:facts>
-              <.row_fact
-                :if={audiobook.chapters > 0}
-                icon="fa-book-bookmark"
-                count={audiobook.chapters}
-                title="# of chapters"
-              />
-            </:facts>
-
             <:action
-              navigate={~p"/admin/audiobooks/#{audiobook.id}/edit"}
-              icon="fa-pencil"
-              title="Edit this audiobook"
+              navigate={~p"/admin/inbox/#{item.superseded_by_id}?#{return_query(assigns)}"}
+              icon="fa-right-long"
+              title="The import that replaced this one"
             >
-              Edit
+              What replaced it
             </:action>
 
-            <%!-- The way back to where it came from — the files, the matches,
-                  the decisions that produced it. Off the row by design, one
-                  click away because a wrong import is diagnosed there. --%>
             <:action
               navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
               icon="fa-inbox"
@@ -154,30 +114,114 @@
             <:footer>Imported {Calendar.strftime(imported_at(item), "%x")}</:footer>
           </.index_row>
         <% else %>
-          <%!-- Deleting an audiobook nilifies the link rather than taking the
+          <%= if audiobook = @audiobooks[item.id] do %>
+            <.index_row
+              navigate={~p"/admin/audiobooks/#{audiobook.id}/edit"}
+              class={rail_class(item)}
+            >
+              <:cover>
+                <div class={["h-16 w-16 rounded-sm", if(!audiobook.thumbnail, do: "bg-zinc-800")]}>
+                  <img
+                    :if={audiobook.thumbnail}
+                    src={audiobook.thumbnail}
+                    alt=""
+                    class="h-full w-full rounded-sm"
+                  />
+                </div>
+              </:cover>
+
+              <:headline>{media_display_title(audiobook)}</:headline>
+
+              <.credit_lines authors={audiobook.authors} narrators={audiobook.narrators} />
+
+              <%!-- No "imported" badge: the footer's date already says it, and
+                  what varies from one imported row to the next is the state
+                  of the audiobook, which is what these say. --%>
+              <:badges>
+                <.badge
+                  :if={audiobook.status != :ready}
+                  color={library_status_color(audiobook.status)}
+                  class="text-xs"
+                >
+                  {audiobook.status}
+                </.badge>
+                <.badge
+                  :if={audiobook.missing_since}
+                  color={:red}
+                  class="text-xs"
+                  title={"Files couldn't be read since #{Calendar.strftime(audiobook.missing_since, "%x %X")}"}
+                  data-role="audiobook-missing"
+                >
+                  missing
+                </.badge>
+              </:badges>
+
+              <%!-- The audiobooks list's line, verbatim: same helper, same
+                  place, same words. It was an inline middle-dot line here and
+                  a footer column there, which is two answers to one question. --%>
+              <p
+                :if={record_meta(audiobook) != ""}
+                class="mt-1 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+              >
+                {record_meta(audiobook)}
+              </p>
+
+              <:facts>
+                <.row_fact
+                  :if={audiobook.chapters > 0}
+                  icon="fa-book-bookmark"
+                  count={audiobook.chapters}
+                  title="# of chapters"
+                />
+              </:facts>
+
+              <:action
+                navigate={~p"/admin/audiobooks/#{audiobook.id}/edit"}
+                icon="fa-pencil"
+                title="Edit this audiobook"
+              >
+                Edit
+              </:action>
+
+              <%!-- The way back to where it came from — the files, the matches,
+                  the decisions that produced it. Off the row by design, one
+                  click away because a wrong import is diagnosed there. --%>
+              <:action
+                navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+                icon="fa-inbox"
+                title="What was imported, and from where"
+              >
+                Import record
+              </:action>
+
+              <:footer>Imported {Calendar.strftime(imported_at(item), "%x")}</:footer>
+            </.index_row>
+          <% else %>
+            <%!-- Deleting an audiobook nilifies the link rather than taking the
                 record of the import with it, so the row outlives the thing it
                 describes. It says that, instead of falling back to matching
                 details for a result that is gone. --%>
-          <.index_row
-            navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
-            class={rail_class(item)}
-          >
-            <:headline>
-              <span class="text-zinc-400">{item_name(item)}</span>
-            </:headline>
-
-            <p class="text-sm text-zinc-400">The audiobook this became has been deleted.</p>
-
-            <:action
+            <.index_row
               navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
-              icon="fa-inbox"
-              title="What was imported, and from where"
+              class={rail_class(item)}
             >
-              Import record
-            </:action>
+              <:headline>
+                <span class="text-zinc-400">{item_name(item)}</span>
+              </:headline>
 
-            <:footer>Imported {Calendar.strftime(imported_at(item), "%x")}</:footer>
-          </.index_row>
+              <p class="text-sm text-zinc-400">The audiobook this became has been deleted.</p>
+
+              <:action
+                navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
+                icon="fa-inbox"
+                title="What was imported, and from where"
+              >
+                Import record
+              </:action>
+
+              <:footer>Imported {Calendar.strftime(imported_at(item), "%x")}</:footer>
+            </.index_row>
+          <% end %>
         <% end %>
       <% else %>
         <.index_row

--- a/priv/repo/migrations/20260822012808_supersede_replaced_imports.exs
+++ b/priv/repo/migrations/20260822012808_supersede_replaced_imports.exs
@@ -1,0 +1,79 @@
+defmodule Ambry.Repo.Migrations.SupersedeReplacedImports do
+  @moduledoc """
+  Which import a recording is actually served from.
+
+  A replacement links a second inbox item to a recording another item already
+  claims, and nothing said the first one had been superseded. Both rows went
+  on rendering as the audiobook, and one of them was describing files that no
+  longer exist.
+
+  ## Why it has to be recorded rather than worked out
+
+  Because the trail on disk does not survive the import. A file can arrive by
+  hardlink, symlink, copy or move, and a `move` leaves no source to compare
+  against; the replacement then deletes the library copy the superseded item
+  produced, so both ends can be gone. Matching bytes answers this for some
+  imports and not others, which is worse than not answering it.
+
+  What *is* reliable is the write path: a replacement is the only way a
+  second item comes to name one recording, so the item that linked last is
+  the one the recording is served from. That is a fact about the code, not
+  about the files, and it is true whatever placement did.
+
+  ## The backfill
+
+  Chains the existing rows by that rule — each item's successor is the next
+  one to link to the same recording. Production has three such pairs, and
+  their probes happen to corroborate it (in each, the later item's probed
+  size matches the recording's live track exactly). That check is why this is
+  safe to run, not how it works: it is unavailable in general for the reasons
+  above.
+
+  The partial index is the invariant the whole design rests on — a recording
+  has at most one import that has not been superseded — enforced rather than
+  remembered, so a future path that forgets to supersede fails loudly instead
+  of quietly recreating this bug.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    alter table(:inbox_items) do
+      add :superseded_by_id, references(:inbox_items, on_delete: :nilify_all)
+    end
+
+    create index(:inbox_items, [:superseded_by_id])
+
+    # `lead` over the items sharing a recording, oldest first: everyone but
+    # the last gets the next one as their successor. `updated_at` is the
+    # import moment for an imported item — nothing writes to one afterwards,
+    # a scan skips them and every write path refuses them — and `id` breaks
+    # a tie that a same-second pair could otherwise leave undefined.
+    execute """
+    WITH ordered AS (
+      SELECT id,
+             lead(id) OVER (PARTITION BY media_id ORDER BY updated_at, id) AS successor_id
+      FROM inbox_items
+      WHERE media_id IS NOT NULL AND status = 'imported'
+    )
+    UPDATE inbox_items i
+    SET superseded_by_id = o.successor_id
+    FROM ordered o
+    WHERE o.id = i.id AND o.successor_id IS NOT NULL
+    """
+
+    create unique_index(:inbox_items, [:media_id],
+             where: "media_id IS NOT NULL AND superseded_by_id IS NULL AND status = 'imported'",
+             name: :inbox_items_one_live_import_per_media
+           )
+  end
+
+  def down do
+    drop index(:inbox_items, [:media_id], name: :inbox_items_one_live_import_per_media)
+    drop index(:inbox_items, [:superseded_by_id])
+
+    alter table(:inbox_items) do
+      remove :superseded_by_id
+    end
+  end
+end

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -681,6 +681,48 @@ defmodule Ambry.Inbox.ManagedImportTest do
       )
     end
 
+    # A replacement is the only way two inbox items come to name one
+    # recording, so it is also the only thing that can make the first of them
+    # stale. Nothing on disk can be asked afterwards — a `move` leaves no
+    # source, and the replacement deletes the library copy the first import
+    # produced — so the write path has to say it.
+    test "the import it replaced is marked superseded" do
+      %{item: first, watched: watched} = downloads_item()
+
+      assert {:ok, media} = Inbox.import_item(first)
+
+      second = watched |> second_release() |> replace_with(media)
+      assert {:ok, _replaced} = Inbox.import_item(second)
+
+      first = Inbox.get_item!(first.id)
+      second = Inbox.get_item!(second.id)
+
+      assert first.superseded_by_id == second.id
+      assert second.superseded_by_id == nil
+
+      # Still imported, and still into that recording: what it did is history
+      # and stays true. Only which import the library plays has changed.
+      assert first.status == :imported
+      assert first.media_id == media.id
+    end
+
+    # The trap this feature is built on: `updated_at` is when an item was
+    # imported, because nothing writes to an imported item afterwards. The
+    # supersede is the first thing that ever wanted to, and a `Repo.update`
+    # instead of `update_all` would have silently restamped the row it was
+    # recording the history of.
+    test "superseding does not rewrite when the older import happened" do
+      %{item: first, watched: watched} = downloads_item()
+
+      assert {:ok, media} = Inbox.import_item(first)
+      imported_at = Inbox.get_item!(first.id).updated_at
+
+      second = watched |> second_release() |> replace_with(media)
+      assert {:ok, _replaced} = Inbox.import_item(second)
+
+      assert Inbox.get_item!(first.id).updated_at == imported_at
+    end
+
     # What the form's replace control does: settle the decision and save it.
     defp replace_with(item, media) do
       {:ok, item} = Inbox.prepare_draft(item)

--- a/test/ambry_web/live/admin/inbox_live/index_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/index_test.exs
@@ -264,6 +264,32 @@ defmodule AmbryWeb.Admin.InboxLive.IndexTest do
     assert item_states(html) == []
   end
 
+  # The row wears the audiobook because it produced it. Once a later import
+  # has, that claim is not merely stale, it is somebody else's — and it keeps
+  # updating, so the row would go on showing a cover and credits another
+  # record is responsible for.
+  test "a superseded row describes itself, not the audiobook", %{conn: conn} do
+    item = probed_item() |> settle()
+    {:ok, media} = Ambry.Inbox.import_item(item)
+
+    successor = probed_item(name: "The Way of Kings [FLAC]") |> settle()
+
+    item
+    |> Ecto.Changeset.change(superseded_by_id: successor.id)
+    |> Ambry.Repo.update!()
+
+    {:ok, view, html} = live(conn, ~p"/admin/inbox?status=imported")
+
+    assert has_element?(view, "[data-role='superseded']", "superseded")
+    assert html =~ "Replaced by a later import"
+    assert has_element?(view, "a[href^='/admin/inbox/#{successor.id}']")
+
+    # it is back to naming its own release, and offers no way to claim the
+    # audiobook as its result
+    assert html =~ item.path
+    refute has_element?(view, "a[href='/admin/audiobooks/#{media.id}/edit']")
+  end
+
   # "Found" is when discovery tripped over the folder, which for a finished
   # row is the least interesting date it has. `updated_at` is stamped by the
   # status change and nothing writes to an imported item afterwards.


### PR DESCRIPTION
Import a release, replace it with a better rip of the same audiobook, and the queue holds two rows that both say "imported" and both render as that audiobook. One of them is describing files that no longer exist. Production has three of these — the Snow Crash pair is items 503 and 122.

## It has to be recorded, because the disk cannot be asked

A file arrives by hardlink, symlink, copy or move, and a `move` leaves no source to compare against. The replacement then deletes the library copy the first import produced, so for a superseded item *both* ends of the trail can be gone. Matching bytes answers this for some imports and not others, which is worse than not answering it at all.

What is reliable is the write path: a replacement is the only way a second item comes to name one recording, so **the item that linked last is the one the recording is served from**. That is a fact about the code, true whatever placement did. `superseded_by_id` records it at the moment it becomes true.

A partial unique index enforces the other side — a recording has at most one import that has not been superseded — so a future path that forgets to supersede fails loudly instead of quietly recreating this bug.

## Two traps worth naming

**Superseding happens before the link, not after.** The index is checked per statement and a partial unique index cannot be deferred, so the old claim has to be released before the new one is made rather than the two overlapping for a statement. Caught by nine failing tests.

**`updated_at` is not touched.** It is when the superseded item was imported — the row's date, the imported tab's sort, and the ordering the backfill uses — and `Repo.update_all` leaving it alone is the behaviour being relied on, not an omission. A `Repo.update` here would have silently restamped the history it was recording. There is a test for exactly that.

## The backfill

Chains existing rows by the same rule. Dry-run against production returns exactly the three expected pairs (503→122, 207→560, 341→152), and their probes corroborate it in all three — in each, the later item's probed size matches the recording's live track byte-for-byte. That is why this was safe to write, not how it works.

## The row

It goes back to describing itself: its release, its files, its date, and a badge for the one thing that shape cannot say. It offers the import that replaced it, and **not** the audiobook — that is the newer record's to give. The form's banner changes the same way.

Design language §2b gains the third state (result exists, but belongs to a later record) and with it the documented exception to "the status badge goes".

## Verified

`mix check` green, full suite 2027 passing, three new tests.

https://claude.ai/code/session_01T6rFUksK4tkZ4ZNS4ZvY3n