### PR TITLE
An inbox item can say its files are gone, and an import can be re-opened

### DIFF
--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -47,8 +47,16 @@ defmodule Ambry.Inbox do
       stale, since the draft describes files that moved under it), where
       "gone" means no candidate in the whole walk claimed it.
 
-  It may never move a file from one item to another, and it never touches an
-  imported item at all. That is what makes a split *and* a combine durable
+  It may never move a file from one item to another, and it never changes
+  what an imported item holds.
+
+  Recording *whether* an item's files are still there is a separate pass with
+  a separate rule — see `Ambry.Inbox.Reconciliation`. It runs over every item
+  of the source, imported ones included, because "can this be re-opened" is a
+  question about an imported item that something has to be able to answer. It
+  asks the filesystem rather than the walk's claims: ownership says which
+  item a file belongs to, existence says whether it is there, and reading one
+  as the other is how the two come to disagree. That is what makes a split *and* a combine durable
   without a marker: once the operator says five folders are five releases, or
   that three are one, the files are owned, and re-walking the folder that
   holds them has nothing to say. It is a property of the construction rather
@@ -76,6 +84,7 @@ defmodule Ambry.Inbox do
   alias Ambry.Inbox.Lookup
   alias Ambry.Inbox.Preflight
   alias Ambry.Inbox.Progress
+  alias Ambry.Inbox.Reconciliation
   alias Ambry.Inbox.ReleaseName
   alias Ambry.Inbox.RunDiscovery
   alias Ambry.Inbox.RunImport
@@ -328,11 +337,18 @@ defmodule Ambry.Inbox do
 
       results = List.flatten(creations) ++ Enum.map(claims, &refresh_claim/1)
 
+      # After the walk, and asking the disk rather than the claims: whether a
+      # file exists and which item owns it are different questions, and this
+      # one has to be answerable for an item the walk deliberately skips.
+      {:ok, %{missing: missing, healed: healed}} = Reconciliation.reconcile_source(source)
+
       {:ok,
        %{
          created: Enum.count(results, &(&1 == :created)),
          updated: Enum.count(results, &(&1 == :updated)),
          skipped: Enum.count(results, &(&1 == :skipped)),
+         missing: missing,
+         healed: healed,
          unreachable: 0
        }}
     else
@@ -992,6 +1008,10 @@ defmodule Ambry.Inbox do
   Nothing is published: the recording is created `pending`.
   """
   def import_item(%InboxItem{} = item) do
+    if Reconciliation.present?(item), do: do_import_item(item), else: {:error, :files_missing}
+  end
+
+  defp do_import_item(%InboxItem{} = item) do
     case Importer.import_item(item) do
       {:ok, media} ->
         # Bookkeeping, and it runs after the records are committed. Neither
@@ -1132,6 +1152,12 @@ defmodule Ambry.Inbox do
 
   def describe_error({:source_missing, _path}), do: "The file has gone away since it was found."
 
+  # The refusal `import_item/1` makes before the importer is entered at all.
+  # The same fact `{:source_missing, _}` reports from inside placement, found
+  # by the scan instead of by the write, which is the point of finding it.
+  def describe_error(:files_missing),
+    do: "This item's files are gone. Nothing can be imported from it until they come back."
+
   # The refusal this whole phase is built around, so it says what to do
   # rather than just what failed.
   def describe_error({:cross_filesystem, _source, _destination}),
@@ -1251,6 +1277,48 @@ defmodule Ambry.Inbox do
   def ignore_item(%InboxItem{} = item), do: update_item(item, %{status: :ignored})
 
   def restore_item(%InboxItem{} = item), do: update_item(item, %{status: :pending})
+
+  @doc """
+  Whether this item's files are all still there.
+
+  One answer, because the badge, the import and the re-open control all ask
+  it and two of them disagreeing is worse than any of them being wrong.
+  """
+  defdelegate item_files_present?(item), to: Reconciliation, as: :present?
+
+  @doc """
+  Puts an imported item back in the queue, so its decisions can be made again.
+
+  There is no undo for an import, and this is deliberately not one: nothing
+  in the library is touched, no files move, and the recording goes on playing
+  exactly what it was playing. All that changes is that this item is work
+  again. Getting a replaced audiobook back onto its old files is then an
+  ordinary import — open it, point the replace decision at the recording,
+  Add — rather than a reversal mechanism with its own rules.
+
+  **Its claim on the audiobook is dropped.** `media_id` and
+  `superseded_by_id` both go, because a pending item has not imported
+  anything: leaving them would have the queue holding a row that says it
+  produced a recording it is no longer the record of, which is the half-truth
+  this whole area has been about. The draft stays exactly as it was, since it
+  is the operator's curation and re-opening is not a reason to throw it away.
+
+  Refused when the files are gone. There is nothing to make decisions about,
+  and the only thing re-opening could produce is an item that cannot import.
+  """
+  def reopen_item(%InboxItem{status: :imported} = item) do
+    if Reconciliation.present?(item) do
+      item
+      |> InboxItem.changeset(%{status: :pending, media_id: nil, issue: nil})
+      |> Ecto.Changeset.put_change(:superseded_by_id, nil)
+      |> InboxItem.versioned()
+      |> Repo.update()
+    else
+      {:error, :files_missing}
+    end
+  end
+
+  def reopen_item(%InboxItem{}), do: {:error, :not_imported}
 
   def delete_item(%InboxItem{} = item), do: Repo.delete(item)
 

--- a/lib/ambry/inbox/inbox_item.ex
+++ b/lib/ambry/inbox/inbox_item.ex
@@ -83,6 +83,13 @@ defmodule Ambry.Inbox.InboxItem do
     field :files, {:array, :string}, default: []
     field :excluded_files, {:array, :string}, default: []
     field :status, Ecto.Enum, values: @statuses, default: :pending
+
+    # When this item's files stopped being there. Deliberately not a status
+    # value, for the reason `media.missing_since` isn't one: status is where
+    # the operator has taken this item, and missing is orthogonal to that and
+    # reversible. A pending item whose files come back is pending again with
+    # its decisions intact, and an unplugged NAS doesn't rewrite the queue.
+    field :missing_since, :utc_datetime
     field :probe, :map
     field :tags, :map
     field :matches, :map

--- a/lib/ambry/inbox/reconciliation.ex
+++ b/lib/ambry/inbox/reconciliation.ex
@@ -1,0 +1,126 @@
+defmodule Ambry.Inbox.Reconciliation do
+  @moduledoc """
+  Noticing that an inbox item's files stopped being there.
+
+  The queue had no answer for this. Discovery's walk only ever *claims*
+  files, so an item whose files are all gone produces no claim, nothing
+  refreshes it, and it sits in the queue with a stale file list looking
+  perfectly importable — until Add fails inside placement with
+  `{:source_missing, path}`, after every decision has been made. This is the
+  same job `Ambry.Media.Reconciliation` does for recordings, and the same
+  answer: only ever *record* what was found. Nothing cascades and nothing is
+  deleted.
+
+  ## Why it asks the disk rather than the walk
+
+  The walk knows which items it claimed files for, and "no claim" looks like
+  a free answer. It isn't: ownership is a statement about which item a file
+  belongs to, not about whether it exists, and reading one as the other ties
+  this to a model that has nothing to do with it. Asking the filesystem
+  directly is one `File.regular?` per file and answers the question that was
+  actually asked.
+
+  ## An unreachable source is not a missing item
+
+  Nothing is checked unless the source's own directory is readable, which is
+  the guard `Ambry.Inbox.scan/1` already applies before walking. A NAS that
+  is unplugged this morning must not turn every item in the queue into an
+  error, and one that comes back must not need a repair pass.
+
+  ## Partly missing is missing
+
+  An item is its files. A release that has lost one of forty cannot be
+  imported as the recording the draft describes, and the count would be a
+  fact nobody can act on differently — the fix is the same either way, and
+  the import is blocked either way.
+
+  ## Empty is not missing
+
+  An item that lists no files has none that went away. "There was never any
+  audio here" already has a better answer than this one — the importer
+  refuses it as `:no_audio_files` — and reporting it as missing would trade a
+  precise refusal for a vague one and send the operator looking for files
+  that never existed.
+  """
+
+  import Ecto.Query
+
+  alias Ambry.Inbox.InboxItem
+  alias Ambry.Repo
+
+  @doc """
+  Checks every item of one source and records what it found.
+
+  Returns `{:ok, %{checked: n, missing: n, healed: n}}`, or
+  `{:error, :source_unreachable}` when the source's directory can't be read,
+  in which case nothing is written.
+  """
+  def reconcile_source(source) do
+    if File.dir?(source.path) do
+      InboxItem
+      |> where([i], i.source_id == ^source.id)
+      |> Repo.all()
+      |> Enum.map(&Repo.preload(&1, :source))
+      |> Enum.reduce(%{checked: 0, missing: 0, healed: 0}, fn item, counts ->
+        counts = Map.update!(counts, :checked, &(&1 + 1))
+
+        case reconcile(item) do
+          {:ok, :missing} -> Map.update!(counts, :missing, &(&1 + 1))
+          {:ok, :healed} -> Map.update!(counts, :healed, &(&1 + 1))
+          {:ok, :unchanged} -> counts
+        end
+      end)
+      |> then(&{:ok, &1})
+    else
+      {:error, :source_unreachable}
+    end
+  end
+
+  @doc """
+  Checks one item and records the result.
+
+  Returns `{:ok, :missing | :healed | :unchanged}`.
+  """
+  def reconcile(%InboxItem{} = item) do
+    case {missing_files(item), item.missing_since} do
+      {[], nil} -> {:ok, :unchanged}
+      {[], _was_missing} -> put_missing_since(item, nil, :healed)
+      {[_ | _], nil} -> put_missing_since(item, DateTime.utc_now(:second), :missing)
+      {[_ | _], _already} -> {:ok, :unchanged}
+    end
+  end
+
+  @doc """
+  Whether this item's files are all still there.
+
+  The question `reopen` and the import both ask, so there is one answer to
+  it. Reads the stored flag rather than the disk: it is what the queue is
+  rendering, and a control that disagreed with the badge beside it would be
+  the worse of the two bugs.
+  """
+  def present?(%InboxItem{missing_since: nil}), do: true
+  def present?(%InboxItem{}), do: false
+
+  # An item that lists no files has none that are gone. "There was never any
+  # audio here" is a different fact with a better answer already — the
+  # importer refuses it as `:no_audio_files` — and calling it missing would
+  # replace a precise refusal with a vague one and invite the operator to go
+  # looking for files that never existed.
+  defp missing_files(%InboxItem{files: []}), do: []
+
+  defp missing_files(%InboxItem{} = item) do
+    item
+    |> InboxItem.owned_disk_files()
+    |> Enum.reject(&File.regular?/1)
+  end
+
+  defp put_missing_since(item, missing_since, result) do
+    item
+    |> Ecto.Changeset.change(%{missing_since: missing_since})
+    |> Repo.update()
+    |> case do
+      {:ok, _item} -> {:ok, result}
+      {:error, _changeset} = error -> error
+    end
+  end
+end

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -1103,7 +1103,9 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
       # facts about the world rather than about the draft — a root that went
       # away, an audiobook that was deleted — so they're read here and not
       # counted as outstanding decisions.
-      blocker: destination.blocker || replacement_blocker(replacing, replaces),
+      blocker:
+        missing_blocker(item) || destination.blocker ||
+          replacement_blocker(replacing, replaces),
       # What each level's search box starts from, resolved once per load
       # rather than per render — the hints are parsed out of the release
       # text.
@@ -1462,6 +1464,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
   # moment the button is pressed, and the one thing this form may not do is
   # offer an action that fails. Not an unresolved *decision* — the operator
   # answered the question, and the answer stopped being true.
+  # The first thing that can be wrong with an import, and the one that makes
+  # every other answer moot: there is nothing left to import. Read here with
+  # the other two because it is the same kind of fact — about the world, not
+  # about the draft — and an outstanding decision is not what it is.
+  defp missing_blocker(%{missing_since: nil}), do: nil
+  defp missing_blocker(%{}), do: Inbox.describe_error(:files_missing)
+
   defp replacement_blocker(true, nil),
     do:
       "The audiobook this was going to replace has been deleted. " <>

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -66,6 +66,25 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
     {:noreply, reload(socket)}
   end
 
+  # Nothing in the library moves. The flash says so, because "re-open" beside
+  # a row that is wearing an audiobook could otherwise read as undoing the
+  # import rather than reopening the paperwork.
+  def handle_event("reopen", %{"id" => id}, socket) do
+    id
+    |> Inbox.get_item!()
+    |> Inbox.reopen_item()
+    |> case do
+      {:ok, _item} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Back in the queue. The library is untouched.")
+         |> reload()}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, Inbox.describe_error(reason))}
+    end
+  end
+
   # Queued, not run here. Importing re-probes every file and then copies every
   # byte, and doing that inside `handle_event` blocked the whole LiveView —
   # the queue froze for the length of a NAS copy, with no sign the click had
@@ -348,11 +367,30 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   defp status_color(:ignored), do: :gray
 
   @doc """
+  Whether this item's files have gone away since it was found.
+  """
+  def missing?(%InboxItem{missing_since: at}), do: not is_nil(at)
+
+  @doc """
+  Whether an imported item can go back into the queue.
+
+  The files it would be worked on again have to still be there. A `move`
+  placement consumed its source at import time, so those never can, and that
+  is the right answer rather than a gap.
+  """
+  def reopenable?(%InboxItem{status: :imported} = item), do: Inbox.item_files_present?(item)
+  def reopenable?(%InboxItem{}), do: false
+
+  @doc """
   What the Import button promises, or why it won't.
 
   A disabled control that doesn't say what is missing is just a dead button;
   the count comes from the same `Draft.unresolved/1` the form lists in full.
   """
+  # Nothing else on the row can be the reason: an item whose files are gone
+  # has nothing to import whatever its decisions say.
+  def import_title(%InboxItem{missing_since: at}) when not is_nil(at), do: "The files are gone"
+
   def import_title(%InboxItem{ready: false, draft: nil}),
     do: "Nothing has been proposed for this yet"
 

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -104,6 +104,17 @@
             </:action>
 
             <:action
+              :if={reopenable?(item)}
+              icon="fa-rotate-left"
+              click="reopen"
+              value={item.id}
+              title="Make its decisions again. The library is untouched."
+              confirm="Put this back in the queue? Nothing in the library changes."
+            >
+              Re-open
+            </:action>
+
+            <:action
               navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
               icon="fa-inbox"
               title="What was imported, and from where"
@@ -187,6 +198,17 @@
                   the decisions that produced it. Off the row by design, one
                   click away because a wrong import is diagnosed there. --%>
               <:action
+                :if={reopenable?(item)}
+                icon="fa-rotate-left"
+                click="reopen"
+                value={item.id}
+                title="Make its decisions again. The library is untouched."
+                confirm="Put this back in the queue? Nothing in the library changes."
+              >
+                Re-open
+              </:action>
+
+              <:action
                 navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
                 icon="fa-inbox"
                 title="What was imported, and from where"
@@ -210,6 +232,17 @@
               </:headline>
 
               <p class="text-sm text-zinc-400">The audiobook this became has been deleted.</p>
+
+              <:action
+                :if={reopenable?(item)}
+                icon="fa-rotate-left"
+                click="reopen"
+                value={item.id}
+                title="Make its decisions again. The library is untouched."
+                confirm="Put this back in the queue? Nothing in the library changes."
+              >
+                Re-open
+              </:action>
 
               <:action
                 navigate={~p"/admin/inbox/#{item}?#{return_query(assigns)}"}
@@ -329,9 +362,21 @@
           </div>
 
           <%!-- One badge. Inside a tab named for the status, printing the
-                status on every row says nothing; what the row owes does. --%>
+                status on every row says nothing; what the row owes does.
+
+                Missing outranks it: what a row owes stops mattering when
+                there is nothing left to do it to, and red is the blocker
+                colour (§5). --%>
           <:badges>
-            <.badge color={elem(state_words(item), 1)} class="text-xs" data-role="item-state">
+            <.badge :if={missing?(item)} color={:red} class="text-xs" data-role="item-missing">
+              missing
+            </.badge>
+            <.badge
+              :if={!missing?(item)}
+              color={elem(state_words(item), 1)}
+              class="text-xs"
+              data-role="item-state"
+            >
               {elem(state_words(item), 0)}
             </.badge>
           </:badges>
@@ -372,7 +417,7 @@
             :if={item.status == :pending}
             icon="fa-check"
             color={:brand}
-            disabled={!item.ready}
+            disabled={!item.ready or missing?(item)}
             click="import"
             value={item.id}
             title={import_title(item)}

--- a/priv/repo/migrations/20260822015631_inbox_items_missing_since.exs
+++ b/priv/repo/migrations/20260822015631_inbox_items_missing_since.exs
@@ -1,0 +1,23 @@
+defmodule Ambry.Repo.Migrations.InboxItemsMissingSince do
+  @moduledoc """
+  When an inbox item's files stopped being there.
+
+  The queue had no answer for this. A pending item whose files are deleted
+  produces no claim during the walk, so nothing refreshes it and nothing
+  notices: it keeps its file list, stays in the queue and still looks
+  importable, right up until Add fails inside placement with
+  `{:source_missing, path}` — after the operator has done all the curation.
+
+  Nullable and reversible, for the same reason `media.missing_since` is: the
+  reasons files vanish are ordinary, and a flag that only goes one way turns
+  an unplugged NAS into a queue full of permanent errors.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:inbox_items) do
+      add :missing_since, :utc_datetime
+    end
+  end
+end

--- a/test/ambry/inbox/managed_import_test.exs
+++ b/test/ambry/inbox/managed_import_test.exs
@@ -8,6 +8,7 @@ defmodule Ambry.Inbox.ManagedImportTest do
   alias Ambry.Inbox
   alias Ambry.Inbox.Draft
   alias Ambry.Inbox.Draft.Destination
+  alias Ambry.Inbox.Reconciliation
   alias Ambry.Library
   alias Ambry.Library.ImportPreference
   alias Ambry.Media
@@ -721,6 +722,67 @@ defmodule Ambry.Inbox.ManagedImportTest do
       assert {:ok, _replaced} = Inbox.import_item(second)
 
       assert Inbox.get_item!(first.id).updated_at == imported_at
+    end
+
+    # There is no undo for an import, and re-open is deliberately not one.
+    # Nothing in the library moves; the paperwork goes back to being work,
+    # and putting a replaced audiobook back on its old files is then an
+    # ordinary import rather than a reversal with its own rules.
+    test "re-opening an imported item touches nothing in the library" do
+      %{item: item} = downloads_item()
+      assert {:ok, media} = Inbox.import_item(item)
+
+      assert {:ok, reopened} = item.id |> Inbox.get_item!() |> Inbox.reopen_item()
+
+      assert reopened.status == :pending
+      assert Media.get_media!(media.id).id == media.id
+      assert [_track] = Media.get_media!(media.id).media_tracks
+    end
+
+    # A pending item has not imported anything. Leaving the claim would put a
+    # row in the queue saying it produced a recording it is no longer the
+    # record of, which is the half-truth the supersede work was about.
+    test "re-opening drops the item's claim on the audiobook" do
+      %{item: first, watched: watched} = downloads_item()
+      assert {:ok, media} = Inbox.import_item(first)
+
+      second = watched |> second_release() |> replace_with(media)
+      assert {:ok, _replaced} = Inbox.import_item(second)
+      assert Inbox.get_item!(first.id).superseded_by_id == second.id
+
+      assert {:ok, reopened} = first.id |> Inbox.get_item!() |> Inbox.reopen_item()
+
+      assert reopened.media_id == nil
+      assert reopened.superseded_by_id == nil
+    end
+
+    test "the draft survives, because it is the operator's curation" do
+      %{item: item} = downloads_item()
+      assert {:ok, _media} = Inbox.import_item(item)
+
+      assert {:ok, reopened} = item.id |> Inbox.get_item!() |> Inbox.reopen_item()
+
+      assert reopened.draft
+      assert Draft.unresolved(reopened.draft) == []
+    end
+
+    # A `move` placement consumed its source at import time, so there is
+    # nothing to make decisions about. Refusing is the right answer, not a gap.
+    test "an item whose files are gone cannot be re-opened" do
+      %{item: item, source: source} = downloads_item()
+      assert {:ok, _media} = Inbox.import_item(item)
+
+      File.rm!(source)
+      {:ok, :missing} = Reconciliation.reconcile(Inbox.get_item!(item.id))
+
+      assert {:error, :files_missing} = item.id |> Inbox.get_item!() |> Inbox.reopen_item()
+      assert Inbox.get_item!(item.id).status == :imported
+    end
+
+    test "a pending item is not something to re-open" do
+      %{item: item} = downloads_item()
+
+      assert {:error, :not_imported} = Inbox.reopen_item(item)
     end
 
     # What the form's replace control does: settle the decision and save it.

--- a/test/ambry/inbox/reconciliation_test.exs
+++ b/test/ambry/inbox/reconciliation_test.exs
@@ -1,0 +1,120 @@
+defmodule Ambry.Inbox.ReconciliationTest do
+  @moduledoc """
+  Noticing that an inbox item's files stopped being there.
+
+  The queue's whole failure mode here was silence: an item whose files were
+  deleted kept its file list and stayed importable until Add failed inside
+  placement, after every decision had been made.
+  """
+  use Ambry.DataCase
+
+  alias Ambry.Inbox
+  alias Ambry.Inbox.Reconciliation
+
+  describe "reconcile/1" do
+    test "an item whose files are all there is unchanged" do
+      %{item: item} = queued_item()
+
+      assert {:ok, :unchanged} = Reconciliation.reconcile(item)
+      refute Inbox.get_item!(item.id).missing_since
+    end
+
+    test "an item whose file was deleted is missing" do
+      %{item: item, files: [file]} = queued_item()
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(item)
+      assert Inbox.get_item!(item.id).missing_since
+    end
+
+    # An item is its files. A release that has lost one of two cannot be
+    # imported as the recording the draft describes.
+    test "losing one file of several is missing" do
+      %{item: item, files: [one, _two]} = queued_item(files: ["a.m4b", "b.m4b"])
+      File.rm!(one)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(item)
+    end
+
+    # The reason this is a timestamp and not a status: files come back.
+    test "an item whose files come back is healed" do
+      %{item: item, files: [file]} = queued_item()
+      contents = File.read!(file)
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(item)
+
+      File.write!(file, contents)
+      item = Inbox.get_item!(item.id)
+
+      assert {:ok, :healed} = Reconciliation.reconcile(item)
+      refute Inbox.get_item!(item.id).missing_since
+    end
+
+    test "an item already known to be missing is not restamped" do
+      %{item: item, files: [file]} = queued_item()
+      File.rm!(file)
+
+      assert {:ok, :missing} = Reconciliation.reconcile(item)
+      first = Inbox.get_item!(item.id).missing_since
+
+      assert {:ok, :unchanged} = Reconciliation.reconcile(Inbox.get_item!(item.id))
+      assert Inbox.get_item!(item.id).missing_since == first
+    end
+  end
+
+  describe "reconcile_source/1" do
+    # The property that keeps an unplugged NAS from rewriting the queue. A
+    # source that cannot be read is not a source full of missing items, and
+    # one that comes back must not need a repair pass.
+    test "an unreachable source is not checked at all" do
+      %{item: item, source: source, downloads: downloads} = queued_item()
+
+      File.rm_rf!(downloads)
+
+      assert {:error, :source_unreachable} = Reconciliation.reconcile_source(source)
+      refute Inbox.get_item!(item.id).missing_since
+    end
+
+    test "counts what it found" do
+      %{item: item, source: source, files: [file]} = queued_item()
+      File.rm!(file)
+
+      assert {:ok, %{checked: 1, missing: 1, healed: 0}} = Reconciliation.reconcile_source(source)
+      assert Inbox.get_item!(item.id).missing_since
+    end
+  end
+
+  describe "importing a missing item" do
+    # Refused before the importer is entered, rather than deep inside
+    # placement after the curation is done.
+    test "is refused" do
+      %{item: item, files: [file]} = queued_item()
+      File.rm!(file)
+      {:ok, :missing} = Reconciliation.reconcile(item)
+
+      assert {:error, :files_missing} = item.id |> Inbox.get_item!() |> Inbox.import_item()
+    end
+  end
+
+  defp queued_item(opts \\ []) do
+    downloads = Path.join(Ambry.Paths.source_media_disk_path("watched"), Ecto.UUID.generate())
+    release = Path.join(downloads, "The Way of Kings [M4B]")
+    File.mkdir_p!(release)
+
+    files =
+      opts
+      |> Keyword.get(:files, ["book.m4b"])
+      |> Enum.map(fn name ->
+        path = Path.join(release, name)
+        File.cp!(tagged_audio(), path)
+        path
+      end)
+
+    source = insert(:source, path: downloads, name: "Downloads #{Ecto.UUID.generate()}")
+    {:ok, _counts} = Inbox.discover(source)
+    {[item], false} = Inbox.list_items(filter: "Way of Kings")
+
+    %{item: Inbox.get_item!(item.id), source: source, files: files, downloads: downloads}
+  end
+end


### PR DESCRIPTION
Two gaps with one question underneath them: are this item's files still there?

## Nothing noticed when they weren't

Discovery's walk only ever *claims* files, so an item whose files are all deleted produces no claim at all — nothing refreshes it, and it sits in the queue with a stale file list looking perfectly importable. The first thing that noticed was Add, failing inside placement with `{:source_missing, path}` after every decision had been made.

`Ambry.Inbox.Reconciliation` answers it, and deliberately the same way `Ambry.Media.Reconciliation` answers it for recordings: record what was found, cascade nothing, and stay reversible — `missing_since` is a fact about this morning, not a verdict. A pending item whose files come back is pending again with its decisions intact.

Three rules worth naming:

- **It asks the disk, not the walk.** "No claim" looks like a free answer and isn't: ownership says which item a file belongs to, existence says whether it's there. Reading one as the other is how the two come to disagree — and it has to answer for items the walk deliberately skips.
- **An unreachable source is not a missing item.** Nothing is checked unless the source's directory reads, the same guard `scan/1` already applies. An unplugged NAS must not turn the queue into errors, and one that comes back must not need a repair pass.
- **Empty is not missing.** An item listing no files has none that went away, and `:no_audio_files` is already the better answer. Two existing tests caught me trading a precise refusal for a vague one.

The queue row wears a red `missing` badge that outranks the decisions badge (what a row owes stops mattering when there's nothing to do it to), Import is disabled with a title saying why, and the form gets it as a `blocker` — alongside "the root went away" and "the audiobook was deleted", which are the same kind of fact.

## Re-open

An imported item whose files are still there goes back to being work. **Deliberately not an undo**: nothing in the library is touched, no files move, the recording goes on playing exactly what it was playing. Putting a replaced audiobook back on its old files is then an ordinary import — open it, point the replace decision at the recording, Add — rather than a reversal mechanism with rules of its own.

Its claim on the audiobook drops: a pending item hasn't imported anything, and leaving `media_id` and `superseded_by_id` would put a row in the queue claiming to be the record of a recording it no longer accounts for. The draft stays, because it's your curation.

Refused when the files are gone — which is also what makes a `move` import un-re-openable, since its source was consumed at import time. Right answer, not a gap.

The scan's documented contract narrows from "never touches an imported item" to never changing what one *holds*; recording whether its files exist is the pass that makes re-open answerable at all.

## Verified

`mix check` green, full suite 2040 passing, 14 new tests.

https://claude.ai/code/session_01T6rFUksK4tkZ4ZNS4ZvY3n