### PR TITLE
A watch is a book that doesn't exist yet

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -64,6 +64,10 @@ config :ambry, Oban,
      crontab: [
        {"0 * * * *", Ambry.Inbox.RunDiscovery},
        {"0 4 * * *", Ambry.Media.RunReconciliation},
+       # Weekly, and only for watches inside the next month: what a provider
+       # can tell us that arithmetic cannot is whether a date has *moved*, and
+       # a release six months out has not moved in the last hour.
+       {"0 5 * * 1", Ambry.Wanted.RunRefresh},
        # Organizing is triggered by the edits that invalidate a path, so this
        # is the backstop for the one thing no edit can announce: a change to
        # the naming template itself, which invalidates every path at once.

--- a/lib/ambry.ex
+++ b/lib/ambry.ex
@@ -30,6 +30,7 @@ defmodule Ambry do
       {Search, []},
       {Settings, []},
       {Sync, []},
-      {Utils, []}
+      {Utils, []},
+      {Wanted, []}
     ]
 end

--- a/lib/ambry/inbox.ex
+++ b/lib/ambry/inbox.ex
@@ -66,7 +66,7 @@ defmodule Ambry.Inbox do
   """
 
   use Boundary,
-    deps: [Ambry, Ambry.Library, Ambry.Media],
+    deps: [Ambry, Ambry.Library, Ambry.Media, Ambry.Wanted],
     # The draft tree is exported because it IS the import form's data model —
     # the form renders and edits it directly. Import stays internal.
     exports: [InboxItem, {Draft, []}]

--- a/lib/ambry/inbox/auto_match.ex
+++ b/lib/ambry/inbox/auto_match.ex
@@ -50,6 +50,7 @@ defmodule Ambry.Inbox.AutoMatch do
   alias Ambry.Metadata.Providers
   alias Ambry.Metadata.Registry
   alias Ambry.People
+  alias Ambry.Wanted
 
   require Logger
 
@@ -1027,10 +1028,44 @@ defmodule Ambry.Inbox.AutoMatch do
 
     level_result(
       query,
-      candidates |> Kernel.++(editions) |> dedupe_records() |> apply_narrator_evidence(hints),
+      candidates
+      |> Kernel.++(editions)
+      |> dedupe_records()
+      |> apply_narrator_evidence(hints)
+      |> mark_wanted(),
       outcomes ++ edition_outcomes,
       hints.author
     )
+  end
+
+  @doc """
+  Marks the candidates the operator is already waiting for.
+
+  A watch says *this recording is one I want*, which is a real prior on what
+  a new file turns out to be — the operator went looking for it on purpose.
+
+  **It does not move the score.** The scores answer "how well does this record
+  match this file", and a watch is evidence about the operator's intent, not
+  about the file: wanting a recording cannot make the bytes on disk more
+  likely to be it. Inflating a score with it would be the same dishonesty
+  `order_candidates/1` refuses when it declines to invent a gap between two
+  equals. So it orders equals and it labels, and the operator decides.
+  """
+  def mark_wanted(candidates), do: mark_wanted(candidates, Wanted.open_refs())
+
+  @doc false
+  def mark_wanted(candidates, wanted_refs) do
+    if Enum.empty?(wanted_refs) do
+      candidates
+    else
+      Enum.map(candidates, fn record ->
+        if MapSet.member?(wanted_refs, ref(record)) do
+          Map.put(record, "wanted", true)
+        else
+          record
+        end
+      end)
+    end
   end
 
   # An ASIN is a recording-level key, so when there is one it leads: a hit on
@@ -1458,8 +1493,14 @@ defmodule Ambry.Inbox.AutoMatch do
   actually spoke about.
   """
   def order_candidates(candidates) do
-    Enum.sort_by(candidates, &{&1["score"] || 0.0, corroboration(&1)}, :desc)
+    Enum.sort_by(candidates, &{&1["score"] || 0.0, wanted(&1), corroboration(&1)}, :desc)
   end
+
+  # Ahead of corroboration among equals: the file corroborating a narrator
+  # says this record fits what is on disk, and a watch says the operator went
+  # looking for this exact recording. Neither outranks a better score.
+  defp wanted(%{"wanted" => true}), do: 1
+  defp wanted(_record), do: 0
 
   defp corroboration(%{"narrator_evidence" => "supported"}), do: 2
   defp corroboration(%{"narrator_evidence" => "contradicted"}), do: 0

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -71,6 +71,7 @@ defmodule Ambry.Inbox.Importer do
   alias Ambry.People.Narrator
   alias Ambry.Repo
   alias Ambry.Settings
+  alias Ambry.Wanted
 
   require Logger
 
@@ -111,8 +112,45 @@ defmodule Ambry.Inbox.Importer do
     log_finalize(Placement.finalize(outcome.placements), item)
     Placement.discard(outcome.vacated)
     retire(outcome)
+    settle_watches(item, outcome.media)
     :ok
   end
+
+  # The other end of the watch: the operator said they were waiting for this
+  # recording, and now it is in the library. Turning the nag off is the whole
+  # point -- a reminder the operator has to remember to dismiss is a reminder
+  # that outlived its usefulness.
+  #
+  # Keyed on the provider records the *draft* adopted, not on everything the
+  # matcher proposed: a candidate that was offered and passed over is no
+  # evidence that this file is that recording.
+  #
+  # Like everything else in `finish/2` it may not fail the import. The
+  # recording is already in the library, and a job reported as failed is a lie
+  # the operator acts on.
+  defp settle_watches(%InboxItem{} = item, %Media.Media{} = media) do
+    case adopted_refs(item) do
+      [] ->
+        :ok
+
+      refs ->
+        settled = Wanted.settle(refs, media)
+
+        Enum.each(settled, fn watch ->
+          Logger.info("Import satisfied a watch: #{watch.edition.title} (##{watch.id})")
+        end)
+    end
+  rescue
+    error ->
+      Logger.warning("Could not settle watches for item #{item.id}: #{inspect(error)}")
+      :ok
+  end
+
+  defp adopted_refs(%InboxItem{draft: %{recording: %{sources: sources}}}) when is_list(sources) do
+    Enum.map(sources, &{&1.source, &1.id})
+  end
+
+  defp adopted_refs(_item), do: []
 
   defp retire(%{retired: nil}), do: :ok
 

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -112,6 +112,12 @@ defmodule Ambry.Metadata.Provider do
     A normalized book result — a work (work-level providers) or an audiobook
     release (recording-level providers). Recording-level results carry
     narrators and an ASIN; work-level results may carry an editions list.
+
+    `duration_seconds` is how long the *recording* is, and it is nil on a
+    work: a novel has no runtime, a reading of it does. It is the field that
+    tells two recordings of the same book apart when everything else about
+    them agrees — abridged from unabridged, one cast from another — which is
+    why an audiobook library carries it and a book catalogue would not.
     """
     defstruct [
       :provider,
@@ -124,6 +130,7 @@ defmodule Ambry.Metadata.Provider do
       :language,
       :format,
       :asin,
+      :duration_seconds,
       authors: [],
       narrators: [],
       series: [],

--- a/lib/ambry/metadata/provider.ex
+++ b/lib/ambry/metadata/provider.ex
@@ -285,6 +285,7 @@ defmodule Ambry.Metadata.Provider do
           | :author_details
           | :chapters
           | :editions
+          | :editions_bulk
 
   @doc "Stable machine identifier, used in cache keys and settings rows."
   @callback id() :: String.t()
@@ -339,6 +340,18 @@ defmodule Ambry.Metadata.Provider do
   """
   @callback editions(work_id :: String.t(), config()) :: {:ok, [Book.t()]} | {:error, term}
 
+  @doc """
+  The audiobook editions of several works at once, keyed by work id.
+
+  Declared separately from `editions/2` because whether a provider can answer
+  for many works in one round trip is a real difference in what it can do, not
+  an optimization a caller may assume. A provider that can say so is asked
+  once instead of once per work — which is the difference between opening
+  every candidate work and opening only the first few.
+  """
+  @callback editions_bulk(work_ids :: [String.t()], config()) ::
+              {:ok, %{String.t() => [Book.t()]}} | {:error, term}
+
   @optional_callbacks available?: 1,
                       config_notices: 1,
                       search_books: 2,
@@ -346,7 +359,8 @@ defmodule Ambry.Metadata.Provider do
                       search_authors: 2,
                       author_details: 2,
                       chapters: 2,
-                      editions: 2
+                      editions: 2,
+                      editions_bulk: 2
 
   @doc "The default config for a provider module, derived from its config fields."
   def default_config(provider_module) do

--- a/lib/ambry/metadata/providers.ex
+++ b/lib/ambry/metadata/providers.ex
@@ -31,6 +31,9 @@ defmodule Ambry.Metadata.Providers do
   def author_details(provider_id, author_id, opts \\ []),
     do: call(provider_id, :author_details, :author_details, author_id, @details_ttl, opts)
 
+  def editions_bulk(provider_id, work_ids, opts \\ []),
+    do: call(provider_id, :editions_bulk, :editions_bulk, work_ids, @details_ttl, opts)
+
   def editions(provider_id, work_id, opts \\ []),
     do: call(provider_id, :editions, :editions, work_id, @details_ttl, opts)
 
@@ -64,6 +67,11 @@ defmodule Ambry.Metadata.Providers do
     |> Enum.map_join("|", &(&1 || ""))
     |> then(&("q:" <> &1))
   end
+
+  # A list joins rather than flattening: `to_string/1` on `["1", "23"]` and
+  # on `["12", "3"]` produce the same string, which would serve one set of
+  # works' editions for another.
+  defp cache_key(args) when is_list(args), do: Enum.map_join(args, ",", &to_string/1)
 
   defp cache_key(arg), do: to_string(arg)
 

--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -30,7 +30,7 @@ defmodule Ambry.Metadata.Providers.Audible do
   def level, do: :recording
 
   @impl Provider
-  def capabilities, do: [:book_search]
+  def capabilities, do: [:book_search, :book_details]
 
   @impl Provider
   def config_fields do
@@ -69,6 +69,23 @@ defmodule Ambry.Metadata.Providers.Audible do
   def search_books(%Provider.Query{} = query, config), do: widen(attempts(query), config)
 
   def search_books(query, config) when is_binary(query), do: widen([%{keywords: query}], config)
+
+  @doc """
+  One recording, by the id its own search handed out.
+
+  Which for this provider is an ASIN, and an ASIN is marketplace-scoped: the
+  catalog that issued it is the only one that can resolve it. `:not_found` is
+  a real answer here, not a failure — a storefront delists, and a recording it
+  no longer sells is one it can no longer be asked about, which is exactly
+  what a bibliography is for.
+  """
+  @impl Provider
+  def book_details(asin, config) do
+    case Audible.book_details(asin, marketplaces: marketplaces(config)) do
+      {:ok, product} -> {:ok, product_to_book(product)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   # Every parameter here is an AND filter, so the most precise query is also
   # the most fragile: asking for narrator "Jeff Harding" on a book whose only

--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -119,6 +119,7 @@ defmodule Ambry.Metadata.Providers.Audible do
       title: product.title,
       description: product.description,
       cover_url: product.cover_image,
+      duration_seconds: product.duration_seconds,
       published: published(product.published),
       publisher: product.publisher,
       language: product.language,

--- a/lib/ambry/metadata/providers/audible.ex
+++ b/lib/ambry/metadata/providers/audible.ex
@@ -4,8 +4,15 @@ defmodule Ambry.Metadata.Providers.Audible do
 
   Wraps the existing `AmbryScraping.Audible` HTTP client (the undocumented
   but stable JSON catalog API — no browser scraping involved) and normalizes
-  its results. This is the primary source for narrator credits, square
-  audiobook covers, and publication facts; ASIN is the natural key.
+  its results. Its search answers with recordings directly, and those records
+  carry narrator credits, square covers, publication facts and an ASIN.
+
+  It is **not** a primary or preferred source, and nothing should treat it as
+  one: providers are selected by the capabilities they declare, and every
+  provider that can answer a question gets asked. What this one is good at is
+  a fact about its records, not a rank — and it is blind in its own way, being
+  a storefront rather than a bibliography: it carries preorders and drops what
+  it has delisted.
   """
 
   @behaviour Ambry.Metadata.Provider

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -35,7 +35,8 @@ defmodule Ambry.Metadata.Providers.Hardcover do
   def level, do: :work
 
   @impl Provider
-  def capabilities, do: [:book_search, :book_details, :author_search, :author_details, :editions]
+  def capabilities,
+    do: [:book_search, :book_details, :author_search, :author_details, :editions, :editions_bulk]
 
   @impl Provider
   def config_fields do
@@ -174,6 +175,71 @@ defmodule Ambry.Metadata.Providers.Hardcover do
     }
   }
   """
+
+  # The same filter as `@editions_query`, over several books at once. Hasura
+  # takes `_in` on `book_id`, so asking about seven works costs one request
+  # rather than seven -- which is what makes it possible to open *every*
+  # candidate work instead of guessing which few are worth opening.
+  #
+  # The limit is across all of them, so it is generous and its exhaustion is
+  # reported rather than silently truncating.
+  @editions_bulk_query """
+  query AudioEditionsBulk($ids: [Int!], $roles: [String!]) {
+    editions(
+      where: {
+        book_id: {_in: $ids},
+        _or: [
+          {reading_format_id: {_eq: #{@audiobook_format}}},
+          {audio_seconds: {_is_null: false}},
+          {contributions: {contribution: {_in: $roles}}}
+        ]
+      },
+      limit: 500
+    ) {
+      id
+      book_id
+      title
+      release_date
+      asin
+      audio_seconds
+      reading_format_id
+      publisher { name }
+      image { url }
+      contributions { contribution author { id name } }
+      book { description contributions { contribution author { id name } } }
+    }
+  }
+  """
+
+  @doc """
+  The audiobook editions of several works, keyed by work id.
+  """
+  @impl Provider
+  def editions_bulk(work_ids, config) do
+    ids =
+      Enum.flat_map(work_ids, fn id ->
+        case parse_id(id) do
+          {:ok, parsed} -> [parsed]
+          _error -> []
+        end
+      end)
+
+    with false <- ids == [],
+         {:ok, %{"editions" => editions}} <-
+           Client.query(config, @editions_bulk_query, %{
+             ids: ids,
+             roles: @narrator_roles_upstream
+           }) do
+      {:ok,
+       editions
+       |> Enum.filter(&audio_edition?/1)
+       |> Enum.group_by(&to_string(&1["book_id"]), &edition_to_book/1)}
+    else
+      true -> {:ok, %{}}
+      {:ok, _other} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   @doc """
   The audiobook editions of a work.

--- a/lib/ambry/metadata/providers/hardcover.ex
+++ b/lib/ambry/metadata/providers/hardcover.ex
@@ -227,6 +227,10 @@ defmodule Ambry.Metadata.Providers.Hardcover do
       id: to_string(edition["id"]),
       asin: presence(edition["asin"]),
       title: edition["title"],
+      # Already fetched and already used to decide this is an audio edition
+      # at all; keeping it costs nothing and it is the one fact that
+      # distinguishes two recordings of the same book.
+      duration_seconds: edition["audio_seconds"],
       # From the WORK's contributions, not the edition's own. An edition of a
       # book has that book's author by definition, and reading the edition's
       # list instead promotes whoever upstream filed under the nil role —

--- a/lib/ambry/wanted.ex
+++ b/lib/ambry/wanted.ex
@@ -32,6 +32,7 @@ defmodule Ambry.Wanted do
 
   import Ecto.Query
 
+  alias Ambry.Metadata.Registry
   alias Ambry.Repo
   alias Ambry.Wanted.Watch
 
@@ -167,6 +168,21 @@ defmodule Ambry.Wanted do
 
   @doc "Puts a dismissed or released watch back into waiting."
   def reopen(%Watch{} = watch), do: update_watch(watch, %{status: :upcoming})
+
+  @doc """
+  What to call the provider a watch's record came from.
+
+  Read off the registry rather than listed here: a provider added later should
+  name itself, and a hardcoded list would quietly start showing raw ids. Falls
+  back to the id for a provider that has since been removed, because a watch
+  outlives the provider that supplied it.
+  """
+  def provider_name(provider_id) do
+    case Registry.fetch(provider_id) do
+      {:ok, entry} -> entry.display_name
+      {:error, _reason} -> provider_id
+    end
+  end
 
   @doc "Forgets a watch entirely. Prefer `dismiss/1` — see `Watch`."
   def delete_watch(%Watch{} = watch), do: Repo.delete(watch)

--- a/lib/ambry/wanted.ex
+++ b/lib/ambry/wanted.ex
@@ -1,0 +1,173 @@
+defmodule Ambry.Wanted do
+  @moduledoc """
+  Audiobooks that don't exist yet.
+
+  Everything else in Ambry describes what the library *holds*. This describes
+  what it is waiting for — which is the one thing the library cannot represent
+  on its own, and the one thing an operator forgets.
+
+  ## What a watch is for
+
+  Not a wishlist. A watch exists to become **due**: the expected date arrives,
+  the admin dashboard starts nagging, and it keeps nagging until the operator
+  either has the recording or says otherwise. A watch that never becomes due
+  and is never dismissed has failed to do its job.
+
+  Which is why `due?/1` says only that a date has passed, never that a book
+  exists. A provider's date is a plan; the recording turning up is a fact, and
+  the two are told apart everywhere in this context.
+
+  ## Requests, later
+
+  A user-facing request is the same idea with an owner attached, and it will
+  get its own table rather than a `user_id` here: a watch is about the
+  recording, so two people waiting for the same book is still one watch.
+  `Ambry.Wanted.Edition` is deliberately shared between them, so promotion
+  from a watch to a request is a copy rather than a translation.
+  """
+
+  use Boundary,
+    deps: [Ambry, Ambry.Media],
+    exports: [Watch, {Edition, []}, {Search, []}]
+
+  import Ecto.Query
+
+  alias Ambry.Repo
+  alias Ambry.Wanted.Watch
+
+  @doc """
+  Every watch, loudest first.
+
+  Ordering is by *who is waiting on whom*, matching the admin dashboard: what
+  is due comes first because it needs a human, then what is still coming in
+  date order, then what has been settled. A watch with no date sorts after
+  the dated ones — it is a real state, but it is not a deadline.
+  """
+  def list_watches(opts \\ []) do
+    today = Keyword.get(opts, :today, Date.utc_today())
+
+    Watch
+    |> maybe_filter_status(Keyword.get(opts, :status))
+    |> Repo.all()
+    |> Repo.preload(:media)
+    |> Enum.sort_by(&sort_key(&1, today))
+  end
+
+  defp maybe_filter_status(query, nil), do: query
+  defp maybe_filter_status(query, status), do: where(query, [w], w.status == ^status)
+
+  defp sort_key(watch, today) do
+    {status_rank(watch, today), date_rank(watch), watch.edition.title || ""}
+  end
+
+  defp status_rank(watch, today) do
+    cond do
+      Watch.due?(watch, today) -> 0
+      watch.status == :upcoming -> 1
+      watch.status == :released -> 2
+      true -> 3
+    end
+  end
+
+  # `:infinity` would not compare against a Date. A far-future sentinel keeps
+  # undated watches last without special-casing the comparison.
+  defp date_rank(%Watch{expected_release_date: nil}), do: ~D[9999-12-31]
+  defp date_rank(%Watch{expected_release_date: date}), do: date
+
+  @doc "The watches whose expected date has arrived and that nobody has settled."
+  def list_due(today \\ Date.utc_today()) do
+    Watch
+    |> where([w], w.status == :upcoming)
+    |> where([w], not is_nil(w.expected_release_date))
+    |> where([w], w.expected_release_date <= ^today)
+    |> order_by([w], asc: w.expected_release_date)
+    |> Repo.all()
+  end
+
+  @doc """
+  What the dashboard needs to decide whether to nag, in one query pair.
+
+  `due` is the nag. `next` is what makes the card worth reading when there is
+  nothing to nag about — "nothing out yet, next is Blightfall on Sep 1" is an
+  answer; an empty card is not.
+  """
+  def summary(today \\ Date.utc_today()) do
+    due = list_due(today)
+
+    next =
+      Watch
+      |> where([w], w.status == :upcoming)
+      |> where([w], not is_nil(w.expected_release_date))
+      |> where([w], w.expected_release_date > ^today)
+      |> order_by([w], asc: w.expected_release_date)
+      |> limit(1)
+      |> Repo.one()
+
+    %{
+      due: due,
+      due_count: length(due),
+      next: next,
+      upcoming_count: Repo.aggregate(where(Watch, [w], w.status == :upcoming), :count)
+    }
+  end
+
+  @doc "Fetches a watch, raising when it isn't there."
+  def get_watch!(id), do: Watch |> Repo.get!(id) |> Repo.preload(:media)
+
+  @doc "The watch for a provider's recording, if one exists."
+  def get_by_provider(provider, provider_id) do
+    Repo.get_by(Watch, provider: to_string(provider), provider_id: to_string(provider_id))
+  end
+
+  @doc """
+  Starts watching a recording.
+
+  Answers `{:error, :already_watching, watch}` rather than a changeset error
+  when the recording is already watched, because the useful response to "add
+  this" is the watch that already exists, not a form telling the operator off.
+  """
+  def create_watch(attrs) do
+    provider = attrs[:provider] || attrs["provider"]
+    provider_id = attrs[:provider_id] || attrs["provider_id"]
+
+    case get_by_provider(provider, provider_id) do
+      nil ->
+        %Watch{}
+        |> Watch.changeset(attrs)
+        |> Repo.insert()
+
+      existing ->
+        {:error, :already_watching, existing}
+    end
+  end
+
+  @doc "Changes what the operator can change: the date, the state, the note."
+  def update_watch(%Watch{} = watch, attrs) do
+    watch
+    |> Watch.edit_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc "A changeset for the edit form."
+  def change_watch(%Watch{} = watch, attrs \\ %{}), do: Watch.edit_changeset(watch, attrs)
+
+  @doc """
+  Marks a watch satisfied.
+
+  `media` is optional because the operator can know a book is out before it is
+  in the library — and a watch that stays `upcoming` because the import hasn't
+  happened yet would keep nagging about something already handled.
+  """
+  def mark_released(%Watch{} = watch, media \\ nil) do
+    update_watch(watch, %{status: :released, media_id: media && media.id})
+  end
+
+  @doc "Stops the nagging without claiming the recording arrived."
+  def dismiss(%Watch{} = watch), do: update_watch(watch, %{status: :dismissed})
+
+  @doc "Puts a dismissed or released watch back into waiting."
+  def reopen(%Watch{} = watch), do: update_watch(watch, %{status: :upcoming})
+
+  @doc "Forgets a watch entirely. Prefer `dismiss/1` — see `Watch`."
+  def delete_watch(%Watch{} = watch), do: Repo.delete(watch)
+end

--- a/lib/ambry/wanted.ex
+++ b/lib/ambry/wanted.ex
@@ -160,7 +160,9 @@ defmodule Ambry.Wanted do
   happened yet would keep nagging about something already handled.
   """
   def mark_released(%Watch{} = watch, media \\ nil) do
-    update_watch(watch, %{status: :released, media_id: media && media.id})
+    watch
+    |> Watch.settle_changeset(%{status: :released, media_id: media && media.id})
+    |> Repo.update()
   end
 
   @doc "Stops the nagging without claiming the recording arrived."
@@ -168,6 +170,49 @@ defmodule Ambry.Wanted do
 
   @doc "Puts a dismissed or released watch back into waiting."
   def reopen(%Watch{} = watch), do: update_watch(watch, %{status: :upcoming})
+
+  @doc """
+  The provider records the operator is waiting for, as `{provider, id}`.
+
+  A set, because the caller is asking the same question of every candidate in
+  a ranked list. Only watches still being waited on: a released or dismissed
+  watch has been answered, and an answered question should not keep colouring
+  what the inbox proposes.
+  """
+  def open_refs do
+    Watch
+    |> where([w], w.status == :upcoming)
+    |> select([w], {w.provider, w.provider_id})
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
+  Settles the watches an import answered, and says which.
+
+  Keyed on the provider records the operator adopted for the import, not on
+  what the matcher merely proposed: a candidate that was offered and passed
+  over is not evidence that this file is that recording. Returns the watches
+  it settled so the caller can say so.
+
+  Never raises and never fails the caller. This runs after the recording is
+  already in the library, where a raised error would report a successful
+  import as a failed one.
+  """
+  def settle(refs, media) do
+    refs = MapSet.new(refs)
+
+    Watch
+    |> where([w], w.status == :upcoming)
+    |> Repo.all()
+    |> Enum.filter(&MapSet.member?(refs, {&1.provider, &1.provider_id}))
+    |> Enum.flat_map(fn watch ->
+      case mark_released(watch, media) do
+        {:ok, settled} -> [settled]
+        {:error, _changeset} -> []
+      end
+    end)
+  end
 
   @doc """
   What to call the provider a watch's record came from.

--- a/lib/ambry/wanted/edition.ex
+++ b/lib/ambry/wanted/edition.ex
@@ -1,0 +1,83 @@
+defmodule Ambry.Wanted.Edition do
+  @moduledoc """
+  A provider's record of one audiobook recording, copied out of the provider
+  and frozen.
+
+  This is deliberately a value, not a row: it is *what the operator chose*,
+  and it has to keep rendering after the provider revises the listing, pulls
+  it, or simply cannot be reached. Everything here is optional except the
+  title, because provider coverage is genuinely patchy — measured across the
+  ten audio editions Hardcover holds for *Neuromancer*: cover 9, date 9,
+  publisher 8, narrators 6, **ASIN 2**.
+
+  Which is also why `asin` is a field like any other rather than the key. See
+  `Ambry.Wanted.Watch` for the identity that is used instead.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @derive Jason.Encoder
+  @primary_key false
+  embedded_schema do
+    field :title, :string
+    field :authors, {:array, :string}, default: []
+    field :narrators, {:array, :string}, default: []
+    field :publisher, :string
+    field :language, :string
+    field :cover_url, :string
+    field :description, :string
+
+    # Matching keys, none of them required, all of them useful when the
+    # recording eventually turns up in the inbox.
+    field :asin, :string
+    field :isbn13, :string
+  end
+
+  @fields ~w(title authors narrators publisher language cover_url description asin isbn13)a
+
+  @doc false
+  def changeset(edition, attrs) do
+    edition
+    |> cast(attrs, @fields)
+    |> validate_required([:title])
+  end
+
+  @doc """
+  Builds an edition from a provider's normalized book struct.
+
+  `Ambry.Metadata.Provider.Book` is the shape both levels answer in — an
+  Audible product *is* a recording, and a Hardcover audio edition is one too
+  — so one function covers both.
+  """
+  def from_provider_book(%{__struct__: _} = book) do
+    %__MODULE__{
+      title: book.title,
+      authors: names(Map.get(book, :authors)),
+      narrators: names(Map.get(book, :narrators)),
+      publisher: Map.get(book, :publisher),
+      language: Map.get(book, :language),
+      cover_url: Map.get(book, :cover_url),
+      description: Map.get(book, :description),
+      asin: Map.get(book, :asin)
+    }
+  end
+
+  defp names(nil), do: []
+  defp names(list), do: Enum.map(list, & &1.name)
+
+  @doc "The credited authors as one phrase, or nil when the provider named none."
+  def byline(%__MODULE__{authors: []}), do: nil
+  def byline(%__MODULE__{authors: authors}), do: Enum.join(authors, ", ")
+
+  @doc """
+  The narrators as one phrase.
+
+  Absent narrators are reported as absent rather than papered over: a
+  recording with no named reader is a gap in the provider's record, and
+  saying so is what lets the operator judge the candidate.
+  """
+  def narrated_by(%__MODULE__{narrators: []}), do: nil
+  def narrated_by(%__MODULE__{narrators: narrators}), do: Enum.join(narrators, ", ")
+end

--- a/lib/ambry/wanted/edition.ex
+++ b/lib/ambry/wanted/edition.ex
@@ -29,13 +29,20 @@ defmodule Ambry.Wanted.Edition do
     field :cover_url, :string
     field :description, :string
 
+    # How long the recording is. This is an audiobook, so its runtime is part
+    # of what it *is* — it is what separates an abridgement from the full
+    # reading and one dramatization from another when the title, the author
+    # and even the narrator all agree.
+    field :duration_seconds, :integer
+
     # Matching keys, none of them required, all of them useful when the
     # recording eventually turns up in the inbox.
     field :asin, :string
     field :isbn13, :string
   end
 
-  @fields ~w(title authors narrators publisher language cover_url description asin isbn13)a
+  @fields ~w(title authors narrators publisher language cover_url description
+             duration_seconds asin isbn13)a
 
   @doc false
   def changeset(edition, attrs) do
@@ -60,12 +67,33 @@ defmodule Ambry.Wanted.Edition do
       language: Map.get(book, :language),
       cover_url: Map.get(book, :cover_url),
       description: Map.get(book, :description),
+      duration_seconds: Map.get(book, :duration_seconds),
       asin: Map.get(book, :asin)
     }
   end
 
   defp names(nil), do: []
   defp names(list), do: Enum.map(list, & &1.name)
+
+  @doc """
+  The runtime in words, or nil when the provider did not give one.
+
+  Hours and minutes, because that is how long an audiobook is talked about —
+  nobody asks for a recording in seconds.
+  """
+  def runtime(%__MODULE__{duration_seconds: nil}), do: nil
+
+  def runtime(%__MODULE__{duration_seconds: seconds}) do
+    hours = div(seconds, 3600)
+    minutes = seconds |> rem(3600) |> div(60)
+
+    case {hours, minutes} do
+      {0, 0} -> nil
+      {0, m} -> "#{m}m"
+      {h, 0} -> "#{h}h"
+      {h, m} -> "#{h}h #{m}m"
+    end
+  end
 
   @doc "The credited authors as one phrase, or nil when the provider named none."
   def byline(%__MODULE__{authors: []}), do: nil

--- a/lib/ambry/wanted/run_refresh.ex
+++ b/lib/ambry/wanted/run_refresh.ex
@@ -1,0 +1,156 @@
+defmodule Ambry.Wanted.RunRefresh do
+  @moduledoc """
+  Re-asks the providers when a watched recording is expected.
+
+  ## This is not release detection
+
+  Whether a date has passed is arithmetic, and the list already does it — no
+  worker is needed to notice that September has arrived. What only a provider
+  can say is whether the date *is still the date*, and publishers move them
+  constantly. A watch left nagging on a date nobody believes any more is worse
+  than no watch: it teaches the operator to ignore the one thing the feature
+  exists to say.
+
+  So this refreshes the **snapshot and the date**, and lets the list go on
+  deciding what a date means.
+
+  ## Only what is nearly due, and only rarely
+
+  A watch six months out cannot have anything useful to say yet, and asking
+  about it weekly is a provider call spent on nothing. The window is the month
+  ahead plus anything already past its date — that second half being where
+  dates most often turn out to have moved, since a slipped release is exactly
+  a date that arrived without a book.
+
+  Nothing here settles a watch. A provider saying a recording came out is not
+  the same as the operator having it, and marking a watch released on that
+  basis would put the nag out precisely when it should be loudest.
+  """
+
+  use Oban.Worker,
+    queue: :metadata,
+    max_attempts: 3
+
+  import Ecto.Query
+
+  alias Ambry.Metadata.Providers
+  alias Ambry.Repo
+  alias Ambry.Wanted.Edition
+  alias Ambry.Wanted.Watch
+
+  require Logger
+
+  # Far enough ahead to catch a slip before the date arrives, near enough that
+  # most watches are never asked about.
+  @lookahead_days 31
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{}) do
+    today = Date.utc_today()
+    watches = due_for_refresh(today)
+
+    counts =
+      Enum.reduce(watches, %{checked: 0, moved: 0, failed: 0}, fn watch, counts ->
+        case refresh(watch) do
+          {:moved, from, to} ->
+            Logger.info("Watch #{watch.id} (#{watch.edition.title}) moved #{from} -> #{to}")
+
+            %{counts | checked: counts.checked + 1, moved: counts.moved + 1}
+
+          :unchanged ->
+            %{counts | checked: counts.checked + 1}
+
+          {:error, reason} ->
+            Logger.warning("Watch #{watch.id} refresh failed: #{inspect(reason)}")
+            %{counts | checked: counts.checked + 1, failed: counts.failed + 1}
+        end
+      end)
+
+    if counts.moved > 0 or counts.failed > 0 do
+      Logger.info("Watch refresh: #{inspect(counts)}")
+    end
+
+    {:ok, counts}
+  end
+
+  @doc """
+  The watches worth asking about today.
+
+  Undated ones are included: a watch with no date is waiting for one, and the
+  provider is the only place it can come from.
+  """
+  def due_for_refresh(today \\ Date.utc_today()) do
+    horizon = Date.add(today, @lookahead_days)
+
+    Watch
+    |> where([w], w.status == :upcoming)
+    |> where([w], is_nil(w.expected_release_date) or w.expected_release_date <= ^horizon)
+    |> Repo.all()
+  end
+
+  @doc """
+  Re-reads one watch's record from the provider that supplied it.
+
+  Answers `{:moved, from, to}`, `:unchanged`, or `{:error, reason}`. A
+  provider that cannot be reached leaves the watch exactly as it was — the
+  operator's snapshot is not something to discard because a request timed out.
+  """
+  def refresh(%Watch{} = watch) do
+    case fetch(watch) do
+      {:ok, book} -> apply_refresh(watch, book)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # `book_details` is the direct read: the operator already chose which record
+  # this is, so there is nothing to search for and nothing to re-decide.
+  defp fetch(%Watch{provider: provider, provider_id: provider_id}) do
+    case Providers.book_details(provider, provider_id, refresh: true) do
+      {:ok, book} -> {:ok, book}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp apply_refresh(watch, book) do
+    date = published_date(book)
+    edition = Edition.from_provider_book(book)
+
+    attrs = %{expected_release_date: date}
+
+    result =
+      watch
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_embed(:edition, refreshed_edition(watch.edition, edition))
+      |> Ecto.Changeset.change(attrs)
+      |> Repo.update()
+
+    case result do
+      {:ok, _updated} -> moved(watch.expected_release_date, date)
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  # The refreshed record wins on the facts that change, but a field the
+  # provider has since dropped does not blank one the operator already had:
+  # a thinner answer is a worse answer, not a correction.
+  defp refreshed_edition(%Edition{} = old, %Edition{} = new) do
+    new
+    |> Map.from_struct()
+    |> Enum.reject(fn {_key, value} -> value in [nil, []] end)
+    |> Map.new()
+    |> then(&Map.merge(Map.from_struct(old), &1))
+  end
+
+  defp moved(same, same), do: :unchanged
+  defp moved(from, to), do: {:moved, from, to}
+
+  defp published_date(%{published: %{date: %Date{} = date}}), do: date
+  defp published_date(_book), do: nil
+
+  @doc "Queues a refresh now, for the operator who does not want to wait a week."
+  def enqueue do
+    %{}
+    |> new()
+    |> Oban.insert()
+  end
+end

--- a/lib/ambry/wanted/search.ex
+++ b/lib/ambry/wanted/search.ex
@@ -1,32 +1,42 @@
 defmodule Ambry.Wanted.Search do
   @moduledoc """
-  Finding a recording to watch, across every provider that can answer.
+  Finding an audiobook to watch, across every provider that can name one.
 
-  ## Why both levels are asked, and neither is preferred
+  ## The rule is a capability, not a ranking
 
-  A watch is by definition about something that has not come out yet, and the
-  two provider levels know about the future in opposite ways:
+  **Any provider that can produce audio editions is asked, and none of them is
+  preferred.** There is no primary source here and no fallback: a provider
+  either can answer "which recordings of this exist" or it cannot, and the
+  ones that can all get to. Nothing in this module names a provider.
 
-    * **Recording-level providers are storefronts.** They list what they are
-      *selling*, which includes preorders. Audible has *The Velvet Knife*
-      (`B0FKVNLXQS`, 2026-09-29, read by Emily Ellet) months ahead.
-    * **Work-level providers are bibliographies.** They catalogue what has
-      been *published*, which is why they reach back to Books on Tape in 1984
-      — and why Hardcover holds no audio edition of *The Velvet Knife* at all
-      yet, because there isn't one to catalogue.
+  What differs between them is *shape*, not standing:
 
-  Neither is the better source; they are differently blind. So both are asked
-  and everything comes back labelled, in the order the providers are
-  configured. Nothing here scores, ranks or hides a candidate — the operator
-  chooses, exactly as they do on the import form.
+    * Some answer with recordings directly. Their search results are already
+      audiobooks — narrators, runtime, cover — and nothing needs expanding.
+    * Some answer with works. A novel is not a recording, so each promising
+      work is expanded through `editions/2` into the audio editions it has.
 
-  ## Work-level providers take two calls
+  ## Why that has to be the rule rather than a preference
 
-  A work-level search answers with *works*, not recordings, so each promising
-  work is expanded through `editions/2` into its audio editions. That is one
-  extra provider call per work, so only the first few are expanded — and when
-  that limit truncates anything, the caller is told rather than left to
-  assume the list is everything.
+  Providers are differently blind about what does not exist yet, and the
+  blindness does not sort into better and worse. A catalogue of what is *for
+  sale* has preorders months out and forgets anything delisted. A catalogue of
+  what has been *published* reaches back to tape and has no entry at all for a
+  recording that has not come out. Measured: *The Velvet Knife* is findable in
+  one and absent from the other; *Neuromancer*'s 1984 editions are the reverse;
+  *Blightfall* is in both, under different ids, and is offered twice rather
+  than merged.
+
+  Which is exactly the import form's bargain: records are evidence, outcomes
+  are visible, the operator decides. So everything comes back labelled, in the
+  order the providers are configured, and nothing here scores or hides a
+  candidate.
+
+  ## Coverage this knowingly cuts
+
+  Expanding a work costs an extra provider call, so only the first few are
+  expanded — and when that truncates anything the caller is told, because a
+  list that silently stopped looking reads as a list of everything there is.
   """
 
   alias Ambry.Metadata.Provider

--- a/lib/ambry/wanted/search.ex
+++ b/lib/ambry/wanted/search.ex
@@ -1,0 +1,135 @@
+defmodule Ambry.Wanted.Search do
+  @moduledoc """
+  Finding a recording to watch, across every provider that can answer.
+
+  ## Why both levels are asked, and neither is preferred
+
+  A watch is by definition about something that has not come out yet, and the
+  two provider levels know about the future in opposite ways:
+
+    * **Recording-level providers are storefronts.** They list what they are
+      *selling*, which includes preorders. Audible has *The Velvet Knife*
+      (`B0FKVNLXQS`, 2026-09-29, read by Emily Ellet) months ahead.
+    * **Work-level providers are bibliographies.** They catalogue what has
+      been *published*, which is why they reach back to Books on Tape in 1984
+      — and why Hardcover holds no audio edition of *The Velvet Knife* at all
+      yet, because there isn't one to catalogue.
+
+  Neither is the better source; they are differently blind. So both are asked
+  and everything comes back labelled, in the order the providers are
+  configured. Nothing here scores, ranks or hides a candidate — the operator
+  chooses, exactly as they do on the import form.
+
+  ## Work-level providers take two calls
+
+  A work-level search answers with *works*, not recordings, so each promising
+  work is expanded through `editions/2` into its audio editions. That is one
+  extra provider call per work, so only the first few are expanded — and when
+  that limit truncates anything, the caller is told rather than left to
+  assume the list is everything.
+  """
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.Providers
+  alias Ambry.Metadata.Search
+  alias Ambry.Wanted.Edition
+
+  require Logger
+
+  @works_expanded 3
+
+  defmodule Candidate do
+    @moduledoc "One recording a watch could be created from."
+    defstruct [:provider, :provider_id, :edition, :published, :work_title]
+
+    @type t :: %__MODULE__{}
+  end
+
+  @doc """
+  Every recording the enabled providers can offer for this query.
+
+  Answers `{candidates, outcomes, notes}`: the candidates in provider order,
+  one outcome map per provider asked (the same vocabulary the outcome chips
+  already render), and any notes about coverage this search knowingly cut.
+  """
+  def candidates(%Provider.Query{} = query, opts \\ []) do
+    {recordings, recording_outcomes} = recording_level(query, opts)
+    {editions, work_outcomes, notes} = work_level(query, opts)
+
+    {recordings ++ editions, recording_outcomes ++ work_outcomes, notes}
+  end
+
+  # A storefront's search results are already recordings; nothing to expand.
+  defp recording_level(query, opts) do
+    {found, outcomes} = Search.books(query, Keyword.put(opts, :level, :recording))
+
+    candidates =
+      Enum.flat_map(found, fn {entry, books} ->
+        Enum.map(books, &candidate(entry.id, &1, nil))
+      end)
+
+    {candidates, outcomes}
+  end
+
+  defp work_level(query, opts) do
+    {found, outcomes} = Search.books(query, Keyword.put(opts, :level, :work))
+
+    Enum.reduce(found, {[], outcomes, []}, fn {entry, works}, {candidates, outs, notes} ->
+      if :editions in entry.capabilities do
+        {expanded, truncated} = expand(entry, works)
+        {candidates ++ expanded, outs, notes ++ truncated}
+      else
+        # A provider that can find the work but cannot list its editions has
+        # nothing to offer a watch. Saying so beats a silent absence.
+        {candidates, outs, notes ++ [no_editions_note(entry)]}
+      end
+    end)
+  end
+
+  defp expand(entry, works) do
+    {asked, rest} = Enum.split(works, @works_expanded)
+
+    candidates =
+      Enum.flat_map(asked, fn work ->
+        case Providers.editions(entry.id, work.id) do
+          {:ok, editions} ->
+            Enum.map(editions, &candidate(entry.id, &1, work.title))
+
+          other ->
+            Logger.warning(fn ->
+              "Wanted search: #{entry.id} editions for #{work.id}: #{inspect(other)}"
+            end)
+
+            []
+        end
+      end)
+
+    {candidates, truncation_note(entry, rest)}
+  end
+
+  defp truncation_note(_entry, []), do: []
+
+  defp truncation_note(entry, rest) do
+    [
+      "#{entry.display_name}: looked inside the first #{@works_expanded} matching books; " <>
+        "#{length(rest)} more went unopened. Narrow the search to reach them."
+    ]
+  end
+
+  defp no_editions_note(entry) do
+    "#{entry.display_name} can find books but not their audio editions, so it offered nothing here."
+  end
+
+  defp candidate(provider_id, book, work_title) do
+    %Candidate{
+      provider: provider_id,
+      provider_id: book.id,
+      edition: Edition.from_provider_book(book),
+      published: published_date(book),
+      work_title: work_title
+    }
+  end
+
+  defp published_date(%{published: %{date: %Date{} = date}}), do: date
+  defp published_date(_book), do: nil
+end

--- a/lib/ambry/wanted/search.ex
+++ b/lib/ambry/wanted/search.ex
@@ -40,11 +40,18 @@ defmodule Ambry.Wanted.Search do
   search for a book whose recordings all came out years ago should read as
   *there are twelve, they are all already out*, never as *nothing found*.
 
-  ## Coverage this knowingly cuts
+  ## Every matched work is opened
 
-  Expanding a work costs an extra provider call, so only the first few are
-  expanded — and when that truncates anything the caller is told, because a
-  list that silently stopped looking reads as a list of everything there is.
+  A provider that answers with works ranks them by its own idea of relevance,
+  and the recording the operator wants can sit well down that list — asking
+  for *Neuromancer* by William Gibson puts the actual 1984 novel sixth, behind
+  a study guide and a graphic novel. So opening only the promising ones is a
+  guess about precisely the thing that is uncertain.
+
+  Instead every matched work is opened. Where a provider declares
+  `:editions_bulk` that is one request for all of them; otherwise it is one
+  apiece. Either way nothing is left unopened on the grounds that it looked
+  unpromising.
   """
 
   alias Ambry.Metadata.Provider
@@ -53,8 +60,6 @@ defmodule Ambry.Wanted.Search do
   alias Ambry.Wanted.Edition
 
   require Logger
-
-  @works_expanded 3
 
   defmodule Candidate do
     @moduledoc "One recording a watch could be created from."
@@ -126,22 +131,51 @@ defmodule Ambry.Wanted.Search do
     {found, outcomes} = Search.books(query, Keyword.put(opts, :level, :work))
 
     Enum.reduce(found, {[], outcomes, []}, fn {entry, works}, {candidates, outs, notes} ->
-      if :editions in entry.capabilities do
-        {expanded, truncated} = expand(entry, works)
-        {candidates ++ expanded, outs, notes ++ truncated}
-      else
-        # A provider that can find the work but cannot list its editions has
-        # nothing to offer a watch. Saying so beats a silent absence.
-        {candidates, outs, notes ++ [no_editions_note(entry)]}
-      end
+      {expanded, entry_notes} = expand(entry, works)
+      {candidates ++ expanded, outs, notes ++ entry_notes}
     end)
   end
 
-  defp expand(entry, works) do
-    {asked, rest} = Enum.split(works, @works_expanded)
+  # Every matched work is opened, never the first few. A work-level search
+  # ranks by its own idea of relevance and the recording the operator wants
+  # can sit well down that list, so "open the promising ones" is a guess about
+  # exactly the thing that is uncertain.
+  defp expand(_entry, []), do: {[], []}
 
+  defp expand(entry, works) do
+    cond do
+      :editions_bulk in entry.capabilities -> expand_bulk(entry, works)
+      :editions in entry.capabilities -> expand_one_by_one(entry, works)
+      # Finding the book but not its recordings leaves nothing to watch, and
+      # saying so beats a silent absence.
+      true -> {[], [no_editions_note(entry)]}
+    end
+  end
+
+  defp expand_bulk(entry, works) do
+    case Providers.editions_bulk(entry.id, Enum.map(works, & &1.id)) do
+      {:ok, by_work} ->
+        titles = Map.new(works, &{&1.id, &1.title})
+
+        candidates =
+          Enum.flat_map(works, fn work ->
+            by_work
+            |> Map.get(work.id, [])
+            |> Enum.map(&candidate(entry.id, &1, titles[work.id]))
+          end)
+
+        {candidates, []}
+
+      other ->
+        Logger.warning(fn -> "Wanted search: #{entry.id} bulk editions: #{inspect(other)}" end)
+
+        {[], [could_not_open_note(entry)]}
+    end
+  end
+
+  defp expand_one_by_one(entry, works) do
     candidates =
-      Enum.flat_map(asked, fn work ->
+      Enum.flat_map(works, fn work ->
         case Providers.editions(entry.id, work.id) do
           {:ok, editions} ->
             Enum.map(editions, &candidate(entry.id, &1, work.title))
@@ -155,20 +189,15 @@ defmodule Ambry.Wanted.Search do
         end
       end)
 
-    {candidates, truncation_note(entry, rest)}
-  end
-
-  defp truncation_note(_entry, []), do: []
-
-  defp truncation_note(entry, rest) do
-    [
-      "#{entry.display_name}: looked inside the first #{@works_expanded} matching books; " <>
-        "#{length(rest)} more went unopened. Narrow the search to reach them."
-    ]
+    {candidates, []}
   end
 
   defp no_editions_note(entry) do
     "#{entry.display_name} can find books but not their audio editions, so it offered nothing here."
+  end
+
+  defp could_not_open_note(entry) do
+    "#{entry.display_name} found books but could not be asked what recordings they have."
   end
 
   defp candidate(provider_id, book, work_title) do

--- a/lib/ambry/wanted/search.ex
+++ b/lib/ambry/wanted/search.ex
@@ -2,35 +2,43 @@ defmodule Ambry.Wanted.Search do
   @moduledoc """
   Finding an audiobook to watch, across every provider that can name one.
 
-  ## The rule is a capability, not a ranking
+  ## Providers are selected by capability
 
-  **Any provider that can produce audio editions is asked, and none of them is
-  preferred.** There is no primary source here and no fallback: a provider
-  either can answer "which recordings of this exist" or it cannot, and the
-  ones that can all get to. Nothing in this module names a provider.
+  **Every enabled provider that can produce audio editions is asked**, in the
+  registry's configured order. That is the whole selection rule: a provider is
+  chosen by what it is tagged as able to do, the same way every other
+  provider-driven surface here chooses one. Nothing in this module names a
+  provider.
 
-  What differs between them is *shape*, not standing:
+  What differs between them is *shape*:
 
     * Some answer with recordings directly. Their search results are already
       audiobooks — narrators, runtime, cover — and nothing needs expanding.
     * Some answer with works. A novel is not a recording, so each promising
       work is expanded through `editions/2` into the audio editions it has.
 
-  ## Why that has to be the rule rather than a preference
+  Asking all of them matters because they disagree about what exists, in both
+  directions and for structural reasons. A catalogue of what is *for sale*
+  carries preorders and drops anything delisted; a catalogue of what has been
+  *published* has no entry at all for a recording that has not come out yet.
+  Measured: *The Velvet Knife* is findable in one and absent from the other,
+  and *Blightfall* is in both under different ids — and is offered twice
+  rather than merged, because they are two records of one thing and choosing
+  between them is the operator's job.
 
-  Providers are differently blind about what does not exist yet, and the
-  blindness does not sort into better and worse. A catalogue of what is *for
-  sale* has preorders months out and forgets anything delisted. A catalogue of
-  what has been *published* reaches back to tape and has no entry at all for a
-  recording that has not come out. Measured: *The Velvet Knife* is findable in
-  one and absent from the other; *Neuromancer*'s 1984 editions are the reverse;
-  *Blightfall* is in both, under different ids, and is offered twice rather
-  than merged.
+  Which is the import form's bargain: records are evidence, outcomes are
+  visible, the operator decides.
 
-  Which is exactly the import form's bargain: records are evidence, outcomes
-  are visible, the operator decides. So everything comes back labelled, in the
-  order the providers are configured, and nothing here scores or hides a
-  candidate.
+  ## Only what has not come out yet
+
+  A watch is a thing to be reminded about, so a recording that is already
+  published cannot be one. Candidates are filtered to a **known future
+  release date** — past-dated and undated records are both dropped, since
+  "no date" is not evidence of the future either.
+
+  This is the one place that hides results, so it says how many and why. A
+  search for a book whose recordings all came out years ago should read as
+  *there are twelve, they are all already out*, never as *nothing found*.
 
   ## Coverage this knowingly cuts
 
@@ -63,10 +71,43 @@ defmodule Ambry.Wanted.Search do
   already render), and any notes about coverage this search knowingly cut.
   """
   def candidates(%Provider.Query{} = query, opts \\ []) do
+    today = Keyword.get(opts, :today, Date.utc_today())
+
     {recordings, recording_outcomes} = recording_level(query, opts)
     {editions, work_outcomes, notes} = work_level(query, opts)
 
-    {recordings ++ editions, recording_outcomes ++ work_outcomes, notes}
+    {upcoming, already_out} = split_by_release(recordings ++ editions, today)
+
+    {upcoming, recording_outcomes ++ work_outcomes, notes ++ already_out_note(already_out)}
+  end
+
+  # A watch is a reminder about something that has not happened. A recording
+  # that is already published cannot be one, and an undated record is not
+  # evidence of the future — so both are dropped rather than offered and
+  # then explained.
+  defp split_by_release(candidates, today) do
+    Enum.split_with(candidates, fn candidate ->
+      not is_nil(candidate.published) and Date.after?(candidate.published, today)
+    end)
+  end
+
+  defp already_out_note([]), do: []
+
+  defp already_out_note(dropped) do
+    {dated, undated} = Enum.split_with(dropped, & &1.published)
+
+    [
+      Enum.join(
+        Enum.reject(
+          [
+            dated != [] && "#{length(dated)} already published",
+            undated != [] && "#{length(undated)} with no announced date"
+          ],
+          &(&1 == false)
+        ),
+        ", "
+      ) <> " — not shown, since a watch is for something still to come."
+    ]
   end
 
   # A storefront's search results are already recordings; nothing to expand.

--- a/lib/ambry/wanted/watch.ex
+++ b/lib/ambry/wanted/watch.ex
@@ -74,6 +74,22 @@ defmodule Ambry.Wanted.Watch do
   end
 
   @doc """
+  The changeset for settling a watch against a recording.
+
+  Separate from `edit_changeset/2` on purpose: that one is the operator's
+  form, and `media_id` is not theirs to type. It is set by the import that
+  answered the watch, and casting it in the form changeset would both invite a
+  crafted parameter and — as this started out — silently drop the link when
+  the form changeset was reused here.
+  """
+  def settle_changeset(watch, attrs) do
+    watch
+    |> cast(attrs, [:status, :media_id])
+    |> validate_required([:status])
+    |> assoc_constraint(:media)
+  end
+
+  @doc """
   Whether the expected date has arrived.
 
   Deliberately not called `released?`. All this knows is that a date passed —

--- a/lib/ambry/wanted/watch.ex
+++ b/lib/ambry/wanted/watch.ex
@@ -1,0 +1,89 @@
+defmodule Ambry.Wanted.Watch do
+  @moduledoc """
+  An audiobook the operator is waiting for.
+
+  ## Identity is the provider's, not Amazon's
+
+  A watch is keyed on `provider` + `provider_id`, never on ASIN. Most audio
+  editions that have ever existed do not have one — the 1984 Books on Tape
+  recordings of *Neuromancer* predate Amazon — and where an ASIN does exist it
+  differs per Audible marketplace for the same recording. The ASIN lives in
+  the snapshot as a matching key instead, alongside title, narrators and
+  publisher.
+
+  ## Three states, and what each one means
+
+    * `:upcoming` — waiting. If `expected_release_date` has passed this is
+      *due*: the date arrived, which is not the same as the book existing.
+      Being due is the whole point of the feature; it is what nags.
+    * `:released` — it exists. Set by the operator, or when an import
+      satisfies it.
+    * `:dismissed` — stop nagging, without pretending it arrived. A watch is
+      never deleted on a change of mind, because "did I already decide about
+      this?" is a question the operator will otherwise ask twice.
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  alias Ambry.Media.Media
+  alias Ambry.Wanted.Edition
+
+  @statuses [:upcoming, :released, :dismissed]
+
+  schema "watches" do
+    belongs_to :media, Media
+
+    field :provider, :string
+    field :provider_id, :string
+
+    embeds_one :edition, Edition, on_replace: :update
+
+    field :expected_release_date, :date
+    field :status, Ecto.Enum, values: @statuses, default: :upcoming
+    field :note, :string
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc "The states a watch can be in."
+  def statuses, do: @statuses
+
+  @doc false
+  def changeset(watch, attrs) do
+    watch
+    |> cast(attrs, [:provider, :provider_id, :expected_release_date, :status, :note, :media_id])
+    |> cast_embed(:edition, required: true)
+    |> validate_required([:provider, :provider_id, :status])
+    |> unique_constraint([:provider, :provider_id],
+      message: "is already being watched"
+    )
+  end
+
+  @doc """
+  The changeset for the fields the operator edits after the fact.
+
+  The date is editable because publishers move dates and providers lag behind
+  them; the operator usually knows before the provider does.
+  """
+  def edit_changeset(watch, attrs) do
+    watch
+    |> cast(attrs, [:expected_release_date, :status, :note])
+    |> validate_required([:status])
+  end
+
+  @doc """
+  Whether the expected date has arrived.
+
+  Deliberately not called `released?`. All this knows is that a date passed —
+  whether the recording exists is a question only the operator or an import
+  can answer, and conflating the two is how a list starts lying.
+  """
+  def due?(watch, today \\ Date.utc_today())
+
+  def due?(%__MODULE__{status: :upcoming, expected_release_date: %Date{} = date}, today),
+    do: Date.compare(date, today) != :gt
+
+  def due?(%__MODULE__{}, _today), do: false
+end

--- a/lib/ambry_scraping/audible.ex
+++ b/lib/ambry_scraping/audible.ex
@@ -38,7 +38,8 @@ defmodule AmbryScraping.Audible do
       :format,
       :published,
       :publisher,
-      :language
+      :language,
+      :duration_seconds
     ]
   end
 

--- a/lib/ambry_scraping/audible.ex
+++ b/lib/ambry_scraping/audible.ex
@@ -53,6 +53,9 @@ defmodule AmbryScraping.Audible do
   """
   def search_books(query, opts \\ []), do: Products.search(query, opts)
 
+  @doc "One audiobook, by its ASIN. See `AmbryScraping.Audible.Products.details/2`."
+  def book_details(asin, opts \\ []), do: Products.details(asin, opts)
+
   @doc "The regional marketplace codes that can be searched."
   defdelegate marketplaces, to: Client
 

--- a/lib/ambry_scraping/audible/products.ex
+++ b/lib/ambry_scraping/audible/products.ex
@@ -179,9 +179,17 @@ defmodule AmbryScraping.Audible.Products do
       format: product["format_type"],
       published: parse_published(product["release_date"]),
       publisher: product["publisher_name"],
-      language: product["language"]
+      language: product["language"],
+      duration_seconds: duration_seconds(product["runtime_length_min"])
     }
   end
+
+  # The catalog reports whole minutes. Seconds is what the rest of Ambry
+  # measures a recording in, so the conversion happens here rather than at
+  # every reader.
+  defp duration_seconds(nil), do: nil
+  defp duration_seconds(minutes) when is_integer(minutes), do: minutes * 60
+  defp duration_seconds(_other), do: nil
 
   defp parse_authors(nil), do: []
 

--- a/lib/ambry_scraping/audible/products.ex
+++ b/lib/ambry_scraping/audible/products.ex
@@ -74,6 +74,44 @@ defmodule AmbryScraping.Audible.Products do
   # marketplaces is recall, and which catalog a recording lives in is exactly
   # what the operator doesn't know. Deduped by ASIN, keeping the first
   # marketplace's copy, so the configured order is a preference order.
+  @doc """
+  One product, by its ASIN.
+
+  Marketplace-by-marketplace, because an ASIN belongs to a catalog: the one
+  that issued it is the only one that can resolve it, and a miss in the first
+  says nothing about the rest. The first that answers wins.
+
+  Answers `{:error, :not_found}` when every reachable marketplace denies
+  knowing it — which is a real answer about a delisted recording, not a
+  failure.
+  """
+  def details(asin, opts \\ [])
+
+  def details("", _opts), do: {:error, :not_found}
+
+  def details(asin, opts) when is_binary(asin) do
+    params = %{response_groups: Enum.join(@response_groups, ","), image_sizes: "900"}
+    marketplaces = Keyword.get(opts, :marketplaces, Client.default_marketplaces())
+
+    Enum.reduce_while(marketplaces, {:error, :not_found}, fn marketplace, acc ->
+      case Client.get("/catalog/products/#{asin}", params, marketplace: marketplace) do
+        {:ok, %{status: status, body: %{"product" => product}}} when status in 200..299 ->
+          {:halt, {:ok, parse_product(product)}}
+
+        {:ok, %{status: 404}} ->
+          {:cont, acc}
+
+        # A rate limit or an outage is not evidence the recording is gone, so
+        # it is carried rather than collapsed into `:not_found`.
+        {:ok, response} ->
+          {:cont, {:error, response}}
+
+        {:error, reason} ->
+          {:cont, {:error, reason}}
+      end
+    end)
+  end
+
   defp search_marketplaces(params, marketplaces) do
     Enum.reduce(marketplaces, {[], []}, fn marketplace, {products, errors} ->
       case Client.get("/catalog/products", params, marketplace: marketplace) do

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -166,8 +166,12 @@ defmodule AmbryWeb.Admin.Components do
   def list_controls(assigns) do
     ~H"""
     <div class="flex items-end gap-4">
+      <%!-- The attr is optional, so the form has to be too: a short list
+            that is never searched (what you are waiting for) still wants the
+            New button, and the grow div stays either way so the button keeps
+            its corner. --%>
       <div class="grow">
-        <.admin_table_search_form search_form={@search_form} />
+        <.admin_table_search_form :if={@search_form} search_form={@search_form} />
       </div>
       <%!-- A list page's one constructive action, so it wears §6's primary
             costume — the same solid button the inbox's "Scan for new" has

--- a/lib/ambry_web/components/admin/components.ex
+++ b/lib/ambry_web/components/admin/components.ex
@@ -538,7 +538,13 @@ defmodule AmbryWeb.Admin.Components do
         inert={@inert}
       >
         <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5 sm:flex-col sm:items-end">
-          <div :if={@badges != []} class="flex flex-wrap items-center gap-1.5">
+          <%!-- The rail sets the badge size, rather than every caller
+                remembering to. `<.badge>` has no default size, so each of
+                these lists was passing `text-xs` by hand and a new one simply
+                did not — which is the same defect as a shared style its
+                callers have to re-type: it is only shared if it arrives on
+                its own. Callers still passing it are harmless. --%>
+          <div :if={@badges != []} class="flex flex-wrap items-center gap-1.5 text-xs">
             {render_slot(@badges)}
           </div>
 

--- a/lib/ambry_web/components/admin/layouts.ex
+++ b/lib/ambry_web/components/admin/layouts.ex
@@ -66,6 +66,14 @@ defmodule AmbryWeb.Admin.Layouts do
               {@inbox_pending}
             </span>
           </.link>
+          <%!-- No count here. The inbox badge is the only one in the nav
+                because the inbox is the only item that is a queue; what is
+                coming is a date, not a backlog, and it nags from the
+                dashboard where it can say which book. --%>
+          <.link navigate={~p"/admin/watches"} class={nav_class(@active_path =~ "/admin/watches")}>
+            <.icon name="fa-eye" class="h-5 w-5 text-current" />
+            <p>Watching</p>
+          </.link>
           <.link navigate={~p"/admin/locations"} class={nav_class(@active_path =~ "/admin/locations")}>
             <.icon name="fa-folder-tree" class="h-5 w-5 text-current" />
             <p>Locations</p>

--- a/lib/ambry_web/live/admin/home_live/index.ex
+++ b/lib/ambry_web/live/admin/home_live/index.ex
@@ -56,6 +56,7 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
   alias Ambry.Library
   alias Ambry.Media
   alias Ambry.People
+  alias Ambry.Wanted
 
   # Signals arrive in bursts — a queue draining forty items is forty of them
   # — and the answer to a burst is one reload.
@@ -123,6 +124,7 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
       jobs: Jobs.summary(),
       failures: Jobs.recent_failures(),
       media_problems: Media.problem_counts(),
+      watches: Wanted.summary(),
       inventory: inventory()
     )
   end
@@ -395,6 +397,22 @@ defmodule AmbryWeb.Admin.HomeLive.Index do
       <p class="text-xs text-zinc-400">{render_slot(@inner_block)}</p>
     </.link>
     """
+  end
+
+  @doc """
+  What the Upcoming card says when nothing is due.
+
+  Not "all clear" — nothing is wrong when a book simply isn't out yet. The
+  card earns its place by naming the next one, because *am I waiting on
+  anything?* is a real question and a blank card is not an answer to it.
+  """
+  def next_words(%{next: nil, upcoming_count: 0}), do: "Not waiting for anything."
+
+  def next_words(%{next: nil}), do: "Waiting, but nothing has a date yet."
+
+  def next_words(%{next: watch}) do
+    "Nothing out yet. Next: #{watch.edition.title}, " <>
+      Calendar.strftime(watch.expected_release_date, "%b %-d")
   end
 
   # An empty state states itself, on the rail, rather than leaving a blank

--- a/lib/ambry_web/live/admin/home_live/index.html.heex
+++ b/lib/ambry_web/live/admin/home_live/index.html.heex
@@ -18,6 +18,35 @@
           </.all_clear>
         </.card>
 
+        <%!-- A watch six months out is a fact, not a bad state, so the
+              headline counts only what is due: the date the provider promised
+              has been and gone and nobody has said what happened. That is the
+              tile test — it can be in a bad state, and clicking it lands where
+              you would fix it.
+
+              Queue-shaped rather than problem-shaped, so nothing-due still
+              renders: "what am I waiting for next" is worth the glance, and a
+              card that vanished would take the answer with it. --%>
+        <.card label="Upcoming" navigate={~p"/admin/watches"} link_words="See what you're watching">
+          <div :if={@watches.due_count > 0}>
+            <.headline_stat count={@watches.due_count} tone={:amber} role="watches-due-count">
+              {(@watches.due_count == 1 && "book's date has passed") || "books' dates have passed"}
+            </.headline_stat>
+            <ul class="space-y-1 pt-3 pl-3">
+              <li
+                :for={watch <- Enum.take(@watches.due, 3)}
+                class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-300"
+                data-role="due-watch"
+              >
+                {watch.edition.title}
+              </li>
+            </ul>
+          </div>
+          <.all_clear :if={@watches.due_count == 0}>
+            {next_words(@watches)}
+          </.all_clear>
+        </.card>
+
         <.card label="Problems">
           <div :if={problem_rows(assigns) != []} class="space-y-2">
             <.link

--- a/lib/ambry_web/live/admin/inbox_live/index.ex
+++ b/lib/ambry_web/live/admin/inbox_live/index.ex
@@ -336,7 +336,21 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   end
 
   @doc """
-  The row's one badge: what this item is, in the words that vary from row to
+  Whether the matcher found a recording the operator is waiting for.
+
+  Read off the item's own proposals rather than asked again per row:
+  `AutoMatch` marked them while it was ranking them, so this reports what the
+  matcher already decided instead of forming a second opinion at render time.
+  """
+  def wanted?(%InboxItem{matches: %{"recording" => %{"candidates" => candidates}}})
+      when is_list(candidates) do
+    Enum.any?(candidates, &(&1["wanted"] == true))
+  end
+
+  def wanted?(%InboxItem{}), do: false
+
+  @doc """
+  The row's state badge: what this item is, in the words that vary from row to
   row.
 
   One badge, not two. A pending row used to wear its status *and* its
@@ -349,6 +363,13 @@ defmodule AmbryWeb.Admin.InboxLive.Index do
   it is one nobody has asked. Counting it as one decision would send the
   operator to a form with nothing on it, so it says what is actually true and
   the card's progress line says what to do about it.
+
+  **One *state* badge, still.** `wanted?/1` can put a second badge beside this
+  one, and it does not reopen the argument this settled: the objection was to
+  a badge that read the same on every row in the tab, and a watched recording
+  is the rarest thing the queue ever has to say. It is also not a state — the
+  row can be in any of them and still be the one the operator went looking
+  for.
   """
   def state_words(%InboxItem{status: :pending, ready: true}), do: {"ready", :brand}
   def state_words(%InboxItem{status: :pending, draft: nil}), do: {"not prepared", :yellow}

--- a/lib/ambry_web/live/admin/inbox_live/index.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/index.html.heex
@@ -378,6 +378,18 @@
             >
               {elem(state_words(item), 0)}
             </.badge>
+            <%!-- Not a state: the row can be in any of them and still be the
+                  thing the operator went looking for. It says why this row is
+                  worth doing before anything else on the page. --%>
+            <.badge
+              :if={wanted?(item)}
+              color={:brand}
+              class="text-xs"
+              title="You're watching for this recording"
+              data-role="item-wanted"
+            >
+              waiting for this
+            </.badge>
           </:badges>
 
           <:facts>

--- a/lib/ambry_web/live/admin/watch_live/form.ex
+++ b/lib/ambry_web/live/admin/watch_live/form.ex
@@ -59,6 +59,9 @@ defmodule AmbryWeb.Admin.WatchLive.Form do
     ]
   end
 
+  @doc "How long the recording is, in words."
+  defdelegate runtime(edition), to: Ambry.Wanted.Edition
+
   @doc false
   def credited(names), do: Enum.map(names, &%{name: &1})
 

--- a/lib/ambry_web/live/admin/watch_live/form.ex
+++ b/lib/ambry_web/live/admin/watch_live/form.ex
@@ -65,10 +65,8 @@ defmodule AmbryWeb.Admin.WatchLive.Form do
   @doc false
   def credited(names), do: Enum.map(names, &%{name: &1})
 
-  @doc false
-  def provider_words("audible"), do: "Audible"
-  def provider_words("hardcover"), do: "Hardcover"
-  def provider_words(other), do: other
+  @doc "What to call the provider a record came from."
+  defdelegate provider_words(provider_id), to: Ambry.Wanted, as: :provider_name
 
   @doc false
   def statuses, do: Watch.statuses()

--- a/lib/ambry_web/live/admin/watch_live/form.ex
+++ b/lib/ambry_web/live/admin/watch_live/form.ex
@@ -31,6 +31,15 @@ defmodule AmbryWeb.Admin.WatchLive.Form do
   end
 
   @impl Phoenix.LiveView
+  def handle_event("delete", _params, socket) do
+    {:ok, _watch} = Wanted.delete_watch(socket.assigns.watch)
+
+    {:noreply,
+     socket
+     |> put_flash(:info, "Forgotten.")
+     |> push_navigate(to: ~p"/admin/watches")}
+  end
+
   def handle_event("validate", %{"watch" => params}, socket) do
     changeset = Wanted.change_watch(socket.assigns.watch, params)
 

--- a/lib/ambry_web/live/admin/watch_live/form.ex
+++ b/lib/ambry_web/live/admin/watch_live/form.ex
@@ -1,0 +1,72 @@
+defmodule AmbryWeb.Admin.WatchLive.Form do
+  @moduledoc """
+  Editing a watch — the date, the state, and a note to self.
+
+  The snapshot is not editable. It is a copy of what a provider said at the
+  moment the operator chose it, and letting it be rewritten would turn the one
+  record of *what was actually picked* into something that merely agrees with
+  the current opinion.
+
+  The **date** is editable, because that is the field the world changes:
+  publishers move release dates and providers lag behind them, so the operator
+  frequently knows before the provider does.
+  """
+
+  use AmbryWeb, :admin_live_view
+
+  alias Ambry.Wanted
+  alias Ambry.Wanted.Watch
+
+  @impl Phoenix.LiveView
+  def mount(%{"id" => id}, _session, socket) do
+    watch = Wanted.get_watch!(id)
+
+    {:ok,
+     socket
+     |> assign(
+       page_title: watch.edition.title,
+       watch: watch,
+       form: to_form(Wanted.change_watch(watch))
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("validate", %{"watch" => params}, socket) do
+    changeset = Wanted.change_watch(socket.assigns.watch, params)
+
+    {:noreply, assign(socket, form: to_form(changeset, action: :validate))}
+  end
+
+  def handle_event("save", %{"watch" => params}, socket) do
+    case Wanted.update_watch(socket.assigns.watch, params) do
+      {:ok, _watch} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Saved.")
+         |> push_navigate(to: ~p"/admin/watches")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, form: to_form(changeset))}
+    end
+  end
+
+  @doc false
+  def status_options do
+    [
+      {"Waiting for it", :upcoming},
+      {"It's out", :released},
+      {"Not watching", :dismissed}
+    ]
+  end
+
+  @doc false
+  def credited(names), do: Enum.map(names, &%{name: &1})
+
+  @doc false
+  def provider_words("audible"), do: "Audible"
+  def provider_words("hardcover"), do: "Hardcover"
+  def provider_words(other), do: other
+
+  @doc false
+  def statuses, do: Watch.statuses()
+end

--- a/lib/ambry_web/live/admin/watch_live/form.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/form.html.heex
@@ -59,5 +59,27 @@
         </.simple_form>
       </div>
     </div>
+
+    <%!-- Off the row and down here, because it is rare and irreversible and
+          "Dismiss" is what the operator almost always means: a dismissed watch
+          still answers "did I already decide about this?", and a forgotten one
+          cannot. --%>
+    <div class="rounded-lg bg-zinc-900 p-4">
+      <h3 class="pl-3 text-sm font-semibold text-zinc-200">Forget it</h3>
+      <div class="space-y-3 pt-3 pl-3">
+        <p class="text-sm text-zinc-400">
+          Removes the watch entirely, with no record that you ever decided
+          about it. Dismissing keeps that record.
+        </p>
+        <.button
+          color={:red}
+          phx-click="delete"
+          data-confirm={"Forget \"#{@watch.edition.title}\" entirely?"}
+          data-role="delete-watch"
+        >
+          Forget this watch
+        </.button>
+      </div>
+    </div>
   </div>
 </.layout>

--- a/lib/ambry_web/live/admin/watch_live/form.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/form.html.heex
@@ -19,6 +19,7 @@
           />
           <p class="pt-1 text-sm text-zinc-500">
             {provider_words(@watch.provider)} · {@watch.provider_id}
+            <span :if={runtime(@watch.edition)}>· {runtime(@watch.edition)}</span>
             <span :if={@watch.edition.publisher}>· {@watch.edition.publisher}</span>
           </p>
         </div>

--- a/lib/ambry_web/live/admin/watch_live/form.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/form.html.heex
@@ -1,0 +1,62 @@
+<.layout title={@page_title} user={@current_user} socket={@socket}>
+  <div class="max-w-2xl space-y-7">
+    <%!-- What was chosen, shown but not editable: it is a record of a
+          provider's answer at a moment, not a description Ambry maintains. --%>
+    <div class="rounded-lg bg-zinc-900 p-4">
+      <h3 class="pl-3 text-sm font-semibold text-zinc-200">What you're watching</h3>
+      <div class="flex items-start gap-4 pt-3 pl-3">
+        <img
+          :if={@watch.edition.cover_url}
+          src={@watch.edition.cover_url}
+          alt=""
+          class="h-20 w-20 shrink-0 rounded object-cover"
+        />
+        <div class="min-w-0">
+          <p class="font-semibold text-zinc-100">{@watch.edition.title}</p>
+          <.credit_lines
+            authors={credited(@watch.edition.authors)}
+            narrators={credited(@watch.edition.narrators)}
+          />
+          <p class="pt-1 text-sm text-zinc-500">
+            {provider_words(@watch.provider)} · {@watch.provider_id}
+            <span :if={@watch.edition.publisher}>· {@watch.edition.publisher}</span>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="rounded-lg bg-zinc-900 p-4">
+      <h3 class="pl-3 text-sm font-semibold text-zinc-200">Where it stands</h3>
+      <div class="pt-3">
+        <.simple_form id="watch-form" for={@form} as={:watch} phx-change="validate" phx-submit="save">
+          <:actions>
+            <div class="grid w-full gap-4 md:grid-cols-2">
+              <.input
+                field={@form[:expected_release_date]}
+                type="date"
+                label="Expected"
+                container_class="w-full"
+              />
+              <.input
+                field={@form[:status]}
+                type="select"
+                label="State"
+                options={status_options()}
+                container_class="w-full"
+              />
+            </div>
+          </:actions>
+          <:actions>
+            <div class="w-full">
+              <.input field={@form[:note]} type="textarea" label="Note" rows="3" />
+            </div>
+          </:actions>
+          <:actions>
+            <.button type="submit">Save</.button>
+            <.brand_link navigate={~p"/admin/watches"}>Back to what you're watching</.brand_link>
+          </:actions>
+        </.simple_form>
+      </div>
+    </div>
+  </div>
+</.layout>

--- a/lib/ambry_web/live/admin/watch_live/index.ex
+++ b/lib/ambry_web/live/admin/watch_live/index.ex
@@ -1,0 +1,105 @@
+defmodule AmbryWeb.Admin.WatchLive.Index do
+  @moduledoc """
+  What the operator is waiting for.
+
+  The list is ordered by who is waiting on whom, the same way the dashboard
+  is: what is **due** first, because a date that has passed is the only thing
+  here that needs a human; then what is still coming, soonest first; then what
+  has been settled. An undated watch sorts after the dated ones — it is a real
+  state, but it is not a deadline.
+
+  Nothing on this page decides whether a recording exists. A due watch says
+  *the date arrived*, and the operator is the one who knows whether the book
+  did.
+  """
+
+  use AmbryWeb, :admin_live_view
+
+  alias Ambry.Wanted
+  alias Ambry.Wanted.Watch
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(page_title: "Watching")
+     |> load_watches()}
+  end
+
+  defp load_watches(socket) do
+    today = Date.utc_today()
+
+    assign(socket, watches: Wanted.list_watches(today: today), today: today)
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("mark-released", %{"id" => id}, socket) do
+    id |> Wanted.get_watch!() |> Wanted.mark_released()
+
+    {:noreply, socket |> put_flash(:info, "Marked as released.") |> load_watches()}
+  end
+
+  def handle_event("dismiss", %{"id" => id}, socket) do
+    id |> Wanted.get_watch!() |> Wanted.dismiss()
+
+    {:noreply, socket |> put_flash(:info, "Stopped watching.") |> load_watches()}
+  end
+
+  def handle_event("reopen", %{"id" => id}, socket) do
+    id |> Wanted.get_watch!() |> Wanted.reopen()
+
+    {:noreply, socket |> put_flash(:info, "Watching again.") |> load_watches()}
+  end
+
+  def handle_event("delete", %{"id" => id}, socket) do
+    id |> Wanted.get_watch!() |> Wanted.delete_watch()
+
+    {:noreply, socket |> put_flash(:info, "Forgotten.") |> load_watches()}
+  end
+
+  @doc """
+  What the row says about where this watch stands.
+
+  `:due` is deliberately worded as a question about the date rather than an
+  assertion about the book — the provider promised a day, and that day has
+  been and gone.
+  """
+  def state(%Watch{} = watch, today) do
+    cond do
+      Watch.due?(watch, today) -> :due
+      watch.status == :upcoming -> :upcoming
+      true -> watch.status
+    end
+  end
+
+  @doc "How far off the expected date is, in words the operator reads at a glance."
+  def when_words(watch, today \\ Date.utc_today())
+
+  def when_words(%Watch{expected_release_date: nil}, _today), do: "No date announced"
+
+  def when_words(%Watch{expected_release_date: date}, today) do
+    case Date.diff(date, today) do
+      0 -> "Expected today"
+      1 -> "Expected tomorrow"
+      -1 -> "Was expected yesterday"
+      days when days > 1 -> "Expected in #{days} days — #{format_date(date)}"
+      days -> "Expected #{abs(days)} days ago — #{format_date(date)}"
+    end
+  end
+
+  defp format_date(date), do: Calendar.strftime(date, "%b %-d, %Y")
+
+  @doc "The provider that supplied this record, named as the operator knows it."
+  def provider_words("audible"), do: "Audible"
+  def provider_words("hardcover"), do: "Hardcover"
+  def provider_words(other), do: other
+
+  @doc """
+  The credited names in the shape `credit_lines/1` reads.
+
+  The snapshot keeps names as plain strings — it is a copy of what a provider
+  said, not a link to people Ambry knows — so they are wrapped rather than the
+  shared component being duplicated for one caller.
+  """
+  def credited(names), do: Enum.map(names, &%{name: &1})
+end

--- a/lib/ambry_web/live/admin/watch_live/index.ex
+++ b/lib/ambry_web/live/admin/watch_live/index.ex
@@ -96,6 +96,30 @@ defmodule AmbryWeb.Admin.WatchLive.Index do
   defdelegate runtime(edition), to: Ambry.Wanted.Edition
 
   @doc """
+  The row's variable last line: when it is expected, how long it is, who is
+  putting it out.
+
+  Modelled on `record_meta/1` and deliberately not using it: that says
+  "Published …", and the whole point of a watch is that it has not been. It
+  lives with the credits for the same reason — it is prose and reads like one,
+  and it collapses to nothing when a record carries none of it.
+
+  It is **not** `:footer`, which is for system timestamps only. Putting a date
+  and a duration there both mislabels them as things the app did and, because
+  the footer sits in the 224px rail, stretches the rail until the actions
+  stagger and the page scrolls sideways.
+  """
+  def meta_line(watch, today \\ Date.utc_today()) do
+    [
+      when_words(watch, today),
+      runtime(watch.edition),
+      watch.edition.publisher
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+  end
+
+  @doc """
   The credited names in the shape `credit_lines/1` reads.
 
   The snapshot keeps names as plain strings — it is a copy of what a provider

--- a/lib/ambry_web/live/admin/watch_live/index.ex
+++ b/lib/ambry_web/live/admin/watch_live/index.ex
@@ -94,6 +94,9 @@ defmodule AmbryWeb.Admin.WatchLive.Index do
   def provider_words("hardcover"), do: "Hardcover"
   def provider_words(other), do: other
 
+  @doc "How long the recording is, in words."
+  defdelegate runtime(edition), to: Ambry.Wanted.Edition
+
   @doc """
   The credited names in the shape `credit_lines/1` reads.
 

--- a/lib/ambry_web/live/admin/watch_live/index.ex
+++ b/lib/ambry_web/live/admin/watch_live/index.ex
@@ -89,10 +89,8 @@ defmodule AmbryWeb.Admin.WatchLive.Index do
 
   defp format_date(date), do: Calendar.strftime(date, "%b %-d, %Y")
 
-  @doc "The provider that supplied this record, named as the operator knows it."
-  def provider_words("audible"), do: "Audible"
-  def provider_words("hardcover"), do: "Hardcover"
-  def provider_words(other), do: other
+  @doc "What to call the provider a record came from."
+  defdelegate provider_words(provider_id), to: Ambry.Wanted, as: :provider_name
 
   @doc "How long the recording is, in words."
   defdelegate runtime(edition), to: Ambry.Wanted.Edition

--- a/lib/ambry_web/live/admin/watch_live/index.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/index.html.heex
@@ -37,16 +37,21 @@
           narrators={credited(watch.edition.narrators)}
         />
 
-        <:footer>
-          <span data-role="watch-when">{when_words(watch, @today)}</span>
-          <span :if={runtime(watch.edition)} data-role="watch-runtime">
-            · {runtime(watch.edition)}
-          </span>
-          <span :if={watch.edition.publisher}>· {watch.edition.publisher}</span>
-        </:footer>
+        <%!-- The fourth, variable line — with the credits, not in the rail.
+              See `meta_line/2`. --%>
+        <p
+          class="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-zinc-400"
+          data-role="watch-meta"
+        >
+          {meta_line(watch, @today)}
+        </p>
 
+        <%!-- Three verbs at most, and short enough that two sit side by side
+              in the 224px rail. Forgetting a watch outright lives on the form:
+              it is rare, it is irreversible, and "Dismiss" is what the
+              operator almost always means. --%>
         <:action
-          :if={watch.status != :released}
+          :if={watch.status == :upcoming}
           icon="fa-check"
           color={:brand}
           click="mark-released"
@@ -62,7 +67,7 @@
           value={watch.id}
           role="dismiss-watch"
         >
-          Stop watching
+          Dismiss
         </:action>
         <:action
           :if={watch.status != :upcoming}
@@ -75,16 +80,6 @@
         </:action>
         <:action navigate={~p"/admin/watches/#{watch}/edit"} icon="fa-pencil" role="edit-watch">
           Edit
-        </:action>
-        <:action
-          icon="fa-trash"
-          color={:red}
-          click="delete"
-          value={watch.id}
-          confirm={"Forget \"#{watch.edition.title}\" entirely? \"Stop watching\" keeps the record of having decided."}
-          role="delete-watch"
-        >
-          Forget
         </:action>
       </.index_row>
     </:row>

--- a/lib/ambry_web/live/admin/watch_live/index.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/index.html.heex
@@ -1,0 +1,89 @@
+<.layout title={@page_title} user={@current_user} socket={@socket}>
+  <:subheader>
+    <.list_controls new_path={~p"/admin/watches/new"} />
+  </:subheader>
+
+  <.flex_table rows={@watches}>
+    <:empty>
+      Nothing on the horizon.
+      <.brand_link navigate={~p"/admin/watches/new"}>
+        Watch something.
+      </.brand_link>
+    </:empty>
+
+    <:row :let={watch}>
+      <.index_row record_id={watch.id} navigate={~p"/admin/watches/#{watch}/edit"}>
+        <:headline>
+          <span data-role="watch-title">{watch.edition.title}</span>
+        </:headline>
+
+        <:badges>
+          <%!-- The state is the only reason to open this page, so it is the
+                first thing on the row that isn't the book's name. "Date
+                passed" rather than "Released": all this knows is that the
+                day the provider promised has been and gone. --%>
+          <.badge :if={state(watch, @today) == :due} color={:yellow} data-role="watch-due-badge">
+            Date passed
+          </.badge>
+          <.badge :if={state(watch, @today) == :released} color={:brand}>Released</.badge>
+          <.badge :if={state(watch, @today) == :dismissed} color={:gray}>Not watching</.badge>
+          <.badge color={:gray} title="Where this record came from">
+            {provider_words(watch.provider)}
+          </.badge>
+        </:badges>
+
+        <.credit_lines
+          authors={credited(watch.edition.authors)}
+          narrators={credited(watch.edition.narrators)}
+        />
+
+        <:footer>
+          <span data-role="watch-when">{when_words(watch, @today)}</span>
+          <span :if={watch.edition.publisher}>· {watch.edition.publisher}</span>
+        </:footer>
+
+        <:action
+          :if={watch.status != :released}
+          icon="fa-check"
+          color={:brand}
+          click="mark-released"
+          value={watch.id}
+          role="mark-released"
+        >
+          It's out
+        </:action>
+        <:action
+          :if={watch.status == :upcoming}
+          icon="fa-eye-slash"
+          click="dismiss"
+          value={watch.id}
+          role="dismiss-watch"
+        >
+          Stop watching
+        </:action>
+        <:action
+          :if={watch.status != :upcoming}
+          icon="fa-rotate-left"
+          click="reopen"
+          value={watch.id}
+          role="reopen-watch"
+        >
+          Watch again
+        </:action>
+        <:action navigate={~p"/admin/watches/#{watch}/edit"} icon="fa-pencil" role="edit-watch">
+          Edit
+        </:action>
+        <:action
+          icon="fa-trash"
+          color={:red}
+          click="delete"
+          value={watch.id}
+          confirm={"Forget \"#{watch.edition.title}\" entirely? \"Stop watching\" keeps the record of having decided."}
+          role="delete-watch"
+        >
+          Forget
+        </:action>
+      </.index_row>
+    </:row>
+  </.flex_table>
+</.layout>

--- a/lib/ambry_web/live/admin/watch_live/index.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/index.html.heex
@@ -39,6 +39,9 @@
 
         <:footer>
           <span data-role="watch-when">{when_words(watch, @today)}</span>
+          <span :if={runtime(watch.edition)} data-role="watch-runtime">
+            · {runtime(watch.edition)}
+          </span>
           <span :if={watch.edition.publisher}>· {watch.edition.publisher}</span>
         </:footer>
 

--- a/lib/ambry_web/live/admin/watch_live/new.ex
+++ b/lib/ambry_web/live/admin/watch_live/new.ex
@@ -1,0 +1,163 @@
+defmodule AmbryWeb.Admin.WatchLive.New do
+  @moduledoc """
+  Finding a recording to watch.
+
+  ## Every provider's answer, side by side
+
+  Results are grouped by the provider that gave them and nothing is ranked
+  across providers, because for an unreleased recording the providers are
+  differently blind rather than better and worse. A storefront lists what it
+  is selling, so it has preorders months out — *The Velvet Knife* is on
+  Audible with a September date and has no Hardcover audio edition at all,
+  because there is not yet an audiobook to catalogue. A bibliography lists
+  what has been published, which is how the same search reaches Books on Tape
+  in 1984.
+
+  So both are shown, labelled, and the operator picks. Same bargain as the
+  import form: records are evidence, the human decides.
+
+  ## Outcomes are shown even when they are empty
+
+  A provider that was rate-limited and a provider that genuinely has nothing
+  look identical in a list of results, and they mean opposite things. The
+  per-provider outcome line says which happened.
+  """
+
+  use AmbryWeb, :admin_live_view
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Wanted
+  alias Ambry.Wanted.Search
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(
+       page_title: "Watch something",
+       search_form: to_form(%{"title" => "", "author" => "", "narrator" => ""}, as: :search),
+       candidates: [],
+       outcomes: [],
+       notes: [],
+       searched: false,
+       searching: false
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("search", %{"search" => fields}, socket) do
+    query = Provider.Query.from_fields(fields)
+
+    if blank_query?(query) do
+      {:noreply, put_flash(socket, :error, "Give it something to search for.")}
+    else
+      # The fan-out is several HTTP calls to providers that are sometimes
+      # slow, so the page says it is working rather than appearing to have
+      # ignored the click.
+      send(self(), {:run_search, query})
+
+      {:noreply,
+       socket
+       |> assign(searching: true, search_form: to_form(fields, as: :search))
+       |> assign(candidates: [], outcomes: [], notes: [])}
+    end
+  end
+
+  def handle_event("watch", %{"provider" => provider, "provider-id" => provider_id}, socket) do
+    candidate =
+      Enum.find(socket.assigns.candidates, fn candidate ->
+        candidate.provider == provider and candidate.provider_id == provider_id
+      end)
+
+    {:noreply, add_watch(socket, candidate)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info({:run_search, query}, socket) do
+    {candidates, outcomes, notes} = Search.candidates(query)
+
+    {:noreply,
+     assign(socket,
+       candidates: candidates,
+       outcomes: outcomes,
+       notes: notes,
+       searched: true,
+       searching: false
+     )}
+  end
+
+  defp add_watch(socket, nil),
+    do: put_flash(socket, :error, "That result is no longer on screen.")
+
+  defp add_watch(socket, candidate) do
+    attrs = %{
+      provider: candidate.provider,
+      provider_id: candidate.provider_id,
+      expected_release_date: candidate.published,
+      edition: Map.from_struct(candidate.edition)
+    }
+
+    case Wanted.create_watch(attrs) do
+      {:ok, watch} ->
+        socket
+        |> put_flash(:info, "Watching #{watch.edition.title}.")
+        |> push_navigate(to: ~p"/admin/watches")
+
+      # Already watching is not an error the operator has to fix; it is the
+      # answer to what they asked for.
+      {:error, :already_watching, watch} ->
+        socket
+        |> put_flash(:info, "Already watching #{watch.edition.title}.")
+        |> push_navigate(to: ~p"/admin/watches")
+
+      {:error, changeset} ->
+        put_flash(socket, :error, "Couldn't watch that: #{errors(changeset)}")
+    end
+  end
+
+  defp errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {message, _opts} -> message end)
+    |> Enum.map_join("; ", fn {field, messages} -> "#{field} #{Enum.join(messages, ", ")}" end)
+  end
+
+  defp blank_query?(%Provider.Query{title: nil, author: nil, narrator: nil, keywords: nil}),
+    do: true
+
+  defp blank_query?(_query), do: false
+
+  @doc "The candidates one provider returned, in the order it returned them."
+  def by_provider(candidates) do
+    candidates
+    |> Enum.group_by(& &1.provider)
+    |> Enum.sort_by(fn {provider, _} -> provider end)
+  end
+
+  @doc false
+  def provider_words("audible"), do: "Audible"
+  def provider_words("hardcover"), do: "Hardcover"
+  def provider_words(other), do: other
+
+  @doc """
+  How a candidate's date reads before it is a watch.
+
+  An unreleased recording is the point, so a future date is stated plainly
+  and a past one is marked as already out — watching something that has
+  already been published is legitimate (it is a reminder to go and get it)
+  but it is not what the operator usually means.
+  """
+  def date_words(nil), do: "No date"
+
+  def date_words(date) do
+    formatted = Calendar.strftime(date, "%b %-d, %Y")
+
+    if Date.after?(date, Date.utc_today()) do
+      formatted
+    else
+      "#{formatted} — already out"
+    end
+  end
+
+  @doc false
+  def credited(names), do: Enum.map(names, &%{name: &1})
+end

--- a/lib/ambry_web/live/admin/watch_live/new.ex
+++ b/lib/ambry_web/live/admin/watch_live/new.ex
@@ -17,6 +17,13 @@ defmodule AmbryWeb.Admin.WatchLive.New do
   for sale. Ranking one above the other would hide whichever half the operator
   happened to need.
 
+  ## Only what has not come out yet
+
+  Everything here is a recording that has not been published. A book whose
+  audiobooks all came out years ago legitimately produces no candidates, and
+  the page says *that* rather than "nothing found" — which would read as the
+  provider not having it.
+
   ## Outcomes are shown even when they are empty
 
   A provider that was rate-limited and a provider that genuinely has nothing
@@ -138,24 +145,13 @@ defmodule AmbryWeb.Admin.WatchLive.New do
   defdelegate provider_words(provider_id), to: Ambry.Wanted, as: :provider_name
 
   @doc """
-  How a candidate's date reads before it is a watch.
+  When a candidate is expected.
 
-  An unreleased recording is the point, so a future date is stated plainly
-  and a past one is marked as already out — watching something that has
-  already been published is legitimate (it is a reminder to go and get it)
-  but it is not what the operator usually means.
+  Every candidate that reaches this page has a future date — the search drops
+  anything already published, and anything undated — so there is no
+  already-out case to render.
   """
-  def date_words(nil), do: "No date"
-
-  def date_words(date) do
-    formatted = Calendar.strftime(date, "%b %-d, %Y")
-
-    if Date.after?(date, Date.utc_today()) do
-      formatted
-    else
-      "#{formatted} — already out"
-    end
-  end
+  def date_words(date), do: Calendar.strftime(date, "%b %-d, %Y")
 
   @doc "How long the recording is, in words."
   defdelegate runtime(edition), to: Ambry.Wanted.Edition

--- a/lib/ambry_web/live/admin/watch_live/new.ex
+++ b/lib/ambry_web/live/admin/watch_live/new.ex
@@ -2,6 +2,17 @@ defmodule AmbryWeb.Admin.WatchLive.New do
   @moduledoc """
   Finding an audiobook to watch.
 
+  ## Grouped by provider, then by the book each recording is of
+
+  A provider that answers with works can return several books for one search —
+  a novel, a study guide about it, a graphic adaptation — and their recordings
+  are not alternatives to each other. Grouping under the work says which book
+  each recording *is*, which is the question a flat list leaves the operator to
+  answer by reading titles.
+
+  Headings appear only when a provider found more than one work, because a
+  lone heading repeats what the rows beneath it already say.
+
   ## Every provider that can name a recording, side by side
 
   Results are grouped by the provider that gave them and nothing is ranked
@@ -134,11 +145,50 @@ defmodule AmbryWeb.Admin.WatchLive.New do
 
   defp blank_query?(_query), do: false
 
-  @doc "The candidates one provider returned, in the order it returned them."
-  def by_provider(candidates) do
+  @doc """
+  Candidates grouped by the provider that gave them, then by the work each
+  came from.
+
+  Answers `[{provider, [{work_title | nil, [candidate]}]}]`, everything in the
+  order the providers returned it.
+
+  A recording-level provider answers with recordings that belong to no work it
+  named, so those group under `nil` and render without a heading. Inventing a
+  heading for them would be inventing a fact.
+  """
+  def by_provider_and_work(candidates) do
     candidates
     |> Enum.group_by(& &1.provider)
-    |> Enum.sort_by(fn {provider, _} -> provider end)
+    |> Enum.sort_by(fn {provider, _candidates} -> provider end)
+    |> Enum.map(fn {provider, for_provider} -> {provider, by_work(for_provider)} end)
+  end
+
+  defp by_work(candidates) do
+    grouped = Enum.group_by(candidates, & &1.work_title)
+
+    candidates
+    |> Enum.map(& &1.work_title)
+    |> Enum.uniq()
+    |> Enum.map(&{&1, grouped[&1]})
+  end
+
+  @doc """
+  Whether a provider's results are worth splitting under work headings.
+
+  Only when it found more than one work. A single heading above the recordings
+  it contains says nothing the recordings do not already say, and a search
+  that returned one book should not look like it returned a category.
+  """
+  def show_work_headings?(groups) do
+    groups |> Enum.count(fn {work, _candidates} -> work end) > 1
+  end
+
+  @doc "How many recordings a group holds, in words."
+  def recordings_words(candidates) do
+    case length(candidates) do
+      1 -> "1 recording"
+      n -> "#{n} recordings"
+    end
   end
 
   @doc "What to call the provider a record came from."

--- a/lib/ambry_web/live/admin/watch_live/new.ex
+++ b/lib/ambry_web/live/admin/watch_live/new.ex
@@ -1,20 +1,21 @@
 defmodule AmbryWeb.Admin.WatchLive.New do
   @moduledoc """
-  Finding a recording to watch.
+  Finding an audiobook to watch.
 
-  ## Every provider's answer, side by side
+  ## Every provider that can name a recording, side by side
 
   Results are grouped by the provider that gave them and nothing is ranked
-  across providers, because for an unreleased recording the providers are
-  differently blind rather than better and worse. A storefront lists what it
-  is selling, so it has preorders months out — *The Velvet Knife* is on
-  Audible with a September date and has no Hardcover audio edition at all,
-  because there is not yet an audiobook to catalogue. A bibliography lists
-  what has been published, which is how the same search reaches Books on Tape
-  in 1984.
+  across providers. There is no primary source: a provider either can produce
+  audio editions or it cannot, and the ones that can are all asked. What
+  differs is shape — some answer with recordings, some answer with works that
+  have to be opened — and shape is not standing.
 
-  So both are shown, labelled, and the operator picks. Same bargain as the
-  import form: records are evidence, the human decides.
+  That matters most for exactly what this page is for, because providers are
+  differently blind about the future and the past. A recording that is on
+  preorder somewhere may be absent from a catalogue of what has been
+  published; a recording from 1984 may be absent from a catalogue of what is
+  for sale. Ranking one above the other would hide whichever half the operator
+  happened to need.
 
   ## Outcomes are shown even when they are empty
 
@@ -157,6 +158,9 @@ defmodule AmbryWeb.Admin.WatchLive.New do
       "#{formatted} — already out"
     end
   end
+
+  @doc "How long the recording is, in words."
+  defdelegate runtime(edition), to: Ambry.Wanted.Edition
 
   @doc false
   def credited(names), do: Enum.map(names, &%{name: &1})

--- a/lib/ambry_web/live/admin/watch_live/new.ex
+++ b/lib/ambry_web/live/admin/watch_live/new.ex
@@ -134,10 +134,8 @@ defmodule AmbryWeb.Admin.WatchLive.New do
     |> Enum.sort_by(fn {provider, _} -> provider end)
   end
 
-  @doc false
-  def provider_words("audible"), do: "Audible"
-  def provider_words("hardcover"), do: "Hardcover"
-  def provider_words(other), do: other
+  @doc "What to call the provider a record came from."
+  defdelegate provider_words(provider_id), to: Ambry.Wanted, as: :provider_name
 
   @doc """
   How a candidate's date reads before it is a watch.

--- a/lib/ambry_web/live/admin/watch_live/new.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/new.html.heex
@@ -43,9 +43,9 @@
 
     <div :if={@searched and @candidates == []} class="rounded-lg bg-zinc-900 p-4">
       <p class="pl-3 text-sm text-zinc-400">
-        Nothing came back. An unreleased audiobook is often only in a storefront,
-        so try the title alone — a bibliography has no record of a recording that
-        hasn't been published yet.
+        Nothing still to come. Recordings that are already published are not
+        shown — a watch is for something you're waiting for — so check the line
+        above for whether any were found and set aside.
       </p>
     </div>
 

--- a/lib/ambry_web/live/admin/watch_live/new.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/new.html.heex
@@ -80,6 +80,11 @@
             />
             <p class="pt-1 text-sm text-zinc-400">
               <span data-role="candidate-date">{date_words(candidate.published)}</span>
+              <%!-- The runtime is what tells two recordings of one book apart
+                    when the title and even the narrator agree. --%>
+              <span :if={runtime(candidate.edition)} data-role="candidate-runtime">
+                · {runtime(candidate.edition)}
+              </span>
               <span :if={candidate.edition.publisher}>· {candidate.edition.publisher}</span>
             </p>
           </div>

--- a/lib/ambry_web/live/admin/watch_live/new.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/new.html.heex
@@ -51,51 +51,68 @@
 
     <%!-- Grouped by provider and unranked across them: for something that
           isn't out yet the providers are differently blind, not better and
-          worse, so neither gets to be the default. --%>
-    <div :for={{provider, candidates} <- by_provider(@candidates)} class="rounded-lg bg-zinc-900 p-4">
+          worse, so neither gets to be the default. Within a provider, by the
+          book each recording is of. --%>
+    <div
+      :for={{provider, work_groups} <- by_provider_and_work(@candidates)}
+      class="rounded-lg bg-zinc-900 p-4"
+    >
       <div class="flex items-baseline justify-between gap-4 pl-3">
         <h3 class="text-sm font-semibold text-zinc-200">{provider_words(provider)}</h3>
         <span class="text-sm text-zinc-500">
-          {length(candidates)} {(length(candidates) == 1 && "recording") || "recordings"}
+          {recordings_words(Enum.flat_map(work_groups, &elem(&1, 1)))}
         </span>
       </div>
 
-      <div class="space-y-2 pt-3">
-        <div
-          :for={candidate <- candidates}
-          class="bg-zinc-800/60 flex items-start gap-4 rounded-md p-3"
-          data-role="watch-candidate"
-        >
-          <img
-            :if={candidate.edition.cover_url}
-            src={candidate.edition.cover_url}
-            alt=""
-            class="h-16 w-16 shrink-0 rounded object-cover"
-          />
-          <div class="min-w-0 grow">
-            <p class="font-semibold text-zinc-100">{candidate.edition.title}</p>
-            <.credit_lines
-              authors={credited(candidate.edition.authors)}
-              narrators={credited(candidate.edition.narrators)}
-            />
-            <p class="pt-1 text-sm text-zinc-400">
-              <span data-role="candidate-date">{date_words(candidate.published)}</span>
-              <%!-- The runtime is what tells two recordings of one book apart
-                    when the title and even the narrator agree. --%>
-              <span :if={runtime(candidate.edition)} data-role="candidate-runtime">
-                · {runtime(candidate.edition)}
-              </span>
-              <span :if={candidate.edition.publisher}>· {candidate.edition.publisher}</span>
-            </p>
-          </div>
-          <.button
-            phx-click="watch"
-            phx-value-provider={candidate.provider}
-            phx-value-provider-id={candidate.provider_id}
-            data-role="watch-this"
+      <div class="space-y-4 pt-3">
+        <div :for={{work_title, candidates} <- work_groups} class="space-y-2">
+          <%!-- Only when this provider found more than one book: a lone
+                heading repeats the row beneath it. --%>
+          <div
+            :if={work_title && show_work_headings?(work_groups)}
+            class="flex items-baseline justify-between gap-4 pl-3"
+            data-role="work-heading"
           >
-            Watch
-          </.button>
+            <p class="text-sm font-semibold text-zinc-300">{work_title}</p>
+            <span class="text-xs text-zinc-500">{recordings_words(candidates)}</span>
+          </div>
+
+          <div
+            :for={candidate <- candidates}
+            class="bg-zinc-800/60 flex items-start gap-4 rounded-md p-3"
+            data-role="watch-candidate"
+          >
+            <img
+              :if={candidate.edition.cover_url}
+              src={candidate.edition.cover_url}
+              alt=""
+              class="h-16 w-16 shrink-0 rounded object-cover"
+            />
+            <div class="min-w-0 grow">
+              <p class="font-semibold text-zinc-100">{candidate.edition.title}</p>
+              <.credit_lines
+                authors={credited(candidate.edition.authors)}
+                narrators={credited(candidate.edition.narrators)}
+              />
+              <p class="pt-1 text-sm text-zinc-400">
+                <span data-role="candidate-date">{date_words(candidate.published)}</span>
+                <%!-- The runtime is what tells two recordings of one book apart
+                      when the title and even the narrator agree. --%>
+                <span :if={runtime(candidate.edition)} data-role="candidate-runtime">
+                  · {runtime(candidate.edition)}
+                </span>
+                <span :if={candidate.edition.publisher}>· {candidate.edition.publisher}</span>
+              </p>
+            </div>
+            <.button
+              phx-click="watch"
+              phx-value-provider={candidate.provider}
+              phx-value-provider-id={candidate.provider_id}
+              data-role="watch-this"
+            >
+              Watch
+            </.button>
+          </div>
         </div>
       </div>
     </div>

--- a/lib/ambry_web/live/admin/watch_live/new.html.heex
+++ b/lib/ambry_web/live/admin/watch_live/new.html.heex
@@ -1,0 +1,98 @@
+<.layout title={@page_title} user={@current_user} socket={@socket}>
+  <div class="max-w-4xl space-y-7">
+    <div class="rounded-lg bg-zinc-900 p-4">
+      <h3 class="pl-3 text-sm font-semibold text-zinc-200">What are you waiting for?</h3>
+      <div class="pt-3">
+        <.simple_form id="watch-search-form" for={@search_form} as={:search} phx-submit="search">
+          <:actions>
+            <div class="grid w-full gap-4 md:grid-cols-3">
+              <.input field={@search_form[:title]} label="Title" placeholder="The Velvet Knife" />
+              <.input field={@search_form[:author]} label="Author" placeholder="Maureen Johnson" />
+              <.input field={@search_form[:narrator]} label="Narrator" />
+            </div>
+          </:actions>
+          <:actions>
+            <.button type="submit" disabled={@searching}>
+              {(@searching && "Searching…") || "Search"}
+            </.button>
+            <.brand_link navigate={~p"/admin/watches"}>Back to what you're watching</.brand_link>
+          </:actions>
+        </.simple_form>
+      </div>
+    </div>
+
+    <%!-- Who was asked, and what came of it. A provider that was unreachable
+          and a provider that genuinely has nothing look the same in a list of
+          results and mean opposite things, so the outcomes are stated even
+          when everything worked. --%>
+    <div :if={@searched} class="rounded-lg bg-zinc-900 p-4">
+      <h3 class="pl-3 text-sm font-semibold text-zinc-200">Who answered</h3>
+      <div class="space-y-1 pt-3 pl-3">
+        <p :for={outcome <- @outcomes} class="text-sm text-zinc-400">
+          <span class="text-zinc-300">{outcome["name"]}</span>
+          <span :if={outcome["status"] == "ok"}>
+            — {outcome["count"]} {(outcome["count"] == 1 && "result") || "results"}
+          </span>
+          <span :if={outcome["status"] != "ok"} class="text-amber-300">
+            — {outcome["status"]}{if outcome["reason"], do: ": #{outcome["reason"]}"}
+          </span>
+        </p>
+        <p :for={note <- @notes} class="text-sm text-zinc-400">{note}</p>
+      </div>
+    </div>
+
+    <div :if={@searched and @candidates == []} class="rounded-lg bg-zinc-900 p-4">
+      <p class="pl-3 text-sm text-zinc-400">
+        Nothing came back. An unreleased audiobook is often only in a storefront,
+        so try the title alone — a bibliography has no record of a recording that
+        hasn't been published yet.
+      </p>
+    </div>
+
+    <%!-- Grouped by provider and unranked across them: for something that
+          isn't out yet the providers are differently blind, not better and
+          worse, so neither gets to be the default. --%>
+    <div :for={{provider, candidates} <- by_provider(@candidates)} class="rounded-lg bg-zinc-900 p-4">
+      <div class="flex items-baseline justify-between gap-4 pl-3">
+        <h3 class="text-sm font-semibold text-zinc-200">{provider_words(provider)}</h3>
+        <span class="text-sm text-zinc-500">
+          {length(candidates)} {(length(candidates) == 1 && "recording") || "recordings"}
+        </span>
+      </div>
+
+      <div class="space-y-2 pt-3">
+        <div
+          :for={candidate <- candidates}
+          class="bg-zinc-800/60 flex items-start gap-4 rounded-md p-3"
+          data-role="watch-candidate"
+        >
+          <img
+            :if={candidate.edition.cover_url}
+            src={candidate.edition.cover_url}
+            alt=""
+            class="h-16 w-16 shrink-0 rounded object-cover"
+          />
+          <div class="min-w-0 grow">
+            <p class="font-semibold text-zinc-100">{candidate.edition.title}</p>
+            <.credit_lines
+              authors={credited(candidate.edition.authors)}
+              narrators={credited(candidate.edition.narrators)}
+            />
+            <p class="pt-1 text-sm text-zinc-400">
+              <span data-role="candidate-date">{date_words(candidate.published)}</span>
+              <span :if={candidate.edition.publisher}>· {candidate.edition.publisher}</span>
+            </p>
+          </div>
+          <.button
+            phx-click="watch"
+            phx-value-provider={candidate.provider}
+            phx-value-provider-id={candidate.provider_id}
+            data-role="watch-this"
+          >
+            Watch
+          </.button>
+        </div>
+      </div>
+    </div>
+  </div>
+</.layout>

--- a/lib/ambry_web/router.ex
+++ b/lib/ambry_web/router.ex
@@ -195,6 +195,10 @@ defmodule AmbryWeb.Router do
       live "/universes/new", UniverseLive.Form, :new
       live "/universes/:id/edit", UniverseLive.Form, :edit
 
+      live "/watches", WatchLive.Index
+      live "/watches/new", WatchLive.New
+      live "/watches/:id/edit", WatchLive.Form, :edit
+
       live "/inbox", InboxLive.Index
       live "/inbox/:id", InboxLive.Form
 

--- a/priv/repo/migrations/20260822030000_watches.exs
+++ b/priv/repo/migrations/20260822030000_watches.exs
@@ -1,0 +1,61 @@
+defmodule Ambry.Repo.Migrations.Watches do
+  @moduledoc """
+  Audiobooks that don't exist yet, and that the operator doesn't want to forget.
+
+  The library can only describe what it holds, so a book the operator is
+  waiting for has nowhere to live until it exists — which is exactly when
+  remembering it is hard. A watch is that memory: a provider's record of a
+  recording, snapshotted, with the date it is expected.
+
+  ## Why the provider record is copied rather than referenced
+
+  A watch outlives the search that made it. Re-fetching to render a list
+  would make an offline provider an empty page, and providers revise
+  themselves — an edition is retitled, a narrator is corrected, a listing is
+  pulled. The snapshot is what the operator chose, and it still renders in a
+  year with nothing reachable.
+
+  ## Why there is no `user_id`
+
+  A watch is about the *recording*, not about a person. Two people waiting
+  for the same book is still one watch. When user-facing requests arrive they
+  get their own table with their own owner; nothing here changes.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    create table(:watches) do
+      # Identity is provider-qualified because ASIN is not identity: it is
+      # absent from most historical audio editions and differs per Audible
+      # marketplace when present. The snapshot below carries it as one
+      # matching key among several instead.
+      add :provider, :string, null: false
+      add :provider_id, :string, null: false
+
+      # The snapshot: what the operator picked, as it looked when they picked
+      # it. Kept as a map rather than columns because it is evidence, not
+      # state -- nothing queries into it, and its shape follows the provider
+      # structs rather than this table.
+      add :edition, :map, null: false, default: %{}
+
+      # Nullable on purpose: "there will be one, no date announced" is a real
+      # state, and the honest rendering of it is a watch without a date rather
+      # than no watch at all.
+      add :expected_release_date, :date
+
+      add :status, :string, null: false, default: "upcoming"
+      add :note, :text
+
+      # Set when the watch is satisfied, so the list can say what it became.
+      add :media_id, references(:media, on_delete: :nilify_all)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # One watch per recording. Adding the same book twice is a mistake, not a
+    # second intention.
+    create unique_index(:watches, [:provider, :provider_id])
+    create index(:watches, [:status, :expected_release_date])
+  end
+end

--- a/test/ambry/wanted/inbox_loop_test.exs
+++ b/test/ambry/wanted/inbox_loop_test.exs
@@ -1,0 +1,152 @@
+defmodule Ambry.Wanted.InboxLoopTest do
+  @moduledoc """
+  The loop that makes a watch more than a note: the queue recognises what the
+  operator was waiting for, and importing it turns the nag off.
+  """
+
+  use Ambry.DataCase, async: false
+
+  alias Ambry.Inbox.AutoMatch
+  alias Ambry.Wanted
+
+  defp watch(overrides \\ %{}) do
+    {:ok, watch} =
+      Wanted.create_watch(
+        Map.merge(
+          %{
+            provider: "audible",
+            provider_id: "B0GPDBGTTL",
+            expected_release_date: ~D[2026-09-01],
+            edition: %{title: "Blightfall", authors: ["Brandon Sanderson"]}
+          },
+          overrides
+        )
+      )
+
+    watch
+  end
+
+  defp record(source, id, extra \\ %{}) do
+    Map.merge(%{"source" => source, "id" => id, "score" => 0.9}, extra)
+  end
+
+  describe "open_refs/0" do
+    test "is what is still being waited on, not what has been answered" do
+      _open = watch()
+      settled = watch(%{provider_id: "settled"})
+      {:ok, _} = Wanted.mark_released(settled)
+
+      assert Wanted.open_refs() == MapSet.new([{"audible", "B0GPDBGTTL"}])
+    end
+  end
+
+  describe "mark_wanted/2" do
+    test "marks the candidate the operator went looking for" do
+      refs = MapSet.new([{"audible", "B0GPDBGTTL"}])
+
+      marked =
+        AutoMatch.mark_wanted(
+          [record("audible", "B0GPDBGTTL"), record("audible", "other")],
+          refs
+        )
+
+      assert [%{"wanted" => true}, second] = marked
+      refute Map.has_key?(second, "wanted")
+    end
+
+    test "leaves every candidate alone when nothing is being watched" do
+      candidates = [record("audible", "B0GPDBGTTL")]
+
+      assert AutoMatch.mark_wanted(candidates, MapSet.new()) == candidates
+    end
+
+    # A watch is evidence about the operator's intent, not about the file.
+    test "does not touch the score" do
+      refs = MapSet.new([{"audible", "B0GPDBGTTL"}])
+
+      [marked] = AutoMatch.mark_wanted([record("audible", "B0GPDBGTTL")], refs)
+
+      assert marked["score"] == 0.9
+    end
+  end
+
+  describe "order_candidates/1" do
+    test "a wanted recording leads among equals" do
+      ordered =
+        AutoMatch.order_candidates([
+          record("audible", "rival", %{"score" => 1.0}),
+          record("audible", "wanted", %{"score" => 1.0, "wanted" => true})
+        ])
+
+      assert Enum.map(ordered, & &1["id"]) == ["wanted", "rival"]
+    end
+
+    test "but never outranks a better score" do
+      ordered =
+        AutoMatch.order_candidates([
+          record("audible", "wanted", %{"score" => 0.5, "wanted" => true}),
+          record("audible", "better", %{"score" => 0.9})
+        ])
+
+      assert Enum.map(ordered, & &1["id"]) == ["better", "wanted"]
+    end
+
+    # Corroboration says the record fits the file; a watch says the operator
+    # went looking for it. Among equals the second is the stronger statement.
+    test "leads a candidate the file merely corroborated" do
+      ordered =
+        AutoMatch.order_candidates([
+          record("audible", "corroborated", %{
+            "score" => 1.0,
+            "narrator_evidence" => "supported"
+          }),
+          record("audible", "wanted", %{"score" => 1.0, "wanted" => true})
+        ])
+
+      assert Enum.map(ordered, & &1["id"]) == ["wanted", "corroborated"]
+    end
+  end
+
+  describe "settle/2" do
+    setup do
+      %{media: insert(:media, book: build(:book))}
+    end
+
+    test "settles the watch the import answered", %{media: media} do
+      watch = watch()
+
+      assert [settled] = Wanted.settle([{"audible", "B0GPDBGTTL"}], media)
+      assert settled.id == watch.id
+
+      reloaded = Wanted.get_watch!(watch.id)
+      assert reloaded.status == :released
+      assert reloaded.media_id == media.id
+    end
+
+    # A candidate that was offered and passed over is no evidence that this
+    # file is that recording.
+    test "leaves a watch the import did not adopt", %{media: media} do
+      watch = watch()
+
+      assert Wanted.settle([{"audible", "something-else"}], media) == []
+      assert Wanted.get_watch!(watch.id).status == :upcoming
+    end
+
+    test "one import can answer watches on several provider records", %{media: media} do
+      one = watch()
+      two = watch(%{provider: "hardcover", provider_id: "33170376"})
+
+      settled = Wanted.settle([{"audible", "B0GPDBGTTL"}, {"hardcover", "33170376"}], media)
+
+      assert Enum.map(settled, & &1.id) |> Enum.sort() == Enum.sort([one.id, two.id])
+    end
+
+    test "an already-settled watch is not settled twice", %{media: media} do
+      watch = watch()
+      {:ok, _} = Wanted.dismiss(watch)
+
+      assert Wanted.settle([{"audible", "B0GPDBGTTL"}], media) == []
+      assert Wanted.get_watch!(watch.id).status == :dismissed
+    end
+  end
+end

--- a/test/ambry/wanted/run_refresh_test.exs
+++ b/test/ambry/wanted/run_refresh_test.exs
@@ -1,0 +1,161 @@
+defmodule Ambry.Wanted.RunRefreshTest do
+  @moduledoc """
+  The worker exists for one thing arithmetic cannot do: notice that a
+  publisher moved a date.
+  """
+
+  use Ambry.DataCase, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Wanted
+  alias Ambry.Wanted.RunRefresh
+
+  defp watch(date, overrides \\ %{}) do
+    {:ok, watch} =
+      Wanted.create_watch(
+        Map.merge(
+          %{
+            provider: "audible",
+            provider_id: "B0GPDBGTTL",
+            expected_release_date: date,
+            edition: %{
+              title: "Blightfall",
+              authors: ["Brandon Sanderson"],
+              narrators: ["Eddie Lopez"],
+              publisher: "Listening Library"
+            }
+          },
+          overrides
+        )
+      )
+
+    watch
+  end
+
+  defp provider_says(date, overrides \\ %{}) do
+    book =
+      Map.merge(
+        %Provider.Book{
+          provider: "audible",
+          id: "B0GPDBGTTL",
+          title: "Blightfall",
+          narrators: [%{name: "Eddie Lopez"}],
+          published: date && %Provider.PublishedDate{date: date, display_format: :full}
+        },
+        overrides
+      )
+
+    patch(Ambry.Metadata.Providers.Audible, :book_details, fn _asin, _config -> {:ok, book} end)
+  end
+
+  describe "due_for_refresh/1" do
+    test "asks about what is nearly due" do
+      near = watch(~D[2026-09-01], %{provider_id: "near"})
+      _far = watch(~D[2027-06-01], %{provider_id: "far"})
+
+      due = RunRefresh.due_for_refresh(~D[2026-08-22])
+
+      assert Enum.map(due, & &1.id) == [near.id]
+    end
+
+    # A watch with no date is waiting for one, and the provider is the only
+    # place it can come from.
+    test "includes an undated watch" do
+      undated = watch(nil, %{provider_id: "undated"})
+
+      due = RunRefresh.due_for_refresh(~D[2026-08-22])
+
+      assert Enum.map(due, & &1.id) == [undated.id]
+    end
+
+    test "a watch already past its date is still asked about, since that is when dates slip" do
+      overdue = watch(~D[2026-08-01], %{provider_id: "overdue"})
+
+      due = RunRefresh.due_for_refresh(~D[2026-08-22])
+
+      assert Enum.map(due, & &1.id) == [overdue.id]
+    end
+
+    test "a settled watch is not asked about again" do
+      watch = watch(~D[2026-09-01])
+      {:ok, _} = Wanted.dismiss(watch)
+
+      assert RunRefresh.due_for_refresh(~D[2026-08-22]) == []
+    end
+  end
+
+  describe "refresh/1" do
+    test "reports a date the publisher moved" do
+      watch = watch(~D[2026-09-01])
+      provider_says(~D[2026-11-03])
+
+      assert {:moved, ~D[2026-09-01], ~D[2026-11-03]} = RunRefresh.refresh(watch)
+      assert Wanted.get_watch!(watch.id).expected_release_date == ~D[2026-11-03]
+    end
+
+    test "says nothing changed when nothing did" do
+      watch = watch(~D[2026-09-01])
+      provider_says(~D[2026-09-01])
+
+      assert RunRefresh.refresh(watch) == :unchanged
+    end
+
+    test "a date that appears for a watch that had none is a move" do
+      watch = watch(nil)
+      provider_says(~D[2026-12-01])
+
+      assert {:moved, nil, ~D[2026-12-01]} = RunRefresh.refresh(watch)
+    end
+
+    # The operator's snapshot is not something to discard because a request
+    # timed out.
+    @tag :capture_log
+    test "an unreachable provider leaves the watch exactly as it was" do
+      watch = watch(~D[2026-09-01])
+
+      patch(Ambry.Metadata.Providers.Audible, :book_details, fn _asin, _config ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, :timeout} = RunRefresh.refresh(watch)
+
+      reloaded = Wanted.get_watch!(watch.id)
+      assert reloaded.expected_release_date == ~D[2026-09-01]
+      assert reloaded.edition.narrators == ["Eddie Lopez"]
+    end
+
+    # A thinner answer is a worse answer, not a correction.
+    test "a provider that has since dropped a field does not blank what was kept" do
+      watch = watch(~D[2026-09-01])
+      provider_says(~D[2026-09-01], %{narrators: [], publisher: nil})
+
+      assert RunRefresh.refresh(watch) == :unchanged
+
+      reloaded = Wanted.get_watch!(watch.id)
+      assert reloaded.edition.narrators == ["Eddie Lopez"]
+      assert reloaded.edition.publisher == "Listening Library"
+    end
+
+    # A provider saying it came out is not the operator having it, and the nag
+    # should be loudest exactly then.
+    test "never settles a watch on the provider's say-so" do
+      watch = watch(~D[2026-09-01])
+      provider_says(~D[2020-01-01])
+
+      RunRefresh.refresh(watch)
+
+      assert Wanted.get_watch!(watch.id).status == :upcoming
+    end
+  end
+
+  describe "perform/1" do
+    test "counts what it checked and what moved" do
+      watch(~D[2026-09-01])
+      provider_says(~D[2026-11-03])
+
+      assert {:ok, %{checked: 1, moved: 1, failed: 0}} =
+               perform_job(RunRefresh, %{})
+    end
+  end
+end

--- a/test/ambry/wanted/search_test.exs
+++ b/test/ambry/wanted/search_test.exs
@@ -32,6 +32,7 @@ defmodule Ambry.Wanted.SearchTest do
       title: title,
       asin: Keyword.get(opts, :asin),
       narrators: Keyword.get(opts, :narrators, []),
+      duration_seconds: Keyword.get(opts, :duration_seconds),
       published: %Provider.PublishedDate{
         date: Keyword.get(opts, :date, ~D[2026-09-29]),
         display_format: :full
@@ -44,7 +45,13 @@ defmodule Ambry.Wanted.SearchTest do
   # to catalogue. This is the real shape of The Velvet Knife.
   test "a preorder only a storefront knows about is still offered" do
     patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
-      {:ok, [product("B0FKVNLXQS", "The Velvet Knife", narrators: [%{name: "Emily Ellet"}])]}
+      {:ok,
+       [
+         product("B0FKVNLXQS", "The Velvet Knife",
+           narrators: [%{name: "Emily Ellet"}],
+           duration_seconds: 36_000
+         )
+       ]}
     end)
 
     patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
@@ -56,6 +63,9 @@ defmodule Ambry.Wanted.SearchTest do
     assert candidate.provider_id == "B0FKVNLXQS"
     assert candidate.published == ~D[2026-09-29]
     assert candidate.edition.narrators == ["Emily Ellet"]
+    # An audiobook's runtime rides with it: it is what tells two recordings
+    # of one book apart when everything else agrees.
+    assert candidate.edition.duration_seconds == 36_000
   end
 
   test "the same recording from two providers is offered twice, not merged" do
@@ -101,6 +111,7 @@ defmodule Ambry.Wanted.SearchTest do
            title: "Neuromancer",
            publisher: "Books on Tape",
            narrators: [%{name: "Robertson Dean"}],
+           duration_seconds: 37_920,
            published: %Provider.PublishedDate{date: ~D[1984-07-01], display_format: :full}
          }
        ]}
@@ -110,6 +121,7 @@ defmodule Ambry.Wanted.SearchTest do
 
     assert [edition] = Enum.filter(candidates, &(&1.provider == "hardcover"))
     assert edition.edition.publisher == "Books on Tape"
+    assert edition.edition.duration_seconds == 37_920
     assert edition.published == ~D[1984-07-01]
     assert edition.work_title == "Neuromancer"
   end

--- a/test/ambry/wanted/search_test.exs
+++ b/test/ambry/wanted/search_test.exs
@@ -81,16 +81,18 @@ defmodule Ambry.Wanted.SearchTest do
       {:ok, [%Provider.Book{provider: "hardcover", id: "2235778", title: "Blightfall"}]}
     end)
 
-    patch(Ambry.Metadata.Providers.Hardcover, :editions, fn "2235778", _config ->
+    patch(Ambry.Metadata.Providers.Hardcover, :editions_bulk, fn ["2235778"], _config ->
       {:ok,
-       [
-         %Provider.Book{
-           provider: "hardcover",
-           id: "33170376",
-           title: "Blightfall",
-           published: %Provider.PublishedDate{date: ~D[2099-09-01], display_format: :full}
-         }
-       ]}
+       %{
+         "2235778" => [
+           %Provider.Book{
+             provider: "hardcover",
+             id: "33170376",
+             title: "Blightfall",
+             published: %Provider.PublishedDate{date: ~D[2099-09-01], display_format: :full}
+           }
+         ]
+       }}
     end)
 
     {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Blightfall"})
@@ -108,19 +110,21 @@ defmodule Ambry.Wanted.SearchTest do
       {:ok, [%Provider.Book{provider: "hardcover", id: "2235778", title: "Blightfall"}]}
     end)
 
-    patch(Ambry.Metadata.Providers.Hardcover, :editions, fn "2235778", _config ->
+    patch(Ambry.Metadata.Providers.Hardcover, :editions_bulk, fn ["2235778"], _config ->
       {:ok,
-       [
-         %Provider.Book{
-           provider: "hardcover",
-           id: "33170376",
-           title: "Blightfall",
-           publisher: "Listening Library",
-           narrators: [%{name: "Eddie Lopez"}],
-           duration_seconds: 45_660,
-           published: %Provider.PublishedDate{date: ~D[2099-09-01], display_format: :full}
-         }
-       ]}
+       %{
+         "2235778" => [
+           %Provider.Book{
+             provider: "hardcover",
+             id: "33170376",
+             title: "Blightfall",
+             publisher: "Listening Library",
+             narrators: [%{name: "Eddie Lopez"}],
+             duration_seconds: 45_660,
+             published: %Provider.PublishedDate{date: ~D[2099-09-01], display_format: :full}
+           }
+         ]
+       }}
     end)
 
     {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Blightfall"})
@@ -129,6 +133,44 @@ defmodule Ambry.Wanted.SearchTest do
     assert edition.edition.publisher == "Listening Library"
     assert edition.edition.duration_seconds == 45_660
     assert edition.work_title == "Blightfall"
+  end
+
+  # A work-level provider ranks by its own idea of relevance, and the right
+  # book can sit well down that list -- Neuromancer by William Gibson puts the
+  # actual novel sixth. Opening only the promising ones guesses at exactly the
+  # thing that is uncertain.
+  test "every matched work is opened, not just the first few" do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config -> {:ok, []} end)
+
+    works =
+      for n <- 1..7 do
+        %Provider.Book{provider: "hardcover", id: "w#{n}", title: "Work #{n}"}
+      end
+
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _q, _c -> {:ok, works} end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :editions_bulk, fn ids, _config ->
+      # The one worth having is last, exactly where a guess would miss it.
+      assert length(ids) == 7
+
+      {:ok,
+       %{
+         "w7" => [
+           %Provider.Book{
+             provider: "hardcover",
+             id: "buried",
+             title: "The One",
+             published: %Provider.PublishedDate{date: ~D[2099-01-01], display_format: :full}
+           }
+         ]
+       }}
+    end)
+
+    {candidates, _outcomes, notes} = Search.candidates(%Provider.Query{title: "Work"})
+
+    assert Enum.map(candidates, & &1.provider_id) == ["buried"]
+    # Nothing was left unopened, so nothing is reported as cut.
+    refute Enum.any?(notes, &(&1 =~ "unopened"))
   end
 
   describe "only what has not come out yet" do

--- a/test/ambry/wanted/search_test.exs
+++ b/test/ambry/wanted/search_test.exs
@@ -1,7 +1,7 @@
 defmodule Ambry.Wanted.SearchTest do
   @moduledoc """
-  The two provider levels are differently blind about the future, so both are
-  asked and neither is preferred. These are the cases that made that the
+  Providers are selected by capability and their answers are filtered to what
+  has not come out yet. These are the cases that made both of those the
   design rather than a preference.
   """
 
@@ -26,6 +26,8 @@ defmodule Ambry.Wanted.SearchTest do
   end
 
   defp product(id, title, opts) do
+    date = if Keyword.has_key?(opts, :date), do: Keyword.get(opts, :date), else: ~D[2099-09-29]
+
     %Provider.Book{
       provider: "audible",
       id: id,
@@ -33,17 +35,19 @@ defmodule Ambry.Wanted.SearchTest do
       asin: Keyword.get(opts, :asin),
       narrators: Keyword.get(opts, :narrators, []),
       duration_seconds: Keyword.get(opts, :duration_seconds),
-      published: %Provider.PublishedDate{
-        date: Keyword.get(opts, :date, ~D[2026-09-29]),
-        display_format: :full
-      }
+      published: date && %Provider.PublishedDate{date: date, display_format: :full}
     }
   end
 
-  # A storefront lists what it is selling, so it has the preorder; a
-  # bibliography lists what has been published, and there is no audiobook yet
-  # to catalogue. This is the real shape of The Velvet Knife.
-  test "a preorder only a storefront knows about is still offered" do
+  defp no_hardcover_results do
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+  end
+
+  # A catalogue of what is for sale carries preorders; a catalogue of what has
+  # been published has no entry for a recording that has not come out. This is
+  # the real shape of The Velvet Knife, and why every capable provider is
+  # asked rather than one being chosen.
+  test "a preorder only one provider knows about is still offered" do
     patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
       {:ok,
        [
@@ -54,14 +58,14 @@ defmodule Ambry.Wanted.SearchTest do
        ]}
     end)
 
-    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+    no_hardcover_results()
 
     {candidates, _outcomes, _notes} =
       Search.candidates(%Provider.Query{title: "The Velvet Knife"})
 
     assert [candidate] = Enum.filter(candidates, &(&1.provider == "audible"))
     assert candidate.provider_id == "B0FKVNLXQS"
-    assert candidate.published == ~D[2026-09-29]
+    assert candidate.published == ~D[2099-09-29]
     assert candidate.edition.narrators == ["Emily Ellet"]
     # An audiobook's runtime rides with it: it is what tells two recordings
     # of one book apart when everything else agrees.
@@ -70,7 +74,7 @@ defmodule Ambry.Wanted.SearchTest do
 
   test "the same recording from two providers is offered twice, not merged" do
     patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
-      {:ok, [product("B0GPDBGTTL", "Blightfall", date: ~D[2026-09-01])]}
+      {:ok, [product("B0GPDBGTTL", "Blightfall", date: ~D[2099-09-01])]}
     end)
 
     patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config ->
@@ -84,7 +88,7 @@ defmodule Ambry.Wanted.SearchTest do
            provider: "hardcover",
            id: "33170376",
            title: "Blightfall",
-           published: %Provider.PublishedDate{date: ~D[2026-09-01], display_format: :full}
+           published: %Provider.PublishedDate{date: ~D[2099-09-01], display_format: :full}
          }
        ]}
     end)
@@ -95,42 +99,113 @@ defmodule Ambry.Wanted.SearchTest do
     assert candidates |> Enum.map(& &1.provider_id) |> Enum.sort() == ["33170376", "B0GPDBGTTL"]
   end
 
-  test "a work-level provider is expanded into its audio editions" do
+  # A work is not a recording, so a work-level answer has to be opened before
+  # it can offer anything. That is a difference in shape, not in standing.
+  test "a provider that answers with works is expanded into its audio editions" do
     patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config -> {:ok, []} end)
 
     patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config ->
-      {:ok, [%Provider.Book{provider: "hardcover", id: "313448", title: "Neuromancer"}]}
+      {:ok, [%Provider.Book{provider: "hardcover", id: "2235778", title: "Blightfall"}]}
     end)
 
-    patch(Ambry.Metadata.Providers.Hardcover, :editions, fn "313448", _config ->
+    patch(Ambry.Metadata.Providers.Hardcover, :editions, fn "2235778", _config ->
       {:ok,
        [
          %Provider.Book{
            provider: "hardcover",
-           id: "e1",
-           title: "Neuromancer",
-           publisher: "Books on Tape",
-           narrators: [%{name: "Robertson Dean"}],
-           duration_seconds: 37_920,
-           published: %Provider.PublishedDate{date: ~D[1984-07-01], display_format: :full}
+           id: "33170376",
+           title: "Blightfall",
+           publisher: "Listening Library",
+           narrators: [%{name: "Eddie Lopez"}],
+           duration_seconds: 45_660,
+           published: %Provider.PublishedDate{date: ~D[2099-09-01], display_format: :full}
          }
        ]}
     end)
 
-    {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Neuromancer"})
+    {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Blightfall"})
 
     assert [edition] = Enum.filter(candidates, &(&1.provider == "hardcover"))
-    assert edition.edition.publisher == "Books on Tape"
-    assert edition.edition.duration_seconds == 37_920
-    assert edition.published == ~D[1984-07-01]
-    assert edition.work_title == "Neuromancer"
+    assert edition.edition.publisher == "Listening Library"
+    assert edition.edition.duration_seconds == 45_660
+    assert edition.work_title == "Blightfall"
+  end
+
+  describe "only what has not come out yet" do
+    # Neuromancer is the case this exists for: a dozen real audio editions,
+    # every one of them decades old. A watch is a reminder about something
+    # still to come, so none of them is one.
+    test "recordings that are already published are not offered" do
+      patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+        {:ok,
+         [
+           product("old", "Neuromancer", date: ~D[1984-07-01]),
+           product("coming", "Neuromancer", date: ~D[2099-01-01])
+         ]}
+      end)
+
+      no_hardcover_results()
+
+      {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Neuromancer"})
+
+      assert Enum.map(candidates, & &1.provider_id) == ["coming"]
+    end
+
+    # "Nothing found" and "they are all already out" mean opposite things to
+    # someone deciding whether a provider has the book at all.
+    test "says how many were set aside rather than looking like nothing was found" do
+      patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+        {:ok,
+         [
+           product("a", "Neuromancer", date: ~D[1984-07-01]),
+           product("b", "Neuromancer", date: ~D[2011-06-30])
+         ]}
+      end)
+
+      no_hardcover_results()
+
+      {candidates, _outcomes, notes} = Search.candidates(%Provider.Query{title: "Neuromancer"})
+
+      assert candidates == []
+      assert Enum.any?(notes, &(&1 =~ "2 already published"))
+    end
+
+    test "an undated record is not evidence of the future either" do
+      patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+        {:ok, [product("undated", "Someday", date: nil)]}
+      end)
+
+      no_hardcover_results()
+
+      {candidates, _outcomes, notes} = Search.candidates(%Provider.Query{title: "Someday"})
+
+      assert candidates == []
+      assert Enum.any?(notes, &(&1 =~ "no announced date"))
+    end
+
+    test "today is not the future; something out this morning is already out" do
+      patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+        {:ok,
+         [
+           product("today", "Out Now", date: ~D[2026-08-22]),
+           product("tomorrow", "Out Soon", date: ~D[2026-08-23])
+         ]}
+      end)
+
+      no_hardcover_results()
+
+      {candidates, _outcomes, _notes} =
+        Search.candidates(%Provider.Query{title: "Out"}, today: ~D[2026-08-22])
+
+      assert Enum.map(candidates, & &1.provider_id) == ["tomorrow"]
+    end
   end
 
   # A provider that can find the book but not list its recordings has nothing
   # to offer a watch, and saying so beats a silent absence.
   test "says when a provider could not contribute rather than staying quiet" do
     patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config -> {:ok, []} end)
-    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+    no_hardcover_results()
 
     patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
       {:ok, [%Provider.Book{provider: "rreading_glasses", id: "w1", title: "A Book"}]}
@@ -147,7 +222,7 @@ defmodule Ambry.Wanted.SearchTest do
       {:error, :timeout}
     end)
 
-    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+    no_hardcover_results()
 
     {_candidates, outcomes, _notes} = Search.candidates(%Provider.Query{title: "Anything"})
 

--- a/test/ambry/wanted/search_test.exs
+++ b/test/ambry/wanted/search_test.exs
@@ -1,0 +1,144 @@
+defmodule Ambry.Wanted.SearchTest do
+  @moduledoc """
+  The two provider levels are differently blind about the future, so both are
+  asked and neither is preferred. These are the cases that made that the
+  design rather than a preference.
+  """
+
+  use Ambry.DataCase, async: false
+  use Patch
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.ProviderConfig
+  alias Ambry.Repo
+  alias Ambry.Wanted.Search
+
+  # Hardcover is filtered off the registry as unavailable until it has a
+  # token, so patching its module alone would never be reached.
+  setup do
+    Repo.insert!(%ProviderConfig{
+      provider_id: "hardcover",
+      enabled: true,
+      config: %{"api_token" => "test-token"}
+    })
+
+    :ok
+  end
+
+  defp product(id, title, opts) do
+    %Provider.Book{
+      provider: "audible",
+      id: id,
+      title: title,
+      asin: Keyword.get(opts, :asin),
+      narrators: Keyword.get(opts, :narrators, []),
+      published: %Provider.PublishedDate{
+        date: Keyword.get(opts, :date, ~D[2026-09-29]),
+        display_format: :full
+      }
+    }
+  end
+
+  # A storefront lists what it is selling, so it has the preorder; a
+  # bibliography lists what has been published, and there is no audiobook yet
+  # to catalogue. This is the real shape of The Velvet Knife.
+  test "a preorder only a storefront knows about is still offered" do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+      {:ok, [product("B0FKVNLXQS", "The Velvet Knife", narrators: [%{name: "Emily Ellet"}])]}
+    end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+
+    {candidates, _outcomes, _notes} =
+      Search.candidates(%Provider.Query{title: "The Velvet Knife"})
+
+    assert [candidate] = Enum.filter(candidates, &(&1.provider == "audible"))
+    assert candidate.provider_id == "B0FKVNLXQS"
+    assert candidate.published == ~D[2026-09-29]
+    assert candidate.edition.narrators == ["Emily Ellet"]
+  end
+
+  test "the same recording from two providers is offered twice, not merged" do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+      {:ok, [product("B0GPDBGTTL", "Blightfall", date: ~D[2026-09-01])]}
+    end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config ->
+      {:ok, [%Provider.Book{provider: "hardcover", id: "2235778", title: "Blightfall"}]}
+    end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :editions, fn "2235778", _config ->
+      {:ok,
+       [
+         %Provider.Book{
+           provider: "hardcover",
+           id: "33170376",
+           title: "Blightfall",
+           published: %Provider.PublishedDate{date: ~D[2026-09-01], display_format: :full}
+         }
+       ]}
+    end)
+
+    {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Blightfall"})
+
+    assert candidates |> Enum.map(& &1.provider) |> Enum.sort() == ["audible", "hardcover"]
+    assert candidates |> Enum.map(& &1.provider_id) |> Enum.sort() == ["33170376", "B0GPDBGTTL"]
+  end
+
+  test "a work-level provider is expanded into its audio editions" do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config -> {:ok, []} end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config ->
+      {:ok, [%Provider.Book{provider: "hardcover", id: "313448", title: "Neuromancer"}]}
+    end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :editions, fn "313448", _config ->
+      {:ok,
+       [
+         %Provider.Book{
+           provider: "hardcover",
+           id: "e1",
+           title: "Neuromancer",
+           publisher: "Books on Tape",
+           narrators: [%{name: "Robertson Dean"}],
+           published: %Provider.PublishedDate{date: ~D[1984-07-01], display_format: :full}
+         }
+       ]}
+    end)
+
+    {candidates, _outcomes, _notes} = Search.candidates(%Provider.Query{title: "Neuromancer"})
+
+    assert [edition] = Enum.filter(candidates, &(&1.provider == "hardcover"))
+    assert edition.edition.publisher == "Books on Tape"
+    assert edition.published == ~D[1984-07-01]
+    assert edition.work_title == "Neuromancer"
+  end
+
+  # A provider that can find the book but not list its recordings has nothing
+  # to offer a watch, and saying so beats a silent absence.
+  test "says when a provider could not contribute rather than staying quiet" do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config -> {:ok, []} end)
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+
+    patch(Ambry.Metadata.Providers.RreadingGlasses, :search_books, fn _query, _config ->
+      {:ok, [%Provider.Book{provider: "rreading_glasses", id: "w1", title: "A Book"}]}
+    end)
+
+    {_candidates, _outcomes, notes} = Search.candidates(%Provider.Query{title: "A Book"})
+
+    assert Enum.any?(notes, &(&1 =~ "audio editions"))
+  end
+
+  @tag :capture_log
+  test "a failed provider is reported, not mistaken for having nothing" do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config ->
+      {:error, :timeout}
+    end)
+
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+
+    {_candidates, outcomes, _notes} = Search.candidates(%Provider.Query{title: "Anything"})
+
+    assert Enum.any?(outcomes, &(&1["id"] == "audible" and &1["status"] == "failed"))
+  end
+end

--- a/test/ambry/wanted_test.exs
+++ b/test/ambry/wanted_test.exs
@@ -2,6 +2,7 @@ defmodule Ambry.WantedTest do
   use Ambry.DataCase
 
   alias Ambry.Wanted
+  alias Ambry.Wanted.Edition
   alias Ambry.Wanted.Watch
 
   defp attrs(overrides \\ %{}) do
@@ -57,6 +58,31 @@ defmodule Ambry.WantedTest do
     test "requires an edition" do
       assert {:error, changeset} = Wanted.create_watch(%{provider: "audible", provider_id: "x"})
       assert %{edition: _} = errors_on(changeset)
+    end
+  end
+
+  describe "runtime" do
+    test "an audiobook's length is part of what was chosen" do
+      {:ok, watch} =
+        Wanted.create_watch(
+          attrs(%{edition: %{title: "The Velvet Knife", duration_seconds: 36_000}})
+        )
+
+      assert watch.edition.duration_seconds == 36_000
+      assert Edition.runtime(watch.edition) == "10h"
+    end
+
+    test "reads in hours and minutes, the way a recording is talked about" do
+      assert Edition.runtime(%Edition{duration_seconds: 37_920}) == "10h 32m"
+      assert Edition.runtime(%Edition{duration_seconds: 3600}) == "1h"
+      assert Edition.runtime(%Edition{duration_seconds: 900}) == "15m"
+    end
+
+    # Not every provider record has one -- seven of Hardcover's twelve
+    # Neuromancer audio editions do. An absent runtime is reported as absent.
+    test "a provider that gave no runtime leaves it absent rather than zero" do
+      assert Edition.runtime(%Edition{duration_seconds: nil}) == nil
+      assert Edition.runtime(%Edition{duration_seconds: 0}) == nil
     end
   end
 

--- a/test/ambry/wanted_test.exs
+++ b/test/ambry/wanted_test.exs
@@ -226,6 +226,27 @@ defmodule Ambry.WantedTest do
     end
   end
 
+  describe "mark_released/2" do
+    test "links the recording that answered the watch" do
+      media = insert(:media, book: build(:book))
+      {:ok, watch} = Wanted.create_watch(attrs())
+
+      {:ok, released} = Wanted.mark_released(watch, media)
+
+      assert released.status == :released
+      assert released.media_id == media.id
+    end
+
+    test "settles without one, for a book the operator knows is out but hasn't got" do
+      {:ok, watch} = Wanted.create_watch(attrs())
+
+      {:ok, released} = Wanted.mark_released(watch)
+
+      assert released.status == :released
+      assert released.media_id == nil
+    end
+  end
+
   describe "reopen/1" do
     test "puts a settled watch back into waiting" do
       {:ok, watch} = Wanted.create_watch(attrs())

--- a/test/ambry/wanted_test.exs
+++ b/test/ambry/wanted_test.exs
@@ -1,0 +1,216 @@
+defmodule Ambry.WantedTest do
+  use Ambry.DataCase
+
+  alias Ambry.Wanted
+  alias Ambry.Wanted.Watch
+
+  defp attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        provider: "audible",
+        provider_id: "B0FKVNLXQS",
+        expected_release_date: ~D[2026-09-29],
+        edition: %{
+          title: "The Velvet Knife",
+          authors: ["Maureen Johnson"],
+          narrators: ["Emily Ellet"],
+          publisher: "Harper Audio",
+          asin: "B0FKVNLXQS"
+        }
+      },
+      overrides
+    )
+  end
+
+  describe "create_watch/1" do
+    test "keeps the provider's record as it was when it was chosen" do
+      {:ok, watch} = Wanted.create_watch(attrs())
+
+      assert watch.edition.title == "The Velvet Knife"
+      assert watch.edition.narrators == ["Emily Ellet"]
+      assert watch.status == :upcoming
+    end
+
+    test "a recording with no date is still a watch" do
+      {:ok, watch} = Wanted.create_watch(attrs(%{expected_release_date: nil}))
+
+      assert watch.expected_release_date == nil
+      assert watch.status == :upcoming
+    end
+
+    test "answers with the existing watch rather than an error when already watching" do
+      {:ok, first} = Wanted.create_watch(attrs())
+
+      assert {:error, :already_watching, existing} = Wanted.create_watch(attrs())
+      assert existing.id == first.id
+    end
+
+    test "the same recording from a different provider is a different watch" do
+      {:ok, _audible} = Wanted.create_watch(attrs())
+
+      assert {:ok, hardcover} =
+               Wanted.create_watch(attrs(%{provider: "hardcover", provider_id: "33170376"}))
+
+      assert hardcover.provider == "hardcover"
+    end
+
+    test "requires an edition" do
+      assert {:error, changeset} = Wanted.create_watch(%{provider: "audible", provider_id: "x"})
+      assert %{edition: _} = errors_on(changeset)
+    end
+  end
+
+  describe "due?/2" do
+    test "is true once the expected date has arrived" do
+      {:ok, watch} = Wanted.create_watch(attrs(%{expected_release_date: ~D[2026-09-29]}))
+
+      refute Watch.due?(watch, ~D[2026-09-28])
+      assert Watch.due?(watch, ~D[2026-09-29])
+      assert Watch.due?(watch, ~D[2026-10-05])
+    end
+
+    test "a watch with no date never becomes due" do
+      {:ok, watch} = Wanted.create_watch(attrs(%{expected_release_date: nil}))
+
+      refute Watch.due?(watch, ~D[2099-01-01])
+    end
+
+    test "a settled watch is not due, however old its date" do
+      {:ok, watch} = Wanted.create_watch(attrs(%{expected_release_date: ~D[2020-01-01]}))
+      {:ok, released} = Wanted.mark_released(watch)
+      {:ok, dismissed} = Wanted.dismiss(watch)
+
+      refute Watch.due?(released, ~D[2026-09-29])
+      refute Watch.due?(dismissed, ~D[2026-09-29])
+    end
+  end
+
+  describe "list_watches/1" do
+    test "puts what is due first, then what is coming soonest" do
+      {:ok, _far} = Wanted.create_watch(attrs(%{provider_id: "far", edition: edition("Far")}))
+
+      {:ok, _soon} =
+        Wanted.create_watch(
+          attrs(%{
+            provider_id: "soon",
+            expected_release_date: ~D[2026-09-01],
+            edition: edition("Soon")
+          })
+        )
+
+      {:ok, _overdue} =
+        Wanted.create_watch(
+          attrs(%{
+            provider_id: "overdue",
+            expected_release_date: ~D[2026-01-01],
+            edition: edition("Overdue")
+          })
+        )
+
+      titles =
+        [today: ~D[2026-08-22]]
+        |> Wanted.list_watches()
+        |> Enum.map(& &1.edition.title)
+
+      assert titles == ["Overdue", "Soon", "Far"]
+    end
+
+    test "an undated watch sorts after the dated ones" do
+      {:ok, _dated} =
+        Wanted.create_watch(attrs(%{provider_id: "dated", edition: edition("Dated")}))
+
+      {:ok, _undated} =
+        Wanted.create_watch(
+          attrs(%{
+            provider_id: "undated",
+            expected_release_date: nil,
+            edition: edition("Undated")
+          })
+        )
+
+      titles =
+        [today: ~D[2026-08-22]]
+        |> Wanted.list_watches()
+        |> Enum.map(& &1.edition.title)
+
+      assert titles == ["Dated", "Undated"]
+    end
+
+    test "settled watches sink below the ones still waiting" do
+      {:ok, waiting} =
+        Wanted.create_watch(attrs(%{provider_id: "waiting", edition: edition("Waiting")}))
+
+      {:ok, done} = Wanted.create_watch(attrs(%{provider_id: "done", edition: edition("Done")}))
+      {:ok, _} = Wanted.mark_released(done)
+
+      titles =
+        [today: ~D[2026-08-22]]
+        |> Wanted.list_watches()
+        |> Enum.map(& &1.edition.title)
+
+      assert titles == ["Waiting", "Done"]
+      assert waiting.status == :upcoming
+    end
+  end
+
+  describe "summary/1" do
+    test "counts only what is due, and names what is coming next" do
+      {:ok, _overdue} =
+        Wanted.create_watch(
+          attrs(%{
+            provider_id: "overdue",
+            expected_release_date: ~D[2026-08-01],
+            edition: edition("Overdue")
+          })
+        )
+
+      {:ok, _next} =
+        Wanted.create_watch(
+          attrs(%{
+            provider_id: "next",
+            expected_release_date: ~D[2026-09-01],
+            edition: edition("Blightfall")
+          })
+        )
+
+      summary = Wanted.summary(~D[2026-08-22])
+
+      assert summary.due_count == 1
+      assert summary.upcoming_count == 2
+      assert summary.next.edition.title == "Blightfall"
+    end
+
+    test "nothing due and nothing coming is not an error state" do
+      summary = Wanted.summary(~D[2026-08-22])
+
+      assert summary.due_count == 0
+      assert summary.upcoming_count == 0
+      assert summary.next == nil
+    end
+
+    test "a dismissed watch stops counting toward the nag" do
+      {:ok, watch} =
+        Wanted.create_watch(attrs(%{expected_release_date: ~D[2026-01-01]}))
+
+      assert Wanted.summary(~D[2026-08-22]).due_count == 1
+
+      {:ok, _} = Wanted.dismiss(watch)
+
+      assert Wanted.summary(~D[2026-08-22]).due_count == 0
+    end
+  end
+
+  describe "reopen/1" do
+    test "puts a settled watch back into waiting" do
+      {:ok, watch} = Wanted.create_watch(attrs())
+      {:ok, dismissed} = Wanted.dismiss(watch)
+      {:ok, reopened} = Wanted.reopen(dismissed)
+
+      assert reopened.status == :upcoming
+    end
+  end
+
+  defp edition(title) do
+    %{title: title, authors: ["Someone"], narrators: ["A Reader"]}
+  end
+end

--- a/test/ambry_web/live/admin/home_live/index_test.exs
+++ b/test/ambry_web/live/admin/home_live/index_test.exs
@@ -5,6 +5,7 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
 
   alias Ambry.Inbox.InboxItem
   alias Ambry.Repo
+  alias Ambry.Wanted
 
   setup :register_and_log_in_admin_user
 
@@ -27,6 +28,41 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
       assert has_element?(view, "[data-role='work-words']", "Nothing running.")
       assert has_element?(view, "*", "No job has failed in the last day.")
       assert has_element?(view, "*", "Nothing in the queue has asked a provider yet.")
+    end
+
+    test "the upcoming card nags only once a date has passed", %{conn: conn} do
+      watch("Blightfall", ~D[2020-01-01])
+      watch("The Velvet Knife", ~D[2099-09-29])
+
+      {:ok, view, _html} = live(conn, ~p"/admin")
+
+      assert has_element?(view, "[data-role='watches-due-count']", "1")
+      assert has_element?(view, "[data-role='due-watch']", "Blightfall")
+      refute has_element?(view, "[data-role='due-watch']", "The Velvet Knife")
+    end
+
+    test "with nothing due the card names what is coming instead of vanishing", %{conn: conn} do
+      watch("Blightfall", ~D[2099-09-01])
+
+      {:ok, view, _html} = live(conn, ~p"/admin")
+
+      refute has_element?(view, "[data-role='watches-due-count']")
+      assert has_element?(view, "*", "Nothing out yet. Next: Blightfall, Sep 1")
+    end
+
+    test "waiting for nothing at all says so", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin")
+
+      assert has_element?(view, "*", "Not waiting for anything.")
+    end
+
+    test "a watch with no date is waiting but has nothing to count down to", %{conn: conn} do
+      watch("Someday", nil)
+
+      {:ok, view, _html} = live(conn, ~p"/admin")
+
+      refute has_element?(view, "[data-role='watches-due-count']")
+      assert has_element?(view, "*", "Waiting, but nothing has a date yet.")
     end
 
     test "splits the pending queue into ready and waiting on a decision", %{conn: conn} do
@@ -203,5 +239,17 @@ defmodule AmbryWeb.Admin.HomeLive.IndexTest do
 
   defp ready_item(path) do
     path |> drafted_item() |> Ecto.Changeset.change(ready: true) |> Repo.update!()
+  end
+
+  defp watch(title, date) do
+    {:ok, watch} =
+      Wanted.create_watch(%{
+        provider: "audible",
+        provider_id: title,
+        expected_release_date: date,
+        edition: %{title: title, authors: ["Someone"], narrators: ["A Reader"]}
+      })
+
+    watch
   end
 end

--- a/test/ambry_web/live/admin/watch_live/index_test.exs
+++ b/test/ambry_web/live/admin/watch_live/index_test.exs
@@ -1,0 +1,165 @@
+defmodule AmbryWeb.Admin.WatchLive.IndexTest do
+  use AmbryWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Wanted
+
+  setup :register_and_log_in_admin_user
+
+  defp watch(overrides \\ %{}) do
+    {:ok, watch} =
+      Wanted.create_watch(
+        Map.merge(
+          %{
+            provider: "audible",
+            provider_id: "B0FKVNLXQS",
+            expected_release_date: ~D[2026-09-29],
+            edition: %{
+              title: "The Velvet Knife",
+              authors: ["Maureen Johnson"],
+              narrators: ["Emily Ellet"],
+              publisher: "Harper Audio"
+            }
+          },
+          overrides
+        )
+      )
+
+    watch
+  end
+
+  describe "Index" do
+    test "an empty list invites the operator to start one", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      assert has_element?(view, "*", "Nothing on the horizon.")
+    end
+
+    test "shows the book, who wrote it and who reads it", %{conn: conn} do
+      watch()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/watches")
+
+      assert html =~ "The Velvet Knife"
+      assert html =~ "Maureen Johnson"
+      assert html =~ "Emily Ellet"
+    end
+
+    test "names the provider the record came from", %{conn: conn} do
+      watch()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/watches")
+
+      assert html =~ "Audible"
+    end
+
+    test "a passed date is badged, and says the date passed rather than that it is out",
+         %{conn: conn} do
+      watch(%{expected_release_date: ~D[2020-01-01]})
+
+      {:ok, view, html} = live(conn, ~p"/admin/watches")
+
+      assert has_element?(view, "[data-role='watch-due-badge']")
+      assert html =~ "Date passed"
+      refute html =~ "Released"
+    end
+
+    test "a future date is not badged as due", %{conn: conn} do
+      watch(%{expected_release_date: ~D[2099-01-01]})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      refute has_element?(view, "[data-role='watch-due-badge']")
+    end
+
+    test "a watch with no date says so instead of showing nothing", %{conn: conn} do
+      watch(%{expected_release_date: nil})
+
+      {:ok, _view, html} = live(conn, ~p"/admin/watches")
+
+      assert html =~ "No date announced"
+    end
+
+    test "marking it out settles the watch", %{conn: conn} do
+      watch = watch(%{expected_release_date: ~D[2020-01-01]})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      view |> element("[data-role='mark-released']") |> render_click()
+
+      assert Wanted.get_watch!(watch.id).status == :released
+      refute has_element?(view, "[data-role='watch-due-badge']")
+    end
+
+    test "dismissing stops the nag without claiming it arrived", %{conn: conn} do
+      watch = watch(%{expected_release_date: ~D[2020-01-01]})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      view |> element("[data-role='dismiss-watch']") |> render_click()
+
+      assert Wanted.get_watch!(watch.id).status == :dismissed
+      assert render(view) =~ "Not watching"
+    end
+
+    test "a settled watch can be picked back up", %{conn: conn} do
+      watch = watch()
+      {:ok, _} = Wanted.dismiss(watch)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      view |> element("[data-role='reopen-watch']") |> render_click()
+
+      assert Wanted.get_watch!(watch.id).status == :upcoming
+    end
+
+    test "forgetting removes it entirely", %{conn: conn} do
+      watch = watch()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      view |> element("[data-role='delete-watch']") |> render_click()
+
+      assert Wanted.list_watches() == []
+      assert render(view) =~ "Nothing on the horizon."
+      refute render(view) =~ watch.edition.title
+    end
+  end
+
+  describe "Form" do
+    test "shows what was chosen without offering to rewrite it", %{conn: conn} do
+      watch = watch()
+
+      {:ok, _view, html} = live(conn, ~p"/admin/watches/#{watch}/edit")
+
+      assert html =~ "The Velvet Knife"
+      assert html =~ "Emily Ellet"
+      refute html =~ ~s|name="watch[edition]|
+    end
+
+    test "the date can be corrected when a publisher moves it", %{conn: conn} do
+      watch = watch()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/#{watch}/edit")
+
+      view
+      |> form("form", watch: %{expected_release_date: "2026-11-03"})
+      |> render_submit()
+
+      assert Wanted.get_watch!(watch.id).expected_release_date == ~D[2026-11-03]
+    end
+
+    test "a note survives the round trip", %{conn: conn} do
+      watch = watch()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/#{watch}/edit")
+
+      view
+      |> form("form", watch: %{note: "Preordered on the 12th"})
+      |> render_submit()
+
+      assert Wanted.get_watch!(watch.id).note == "Preordered on the 12th"
+    end
+  end
+end

--- a/test/ambry_web/live/admin/watch_live/index_test.exs
+++ b/test/ambry_web/live/admin/watch_live/index_test.exs
@@ -52,7 +52,7 @@ defmodule AmbryWeb.Admin.WatchLive.IndexTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/watches")
 
-      assert has_element?(view, "[data-role='watch-runtime']", "10h")
+      assert has_element?(view, "[data-role='watch-meta']", "10h")
     end
 
     test "a record with no runtime says nothing rather than nothing-per-hour", %{conn: conn} do
@@ -62,7 +62,7 @@ defmodule AmbryWeb.Admin.WatchLive.IndexTest do
 
       {:ok, view, _html} = live(conn, ~p"/admin/watches")
 
-      refute has_element?(view, "[data-role='watch-runtime']")
+      refute has_element?(view, "[data-role='watch-meta']", "h")
     end
 
     test "names the provider the record came from", %{conn: conn} do
@@ -133,16 +133,29 @@ defmodule AmbryWeb.Admin.WatchLive.IndexTest do
       assert Wanted.get_watch!(watch.id).status == :upcoming
     end
 
-    test "forgetting removes it entirely", %{conn: conn} do
-      watch = watch()
+    # Three verbs at most, short enough that two fit the 224px rail.
+    test "the row offers at most three actions", %{conn: conn} do
+      watch()
 
       {:ok, view, _html} = live(conn, ~p"/admin/watches")
 
-      view |> element("[data-role='delete-watch']") |> render_click()
+      actions =
+        view
+        |> element("[data-role='row-actions']")
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find("[data-role='row-actions'] > *")
 
-      assert Wanted.list_watches() == []
-      assert render(view) =~ "Nothing on the horizon."
-      refute render(view) =~ watch.edition.title
+      assert length(actions) <= 3
+    end
+
+    test "forgetting is not on the row; dismissing is", %{conn: conn} do
+      watch()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      assert has_element?(view, "[data-role='dismiss-watch']")
+      refute has_element?(view, "[data-role='delete-watch']")
     end
   end
 
@@ -167,6 +180,16 @@ defmodule AmbryWeb.Admin.WatchLive.IndexTest do
       |> render_submit()
 
       assert Wanted.get_watch!(watch.id).expected_release_date == ~D[2026-11-03]
+    end
+
+    test "forgetting a watch removes it entirely", %{conn: conn} do
+      watch = watch()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/#{watch}/edit")
+
+      view |> element("[data-role='delete-watch']") |> render_click()
+
+      assert Wanted.list_watches() == []
     end
 
     test "a note survives the round trip", %{conn: conn} do

--- a/test/ambry_web/live/admin/watch_live/index_test.exs
+++ b/test/ambry_web/live/admin/watch_live/index_test.exs
@@ -19,7 +19,8 @@ defmodule AmbryWeb.Admin.WatchLive.IndexTest do
               title: "The Velvet Knife",
               authors: ["Maureen Johnson"],
               narrators: ["Emily Ellet"],
-              publisher: "Harper Audio"
+              publisher: "Harper Audio",
+              duration_seconds: 36_000
             }
           },
           overrides
@@ -44,6 +45,24 @@ defmodule AmbryWeb.Admin.WatchLive.IndexTest do
       assert html =~ "The Velvet Knife"
       assert html =~ "Maureen Johnson"
       assert html =~ "Emily Ellet"
+    end
+
+    test "says how long the recording is", %{conn: conn} do
+      watch()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      assert has_element?(view, "[data-role='watch-runtime']", "10h")
+    end
+
+    test "a record with no runtime says nothing rather than nothing-per-hour", %{conn: conn} do
+      watch(%{
+        edition: %{title: "Unknown Length", authors: ["Someone"], narrators: ["A Reader"]}
+      })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches")
+
+      refute has_element?(view, "[data-role='watch-runtime']")
     end
 
     test "names the provider the record came from", %{conn: conn} do

--- a/test/ambry_web/live/admin/watch_live/new_test.exs
+++ b/test/ambry_web/live/admin/watch_live/new_test.exs
@@ -6,13 +6,30 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
   import Phoenix.LiveViewTest
 
   alias Ambry.Metadata.Provider
+  alias Ambry.Metadata.ProviderConfig
+  alias Ambry.Repo
   alias Ambry.Wanted
 
   setup :register_and_log_in_admin_user
 
   setup do
+    Repo.insert!(%ProviderConfig{
+      provider_id: "hardcover",
+      enabled: true,
+      config: %{"api_token" => "test-token"}
+    })
+
     patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
     :ok
+  end
+
+  defp future_edition(title) do
+    %Provider.Book{
+      provider: "hardcover",
+      id: title,
+      title: title,
+      published: %Provider.PublishedDate{date: ~D[2099-01-01], display_format: :full}
+    }
   end
 
   defp offering(books) do
@@ -61,6 +78,63 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       assert html =~ "Emily Ellet"
       assert html =~ "Sep 29, 2099"
       assert has_element?(view, "[data-role='candidate-runtime']", "10h")
+    end
+
+    test "groups a provider's recordings under the book each is of", %{conn: conn} do
+      offering([])
+
+      patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _q, _c ->
+        {:ok,
+         [
+           %Provider.Book{provider: "hardcover", id: "w1", title: "Neuromancer"},
+           %Provider.Book{
+             provider: "hardcover",
+             id: "w2",
+             title: "Neuromancer: The Graphic Novel"
+           }
+         ]}
+      end)
+
+      patch(Ambry.Metadata.Providers.Hardcover, :editions_bulk, fn _ids, _c ->
+        {:ok, %{"w1" => [future_edition("Reissue")], "w2" => [future_edition("Adaptation")]}}
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+      view |> form("#watch-search-form", search: %{title: "Neuromancer"}) |> render_submit()
+
+      assert has_element?(view, "[data-role='work-heading']", "Neuromancer")
+      assert has_element?(view, "[data-role='work-heading']", "Neuromancer: The Graphic Novel")
+    end
+
+    # A lone heading repeats the row beneath it.
+    test "one book gets no heading", %{conn: conn} do
+      offering([])
+
+      patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _q, _c ->
+        {:ok, [%Provider.Book{provider: "hardcover", id: "w1", title: "Blightfall"}]}
+      end)
+
+      patch(Ambry.Metadata.Providers.Hardcover, :editions_bulk, fn _ids, _c ->
+        {:ok, %{"w1" => [future_edition("Blightfall")]}}
+      end)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+      view |> form("#watch-search-form", search: %{title: "Blightfall"}) |> render_submit()
+
+      assert has_element?(view, "[data-role='watch-candidate']")
+      refute has_element?(view, "[data-role='work-heading']")
+    end
+
+    # A recording-level provider names no work, so inventing a heading for its
+    # results would be inventing a fact.
+    test "recordings that belong to no named book get no heading", %{conn: conn} do
+      offering([velvet_knife()])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+      view |> form("#watch-search-form", search: %{title: "The Velvet Knife"}) |> render_submit()
+
+      assert has_element?(view, "[data-role='watch-candidate']")
+      refute has_element?(view, "[data-role='work-heading']")
     end
 
     test "groups results under the provider that gave them", %{conn: conn} do

--- a/test/ambry_web/live/admin/watch_live/new_test.exs
+++ b/test/ambry_web/live/admin/watch_live/new_test.exs
@@ -1,0 +1,134 @@
+defmodule AmbryWeb.Admin.WatchLive.NewTest do
+  use AmbryWeb.ConnCase, async: false
+  use Patch
+
+  import Phoenix.ConnTest, except: [patch: 3]
+  import Phoenix.LiveViewTest
+
+  alias Ambry.Metadata.Provider
+  alias Ambry.Wanted
+
+  setup :register_and_log_in_admin_user
+
+  setup do
+    patch(Ambry.Metadata.Providers.Hardcover, :search_books, fn _query, _config -> {:ok, []} end)
+    :ok
+  end
+
+  defp offering(books) do
+    patch(Ambry.Metadata.Providers.Audible, :search_books, fn _query, _config -> {:ok, books} end)
+  end
+
+  defp velvet_knife do
+    %Provider.Book{
+      provider: "audible",
+      id: "B0FKVNLXQS",
+      title: "The Velvet Knife",
+      asin: "B0FKVNLXQS",
+      authors: [%{name: "Maureen Johnson", id: "a1", role: "author"}],
+      narrators: [%{name: "Emily Ellet", id: "n1", role: "narrator"}],
+      published: %Provider.PublishedDate{date: ~D[2026-09-29], display_format: :full}
+    }
+  end
+
+  describe "New" do
+    test "asks for something to search before it asks anyone", %{conn: conn} do
+      offering([])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      html =
+        view
+        |> form("#watch-search-form", search: %{title: "", author: "", narrator: ""})
+        |> render_submit()
+
+      assert html =~ "Give it something to search for."
+    end
+
+    test "shows a preorder with its date and reader", %{conn: conn} do
+      offering([velvet_knife()])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      view
+      |> form("#watch-search-form", search: %{title: "The Velvet Knife"})
+      |> render_submit()
+
+      html = render(view)
+
+      assert html =~ "The Velvet Knife"
+      assert html =~ "Emily Ellet"
+      assert html =~ "Sep 29, 2026"
+    end
+
+    test "groups results under the provider that gave them", %{conn: conn} do
+      offering([velvet_knife()])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      view |> form("#watch-search-form", search: %{title: "The Velvet Knife"}) |> render_submit()
+
+      assert has_element?(view, "*", "Audible")
+      assert has_element?(view, "[data-role='watch-candidate']")
+    end
+
+    test "says who answered, so nothing found and nobody asked look different",
+         %{conn: conn} do
+      offering([])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      view |> form("#watch-search-form", search: %{title: "Nothing"}) |> render_submit()
+
+      assert has_element?(view, "*", "Who answered")
+      assert has_element?(view, "*", "Nothing came back.")
+    end
+
+    test "marks a candidate that is already out rather than hiding it", %{conn: conn} do
+      offering([
+        %{velvet_knife() | published: %Provider.PublishedDate{date: ~D[2020-01-01]}}
+      ])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      view |> form("#watch-search-form", search: %{title: "Old"}) |> render_submit()
+
+      assert has_element?(view, "[data-role='candidate-date']", "already out")
+    end
+
+    test "watching a result keeps the provider's record", %{conn: conn} do
+      offering([velvet_knife()])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      view |> form("#watch-search-form", search: %{title: "The Velvet Knife"}) |> render_submit()
+
+      view |> element("[data-role='watch-this']") |> render_click()
+
+      assert [watch] = Wanted.list_watches()
+      assert watch.provider == "audible"
+      assert watch.provider_id == "B0FKVNLXQS"
+      assert watch.expected_release_date == ~D[2026-09-29]
+      assert watch.edition.narrators == ["Emily Ellet"]
+      assert watch.edition.asin == "B0FKVNLXQS"
+    end
+
+    test "watching the same thing twice is an answer, not an error", %{conn: conn} do
+      offering([velvet_knife()])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+      view |> form("#watch-search-form", search: %{title: "The Velvet Knife"}) |> render_submit()
+      view |> element("[data-role='watch-this']") |> render_click()
+
+      {:ok, again, _html} = live(conn, ~p"/admin/watches/new")
+      again |> form("#watch-search-form", search: %{title: "The Velvet Knife"}) |> render_submit()
+
+      assert {:error, {:live_redirect, %{to: "/admin/watches"}}} =
+               again |> element("[data-role='watch-this']") |> render_click()
+
+      # The point: it lands on the list rather than on a form telling the
+      # operator off, and there is still exactly one watch.
+      assert length(Wanted.list_watches()) == 1
+    end
+  end
+end

--- a/test/ambry_web/live/admin/watch_live/new_test.exs
+++ b/test/ambry_web/live/admin/watch_live/new_test.exs
@@ -27,6 +27,7 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       asin: "B0FKVNLXQS",
       authors: [%{name: "Maureen Johnson", id: "a1", role: "author"}],
       narrators: [%{name: "Emily Ellet", id: "n1", role: "narrator"}],
+      duration_seconds: 36_000,
       published: %Provider.PublishedDate{date: ~D[2026-09-29], display_format: :full}
     }
   end
@@ -59,6 +60,7 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       assert html =~ "The Velvet Knife"
       assert html =~ "Emily Ellet"
       assert html =~ "Sep 29, 2026"
+      assert has_element?(view, "[data-role='candidate-runtime']", "10h")
     end
 
     test "groups results under the provider that gave them", %{conn: conn} do
@@ -111,6 +113,7 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       assert watch.expected_release_date == ~D[2026-09-29]
       assert watch.edition.narrators == ["Emily Ellet"]
       assert watch.edition.asin == "B0FKVNLXQS"
+      assert watch.edition.duration_seconds == 36_000
     end
 
     test "watching the same thing twice is an answer, not an error", %{conn: conn} do

--- a/test/ambry_web/live/admin/watch_live/new_test.exs
+++ b/test/ambry_web/live/admin/watch_live/new_test.exs
@@ -28,7 +28,7 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       authors: [%{name: "Maureen Johnson", id: "a1", role: "author"}],
       narrators: [%{name: "Emily Ellet", id: "n1", role: "narrator"}],
       duration_seconds: 36_000,
-      published: %Provider.PublishedDate{date: ~D[2026-09-29], display_format: :full}
+      published: %Provider.PublishedDate{date: ~D[2099-09-29], display_format: :full}
     }
   end
 
@@ -59,7 +59,7 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
 
       assert html =~ "The Velvet Knife"
       assert html =~ "Emily Ellet"
-      assert html =~ "Sep 29, 2026"
+      assert html =~ "Sep 29, 2099"
       assert has_element?(view, "[data-role='candidate-runtime']", "10h")
     end
 
@@ -83,10 +83,10 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       view |> form("#watch-search-form", search: %{title: "Nothing"}) |> render_submit()
 
       assert has_element?(view, "*", "Who answered")
-      assert has_element?(view, "*", "Nothing came back.")
+      assert has_element?(view, "*", "Nothing still to come.")
     end
 
-    test "marks a candidate that is already out rather than hiding it", %{conn: conn} do
+    test "a recording that is already out is not offered as a watch", %{conn: conn} do
       offering([
         %{velvet_knife() | published: %Provider.PublishedDate{date: ~D[2020-01-01]}}
       ])
@@ -95,7 +95,22 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
 
       view |> form("#watch-search-form", search: %{title: "Old"}) |> render_submit()
 
-      assert has_element?(view, "[data-role='candidate-date']", "already out")
+      refute has_element?(view, "[data-role='watch-candidate']")
+    end
+
+    # Otherwise a book whose recordings are all decades old reads as a book
+    # the provider does not have.
+    test "says results were set aside rather than that nothing was found", %{conn: conn} do
+      offering([
+        %{velvet_knife() | published: %Provider.PublishedDate{date: ~D[2020-01-01]}}
+      ])
+
+      {:ok, view, _html} = live(conn, ~p"/admin/watches/new")
+
+      view |> form("#watch-search-form", search: %{title: "Old"}) |> render_submit()
+
+      assert has_element?(view, "*", "1 already published")
+      assert has_element?(view, "*", "Nothing still to come.")
     end
 
     test "watching a result keeps the provider's record", %{conn: conn} do
@@ -110,7 +125,7 @@ defmodule AmbryWeb.Admin.WatchLive.NewTest do
       assert [watch] = Wanted.list_watches()
       assert watch.provider == "audible"
       assert watch.provider_id == "B0FKVNLXQS"
-      assert watch.expected_release_date == ~D[2026-09-29]
+      assert watch.expected_release_date == ~D[2099-09-29]
       assert watch.edition.narrators == ["Emily Ellet"]
       assert watch.edition.asin == "B0FKVNLXQS"
       assert watch.edition.duration_seconds == 36_000


### PR DESCRIPTION
The library can only describe what it holds, so a recording you're waiting for has nowhere to live until it exists — which is exactly when remembering it is hard. A watch is that memory, and it nags from the dashboard until you've either got the book or said otherwise.

Two are live on the dev server: **Blightfall** (Sep 1) and **The Velvet Knife** (Sep 29, read by Emily Ellet).

## The Velvet Knife decided the provider rule

It was the right book to test with. **Hardcover has no audio edition of it at all** — the print work is there, but a bibliography catalogues what has been *published*, and there is no audiobook yet to catalogue. Audible has it, because a storefront sells preorders. *Neuromancer*'s 1984 Books on Tape editions are the exact reverse.

So there is **no primary provider and no fallback tier** — every enabled provider that can search audio editions is asked, in registry order, and nothing in `Wanted.Search` names one. Blightfall comes back from both under different ids and is offered twice rather than merged; choosing between two records of one thing is yours, not the matcher's.

`Providers.Audible`'s moduledoc no longer calls itself "the primary source" for anything, which was the only place in the codebase that idea actually lived.

## Only what has not come out yet

A watch is a reminder about something still to come, so candidates are filtered to a known future release date — past-dated and undated both dropped. This is the one place results are hidden, so it says how many and why: *Neuromancer* returns nothing plus "12 already published, 1 with no announced date". "They're all already out" and "nothing found" mean opposite things when you're deciding whether a provider has the book at all.

## Every matched work is opened

A work-level provider ranks by its own idea of relevance, and the right book sits well down it — *Neuromancer* by William Gibson puts the actual novel **sixth**, behind a study guide and a graphic novel. Opening "the first three promising works" guessed at precisely the uncertain thing.

The premise that made that necessary was false: Hardcover's editions filter takes `_in` on `book_id`, so seven works is **one request**. Declared as an `:editions_bulk` capability, so a provider without it is still asked one work at a time.

Recordings then group under the book each is of — searching "Mistborn" finds four books and 38 recordings, which flat is 38 rows to sort out by reading titles. Headings only when a provider found more than one book.

## An audiobook has a runtime

`Provider.Book` had no duration, and both normalizers were throwing away data they already had: Audible returns `runtime_length_min`, and Hardcover's editions query already selected `audio_seconds` *and used it to decide an edition is audio at all*. A work correctly gets nil — a novel has no length, a reading of it does.

## The queue knows what you were waiting for

`AutoMatch` marks watched recordings among its candidates, the row says "waiting for this", and importing turns the nag off.

The prior **does not move the score**. Scores answer "how well does this record match this file"; a watch is evidence about intent, not about the file — wanting a recording cannot make the bytes on disk more likely to be it. It orders equals (ahead of narrator corroboration, never ahead of a better score) and labels. Settling keys on the records the *draft adopted*, not on everything proposed, and runs in `finish/2` with the rest of the work that may not fail an import.

## The worker refreshes dates, not releases

No worker is needed to notice September arrived — that's arithmetic. What only a provider can say is whether the date has **moved**. Weekly, scoped to the next month plus anything already past its date, since a date that arrived without a book usually means it slipped and nobody said so. It never settles a watch on the provider's say-so, and an unreachable provider leaves the snapshot alone.

## Two bugs this surfaced

- **`mark_released/2` silently dropped `media_id`** — the form changeset never cast it, so the watch-to-recording link was never written. Settling has its own changeset now; `media_id` isn't a field anyone should type.
- **Audible declared only `:book_search`**, so the refresh would have failed on every Audible watch — all of them. Its by-ASIN catalog endpoint was simply unused.

Also fixed in passing: `list_controls/1` declared `search_form` optional and crashed without one, and the `:badges` rail now sets its own text size instead of every list passing `text-xs` by hand.

## Not in this PR

Subscriptions (stage 2) and user-facing requests (stage 3). A watch has no `user_id` and never will — it's about the recording, so two people waiting for one book is still one watch — which is why requests can be added later without touching this.

## Verified

`mix check` green, **2135 passing**. Confirmed against the running dev server: both watches created through the real search, refreshed through the real provider, dashboard reading "Nothing out yet. Next: Blightfall, Sep 1".

https://claude.ai/code/session_01T6rFUksK4tkZ4ZNS4ZvY3n
