### PR TITLE
The watch list is ordered by date, not by day of the month

### DIFF
--- a/lib/ambry/wanted.ex
+++ b/lib/ambry/wanted.ex
@@ -29,42 +29,31 @@ defmodule Ambry.Wanted do
   alias Ambry.Wanted.Watch
 
   @doc """
-  Every watch, loudest first.
+  Every watch, loudest first: what is still coming, soonest first, then what
+  has been settled. A watch with no date sorts after the dated ones.
 
-  Ordering is by who is waiting on whom, matching the admin dashboard: due
-  first, then what is still coming in date order, then what has been settled.
-  A watch with no date sorts after the dated ones.
+  Due watches need no rank of their own -- due is an upcoming watch whose date
+  has passed, so ordering the upcoming ones by date floats them to the top.
+
+  Ordered in SQL, not by `Enum.sort_by/2`: a `Date` inside a sort-key tuple is
+  compared in Erlang term order, which ranks the struct's `day` above its
+  `year`. The title tiebreaker only settles watches sharing a status and a
+  date, so the list is stable between reloads.
   """
   def list_watches(opts \\ []) do
-    today = Keyword.get(opts, :today, Date.utc_today())
-
     Watch
     |> maybe_filter_status(Keyword.get(opts, :status))
+    |> order_by([w],
+      asc: fragment("CASE ? WHEN 'upcoming' THEN 0 WHEN 'released' THEN 1 ELSE 2 END", w.status),
+      asc_nulls_last: w.expected_release_date,
+      asc: fragment("? ->> 'title'", w.edition)
+    )
     |> Repo.all()
     |> Repo.preload(:media)
-    |> Enum.sort_by(&sort_key(&1, today))
   end
 
   defp maybe_filter_status(query, nil), do: query
   defp maybe_filter_status(query, status), do: where(query, [w], w.status == ^status)
-
-  defp sort_key(watch, today) do
-    {status_rank(watch, today), date_rank(watch), watch.edition.title || ""}
-  end
-
-  defp status_rank(watch, today) do
-    cond do
-      Watch.due?(watch, today) -> 0
-      watch.status == :upcoming -> 1
-      watch.status == :released -> 2
-      true -> 3
-    end
-  end
-
-  # `:infinity` would not compare against a Date. A far-future sentinel keeps
-  # undated watches last without special-casing the comparison.
-  defp date_rank(%Watch{expected_release_date: nil}), do: ~D[9999-12-31]
-  defp date_rank(%Watch{expected_release_date: date}), do: date
 
   @doc "The watches whose expected date has arrived and that nobody has settled."
   def list_due(today \\ Date.utc_today()) do

--- a/lib/ambry_web/live/admin/watch_live/index.ex
+++ b/lib/ambry_web/live/admin/watch_live/index.ex
@@ -29,7 +29,7 @@ defmodule AmbryWeb.Admin.WatchLive.Index do
   defp load_watches(socket) do
     today = Date.utc_today()
 
-    assign(socket, watches: Wanted.list_watches(today: today), today: today)
+    assign(socket, watches: Wanted.list_watches(), today: today)
   end
 
   @impl Phoenix.LiveView

--- a/test/ambry/wanted_test.exs
+++ b/test/ambry/wanted_test.exs
@@ -133,12 +133,26 @@ defmodule Ambry.WantedTest do
           })
         )
 
-      titles =
-        [today: ~D[2026-08-22]]
-        |> Wanted.list_watches()
-        |> Enum.map(& &1.edition.title)
+      titles = Wanted.list_watches() |> Enum.map(& &1.edition.title)
 
       assert titles == ["Overdue", "Soon", "Far"]
+    end
+
+    test "orders by the whole date, not the day of the month" do
+      for {id, date} <- [
+            {"december", ~D[2026-12-01]},
+            {"next-year", ~D[2027-01-15]},
+            {"september", ~D[2026-09-30]}
+          ] do
+        {:ok, _} =
+          Wanted.create_watch(
+            attrs(%{provider_id: id, expected_release_date: date, edition: edition(id)})
+          )
+      end
+
+      titles = Wanted.list_watches() |> Enum.map(& &1.edition.title)
+
+      assert titles == ["september", "december", "next-year"]
     end
 
     test "an undated watch sorts after the dated ones" do
@@ -154,10 +168,7 @@ defmodule Ambry.WantedTest do
           })
         )
 
-      titles =
-        [today: ~D[2026-08-22]]
-        |> Wanted.list_watches()
-        |> Enum.map(& &1.edition.title)
+      titles = Wanted.list_watches() |> Enum.map(& &1.edition.title)
 
       assert titles == ["Dated", "Undated"]
     end
@@ -169,10 +180,7 @@ defmodule Ambry.WantedTest do
       {:ok, done} = Wanted.create_watch(attrs(%{provider_id: "done", edition: edition("Done")}))
       {:ok, _} = Wanted.mark_released(done)
 
-      titles =
-        [today: ~D[2026-08-22]]
-        |> Wanted.list_watches()
-        |> Enum.map(& &1.edition.title)
+      titles = Wanted.list_watches() |> Enum.map(& &1.edition.title)
 
       assert titles == ["Waiting", "Done"]
       assert waiting.status == :upcoming


### PR DESCRIPTION
The sort key packed a `Date` struct into a tuple, so it compared in Erlang term order — `day` before `month` before `year` — and the list came out looking shuffled.

Ordered in SQL now. The separate "due" rank was redundant: due is an upcoming watch whose date has passed, so ordering upcoming by date floats them to the top.