### PR TITLE
Unlisted audiobooks: hidden from browsing, reachable by link

### DIFF
--- a/lib/ambry/books.ex
+++ b/lib/ambry/books.ex
@@ -262,7 +262,10 @@ defmodule Ambry.Books do
   Gets a book and all of its media.
   """
   def get_book_with_media!(book_id) do
-    media_query = from m in Media, where: [status: :ready], order_by: {:desc, :published}
+    media_query =
+      from m in Media,
+        where: m.status == :ready and is_nil(m.unlisted_at),
+        order_by: {:desc, :published}
 
     Book
     |> preload([
@@ -362,7 +365,12 @@ defmodule Ambry.Books do
       from b in Ecto.assoc(author, :books),
         as: :book,
         where:
-          exists(from m in Media, where: m.book_id == parent_as(:book).id and m.status == :ready),
+          exists(
+            from m in Media,
+              where:
+                m.book_id == parent_as(:book).id and m.status == :ready and
+                  is_nil(m.unlisted_at)
+          ),
         order_by: [desc: b.published],
         offset: ^offset,
         limit: ^over_limit,

--- a/lib/ambry/inbox/draft/recording.ex
+++ b/lib/ambry/inbox/draft/recording.ex
@@ -52,6 +52,10 @@ defmodule Ambry.Inbox.Draft.Recording do
     field :doubt, Ecto.Enum, values: [:none, :nothing_found, :narrator_conflict, :low_confidence]
     field :doubt_detail, :string
 
+    # Whether the created Media is born hidden from browsing and search
+    # (`unlisted_at` stamped at import), for curating after the files land.
+    field :start_unlisted, :boolean, default: false
+
     embeds_one :title, Field, on_replace: :update
     embeds_one :published, Field, on_replace: :update
 
@@ -84,7 +88,8 @@ defmodule Ambry.Inbox.Draft.Recording do
       :approved,
       :evidence_curated,
       :doubt,
-      :doubt_detail
+      :doubt_detail,
+      :start_unlisted
     ])
     |> cast_embed(:recording_group)
     |> cast_embed(:sources)

--- a/lib/ambry/inbox/importer.ex
+++ b/lib/ambry/inbox/importer.ex
@@ -483,6 +483,7 @@ defmodule Ambry.Inbox.Importer do
       # bookkeeping, and an import has no transcode.
       library_root_id: root.id,
       status: :pending,
+      unlisted_at: if(recording.start_unlisted, do: DateTime.utc_now()),
       # The recording's settled place in its part set, if any.
       part_number: part_number(recording.recording_group),
       recording_group_id: group && group.id,

--- a/lib/ambry/media.ex
+++ b/lib/ambry/media.ex
@@ -404,8 +404,12 @@ defmodule Ambry.Media do
 
   defp media_with_book_details_query(id) do
     media_query =
-      from m in Media, where: m.status == :ready and m.id != ^id, order_by: {:desc, :published}
+      from m in Media,
+        where: m.status == :ready and is_nil(m.unlisted_at) and m.id != ^id,
+        order_by: {:desc, :published}
 
+    # unlisted parts stay in the set rail: whoever reached one part of a
+    # hidden set must still be able to reach the others
     group_media_query =
       from m in Media,
         where: m.status == :ready,
@@ -494,6 +498,20 @@ defmodule Ambry.Media do
       end
     end)
   end
+
+  @doc """
+  Hides a media from browsing and search; it stays reachable by direct link.
+  """
+  def unlist_media(%Media{unlisted_at: nil} = media),
+    do: update_media(media, %{unlisted_at: DateTime.utc_now()})
+
+  def unlist_media(%Media{} = media), do: {:ok, media}
+
+  @doc """
+  Restores an unlisted media to browsing and search.
+  """
+  def relist_media(%Media{unlisted_at: nil} = media), do: {:ok, media}
+  def relist_media(%Media{} = media), do: update_media(media, %{unlisted_at: nil})
 
   defp delete_unused_files_async(%Media{} = old_media, %Media{} = new_media) do
     (all_web_paths(old_media) -- all_web_paths(new_media))
@@ -1074,7 +1092,7 @@ defmodule Ambry.Media do
     # users never see non-ready audiobooks (tile system v2, rule 1)
     query =
       from b in Ecto.assoc(narrator, :media),
-        where: b.status == :ready,
+        where: b.status == :ready and is_nil(b.unlisted_at),
         order_by: [desc: b.published],
         offset: ^offset,
         limit: ^over_limit,
@@ -1097,7 +1115,7 @@ defmodule Ambry.Media do
     # recording group represents its set
     query =
       from m in Media,
-        where: m.status == :ready,
+        where: m.status == :ready and is_nil(m.unlisted_at),
         where:
           is_nil(m.recording_group_id) or
             m.id ==
@@ -1105,6 +1123,7 @@ defmodule Ambry.Media do
                 """
                 (SELECT m2.id FROM media m2
                  WHERE m2.recording_group_id = ? AND m2.status = 'ready'
+                   AND m2.unlisted_at IS NULL
                  ORDER BY m2.part_number ASC NULLS LAST, m2.id ASC
                  LIMIT 1)
                 """,
@@ -1116,7 +1135,7 @@ defmodule Ambry.Media do
 
     group_media_query =
       from m in Media,
-        where: m.status == :ready,
+        where: m.status == :ready and is_nil(m.unlisted_at),
         order_by: [asc_nulls_last: m.part_number, asc: m.id]
 
     media =

--- a/lib/ambry/media/editions.ex
+++ b/lib/ambry/media/editions.ex
@@ -38,16 +38,16 @@ defmodule Ambry.Media.Editions do
   @doc """
   Partitions a book's media list into editions, newest first.
 
-  Only ready media are considered unless `all_statuses: true` (admin
-  surfaces — operators always see non-ready). A book whose media are all
-  filtered out yields `[]` — user-facing surfaces hide such books
-  entirely.
+  Only ready, listed media are considered unless `all_statuses: true` (admin
+  surfaces — operators always see non-ready and unlisted). A book whose
+  media are all filtered out yields `[]` — user-facing surfaces hide such
+  books entirely.
   """
   def from_media(media_list, opts \\ []) do
     media_list =
       if opts[:all_statuses],
         do: media_list,
-        else: Enum.filter(media_list, &(&1.status == :ready))
+        else: Enum.filter(media_list, &(&1.status == :ready and is_nil(&1.unlisted_at)))
 
     {grouped, singles} = Enum.split_with(media_list, & &1.recording_group_id)
 

--- a/lib/ambry/media/media.ex
+++ b/lib/ambry/media/media.ex
@@ -69,6 +69,11 @@ defmodule Ambry.Media.Media do
     # destroy every recording's status.
     field :missing_since, :utc_datetime
 
+    # When an operator hid this recording from browsing and search. Not a
+    # `status` value for the same reason as `missing_since`: orthogonal and
+    # reversible, and an unlisted recording stays playable by direct link.
+    field :unlisted_at, :utc_datetime
+
     field :abridged, :boolean, default: false
 
     # display-title override: how this recording's title differs from the
@@ -150,6 +155,7 @@ defmodule Ambry.Media.Media do
       :mpd_path,
       :hls_path,
       :status,
+      :unlisted_at,
       :chapter_marker_source
     ])
     |> cast_assoc(:media_narrators,

--- a/lib/ambry/media/media_flat.ex
+++ b/lib/ambry/media/media_flat.ex
@@ -17,6 +17,7 @@ defmodule Ambry.Media.MediaFlat do
     field :part_word, :string
     field :status, Ecto.Enum, values: [:pending, :processing, :error, :ready]
     field :missing_since, :utc_datetime
+    field :unlisted_at, :utc_datetime
     field :full_cast, :boolean
     field :abridged, :boolean
     field :duration, :decimal
@@ -50,6 +51,9 @@ defmodule Ambry.Media.MediaFlat do
 
   def filter(query, :missing, true), do: from(p in query, where: not is_nil(p.missing_since))
   def filter(query, :missing, false), do: from(p in query, where: is_nil(p.missing_since))
+
+  def filter(query, :unlisted, true), do: from(p in query, where: not is_nil(p.unlisted_at))
+  def filter(query, :unlisted, false), do: from(p in query, where: is_nil(p.unlisted_at))
 
   def filter(query, :direct_play, direct_play?),
     do: from(p in query, where: p.direct_play == ^direct_play?)

--- a/lib/ambry_schema/media.ex
+++ b/lib/ambry_schema/media.ex
@@ -41,6 +41,9 @@ defmodule AmbrySchema.Media do
   node object(:media) do
     field :status, non_null(:media_processing_status)
 
+    @desc "When an operator hid this recording from browsing and search; null means listed"
+    field :unlisted_at, :datetime
+
     field :full_cast, non_null(:boolean)
     field :abridged, non_null(:boolean)
 

--- a/lib/ambry_schema/resolvers.ex
+++ b/lib/ambry_schema/resolvers.ex
@@ -214,7 +214,7 @@ defmodule AmbrySchema.Resolvers do
       if params[:allow_all_media] do
         from(m in Media)
       else
-        from m in Media, where: m.status == :ready
+        from m in Media, where: m.status == :ready and is_nil(m.unlisted_at)
       end
 
     apply_params(query, params)

--- a/lib/ambry_web/live/admin/inbox_live/form.ex
+++ b/lib/ambry_web/live/admin/inbox_live/form.ex
@@ -828,6 +828,13 @@ defmodule AmbryWeb.Admin.InboxLive.Form do
      end)}
   end
 
+  def handle_event("choose-start-unlisted", %{"start_unlisted" => value}, socket) do
+    {:noreply,
+     edit(socket, fn draft ->
+       update_in(draft.recording, &%{&1 | start_unlisted: value == "true"})
+     end)}
+  end
+
   def handle_event("rebuild", _params, socket) do
     {:ok, item} = Inbox.rebuild_draft(socket.assigns.item)
 

--- a/lib/ambry_web/live/admin/inbox_live/form.html.heex
+++ b/lib/ambry_web/live/admin/inbox_live/form.html.heex
@@ -959,6 +959,24 @@
             </select>
           </form>
         </div>
+        <%!-- Visibility on arrival: born hidden, curated, then relisted from
+            the audiobook's edit form. Its own card, not part of the
+            root/policy decision block — false is an answer, so it never
+            gates the import. --%>
+        <div class="rounded-lg bg-zinc-900 p-4">
+          <form id="destination-start-unlisted" phx-change="choose-start-unlisted">
+            <.input
+              type="checkbox"
+              id="start-unlisted"
+              name="start_unlisted"
+              label="Start unlisted"
+              checked={@item.draft.recording.start_unlisted}
+            />
+          </form>
+          <p class="pl-9 text-sm text-zinc-400">
+            Hidden from browsing and search until unticked on the audiobook's edit form.
+          </p>
+        </div>
         <p
           :if={@destination.blocker}
           class="flex items-baseline gap-1.5 pl-3 text-sm text-red-400"

--- a/lib/ambry_web/live/admin/media_live/form.ex
+++ b/lib/ambry_web/live/admin/media_live/form.ex
@@ -208,6 +208,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       media_params
       |> mark_typed_titles(current_chapters(socket.assigns.form))
       |> naming_a_set(socket)
+      |> apply_unlisted(socket.assigns.media)
 
     changeset =
       socket.assigns.media
@@ -230,6 +231,7 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       media_params
       |> mark_typed_titles(current_chapters(socket.assigns.form))
       |> naming_a_set(socket)
+      |> apply_unlisted(socket.assigns.media)
 
     socket =
       assign(socket,
@@ -814,6 +816,20 @@ defmodule AmbryWeb.Admin.MediaLive.Form do
       {:error, _reason} -> {:error, :failed_import}
     end
   end
+
+  # The form speaks a checkbox; the record keeps a timestamp. Stamped only on
+  # the flip, so re-saving an unlisted recording keeps when it was hidden.
+  defp apply_unlisted(%{"unlisted" => unlisted} = media_params, media) do
+    media_params = Map.delete(media_params, "unlisted")
+
+    case {unlisted, media.unlisted_at} do
+      {"true", nil} -> Map.put(media_params, "unlisted_at", DateTime.utc_now())
+      {"true", _since} -> media_params
+      {"false", _any} -> Map.put(media_params, "unlisted_at", nil)
+    end
+  end
+
+  defp apply_unlisted(media_params, _media), do: media_params
 
   defp save_media(socket, :edit, media_params) do
     opts = [provenance: ProvenanceHints.sources(socket.assigns.provenance_hints)]

--- a/lib/ambry_web/live/admin/media_live/form.html.heex
+++ b/lib/ambry_web/live/admin/media_live/form.html.heex
@@ -85,6 +85,13 @@
             <div class="flex gap-4">
               <.input field={@form[:abridged]} label="Abridged" type="checkbox" />
               <.input field={@form[:full_cast]} label="Full cast" type="checkbox" />
+              <.input
+                type="checkbox"
+                id="media-unlisted"
+                name="media[unlisted]"
+                label="Unlisted"
+                checked={!!@form[:unlisted_at].value}
+              />
             </div>
           </.field_group>
 

--- a/lib/ambry_web/live/admin/media_live/index.ex
+++ b/lib/ambry_web/live/admin/media_live/index.ex
@@ -48,6 +48,14 @@ defmodule AmbryWeb.Admin.MediaLive.Index do
       filters: %{direct_play: false},
       words: "Streaming only",
       empty: "Every audiobook is direct-play."
+    },
+    # Not trouble, but the same shape: a named list the operator can reach
+    # and paste. Unlisted recordings are invisible everywhere users browse,
+    # so this page is the one place to see what has been hidden.
+    "unlisted" => %{
+      filters: %{unlisted: true},
+      words: "Hidden from browsing",
+      empty: "No audiobooks are unlisted."
     }
   }
 

--- a/lib/ambry_web/live/admin/media_live/index.html.heex
+++ b/lib/ambry_web/live/admin/media_live/index.html.heex
@@ -64,6 +64,15 @@
           >
             missing
           </.badge>
+          <.badge
+            :if={media.unlisted_at}
+            color={:gray}
+            class="text-xs"
+            title={"Hidden from browsing and search since #{Calendar.strftime(media.unlisted_at, "%x %X")}"}
+            data-role="media-unlisted"
+          >
+            unlisted
+          </.badge>
         </:badges>
 
         <%!-- Everything that varies, on one line: the series, when it came

--- a/priv/repo/migrations/20260829162138_add_unlisted_at_to_media.exs
+++ b/priv/repo/migrations/20260829162138_add_unlisted_at_to_media.exs
@@ -1,0 +1,9 @@
+defmodule Ambry.Repo.Migrations.AddUnlistedAtToMedia do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media) do
+      add :unlisted_at, :utc_datetime
+    end
+  end
+end

--- a/priv/repo/migrations/20260829162331_media_flat_unlisted_at.exs
+++ b/priv/repo/migrations/20260829162331_media_flat_unlisted_at.exs
@@ -1,0 +1,9 @@
+defmodule Ambry.Repo.Migrations.MediaFlatUnlistedAt do
+  use Ecto.Migration
+  use Familiar
+
+  # Surfaces `unlisted_at` on the admin media list; admin lists show all
+  # recordings, so unlisted rows need a badge and a filter, not an absence.
+  def up, do: update_view("media_flat", version: 17)
+  def down, do: update_view("media_flat", version: 16)
+end

--- a/priv/repo/views/media_flat_v17.sql
+++ b/priv/repo/views/media_flat_v17.sql
@@ -1,0 +1,108 @@
+SELECT
+  media.id,
+  media.book_id,
+  media.status,
+  media.missing_since,
+  media.unlisted_at,
+  media.title,
+  media.part_number,
+  (
+    SELECT
+      recording_group.parts_total
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS parts_total,
+  (
+    SELECT
+      recording_group.part_word
+    FROM
+      recording_groups AS recording_group
+    WHERE
+      recording_group.id = media.recording_group_id
+  ) AS part_word,
+  media.full_cast,
+  media.abridged,
+  media.duration,
+  media.published,
+  media.published_format,
+  media.publisher,
+  media.thumbnails -> 'small' AS thumbnail,
+  CASE
+    WHEN media.chapters IS NOT NULL THEN JSONB_ARRAY_LENGTH(media.chapters)
+    ELSE 0
+  END chapters,
+  book.title AS book,
+  ARRAY(
+    SELECT
+      (series.name, books_series.book_number) :: series_book
+    FROM
+      books_series
+      INNER JOIN series ON series.id = books_series.series_id
+    WHERE
+      books_series.book_id = book.id
+    ORDER BY
+      books_series.position,
+      books_series.id
+  ) AS series,
+  (
+    SELECT
+      STRING_AGG(universe.name, ', ' ORDER BY universe.name)
+    FROM
+      books_universes AS book_universe
+      INNER JOIN universes AS universe ON universe.id = book_universe.universe_id
+    WHERE
+      book_universe.book_id = book.id
+  ) AS universes,
+  ARRAY(
+    SELECT
+      (
+        author.name,
+        (
+          SELECT
+            STRING_AGG(person.name, ', ' ORDER BY author_link.id)
+          FROM
+            authors_people AS author_link
+            INNER JOIN people AS person ON person.id = author_link.person_id
+          WHERE
+            author_link.author_id = author.id
+        )
+      ) :: person_name
+    FROM
+      authors_books AS authored_by
+      INNER JOIN authors AS author ON author.id = authored_by.author_id
+    WHERE
+      authored_by.book_id = book.id
+    ORDER BY
+      authored_by.position,
+      authored_by.id
+  ) AS authors,
+  ARRAY(
+    SELECT
+      (narrator.name, person.name) :: person_name
+    FROM
+      media_narrators AS narrated_by
+      INNER JOIN narrators AS narrator ON narrator.id = narrated_by.narrator_id
+      INNER JOIN people AS person ON person.id = narrator.person_id
+    WHERE
+      narrated_by.media_id = media.id
+    ORDER BY
+      narrated_by.position,
+      narrated_by.id
+  ) AS narrators,
+  media.description IS NOT NULL AS has_description,
+  EXISTS (
+    SELECT
+    FROM
+      media_tracks AS track
+    WHERE
+      track.media_id = media.id
+  ) AS direct_play,
+  media.inserted_at,
+  media.updated_at
+FROM
+  media
+  INNER JOIN books AS book ON book.id = media.book_id
+ORDER BY
+  book

--- a/test/ambry/books_test.exs
+++ b/test/ambry/books_test.exs
@@ -289,6 +289,38 @@ defmodule Ambry.BooksTest do
     end
   end
 
+  describe "browsing hides unlisted media" do
+    test "get_book_with_media!/1 omits unlisted media" do
+      book = insert(:book)
+      %{id: listed_id} = insert(:media, book: book, status: :ready)
+
+      insert(:media, book: book, status: :ready, unlisted_at: DateTime.utc_now(:second))
+
+      assert %{media: [%{id: ^listed_id}]} = Books.get_book_with_media!(book.id)
+    end
+
+    test "get_authored_books/3 hides a book whose only media are unlisted" do
+      author = insert(:author, person: build(:person))
+
+      %{id: listed_book_id} =
+        listed_book = insert(:book, book_authors: [build(:book_author, author: author)])
+
+      insert(:media, book: listed_book, status: :ready)
+
+      hidden_book = insert(:book, book_authors: [build(:book_author, author: author)])
+
+      insert(:media,
+        book: hidden_book,
+        status: :ready,
+        unlisted_at: DateTime.utc_now(:second)
+      )
+
+      {books, false} = Books.get_authored_books(author)
+
+      assert Enum.map(books, & &1.id) == [listed_book_id]
+    end
+  end
+
   describe "delete_book/1" do
     test "deletes a book" do
       book = insert(:book)

--- a/test/ambry/inbox/importer_test.exs
+++ b/test/ambry/inbox/importer_test.exs
@@ -119,6 +119,23 @@ defmodule Ambry.Inbox.ImporterTest do
       assert media.status == :pending
     end
 
+    test "a start-unlisted import is born hidden" do
+      item = tagged_item()
+
+      item = update_in(item.draft.recording, &%{&1 | start_unlisted: true})
+      {:ok, item} = Inbox.update_draft(item, Inbox.dump_draft(item.draft))
+
+      assert {:ok, media} = Inbox.import_item(item)
+
+      assert %DateTime{} = Media.get_media!(media.id).unlisted_at
+    end
+
+    test "an ordinary import is born listed" do
+      assert {:ok, media} = tagged_item() |> Inbox.import_item()
+
+      assert Media.get_media!(media.id).unlisted_at == nil
+    end
+
     # A curated list is the operator's answer — including hand-nudged times —
     # and lands verbatim. Safe against the import-time re-probe because a
     # file change flips the draft stale, and a stale draft refuses import.

--- a/test/ambry/media/editions_test.exs
+++ b/test/ambry/media/editions_test.exs
@@ -59,6 +59,22 @@ defmodule Ambry.Media.EditionsTest do
       assert admin_rep_id == pending_first.id
     end
 
+    test "unlisted media are filtered like non-ready, unless all_statuses" do
+      book = insert(:book)
+
+      listed = insert(:media, book: book, status: :ready)
+
+      unlisted =
+        insert(:media, book: book, status: :ready, unlisted_at: DateTime.utc_now(:second))
+
+      assert [%Edition{representative: %{id: rep_id}}] =
+               Editions.from_media([unlisted, listed])
+
+      assert rep_id == listed.id
+
+      assert length(Editions.from_media([unlisted, listed], all_statuses: true)) == 2
+    end
+
     test "a book with nothing ready yields no editions" do
       book = insert(:book)
       insert(:media, book: book, status: :pending)

--- a/test/ambry/media_test.exs
+++ b/test/ambry/media_test.exs
@@ -837,6 +837,92 @@ defmodule Ambry.MediaTest do
     end
   end
 
+  describe "unlist_media/1 and relist_media/1" do
+    test "unlisting stamps unlisted_at once and relisting clears it" do
+      media = insert(:media, book: build(:book))
+
+      {:ok, unlisted} = Media.unlist_media(media)
+      assert %DateTime{} = unlisted.unlisted_at
+
+      {:ok, still_unlisted} = Media.unlist_media(unlisted)
+      assert still_unlisted.unlisted_at == unlisted.unlisted_at
+
+      {:ok, relisted} = Media.relist_media(still_unlisted)
+      assert relisted.unlisted_at == nil
+
+      {:ok, still_listed} = Media.relist_media(relisted)
+      assert still_listed.unlisted_at == nil
+    end
+
+    test "an unlisted media keeps its processing status" do
+      media = insert(:media, book: build(:book), status: :error)
+
+      {:ok, unlisted} = Media.unlist_media(media)
+      assert unlisted.status == :error
+
+      {:ok, relisted} = Media.relist_media(unlisted)
+      assert relisted.status == :error
+    end
+  end
+
+  describe "browsing hides unlisted media" do
+    test "get_recent_media/2 skips unlisted media" do
+      %{id: listed_id} = insert(:media, book: build(:book), status: :ready)
+
+      insert(:media,
+        book: build(:book),
+        status: :ready,
+        unlisted_at: DateTime.utc_now(:second)
+      )
+
+      {media, false} = Media.get_recent_media()
+
+      assert Enum.map(media, & &1.id) == [listed_id]
+    end
+
+    test "an unlisted part cannot represent its set" do
+      book = insert(:book)
+      group = insert(:recording_group, book: book)
+
+      insert(:media,
+        book: book,
+        recording_group: group,
+        part_number: 1,
+        status: :ready,
+        unlisted_at: DateTime.utc_now(:second)
+      )
+
+      %{id: part_two_id} =
+        insert(:media, book: book, recording_group: group, part_number: 2, status: :ready)
+
+      {media, false} = Media.get_recent_media()
+
+      assert Enum.map(media, & &1.id) == [part_two_id]
+    end
+
+    test "get_narrated_media/3 skips unlisted media" do
+      narrator = insert(:narrator, person: build(:person))
+
+      %{id: listed_id} =
+        insert(:media,
+          book: build(:book),
+          status: :ready,
+          media_narrators: [build(:media_narrator, narrator: narrator)]
+        )
+
+      insert(:media,
+        book: build(:book),
+        status: :ready,
+        unlisted_at: DateTime.utc_now(:second),
+        media_narrators: [build(:media_narrator, narrator: narrator)]
+      )
+
+      {media, false} = Media.get_narrated_media(narrator)
+
+      assert Enum.map(media, & &1.id) == [listed_id]
+    end
+  end
+
   describe "delete_media/1" do
     test "deletes a media" do
       media =

--- a/test/ambry_web/live/admin/inbox_live/form_test.exs
+++ b/test/ambry_web/live/admin/inbox_live/form_test.exs
@@ -119,6 +119,25 @@ defmodule AmbryWeb.Admin.InboxLive.FormTest do
       refute has_element?(view, "button[data-role='import'][disabled]")
     end
 
+    test "ticking Start unlisted carries through the import", %{conn: conn} do
+      item = probed_item() |> settle()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/inbox/#{item}")
+
+      view
+      |> form("#destination-start-unlisted", %{"start_unlisted" => "true"})
+      |> render_change()
+
+      # a visibility choice is an answer, never an open question
+      refute has_element?(view, "button[data-role='import'][disabled]")
+
+      view |> element("button[data-role='import']") |> render_click()
+      assert %{success: 1} = Oban.drain_queue(queue: :media)
+
+      %{media_id: media_id} = Inbox.get_item!(item.id)
+      assert %DateTime{} = Ambry.Media.get_media!(media_id).unlisted_at
+    end
+
     # The import is queued and the operator is handed back to the queue at
     # once. It used to run in an async task owned by this LiveView, which
     # pinned them to a spinner and — the real defect — died with the process,

--- a/test/ambry_web/live/admin/media_live/unlisted_test.exs
+++ b/test/ambry_web/live/admin/media_live/unlisted_test.exs
@@ -1,0 +1,70 @@
+defmodule AmbryWeb.Admin.MediaLive.UnlistedTest do
+  @moduledoc """
+  Unlisted recordings are invisible everywhere users browse, so the admin
+  list is the one place that has to say so.
+  """
+  use AmbryWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  setup :register_and_log_in_admin_user
+
+  test "badges an unlisted recording", %{conn: conn} do
+    insert(:media, book: build(:book), status: :ready, unlisted_at: DateTime.utc_now(:second))
+
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
+
+    assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-unlisted']") != []
+    assert html =~ "unlisted"
+  end
+
+  test "leaves a listed recording unbadged", %{conn: conn} do
+    insert(:media, book: build(:book), status: :ready, unlisted_at: nil)
+
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks")
+
+    assert html |> Floki.parse_document!() |> Floki.find("[data-role='media-unlisted']") == []
+  end
+
+  test "the form checkbox unlists and relists without churning the timestamp", %{conn: conn} do
+    media = insert(:media, book: build(:book))
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+    view
+    |> form("#media-form", %{"media" => %{"unlisted" => "true"}})
+    |> render_submit()
+
+    assert %{unlisted_at: %DateTime{} = hidden_at} = Ambry.Media.get_media!(media.id)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+    assert has_element?(view, "input#media-unlisted[checked]")
+
+    view
+    |> form("#media-form", %{"media" => %{"unlisted" => "true"}})
+    |> render_submit()
+
+    assert %{unlisted_at: ^hidden_at} = Ambry.Media.get_media!(media.id)
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audiobooks/#{media.id}/edit")
+
+    view
+    |> form("#media-form", %{"media" => %{"unlisted" => "false"}})
+    |> render_submit()
+
+    assert %{unlisted_at: nil} = Ambry.Media.get_media!(media.id)
+  end
+
+  test "?problem=unlisted narrows the list to unlisted recordings", %{conn: conn} do
+    listed = insert(:media, book: build(:book), status: :ready)
+
+    unlisted =
+      insert(:media, book: build(:book), status: :ready, unlisted_at: DateTime.utc_now(:second))
+
+    {:ok, _view, html} = live(conn, ~p"/admin/audiobooks?problem=unlisted")
+
+    assert html =~ html_escape(unlisted.book.title)
+    refute html =~ html_escape(listed.book.title)
+    assert html =~ "Hidden from browsing"
+  end
+end

--- a/test/ambry_web/live/audiobook_live_part_test.exs
+++ b/test/ambry_web/live/audiobook_live_part_test.exs
@@ -24,6 +24,28 @@ defmodule AmbryWeb.AudiobookLivePartTest do
     refute html =~ "Season One"
   end
 
+  # whoever reached one part of a hidden set must still be able to reach the
+  # others
+  test "the set rail keeps unlisted sibling parts", %{conn: conn} do
+    book = insert(:book)
+    group = insert(:recording_group, book: book, parts_total: 2)
+
+    media = insert(:media, book: book, part_number: 1, recording_group: group, status: :ready)
+
+    sibling =
+      insert(:media,
+        book: book,
+        part_number: 2,
+        recording_group: group,
+        status: :ready,
+        unlisted_at: DateTime.utc_now(:second)
+      )
+
+    {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
+
+    assert Floki.find(Floki.parse_document!(html), "a[href='/audiobooks/#{sibling.id}']") != []
+  end
+
   test "tiles show composed titles for parts", %{conn: conn} do
     book = insert(:book, title: "The Way of Kings")
     group = insert(:recording_group, parts_total: 3)

--- a/test/ambry_web/live/audiobook_live_test.exs
+++ b/test/ambry_web/live/audiobook_live_test.exs
@@ -21,4 +21,39 @@ defmodule AmbryWeb.AudiobookLiveTest do
 
     assert html =~ html_escape(book_title)
   end
+
+  test "an unlisted audiobook still renders by direct link", %{conn: conn} do
+    media =
+      :media
+      |> build(book: build(:book), unlisted_at: DateTime.utc_now(:second))
+      |> with_image()
+      |> with_thumbnails()
+      |> with_copied_source_files()
+      |> insert()
+      |> with_output_files()
+
+    {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
+
+    assert html =~ html_escape(media.book.title)
+  end
+
+  test "the other-editions rail hides an unlisted edition", %{conn: conn} do
+    book = insert(:book)
+
+    media =
+      :media
+      |> build(book: book)
+      |> with_image()
+      |> with_thumbnails()
+      |> with_copied_source_files()
+      |> insert()
+      |> with_output_files()
+
+    unlisted =
+      insert(:media, book: book, status: :ready, unlisted_at: DateTime.utc_now(:second))
+
+    {:ok, _view, html} = live(conn, ~p"/audiobooks/#{media.id}")
+
+    assert Floki.find(Floki.parse_document!(html), "a[href='/audiobooks/#{unlisted.id}']") == []
+  end
 end

--- a/test/ambry_web/live/library_live_test.exs
+++ b/test/ambry_web/live/library_live_test.exs
@@ -21,4 +21,17 @@ defmodule AmbryWeb.LibraryLiveTest do
 
     assert html =~ html_escape(book_title)
   end
+
+  test "hides unlisted media", %{conn: conn} do
+    media =
+      insert(:media,
+        book: build(:book),
+        status: :ready,
+        unlisted_at: DateTime.utc_now(:second)
+      )
+
+    {:ok, _view, html} = live(conn, ~p"/library")
+
+    refute html =~ html_escape(media.book.title)
+  end
 end

--- a/test/ambry_web/live/search_live_test.exs
+++ b/test/ambry_web/live/search_live_test.exs
@@ -13,6 +13,19 @@ defmodule AmbryWeb.SearchLiveTest do
     assert html =~ html_escape(book_title)
   end
 
+  test "hides a book whose only media are unlisted", %{conn: conn} do
+    book = insert(:book)
+
+    media =
+      insert(:media, book: book, status: :ready, unlisted_at: DateTime.utc_now(:second))
+
+    {:ok, _view, html} = live(conn, ~p"/search/#{book.title}")
+
+    doc = Floki.parse_document!(html)
+    assert Floki.find(doc, "a[href='/audiobooks/#{media.id}']") == []
+    assert Floki.find(doc, "a[href='/books/#{book.id}']") == []
+  end
+
   test "renders search results page when searching for a person", %{conn: conn} do
     %{name: person_name} = :person |> insert()
 


### PR DESCRIPTION
A way to intentionally hide audiobooks from all browsing and search while keeping them fully functional: reachable by direct link, resumable, downloadable, and still on a listener's shelf in the mobile app.

## Design

- New nullable `media.unlisted_at` timestamp, the orthogonal twin of `missing_since`, deliberately **not** a fifth `status` value: status is machine-written lifecycle (importer sets pending/ready, publishing keys on it), unlisting is a reversible operator choice, and the two must compose — a recording can be born unlisted, finish processing, and stay hidden until curated.
- Every existing `status == :ready` browsing filter gains `and is_nil(unlisted_at)`: library grid, author/narrator rails, book editions, the `Editions` chokepoint (search and series pages get it free), the GraphQL dataloader default, and the set-representative SQL.
- **Set-sibling exception**: the parts rail on an audiobook's own page keeps unlisted siblings, so someone resuming part 1 of a hidden set can still reach part 2. The other-editions rail hides them.
- Direct links, tracks, and downloads never filtered on status and still don't.
- `unlistedAt` is exposed on the GraphQL Media node and flows through `mediaChangedSince`; hiding is a synced flag the mobile app filters on, never an omission from sync (omission would strand stale local copies). Mobile-side filtering is a follow-up PR in the app repo.

## Admin

- "Unlisted" checkbox on the media form; the timestamp is stamped only on the flip, so re-saving keeps when it was hidden.
- "unlisted" badge on the list, plus `?problem=unlisted` to see everything hidden; `media_flat` v17 carries the column.
- "Start unlisted" checkbox on the import form (draft-persisted), so a new audiobook can be curated before it becomes visible.

## Tests

Filter coverage per query site, Editions, importer (born hidden / born listed), form round-trip without timestamp churn, badge/filter, direct-link access, and the set-sibling rule. Full suite + `mix check` green.